### PR TITLE
feat(clawgate): host-side terminal WRITE agent — outbound short poll, SHIPPED DISABLED

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,14 @@
         gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
         pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
         pkgs.rsync pkgs.zsh pkgs.age
+        # 🔴 tmux, because two of tmux-reply-agent's guards CANNOT be written
+        # against a stub. A stub tmux always exits 0, so it models neither the
+        # session PREFIX-MATCH (`-t scratch2:` opening a window in `scratch20`)
+        # nor the `-c <missing path>` fallback to the home directory -- both
+        # measured live, both shipped, both invisible to a stubbed suite. Those
+        # tests drive a REAL tmux on a private `-L` socket, and this entry is what
+        # stops them SKIPPING in the check sandbox, where a skip is an error.
+        pkgs.tmux
       ];
     in
     {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -137,6 +137,37 @@ let
   # rejected outright (the server 4xx's and CHANGES NOTHING, leaving the previous tail in
   # place), and the server sweeps rows older than 7 days.
   enableTranscriptPush = true;
+  # clawgate TERMINAL WRITE agent master switch (scripts/tmux-reply-agent) — the
+  # host half of the reply channel. Gates ONLY whether the long-running SERVICE is
+  # wired into `default.target`; the unit definition is always emitted, so it can
+  # be started by hand regardless.
+  #
+  # 🔴 IT SHIPS **false**, AND THAT IS THE POINT OF THE WHOLE SHAPE — not caution
+  # about an unfinished feature. What this agent delivers is `tmux send-keys`
+  # followed by Enter, i.e. arbitrary command execution as the operator on this
+  # host, driven by a route on a LAN NodePort that has no human auth. The operator
+  # took that decision deliberately, with the blast radius stated; what was ALSO
+  # decided is that building it and ARMING it are separate acts, so the write path
+  # can be merged, deployed, read and audited before it can execute anything.
+  #
+  # 🔴 TWO INDEPENDENT SWITCHES, AND NEITHER IMPLIES THE OTHER. Arming needs
+  # (1) CLAWGATE_TERMINAL_TOKEN provisioned into the POD's secret — until then the
+  # server's write routes answer 503 and the pod says so at boot, unconditionally
+  # and in both directions ("terminal write surface: DISABLED (fail-closed)") —
+  # and (2) this flag true, with the same secret readable on this host from
+  # ~/.claude/clawgate.env. Flipping only this one gets a unit that exits 2 saying
+  # the surface is not armed; provisioning only the secret gets a server with a
+  # live route and nobody polling it. Disarming is removing the secret, which is
+  # reversible and takes effect on the pod's next boot.
+  #
+  # 🔴 NOT serverMode-GATED, and the asymmetry with enableTmuxSnapshotPush is the
+  # same one transcript-push has. That feeder is workbench-only as a CORRECTNESS
+  # requirement (its collector already reaches both hosts over ssh, so a second
+  # reporter would fight over every row). A tmux socket, by contrast, is visible
+  # ONLY from the machine it lives on, so a workbench-only agent would leave every
+  # laptop pane permanently unanswerable. The queue is keyed on the host label, so
+  # two agents claiming disjoint host scopes cannot collide.
+  enableTmuxReplyAgent = false;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -3759,6 +3790,87 @@ in
     Install = {
       # 🔴 NO serverMode GATE — both hosts, on purpose. See enableTranscriptPush.
       WantedBy = lib.optionals enableTranscriptPush [ "timers.target" ];
+    };
+  };
+
+  # ── CLAWGATE TERMINAL WRITE AGENT (scripts/tmux-reply-agent) ────────────────
+  # The host half of clawgate's reply channel: a long-running OUTBOUND short poll
+  # that claims queued writes for this host, runs `tmux send-keys` locally, and
+  # reports the outcome. It is the return direction the two feeders above never
+  # had — and it is outbound for the same reason they are: the pod cannot see
+  # either host's tmux socket, and the alternative (an inbound port, or an ssh
+  # credential inside a pod on an unauthenticated LAN surface) is strictly worse.
+  #
+  # 🔴 SHIPPED DISABLED. `enableTmuxReplyAgent` is false — see its comment above
+  # for the two independent switches that arm this and why building it and arming
+  # it were deliberately separated. The unit below EXISTS on both hosts and is
+  # wired into nothing.
+  #
+  # 🔴 Type = "simple", NOT the oneshot-plus-timer shape its two siblings use, and
+  # the difference is the cadence. A ~5s poll cannot be a timer: the user manager
+  # would fork a process, a Python interpreter and a TCP connection 17,280 times a
+  # day for a queue that is empty almost always. A resident process holding one
+  # loop is the cheaper and simpler thing, and it is what lets a reply land within
+  # seconds of being typed — which is the entire point of the feature.
+  systemd.user.services.tmux-reply-agent = {
+    Unit = {
+      Description = "Deliver clawgate's queued terminal writes into this host's tmux panes";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      # 🔴 NO OnFailure, DELIBERATELY, and for the reason spelled out at
+      # tmux-snapshot-push: notify-failure@ toasts are wired to DEFEAT
+      # do-not-disturb, and that bypass is justified by a MEASURED rate of about
+      # one firing in nine days. This unit polls every few seconds, so any
+      # sustained condition — the surface not armed (which is the state it ships
+      # in), clawgate mid-redeploy, the laptop's network down — would fire a
+      # DND-bypassing toast on every restart and burn down the one alert channel
+      # that has to keep its meaning.
+      #
+      # What surfaces a genuinely broken agent instead: the two exit codes it can
+      # actually take (2 = no credentials, 3 = tmux unusable) are both permanent
+      # configuration faults, and StartLimit below turns a repeat of either into a
+      # FAILED unit, which `/standup` reads. Everything transient is backed off
+      # from inside the loop rather than exited on, precisely so a restart storm
+      # is not the failure mode.
+      StartLimitIntervalSec = 600;
+      StartLimitBurst = 5;
+    };
+    Service = {
+      Type = "simple";
+      Restart = "on-failure";
+      # Long enough that five restarts cannot happen inside the 600s window above
+      # unless the fault is permanent — which is what should mark the unit failed.
+      RestartSec = 60;
+      Environment = [
+        # 🔴 EVERY ENTRY IS FOR THE CHILD — under systemd there is no login-shell
+        # PATH to fall back on, and drift-check.service already paid for that
+        # lesson (it reported COULD NOT MEASURE on every run forever, from a unit
+        # that looked completely correct).
+        #
+        # The agent is pure stdlib Python plus `tmux`. It needs NEITHER curl (it
+        # uses urllib) NOR openssh/gawk (it never leaves this host) — copying
+        # tmux-snapshot-push's list would be carrying binaries to justify later.
+        # Pinned by `test_tmux_reply_agent.py::test_the_unit_PATH_carries_tmux_and_python`.
+        "PATH=${lib.makeBinPath [ pkgs.coreutils pkgs.python3 pkgs.tmux ]}"
+        "HOME=%h"
+        # 🔴 THE SOCKET DIRECTORY, AND HERE IT IS LOAD-BEARING RATHER THAN
+        # DEFENSIVE. This host's tmux socket is at $XDG_RUNTIME_DIR/tmux-UID/,
+        # not tmux's compiled-in /tmp/tmux-UID/. tmux-snapshot-push sets this
+        # defensively — if IT cannot connect, a host is reported with an empty
+        # window list, which is silent and destructive. If THIS unit cannot
+        # connect, every delivery fails loudly and is recorded as `failed` in the
+        # audit log, which is the safe direction; the pin is here so the ordinary
+        # case works at all rather than to prevent a silent one. `%t` is the user
+        # runtime dir (/run/user/UID).
+        "TMUX_TMPDIR=%t"
+      ];
+      ExecStart = "${pkgs.python3}/bin/python3 %h/workspace/devrc/scripts/tmux-reply-agent";
+      X-Restart-Triggers = [ "${../scripts/tmux-reply-agent}" ];
+    };
+    Install = {
+      # 🔴 SHIPPED DISABLED — see enableTmuxReplyAgent. A `default.target` want,
+      # not `timers.target`: this is a resident service, not a timer.
+      WantedBy = lib.optionals enableTmuxReplyAgent [ "default.target" ];
     };
   };
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3865,7 +3865,15 @@ in
         "TMUX_TMPDIR=%t"
       ];
       ExecStart = "${pkgs.python3}/bin/python3 %h/workspace/devrc/scripts/tmux-reply-agent";
-      X-Restart-Triggers = [ "${../scripts/tmux-reply-agent}" ];
+      # 🔴 THE POLICY MODULE IS A TRIGGER TOO. This is a RESIDENT service, not a
+      # timer: it imports scripts/lib/tmux_text_policy.py once at startup and then
+      # runs for weeks. Without this line, TIGHTENING the text allowlist would
+      # leave the running agent on the OLD predicate indefinitely -- a security
+      # change that appears deployed and is not, on the process that executes.
+      X-Restart-Triggers = [
+        "${../scripts/tmux-reply-agent}"
+        "${../scripts/lib/tmux_text_policy.py}"
+      ];
     };
     Install = {
       # 🔴 SHIPPED DISABLED — see enableTmuxReplyAgent. A `default.target` want,

--- a/scripts/lib/tmux_text_policy.py
+++ b/scripts/lib/tmux_text_policy.py
@@ -1,0 +1,100 @@
+"""THE policy for what may be delivered to a tmux pane as literal text.
+
+🔴 ONE PREDICATE, ONE PLACE — AND THIS MODULE EXISTS BECAUSE THE SECOND COPY WAS
+ALREADY WRONG. `session-write` reached this rule the hard way and wrote the
+reason down; `tmux-reply-agent` then shipped its own version at the
+NETWORK-FACING site, and that version was a DENYLIST:
+
+    def has_control(value):
+        return any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+
+It refuses NUL, `\\n`, `\\r`, ESC and DEL — and passes every C1 control
+(U+0080–U+009F), U+0085 NEL (which some terminals treat as a line break), and
+U+2028/U+2029. That is the exact shape `session-write`'s docstring records as the
+bug it had already fixed: *"the previous version asked 'is this character one of
+the four we banned', so U+000F (Ctrl-O) passed and `type` executed arbitrary
+commands in any shell pane."* Two sites, one rule, wrong at the one reachable
+from the network — which is `claude/RULES.md`'s "a predicate open-coded at N
+sites is typically wrong at N−1 of them, in the same direction", measured.
+
+So the rule now lives here and both callers import it. There is no second copy
+to disagree with, and `test_tmux_text_policy_is_the_only_copy.py` fails if one
+appears.
+
+🔴 IT IS AN ALLOWLIST, AND THE DIRECTION IS THE WHOLE POINT. The question asked
+is "is this character safe to deliver", never "is this one of the dangerous ones
+we thought of". The set of characters bound to an accept-line variant is a
+property of the OPERATOR'S shell config, which no process here can read — so a
+denylist is a guess about someone else's keymap, and this one is not.
+
+`str.isprintable()` is False for exactly the Unicode categories that make a
+codepoint a control or an invisible: Cc (NUL, `\\n`, `\\r`, `\\x0f`, ESC, DEL),
+Cf, Cs, Co (private use — the U+E000 that once rendered a diff identical to an
+unedited line), Cn, Zl, Zp and Zs-except-ASCII-space. Tab is Cc and is
+re-permitted explicitly; it is the one control character with an ordinary
+typographic use and it cannot accept a line.
+"""
+from __future__ import annotations
+
+import unicodedata
+
+#: The character whose TRAILING occurrence tmux eats off an argv token. tmux's
+#: own command parser treats it as a separator, so `send-keys -l -- 'x;'`
+#: delivers `x`.
+#:
+#: 🔴 It is spelled here rather than imported from `session-resolve`, because a
+#: long-running daemon must not load a 3,000-line CLI to learn one character.
+#: `session-write` PINS the two against each other at import time, so the
+#: duplication cannot drift silently — an assertion, not a convention.
+TMUX_ARGV_SEPARATOR = ";"
+
+#: The one control character re-permitted. See the module docstring.
+TEXT_EXTRA_ALLOWED = ("\t",)
+
+#: Characters `send-keys -l` delivers as a real Enter (measured).
+#: 🔴 NOT A GATE — both are non-printable, so `TEXT_IS_ALLOWED` has already
+#: refused them. This exists only to give them a message that names the hazard.
+SUBMITTING_CHARS = ("\n", "\r")
+
+#: Refused, but not control characters — a DIAGNOSIS set, never a gate.
+TEXT_INVISIBLE_CATEGORIES = ("Cf", "Zl", "Zp", "Zs")
+
+
+def TEXT_IS_ALLOWED(ch: str) -> bool:
+    """THE allowlist predicate. Every delivered codepoint passes through here."""
+    return ch in TEXT_EXTRA_ALLOWED or ch.isprintable()
+
+
+def first_disallowed(text: str):
+    """-> (index, char) of the first codepoint the allowlist refuses, or None.
+
+    The offset is COMPUTED from the scan, INCLUDING offset 0 — `session-write`
+    records that `enumerate(text[1:], 1)` survived its whole suite and its
+    committed mutation sweep, because every fixture put the bad character later.
+    """
+    for idx, ch in enumerate(text):
+        if not TEXT_IS_ALLOWED(ch):
+            return idx, ch
+    return None
+
+
+def describe_disallowed(idx: int, ch: str) -> str:
+    """A human reason for a refused codepoint. Wording only — the gate has
+    already decided. Names the codepoint by NUMBER, never by rendering it: the
+    whole class here is characters that render as nothing or as something else.
+    """
+    if ch == "\x00":
+        return f"a NUL at offset {idx}"
+    if ch in SUBMITTING_CHARS:
+        name = "a newline" if ch == "\n" else "a carriage return"
+        return f"{name} at offset {idx}, which tmux delivers as a real Enter"
+    category = unicodedata.category(ch)
+    if category in TEXT_INVISIBLE_CATEGORIES:
+        return (f"an invisible character U+{ord(ch):04X} "
+                f"({unicodedata.name(ch, 'unnamed')}, category {category}) at offset {idx}")
+    return f"a non-printable character U+{ord(ch):04X} (category {category}) at offset {idx}"
+
+
+def ends_with_separator(text: str) -> bool:
+    """Whether tmux would EAT the last character off this token."""
+    return text.endswith(TMUX_ARGV_SEPARATOR)

--- a/scripts/lib/tmux_text_policy.py
+++ b/scripts/lib/tmux_text_policy.py
@@ -18,8 +18,10 @@ from the network — which is `claude/RULES.md`'s "a predicate open-coded at N
 sites is typically wrong at N−1 of them, in the same direction", measured.
 
 So the rule now lives here and both callers import it. There is no second copy
-to disagree with, and `test_tmux_text_policy_is_the_only_copy.py` fails if one
-appears.
+to disagree with: `test_tmux_reply_agent.py::test_neither_script_defines_a_SECOND_
+text_predicate` AST-scans both scripts and fails if one reappears, and
+`::test_the_agent_and_session_write_share_ONE_predicate` pins both consumers'
+predicates to THIS file by `__code__.co_filename`.
 
 🔴 IT IS AN ALLOWLIST, AND THE DIRECTION IS THE WHOLE POINT. The question asked
 is "is this character safe to deliver", never "is this one of the dangerous ones

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -482,7 +482,7 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 # 🔴 `python` is listed as well as `python3` because THIS SCRIPT invokes
 # `python -m pytest`, not `python3`. Asserting only `python3` checked a binary
 # the runner never calls.
-REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python python3 nix-instantiate opencode logrotate rsync zsh)
+REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python python3 nix-instantiate opencode logrotate rsync zsh tmux)
 missing_tools=()
 for t in "${REQUIRED_TOOLS[@]}"; do
   command -v "$t" >/dev/null 2>&1 || missing_tools+=("$t")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -479,6 +479,23 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 #           cannot occur in. Both hosts run zsh as the login shell, and
 #           flake.nix's `gateTools` carries it for the sandbox.
 #
+# tmux:     scripts/tests/test_tmux_reply_agent.py drives a REAL tmux on a
+#           private `-L` socket, because two of the reply agent's guards CANNOT
+#           be written against a stub. A stub tmux exits 0 for everything, so it
+#           models neither rule that shipped as a defect:
+#             * `-t <name>:` PREFIX-MATCHES a session. Measured on 3.7c against
+#               the operator's own server, which holds `scratch` … `scratch20`:
+#               `-t scratch2:` with scratch2 absent returned rc 0 and opened the
+#               window in scratch20, where the agent then typed a command and
+#               pressed Enter.
+#             * `-c <path that does not exist>` also returns rc 0, with the
+#               window in $HOME — so a build or a recursive delete ran there and
+#               was reported `delivered`.
+#           Both are on the path that always presses Enter, and both were
+#           invisible to a fully green stubbed suite. Those tests FAIL rather
+#           than skip when tmux is absent, and flake.nix's `gateTools` carries
+#           it for the sandbox.
+
 # 🔴 `python` is listed as well as `python3` because THIS SCRIPT invokes
 # `python -m pytest`, not `python3`. Asserting only `python3` checked a binary
 # the runner never calls.

--- a/scripts/session-write
+++ b/scripts/session-write
@@ -356,6 +356,25 @@ def _load_session_resolve(path: str = SESSION_RESOLVE_PATH):
 
 
 sr = _load_session_resolve()
+def _load_tmux_text_policy(path: str = None):
+    """Load `scripts/lib/tmux_text_policy.py` by EXPLICIT PATH.
+
+    By path, like `_load_session_resolve` above and for the same reason: this
+    file is a SCRIPT with no package around it, so an ordinary import cannot
+    find a sibling directory, and a `sys.path` mutation would leak into every
+    module this process later loads.
+
+    🔴 IT RAISES RATHER THAN FALLING BACK. A missing policy module must stop
+    this program, not quietly leave it with a weaker check — the whole reason
+    the module exists is that a weaker check shipped once already.
+    """
+    path = path or os.path.join(_HERE, "lib", "tmux_text_policy.py")
+    loader = importlib.machinery.SourceFileLoader("_sw_tmux_text_policy", path)
+    spec = importlib.util.spec_from_loader("_sw_tmux_text_policy", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
 
 
 # --------------------------------------------------------------------------- #
@@ -396,58 +415,39 @@ LOG_ROOT = os.path.join(os.path.expanduser("~"), ".claude")
 DEFAULT_LOG_PATH = os.path.join(LOG_ROOT, "session-write.log")
 LOG_PATH_ENV = "SESSION_WRITE_LOG"
 
-#: The character whose trailing occurrence tmux EATS off an argv token — see the
-#: measurement in the docstring. Named so the refusal and the check cannot drift.
+#: 🔴 THE TEXT POLICY NOW LIVES IN ONE MODULE, AND THIS FILE IMPORTS IT.
+#: `scripts/lib/tmux_text_policy.py` holds the allowlist, its two diagnosis sets
+#: and the argv separator. The reason it moved is recorded there: a SECOND copy
+#: of this rule shipped at the network-facing site (`tmux-reply-agent`) as a
+#: DENYLIST — `ord(ch) < 0x20 or ord(ch) == 0x7F` — which passes every C1
+#: control and U+0085 NEL, i.e. exactly the bug whose fix `validate_text`'s
+#: docstring below describes. One rule, two sites, wrong at the one reachable
+#: from the network.
+#:
+#: The names are RE-EXPORTED under their existing spellings so nothing that
+#: reads them (this file's guards, and `test_session_write.py`, which asserts on
+#: `sw.TEXT_IS_ALLOWED` and `sw.TEXT_EXTRA_ALLOWED`) has to change. The behaviour
+#: is byte-for-byte the same predicate that was here.
+_tp = _load_tmux_text_policy()
+
+TEXT_EXTRA_ALLOWED = _tp.TEXT_EXTRA_ALLOWED
+TEXT_INVISIBLE_CATEGORIES = _tp.TEXT_INVISIBLE_CATEGORIES
+SUBMITTING_CHARS = _tp.SUBMITTING_CHARS
+TEXT_IS_ALLOWED = _tp.TEXT_IS_ALLOWED
+
+#: The character whose trailing occurrence tmux EATS off an argv token.
+#:
+#: 🔴 PINNED AGAINST session-resolve's OWN CONSTANT, not merely copied. The
+#: shared policy module spells the character itself (a daemon must not import a
+#: 3,000-line CLI to learn one character), so the two could drift — and this
+#: assertion is what makes that impossible rather than unlikely. It fires at
+#: import, before any caller can be given a wrong answer.
 TMUX_ARGV_SEPARATOR = sr.TMUX_SEPARATOR_CHAR
-
-#: Characters that `send-keys -l` delivers as a real Enter (measured).
-#: 🔴 NOT THE GATE — these two are non-printable, so `TEXT_IS_ALLOWED` already
-#: refuses them. This tuple exists only to give them a message that names the
-#: hazard. Deleting it weakens the DIAGNOSIS, never the refusal; that is the
-#: whole point of replacing the denylist, and a test pins it.
-SUBMITTING_CHARS = ("\n", "\r")
-
-#: 🔴 G13. The `--text` ALLOWLIST. Every codepoint not permitted here is refused
-#: by number — see measurement (c): a Ctrl-O executed a pane's buffer with no
-#: Enter sent, and the set of characters bound to an accept-line variant is a
-#: property of the OPERATOR'S shell config, which this process cannot read. So
-#: the question asked is "is this character safe to deliver", never "is this one
-#: of the dangerous ones we thought of".
-#:
-#: `str.isprintable()` is False for exactly the Unicode categories that make a
-#: byte a control or an invisible: Cc (NUL, `\n`, `\r`, `\x0f`, ESC, DEL), Cf,
-#: Cs, Co (private use — the U+E000 that once rendered a diff identical to an
-#: unedited line), Cn, Zl, Zp and Zs-except-ASCII-space. Tab is Cc and so must
-#: be re-permitted explicitly; it is the one control character with an ordinary
-#: typographic use and it cannot accept a line.
-TEXT_EXTRA_ALLOWED = ("\t",)
-
-#: 🔴 THE CATEGORIES THAT ARE REFUSED BUT ARE NOT CONTROL CHARACTERS — a
-#: DIAGNOSIS set, never a gate (`TEXT_IS_ALLOWED` has already rejected every
-#: member before this is consulted; a test pins that).
-#:
-#: Zs is every Unicode space EXCEPT the ASCII one (`" ".isprintable()` is True,
-#: so U+0020 never reaches here); Zl/Zp are the line and paragraph separators;
-#: Cf is the format characters — ZWSP, ZWJ, the soft hyphen, the bidi marks,
-#: the BOM. Measured against the shipped predicate: U+00A0, U+202F, U+2003,
-#: U+00AD, U+200B, U+200F, U+FEFF and every ZWJ emoji sequence land here.
-#:
-#: 🔴 THEY STAY REFUSED, AND THE ALLOWLIST IS NOT WIDENED. Two measurements say
-#: so. (a) In a real bash pane on a private `-L` server, `touch<U+00A0>/tmp/f`
-#: sent with `send-keys -l` was delivered verbatim and bash answered
-#: `bash: touch\xa0/tmp/f: No such file or directory` — the payload became ONE
-#: word and failed wearing a diagnosis about a PATH. That is the same class as
-#: the trailing `;` this file already refuses: a payload silently corrupted
-#: somewhere the caller will not look. (b) Normalising it to U+0020 behind the
-#: caller's back is the mutation this file refuses on principle everywhere else.
-#: So the fix is a REMEDY IN THE MESSAGE, not a wider gate.
-TEXT_INVISIBLE_CATEGORIES = ("Cf", "Zl", "Zp", "Zs")
-
-
-def TEXT_IS_ALLOWED(ch: str) -> bool:
-    """🔴 THE allowlist predicate, ONE place. Every `--text` codepoint passes
-    through exactly this function; there is no second copy to disagree with."""
-    return ch in TEXT_EXTRA_ALLOWED or ch.isprintable()
+assert TMUX_ARGV_SEPARATOR == _tp.TMUX_ARGV_SEPARATOR, (
+    "session-resolve says the tmux argv separator is "
+    f"{sr.TMUX_SEPARATOR_CHAR!r} and lib/tmux_text_policy.py says "
+    f"{_tp.TMUX_ARGV_SEPARATOR!r}. One of them is wrong and every refusal that "
+    "names the separator is now wrong with it.")
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -861,3 +861,98 @@ def test_an_absent_kind_still_means_send_keys(server, tmux_stub, tmp_path):
     server.claim_batches = [[w]]
     run_agent(server, tmux_stub, tmp_path)
     assert len(tmux_stub.send_keys_calls()) == 2
+
+
+# --------------------------------------------------------------------------- #
+# 9. The trust boundary: the host refuses what the server should never have sent.
+# --------------------------------------------------------------------------- #
+#
+# 🔴 THIS IS NOT DUPLICATED VALIDATION, IT IS A BOUNDARY. "One rule, one place"
+# governs two copies of a rule on the same side of a trust boundary. Here the
+# server is a pod reachable from an unauthenticated LAN NodePort and THIS process
+# is the thing that runs commands as the operator — the two sides fail
+# independently, and the side that executes is the one that must refuse.
+#
+# Every case below is something the server also rejects. The point is that the
+# host does not depend on that.
+
+@pytest.mark.parametrize("mutation,expect_in", [
+    # A name-shaped target does not FAIL in tmux — it resolves fuzzily and runs
+    # the command in some other pane.
+    ({"pane": "scratch:1"}, "pane id"),
+    ({"pane": "@41"}, "pane id"),
+    ({"pane": ""}, "pane id"),
+    ({"pane": "-t"}, "pane id"),
+    # A newline makes ONE write into TWO submissions.
+    ({"text": "yes\nrm -rf /"}, "control character"),
+    ({"text": "yes\x1b[A"}, "control character"),
+    ({"text": ""}, "no text"),
+    ({"text": "x" * 4000}, "size limit"),
+])
+def test_the_host_refuses_a_write_the_server_should_never_have_sent(
+        server, tmux_stub, tmp_path, mutation, expect_in):
+    server.claim_batches = [[write(**mutation)]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], (
+        f"the agent EXECUTED a write with {mutation} — the host is trusting the server's "
+        "validation, and the host is where commands run")
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert results, "the refusal was not reported"
+    body = json.loads(results[0]["body"])
+    assert body["state"] == "refused", body
+    assert expect_in in body["detail"], body
+
+
+@pytest.mark.parametrize("cwd", ["workspace/devrc", "/home/../root", "/tmp/a\nb", ""])
+def test_the_host_refuses_a_new_session_with_an_unsafe_cwd(server, tmux_stub, tmp_path, cwd):
+    """A relative cwd resolves against THIS process's directory, which differs per
+    host and after every restart — the silent-wrong-place failure in its purest
+    form, on the one code path that creates its own target."""
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=cwd, text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert [c for c in tmux_stub.calls() if c and c[0] in ("new-window", "send-keys")] == [], (
+        f"the agent opened a window at {cwd!r}")
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "refused", body
+
+
+def test_an_oversized_claim_batch_is_refused_WHOLE(server, tmux_stub, tmp_path):
+    """🔴 REFUSE THE ROUND, DO NOT TRUNCATE IT.
+
+    The server caps a claim at 4. A batch of a thousand — from a server that is
+    wrong, compromised, or simply newer than this agent — is a thousand commands,
+    and nothing downstream would stop them. Executing the first four and dropping
+    the rest would be worse than refusing: it runs commands the server believes
+    are in flight while silently abandoning others, a partial delivery nobody can
+    reason about. Refusing leaves every row to be relabelled `abandoned`
+    (delivery UNKNOWN), which is the honest record.
+    """
+    server.claim_batches = [[write(id=f"w-{i}") for i in range(40)]]
+    _rc, out = run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], (
+        f"the agent executed part of an oversized batch: {tmux_stub.send_keys_calls()}")
+    assert [r for r in server.requests if r["path"].endswith("/result")] == [], (
+        "the agent reported outcomes for a batch it refused as a whole")
+    assert "over the" in out and "writes in one claim" in out, out
+
+
+def test_a_batch_at_the_cap_is_still_executed(server, tmux_stub, tmp_path):
+    """The control for the refusal above: exactly at the cap goes through, so the
+    refusal is the bound and not an unconditional no."""
+    server.claim_batches = [[write(id=f"w-{i}") for i in range(4)]]
+    run_agent(server, tmux_stub, tmp_path)
+    text_sends = [s for s in tmux_stub.send_keys_calls() if "-l" in s]
+    assert len(text_sends) == 4, f"expected 4 deliveries, got {text_sends}"
+
+
+def test_the_validator_is_exercised_directly():
+    """Every branch, including the accepting ones — without which the table above
+    is satisfied by a validator that refuses everything."""
+    assert AGENT.validate({"kind": "send-keys", "pane": "%12", "text": "hi"}) == ""
+    assert AGENT.validate({"pane": "%12", "text": "hi"}) == ""  # absent kind
+    assert AGENT.validate({"kind": "new-session", "cwd": "/tmp", "text": "hi"}) == ""
+    assert AGENT.validate({"kind": "new-session", "cwd": "/tmp", "text": ""}) == ""  # bare window
+    assert "unknown write kind" in AGENT.validate({"kind": "exec", "pane": "%1", "text": "hi"})
+    # Non-string fields from a malformed payload must not raise.
+    assert AGENT.validate({"kind": "send-keys", "pane": 12, "text": "hi"}) != ""
+    assert AGENT.validate({"kind": "new-session", "cwd": None, "text": "hi"}) != ""

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -1101,7 +1101,11 @@ def test_the_text_gate_still_accepts_ordinary_text():
     """The positive control. Without it every case above is satisfied by a gate
     that refuses everything, which would make the feature inert rather than safe.
     """
-    for text in ("yes, go ahead", "café — naïve ünïcode ✓", "a\tb",
+    # ⚠ A TAB IS DELIBERATELY ABSENT from this list — the shared policy permits
+    # one, and THIS surface refuses it anyway because shell completion rewrites
+    # the buffer after the audit row is written. See
+    # test_the_host_refuses_a_tab_even_though_the_shared_policy_allows_one.
+    for text in ("yes, go ahead", "café — naïve ünïcode ✓",
                  "run `make test` && echo $HOME; then stop", "  spaced  "):
         assert AGENT.validate({"id": "w-abc123", "kind": "send-keys",
                                "pane": "%1", "text": text}) == "", text
@@ -1362,3 +1366,30 @@ def test_the_host_refuses_a_compound_tmux_target(server, tmux_stub, tmp_path, na
         f"the agent opened a window targeting {name!r}")
     body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
     assert body["state"] == "refused", body
+
+
+def test_the_host_refuses_a_tab_even_though_the_shared_policy_allows_one():
+    """🔴 A DELIBERATE DIVERGENCE FROM THE SHARED POLICY, IN THE SAFE DIRECTION.
+
+    `send-keys -l` delivers a tab literally and a bash/zsh pane runs COMPLETION on
+    it: `rm -rf ~/pro` + TAB becomes `rm -rf ~/projects/`, and the Enter this path
+    presses submits THAT — while clawgate's audit row still says `rm -rf ~/pro`.
+    That is the identical property the trailing-`;` refusal exists for.
+
+    `session-write` keeps the tab because it is invoked by the operator at their
+    own keyboard, where the buffer is visible before anything runs. Here the row
+    IS the compensating control, so a character that makes it lie costs more than
+    the typography is worth.
+
+    Both halves are asserted: the shared policy still permits it (so this is a
+    divergence, not a policy change that would surprise session-write), and this
+    surface refuses it anyway.
+    """
+    assert AGENT.TEXT_POLICY.TEXT_IS_ALLOWED("\t"), (
+        "the shared policy no longer allows a tab — this test is now asserting a divergence "
+        "that does not exist, and session-write's own guards would have moved too")
+    assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                           "text": "rm -rf ~/pro\t"}) != ""
+    # The control: the same text without the tab is ordinary and passes.
+    assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                           "text": "rm -rf ~/projects/"}) == ""

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -232,6 +232,7 @@ def write(**kw):
         "id": "w-abc123",
         "kind": "send-keys",
         "cwd": "",
+        "tmuxSessionName": "",
         "host": "workbench",
         "pane": "%12",
         "text": "yes, go ahead",
@@ -1317,3 +1318,61 @@ def test_a_server_supplied_pane_cannot_forge_a_log_line(server, tmux_stub, tmp_p
     _rc, out = run_agent(server, tmux_stub, tmp_path)
     assert "delivered everything" not in out, out
     assert tmux_stub.send_keys_calls() == []
+
+
+# --------------------------------------------------------------------------- #
+# 12. The launched window goes where the CALLER said, not where tmux felt like.
+# --------------------------------------------------------------------------- #
+def test_a_named_tmux_session_is_passed_to_tmux_as_a_target(server, tmux_stub, tmp_path):
+    """🔴 WITHOUT `-t` THE TARGET IS DECIDED BY tmux, NOT BY THE CALLER.
+
+    `new-window` with no target joins whatever session this server considers
+    CURRENT — which depends on what the operator last looked at — so a launched
+    window lands somewhere nobody chose. That is the same wrong-place class the
+    pane rule exists for, one level up: a whole WINDOW rather than a keystroke.
+
+    The trailing colon is part of the contract: `-t "name:"` means "this session,
+    next free index", and a session that does not exist makes tmux FAIL rather
+    than silently fall back to the current one.
+    """
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir",
+                                   tmuxSessionName="scratch2", text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    new_windows = [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
+    assert len(new_windows) == 1, tmux_stub.calls()
+    assert new_windows[0] == ["new-window", "-P", "-F", "#{pane_id}", "-c", "/tmp/some/dir",
+                              "-t", "scratch2:"], new_windows[0]
+
+
+def test_an_absent_tmux_session_leaves_the_target_to_tmux(server, tmux_stub, tmp_path):
+    """The control, and the back-compatible half: absent means "wherever this
+    server considers current", which is what happened before the field existed
+    and the only honest answer when nobody expressed a preference. A `-t` with an
+    empty value would be a target of its own."""
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    new_windows = [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
+    assert len(new_windows) == 1
+    assert "-t" not in new_windows[0], new_windows[0]
+
+
+@pytest.mark.parametrize("name", [
+    "scratch:2",            # a window index inside another session
+    "scratch:2.0",          # ...and a pane inside it
+    "main.0",               # a pane address
+    "-t",                   # option-shaped
+    "has space",
+    "weirdname",      # a C1 control the old denylist would have passed
+    "a" * 65,
+])
+def test_the_host_refuses_a_compound_tmux_target(server, tmux_stub, tmp_path, name):
+    """🔴 RE-VALIDATED ON THE HOST, NOT TRUSTED. The server checks this too; this
+    process is the one that hands the value to tmux, and the two sides of the
+    boundary fail independently."""
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/d",
+                                   tmuxSessionName=name, text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert [c for c in tmux_stub.calls() if c and c[0] in ("new-window", "send-keys")] == [], (
+        f"the agent opened a window targeting {name!r}")
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "refused", body

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -1,0 +1,863 @@
+"""Behavioural tests for scripts/tmux-reply-agent — the host half of clawgate's
+terminal WRITE surface.
+
+Everything here runs against a STUB HTTP server bound to loopback on an ephemeral
+port and a STUB tmux binary that records its own argv. Nothing touches the real
+clawgate, either host's tmux server, any pane, or the network.
+
+WHAT THIS SUITE IS FOR
+----------------------
+🔴 ONE DELIVERY BY THIS AGENT IS ARBITRARY COMMAND EXECUTION AS THE OPERATOR.
+It runs `tmux send-keys` into a named pane and then presses Enter, on text that
+arrived over a LAN route with no human auth. So the load-bearing tests are not
+the happy path — they are the four ways that execution can go wrong in a way
+nobody would notice:
+
+  1. THE TEXT MUST NEVER REACH A SHELL. It is arbitrary operator input, so
+     `$(…)`, backticks, `;` and quotes in it are code the moment anything
+     interpolates them into a command string. `test_the_text_is_delivered_as_one
+     _argv_element_with_no_shell` asserts the exact bytes arrive as a single
+     argument.
+
+  2. `-l` AND `--` ARE PART OF THE COMMAND, NOT DECORATION. Without `-l`,
+     `send-keys` reads its argument as KEY NAMES — a reply containing "C-c"
+     interrupts whatever is running instead of typing three characters. Without
+     `--`, text starting with `-` is parsed as a flag.
+
+  3. THE WRITE-TIME GUARD MUST ACTUALLY REFUSE. A tmux server restart re-mints
+     pane ids from %0, so a stored `%12` names a different pane. The refusal has
+     to happen with NO send-keys at all — a guard that runs after the write is
+     not a guard.
+
+  4. THE TEXT MUST NEVER BE LOGGED. The operator chose a full audit log INCLUDING
+     the reply text, and was told the cost: a reply may contain a secret. The
+     audit log lives in the server's table behind the terminal token; the
+     journal does not.
+
+  5. THE POSITIVE CONTROL. `test_a_claimed_write_is_delivered_and_reported`
+     proves the stub tmux and the stub server can observe anything at all. Every
+     "no send-keys happened" assertion below is meaningless without it.
+
+⚠ THE AGENT SHIPS DISABLED and cannot be exercised on a live host at all: the
+server's routes answer 503 until CLAWGATE_TERMINAL_TOKEN is provisioned, and the
+unit is not wired into `default.target` until `enableTmuxReplyAgent` is true.
+That is why these tests drive the script directly against stubs rather than
+asserting anything about a running system.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "tmux-reply-agent"
+COLLECTOR = REPO_ROOT / "scripts" / "session-manager"
+HOME_NIX = REPO_ROOT / "nix" / "home.nix"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# 🔴 EVERY RUNTIME STUB GOES THROUGH `testlib.mockbin.write_exec`, WHICH OWNS THE
+# SHEBANG. The nix check sandbox — the tier that gates the merge — has no
+# `/usr/bin/env`, so a hand-written shebang cannot exec there, and the failure
+# does not present as a fixture fault: the stub fails, the code under test
+# correctly reports an error, and the assertion that fires points at production.
+from testlib.mockbin import write_exec  # noqa: E402
+from testlib import nix_units  # noqa: E402
+
+# A synthetic marker used wherever a test needs to prove a specific string did or
+# did not travel. Pairwise distinct from every other literal in this file, so a
+# match cannot come from somewhere else.
+MARKER = "ZZ-SYNTHETIC-REPLY-MARKER-4471-ZZ"
+
+
+def load_agent():
+    """Import the agent as a module so its pure functions can be tested directly.
+
+    It has no `.py` extension (matching `session-manager` and the rest of
+    `scripts/`), so it is loaded by path.
+    """
+    loader = importlib.machinery.SourceFileLoader("tmux_reply_agent_undertest", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("tmux_reply_agent_undertest", str(SCRIPT),
+                                                  loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+AGENT = load_agent()
+
+
+# --------------------------------------------------------------------------- #
+# The stub server: hands out a fixed claim batch, records every request.
+# --------------------------------------------------------------------------- #
+class _Recorder(HTTPServer):
+    def __init__(self, addr, handler):
+        super().__init__(addr, handler)
+        self.requests = []
+        self.claim_batches = []      # popped one per claim; [] when exhausted
+        self.claim_status = 200
+        self.result_status = 200
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802 — name fixed by BaseHTTPRequestHandler
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length)
+        self.server.requests.append({
+            "path": self.path,
+            "body": raw,
+            "auth": self.headers.get("Authorization"),
+        })
+        if self.path.endswith("/claim"):
+            status = self.server.claim_status
+            if status != 200:
+                self._reply(status, b'{"error":"no"}')
+                return
+            batch = self.server.claim_batches.pop(0) if self.server.claim_batches else []
+            self._reply(200, json.dumps({"writes": batch}).encode())
+            return
+        self._reply(self.server.result_status, b'{"ok":true}')
+
+    def _reply(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002 — signature fixed by the base class
+        pass
+
+
+@pytest.fixture
+def server():
+    srv = _Recorder(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield srv
+    srv.shutdown()
+    srv.server_close()
+
+
+def base_url(server) -> str:
+    return f"http://{server.server_address[0]}:{server.server_address[1]}"
+
+
+@pytest.fixture
+def tmux_stub(tmp_path):
+    """A stub `tmux` that appends its own argv, one JSON array per invocation.
+
+    🔴 IT RECORDS ARGV, NOT A COMMAND LINE. The whole point of the shell test is
+    that the text arrives as ONE argument; a stub that recorded `"$*"` would
+    flatten exactly the distinction under test and report success either way.
+    """
+    log = tmp_path / "tmux-argv.jsonl"
+    log.write_text("")
+    server_id = tmp_path / "tmux-server-id"
+    server_id.write_text("1234:5678\n")
+    rc_file = tmp_path / "tmux-sendkeys-rc"
+    rc_file.write_text("0")
+    err_file = tmp_path / "tmux-sendkeys-err"
+    err_file.write_text("")
+    new_window_out = tmp_path / "tmux-new-window-out"
+    new_window_out.write_text("%77\n")
+
+    path = tmp_path / "bin" / "tmux"
+    path.parent.mkdir(exist_ok=True)
+    # POSIX-sh body, no shebang — write_exec owns that. Python does the JSON
+    # quoting so an argument containing quotes, backslashes or newlines is
+    # recorded faithfully rather than through a shell's idea of escaping.
+    write_exec(path, (
+        f'''if [ "$1" = "-V" ]; then echo 'tmux 3.4'; exit 0; fi\n'''
+        f'''python3 -c 'import json,sys; open(sys.argv[1],"a").write(json.dumps(sys.argv[2:])+"\\n")' '''
+        f'''{log} "$@"\n'''
+        f'''if [ "$1" = "display-message" ]; then cat {server_id}; exit 0; fi\n'''
+        f'''if [ "$1" = "new-window" ]; then cat {new_window_out}; exit 0; fi\n'''
+        f'''if [ "$1" = "send-keys" ]; then cat {err_file} >&2; exit "$(cat {rc_file})"; fi\n'''
+        f'''exit 0\n'''
+    ))
+
+    class Stub:
+        binary = path
+        argv_log = log
+
+        @staticmethod
+        def calls():
+            return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+        @staticmethod
+        def send_keys_calls():
+            return [c for c in Stub.calls() if c and c[0] == "send-keys"]
+
+        @staticmethod
+        def set_server_id(value):
+            server_id.write_text(value + "\n")
+
+        @staticmethod
+        def fail_send_keys(rc=1, stderr=""):
+            rc_file.write_text(str(rc))
+            err_file.write_text(stderr)
+
+        @staticmethod
+        def set_new_window_output(value):
+            new_window_out.write_text(value)
+
+        @staticmethod
+        def new_pane_id():
+            return new_window_out.read_text().strip()
+
+    return Stub
+
+
+def write(**kw):
+    """One claim-batch entry, with defaults that are pairwise distinct."""
+    out = {
+        "id": "w-abc123",
+        "kind": "send-keys",
+        "cwd": "",
+        "host": "workbench",
+        "pane": "%12",
+        "text": "yes, go ahead",
+        "submit": True,
+        "expectTmuxServerId": "",
+    }
+    out.update(kw)
+    return out
+
+
+def run_agent(server, tmux_stub, tmp_path, *, env_extra=None, conf_text=None,
+              token="not-a-real-terminal-token-not-a-real-token", timeout=30):
+    """Run the agent for ONE productive round and then let it stop.
+
+    The loop is driven to completion by the stub server: the first claim returns
+    the batch, the second returns an empty one, and TMUX_REPLY_MAX_ROUNDS is not
+    a thing the agent has — so the process is stopped with SIGTERM once the
+    expected traffic has been seen.
+    """
+    conf = tmp_path / "clawgate.env"
+    conf.write_text(conf_text if conf_text is not None else "")
+    env = dict(os.environ)
+    # Start from a clean slate so an operator's real credentials in the ambient
+    # environment can never leak into a test run and aim it at production.
+    for k in ("CLAWGATE_API_URL", "CLAWGATE_TERMINAL_TOKEN", "CLAWGATE_HOOK_TOKEN", "ACTIVITY_HOST"):
+        env.pop(k, None)
+    env["CLAWGATE_CONF_FILE"] = str(conf)
+    env["HOME"] = str(tmp_path)
+    env["CLAWGATE_API_URL"] = base_url(server)
+    if token:
+        env["CLAWGATE_TERMINAL_TOKEN"] = token
+    env["TMUX_REPLY_TMUX_BIN"] = str(tmux_stub.binary)
+    env["TMUX_REPLY_POLL_SECONDS"] = "0.05"
+    env["TMUX_REPLY_BACKOFF_SECONDS"] = "0.05"
+    env["ACTIVITY_HOST"] = "workbench"
+    env.update(env_extra or {})
+
+    proc = subprocess.Popen([sys.executable, str(SCRIPT)], env=env,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    # Wait until the stub has seen enough traffic, then stop the loop.
+    deadline = threading.Event()
+    for _ in range(int(timeout / 0.05)):
+        if proc.poll() is not None:
+            break
+        if len(server.requests) >= 2:
+            break
+        deadline.wait(0.05)
+    proc.terminate()
+    out, _ = proc.communicate(timeout=timeout)
+    return proc.returncode, out
+
+
+# --------------------------------------------------------------------------- #
+# 1. The positive control.
+# --------------------------------------------------------------------------- #
+def test_a_claimed_write_is_delivered_and_reported(server, tmux_stub, tmp_path):
+    """THE POSITIVE CONTROL for this whole file.
+
+    Every "no send-keys happened" and "the text was not in X" assertion below is
+    a claim about an instrument that must first be shown to observe SOMETHING.
+    """
+    server.claim_batches = [[write()]]
+    rc, out = run_agent(server, tmux_stub, tmp_path)
+
+    sends = tmux_stub.send_keys_calls()
+    assert len(sends) == 2, f"expected the text send and the Enter send, got {sends}\n{out}"
+    assert sends[0] == ["send-keys", "-t", "%12", "-l", "--", "yes, go ahead"], sends[0]
+    assert sends[1] == ["send-keys", "-t", "%12", "Enter"], sends[1]
+
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert len(results) == 1, f"the agent did not report an outcome: {server.requests}"
+    body = json.loads(results[0]["body"])
+    assert body["state"] == "delivered", body
+    assert body["agent"].startswith("workbench:"), body
+
+    claims = [r for r in server.requests if r["path"].endswith("/claim")]
+    assert claims, "the agent never claimed"
+    assert json.loads(claims[0]["body"])["host"] == "workbench"
+    assert claims[0]["auth"] == "Bearer not-a-real-terminal-token-not-a-real-token"
+
+
+# --------------------------------------------------------------------------- #
+# 2. The text never reaches a shell, and the flags are part of the command.
+# --------------------------------------------------------------------------- #
+def test_the_text_is_delivered_as_one_argv_element_with_no_shell(server, tmux_stub, tmp_path):
+    """🔴 THE SINGLE MOST IMPORTANT TEST IN THIS FILE.
+
+    The text is arbitrary operator input that arrived over the network. If
+    anything between this process and execve interpolates it into a command
+    string, `$(…)` and backticks are code that runs on THIS host with the
+    operator's privileges, before tmux ever sees them.
+
+    The fixture is deliberately hostile AND pairwise distinct in its parts, so a
+    partial mangle (quotes eaten, `;` split, `$(` expanded) is visible as a
+    difference rather than absorbed.
+    """
+    hostile = """-n $(id) `id` "q" 'p' ;echo x |tee /dev/null && true \\n $HOME"""
+    server.claim_batches = [[write(text=hostile)]]
+    run_agent(server, tmux_stub, tmp_path)
+
+    sends = tmux_stub.send_keys_calls()
+    assert sends, "nothing was sent; this test would prove nothing"
+    assert sends[0][-1] == hostile, (
+        "the text did not arrive byte-identical as ONE argument.\n"
+        f"sent:     {sends[0][-1]!r}\nexpected: {hostile!r}\n"
+        "Anything that changes here means a shell, a quoting layer or a split is "
+        "standing between this agent and execve.")
+    # And it really is one element, not several.
+    assert len(sends[0]) == 6, f"the text was split across arguments: {sends[0]}"
+
+
+def test_send_keys_is_literal_and_ends_option_parsing(server, tmux_stub, tmp_path):
+    """🔴 `-l` AND `--` ARE THE COMMAND, NOT STYLE.
+
+    Without `-l`, `send-keys` reads its argument as KEY NAMES: a reply containing
+    "C-c" would interrupt whatever is running in the pane instead of typing three
+    characters, and "Enter" would submit in the middle of a sentence. Without
+    `--`, a reply beginning with `-` is parsed as a flag and either errors or
+    changes what the command does.
+
+    Asserting the flags' PRESENCE is not enough — their ORDER relative to the
+    text is what makes them apply — so this pins the exact argv.
+    """
+    server.claim_batches = [[write(text="-l C-c Enter q")]]
+    run_agent(server, tmux_stub, tmp_path)
+    sends = tmux_stub.send_keys_calls()
+    assert sends, "nothing was sent"
+    assert sends[0] == ["send-keys", "-t", "%12", "-l", "--", "-l C-c Enter q"], sends[0]
+
+
+def test_type_only_sends_no_enter(server, tmux_stub, tmp_path):
+    """`submit: false` must type and stop.
+
+    The operator chose that clawgate PRESSES ENTER by default, and the server
+    defaults the field accordingly — but the field exists, and honouring it is
+    the difference between a reply that sits visibly in a pane and one that runs.
+    Without this test a mutant that ignores `submit` entirely (always Enter)
+    survives every other case in this file, because they all set it true.
+    """
+    server.claim_batches = [[write(submit=False)]]
+    run_agent(server, tmux_stub, tmp_path)
+    sends = tmux_stub.send_keys_calls()
+    assert len(sends) == 1, f"expected the text send alone, got {sends}"
+    assert "Enter" not in sends[0]
+
+
+# --------------------------------------------------------------------------- #
+# 3. The write-time guard.
+# --------------------------------------------------------------------------- #
+def test_a_moved_tmux_server_is_refused_with_no_send_at_all(server, tmux_stub, tmp_path):
+    """🔴 THE GUARD MUST RUN BEFORE THE WRITE, NOT AROUND IT.
+
+    Within one tmux server a pane id `%N` is never reused, so a stale one simply
+    fails to resolve. The dangerous case is a tmux server RESTART: ids are minted
+    again from %0, so a `%12` the enqueuer saw an hour ago now names a completely
+    different pane — and a submitted reply would execute there.
+
+    The assertion is that NO send-keys happened, not merely that the outcome says
+    `refused`: a guard that reports a refusal after the keys have gone is not a
+    guard, and a status-only assertion cannot tell the two apart.
+    """
+    tmux_stub.set_server_id("9999:1111")
+    server.claim_batches = [[write(expectTmuxServerId="1234:5678")]]
+    run_agent(server, tmux_stub, tmp_path)
+
+    assert tmux_stub.send_keys_calls() == [], (
+        "the agent sent keys into a pane on a tmux server that is not the one the write "
+        "was addressed to")
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert results, "the refusal was not reported"
+    body = json.loads(results[0]["body"])
+    assert body["state"] == "refused", body
+    assert "identity moved" in body["detail"], body
+
+
+def test_a_matching_tmux_server_is_delivered(server, tmux_stub, tmp_path):
+    """The control for the refusal above: with the expectation SATISFIED the
+    write goes through, so the refusal is the guard firing and not the agent
+    declining everything that carries an expectation."""
+    tmux_stub.set_server_id("1234:5678")
+    server.claim_batches = [[write(expectTmuxServerId="1234:5678")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert len(tmux_stub.send_keys_calls()) == 2
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "delivered", body
+
+
+def test_an_absent_expectation_is_not_checked(server, tmux_stub, tmp_path):
+    """An empty expectation means NOT CHECKED, not "matches".
+
+    The collector reports its `tmux_server_id` as UNMEASURED in real conditions,
+    so refusing every write that carries no expectation would make the feature
+    fail exactly when the read model is degraded — while protecting against
+    nothing, since a caller that cannot measure the id cannot supply a right one.
+    """
+    tmux_stub.set_server_id("9999:1111")   # different from anything, and irrelevant
+    server.claim_batches = [[write(expectTmuxServerId="")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert len(tmux_stub.send_keys_calls()) == 2
+
+
+def test_the_guard_refuses_when_the_identity_cannot_be_measured():
+    """An unmeasurable live identity is a REFUSAL, not a pass.
+
+    Driven through the predicate directly so every branch is covered, including
+    the pair the behavioural tests above cannot both reach in one run.
+    """
+    assert AGENT.should_refuse("", "1234:5678") == (False, "")
+    assert AGENT.should_refuse("", "") == (False, "")
+    refuse, why = AGENT.should_refuse("1234:5678", "")
+    assert refuse and "could not be measured" in why
+    refuse, why = AGENT.should_refuse("1234:5678", "9999:1")
+    assert refuse and "identity moved" in why
+    assert AGENT.should_refuse("1234:5678", "1234:5678") == (False, "")
+
+
+# --------------------------------------------------------------------------- #
+# 4. The text is never logged, and never leaves in a diagnostic.
+# --------------------------------------------------------------------------- #
+def test_the_reply_text_is_never_written_to_the_journal(server, tmux_stub, tmp_path):
+    """🔴 A CREDENTIAL-HANDLING GUARD, PINNING A RELATIONSHIP.
+
+    The operator chose a full audit log INCLUDING the reply text over a
+    metadata-only one, and was told the cost: a reply may contain a secret. That
+    log lives in the server's table behind the terminal token. This unit's output
+    goes to the journal, which is a different and much wider readership.
+
+    The failing case is not hypothetical — the equivalent guard on the SERVER
+    side caught a real leak in its first draft, where an agent-supplied `detail`
+    string was logged and tmux quotes its arguments in its own errors. So this
+    drives a delivery that FAILS, with tmux's stderr echoing the text back, and
+    asserts the marker appears nowhere in the agent's output.
+    """
+    tmux_stub.fail_send_keys(rc=1, stderr=f"can't find pane: sending {MARKER} failed")
+    server.claim_batches = [[write(text=MARKER)]]
+    rc, out = run_agent(server, tmux_stub, tmp_path)
+
+    # The positive control: the agent must have LOGGED SOMETHING about this write,
+    # or "the marker is absent" is a claim about an empty buffer.
+    assert "tmux-reply-agent:" in out, f"the agent logged nothing at all:\n{out}"
+    assert "w-abc123" in out, f"the agent's log does not name the write:\n{out}"
+    assert "failed" in out, f"the agent did not log the outcome:\n{out}"
+    # …and the control that the marker was really in play.
+    assert tmux_stub.send_keys_calls(), "no send was attempted; the fixture is inert"
+    assert tmux_stub.send_keys_calls()[0][-1] == MARKER
+
+    assert MARKER not in out, (
+        "the operator's literal reply text reached this unit's journal. It is "
+        "credential-grade and the journal is not the audit log.\n" + out)
+
+
+def test_the_reported_detail_is_redacted_of_the_text(server, tmux_stub, tmp_path):
+    """The same hazard, one hop further out: `detail` is stored in the audit log
+    AND logged, and tmux quotes its arguments in its own errors.
+
+    The redaction is an EXACT substitution — the agent knows the precise string —
+    rather than a secret-shaped pattern, so it cannot miss the way a heuristic
+    misses and cannot claim to have scrubbed something it did not.
+    """
+    tmux_stub.fail_send_keys(rc=1, stderr=f"can't find pane: {MARKER}")
+    server.claim_batches = [[write(text=MARKER)]]
+    run_agent(server, tmux_stub, tmp_path)
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert results, "no outcome was reported"
+    body = json.loads(results[0]["body"])
+    assert body["state"] == "failed", body
+    assert MARKER not in body["detail"], body
+    assert "<text>" in body["detail"], body
+    # The control: the rest of the diagnostic survives, so redaction is not just
+    # "throw the detail away".
+    assert "can't find pane" in body["detail"], body
+
+
+def test_redact_is_exact_and_bounded():
+    """The redaction helper, directly. A bounded detail matters because it lands
+    in a retained column and in a log line."""
+    assert AGENT.redact("before secret after", "secret") == "before <text> after"
+    assert AGENT.redact("a\nb\tc", "") == "a b c"
+    assert len(AGENT.redact("x" * 2000, "")) == 400
+    # An empty text must not redact everything.
+    assert AGENT.redact("nothing to hide", "") == "nothing to hide"
+
+
+# --------------------------------------------------------------------------- #
+# 5. At-most-once, and the states that are NOT errors.
+# --------------------------------------------------------------------------- #
+def test_a_failed_result_post_does_NOT_re_execute_the_write(server, tmux_stub, tmp_path):
+    """🔴 AT MOST ONCE. A retried `send-keys` runs a command twice.
+
+    The server's claim moved this row out of `pending` permanently, so if the
+    outcome report fails the correct behaviour is to LOSE the record of it — the
+    row is relabelled `abandoned`, whose meaning is "delivery UNKNOWN" — and
+    never to re-run the send. This is the one place in the whole path where a
+    duplicate execution could be introduced.
+    """
+    server.result_status = 500
+    server.claim_batches = [[write()]]
+    _rc, out = run_agent(server, tmux_stub, tmp_path)
+
+    text_sends = [s for s in tmux_stub.send_keys_calls() if "-l" in s]
+    assert len(text_sends) == 1, (
+        f"the agent executed the text {len(text_sends)} times for ONE claimed write; it is "
+        f"retrying a send after a failed report: {tmux_stub.send_keys_calls()}")
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert len(results) == 1, (
+        f"the agent re-POSTed the outcome {len(results)} times. A retry of the REPORT is "
+        "harmless in itself, but it is one line away from a retry of the SEND, and the "
+        "server refuses a replayed completion anyway.")
+    # And what it says about the loss is the truthful thing, not "did not run".
+    assert "UNKNOWN" in out, out
+
+
+def test_an_unarmed_server_is_backed_off_from_not_crashed_on(server, tmux_stub, tmp_path):
+    """🔴 503 IS THE SHIPPED STATE, NOT A FAULT.
+
+    The server's write routes are behind a fail-closed wrapper that answers 503
+    until CLAWGATE_TERMINAL_TOKEN is provisioned on the pod. That is how this
+    change is deployed, so the agent must treat it as a quiet, logged-once
+    condition — never as an error that fails the unit or spams the journal.
+    """
+    server.claim_status = 503
+    rc, out = run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], "the agent sent keys off a 503"
+    assert "NOT ARMED" in out, out
+    # Logged ONCE per condition, not per tick: the poll here is 50ms, so a
+    # per-tick line would appear many times over the run.
+    assert out.count("NOT ARMED") == 1, (
+        "a permanent condition was logged on every tick; at the real cadence that is "
+        f"17,280 lines a day and buries every real event:\n{out}")
+
+
+def test_no_credentials_exits_two_and_makes_no_request(server, tmux_stub, tmp_path):
+    """A configuration error that cannot self-heal, so this one EXITS.
+
+    It is also the state the change ships in on the host side, which is why the
+    message says so rather than just "missing token".
+    """
+    rc, out = run_agent(server, tmux_stub, tmp_path, token=None)
+    assert rc == 2, f"rc={rc}\n{out}"
+    assert server.requests == [], f"the agent contacted the server with no token: {server.requests}"
+    assert "not armed" in out
+
+
+def test_the_environment_beats_the_credential_file(tmp_path):
+    """🔴 A REGRESSION GUARD FOR A MEASURED INCIDENT, NOT A PREFERENCE.
+
+    `clawgate-stop-hook.sh` sources the same credential file with `set -a`, which
+    makes the FILE beat the environment. The measured consequence over there was
+    a probe aimed at a harmless address silently POSTing to PRODUCTION. On THIS
+    surface the equivalent mistake sends a reply into a live pane.
+    """
+    conf = tmp_path / "clawgate.env"
+    conf.write_text("CLAWGATE_API_URL=http://from-the-file:1\n"
+                    "export CLAWGATE_TERMINAL_TOKEN='from-the-file'\n")
+    env = {"CLAWGATE_API_URL": "http://from-the-env:2"}
+    assert AGENT.resolve("CLAWGATE_API_URL", str(conf), env=env) == "http://from-the-env:2"
+    # …and the file is still read for keys the environment does not set, in both
+    # spellings a sourceable file actually carries.
+    assert AGENT.resolve("CLAWGATE_TERMINAL_TOKEN", str(conf), env=env) == "from-the-file"
+
+
+def test_the_credential_reader_takes_the_last_assignment(tmp_path):
+    """As sourcing would. A file that sets a key twice is ordinary."""
+    conf = tmp_path / "clawgate.env"
+    conf.write_text("CLAWGATE_TERMINAL_TOKEN=first\n  export CLAWGATE_TERMINAL_TOKEN=\"second\"\n")
+    assert AGENT.read_conf_key("CLAWGATE_TERMINAL_TOKEN", str(conf)) == "second"
+
+
+def test_the_token_is_never_in_argv(server, tmux_stub, tmp_path):
+    """Everything on this box can read /proc/<pid>/cmdline, and a URL lands in
+    access logs — so the credential travels in a header.
+
+    Asserted through the stub tmux's recorded argv and through the request the
+    stub server received, not by reading the source: a structural check would
+    type-check past a token added to a URL somewhere else.
+    """
+    server.claim_batches = [[write()]]
+    run_agent(server, tmux_stub, tmp_path, token=MARKER + "-token-longer-than-32-chars")
+    for call in tmux_stub.calls():
+        assert not any(MARKER in a for a in call), f"the token reached tmux's argv: {call}"
+    for req in server.requests:
+        assert MARKER not in req["path"], f"the token reached the URL: {req['path']}"
+        assert req["auth"] and MARKER in req["auth"], "the token was not sent as a header"
+
+
+# --------------------------------------------------------------------------- #
+# 6. The seams: the host label and the tmux server-id spelling.
+# --------------------------------------------------------------------------- #
+def test_the_host_label_follows_the_same_rule_as_the_collector(tmp_path):
+    """🔴 ONE RULE, AND A DISAGREEMENT HERE IS SILENT.
+
+    The server's queue is keyed on the host label the READ MODEL stores, which
+    the collector computes from ACTIVITY_HOST (`hostname` is "nixos" on BOTH
+    machines, so it cannot be the source of truth). An agent that computed a
+    different label would poll for a host nobody enqueues to and deliver nothing
+    at all, with no error anywhere.
+    """
+    env_file = tmp_path / "collector-env"
+    env_file.write_text('ACTIVITY_HOST="laptop"\n')
+    assert AGENT.local_host_label(env={}, env_file=str(env_file)) == "laptop"
+    assert AGENT.local_host_label(env={"ACTIVITY_HOST": "WORKBENCH"}, env_file=str(env_file)) == "workbench"
+    # An unrecognised label falls back rather than inventing a host.
+    assert AGENT.local_host_label(env={"ACTIVITY_HOST": "nixos"}, env_file=str(tmp_path / "absent")) == "workbench"
+    # And the vocabulary is the collector's own, read from its source rather than
+    # restated here.
+    collector_src = COLLECTOR.read_text()
+    assert 'HOST_NAMES = ("workbench", "laptop")' in collector_src, (
+        "the collector's host vocabulary changed; this agent's HOST_NAMES must follow it")
+    assert AGENT.HOST_NAMES == ("workbench", "laptop")
+    assert 'DEFAULT_LOCAL_HOST = "workbench"' in collector_src
+    assert AGENT.DEFAULT_LOCAL_HOST == "workbench"
+
+
+def test_the_server_id_format_matches_the_collectors():
+    """🔴 A SEAM GUARD: two spellings of one token would refuse EVERY write.
+
+    The enqueuer takes its expectation from the read model, whose
+    `tmux_server_id` the collector builds as `<pid>:<start_time>` from the
+    server-level tmux formats `#{pid}` and `#{start_time}`. If this agent asked
+    tmux for a differently-shaped value it would compare apples to oranges and
+    refuse everything — which reads exactly like "the feature does not work",
+    with no error naming the cause.
+
+    The check reads the COLLECTOR'S OWN SOURCE rather than restating the format,
+    so a change there fails here instead of drifting silently.
+    """
+    src = COLLECTOR.read_text()
+    assert 'WINDOW_FORMAT = "#{window_id}|#{window_index}|#{pid}|#{start_time}|#{session_name}"' in src, (
+        "the collector's window format changed; re-derive TMUX_SERVER_ID_FORMAT from it")
+    assert 'return f"{pid}:{started}", None' in src, (
+        "the collector no longer joins the server id as `<pid>:<start_time>`")
+    assert AGENT.TMUX_SERVER_ID_FORMAT == "#{pid}:#{start_time}", (
+        f"the agent asks tmux for {AGENT.TMUX_SERVER_ID_FORMAT!r}, which is not the shape the "
+        "collector stores; every write carrying an expectation would be refused")
+
+
+def test_an_unmeasurable_server_id_reads_as_empty(tmp_path, monkeypatch):
+    """tmux renders an unknown format verbatim, so an old tmux that does not know
+    `#{start_time}` yields a bare ':'. That must read as "cannot measure" — which
+    the guard turns into a REFUSAL — and never as the literal identity ':'."""
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+        return 0, ":\n", ""
+
+    monkeypatch.setattr(AGENT, "run_tmux", fake_run)
+    assert AGENT.tmux_server_id() == ""
+    monkeypatch.setattr(AGENT, "run_tmux", lambda a: (0, "1234:5678\n", ""))
+    assert AGENT.tmux_server_id() == "1234:5678"
+    monkeypatch.setattr(AGENT, "run_tmux", lambda a: (1, "", "no server running"))
+    assert AGENT.tmux_server_id() == ""
+
+
+# --------------------------------------------------------------------------- #
+# 7. The unit ships DISABLED, and carries what the child needs.
+# --------------------------------------------------------------------------- #
+def home_nix() -> str:
+    return HOME_NIX.read_text()
+
+
+def test_the_agent_unit_SHIPS_DISABLED():
+    """🔴 THE CENTRAL CLAIM OF THIS CHANGE, ASSERTED AGAINST THE CONFIGURATION.
+
+    What this agent delivers is arbitrary command execution as the operator on
+    this host. Building it and ARMING it were deliberately separated so the write
+    path could be merged, deployed and audited before it could execute anything.
+
+    The flag is read through the comment-stripping reader, not a substring
+    search: this file's blocks quote directives verbatim in prose, so a raw
+    `in src` check cannot tell a declaration from a comment describing one — and
+    that exact failure once left a guard green over a deleted unit.
+    """
+    src = nix_units.strip_nix_comments(home_nix())
+    assert "enableTmuxReplyAgent = false;" in src, (
+        "the terminal-write agent's master switch is not false. Arming this is an "
+        "operator act, deliberately separate from shipping it: it needs "
+        "CLAWGATE_TERMINAL_TOKEN provisioned on the POD *and* this flag flipped, and "
+        "neither implies the other.")
+    assert "enableTmuxReplyAgent = true;" not in src
+
+
+def test_the_agent_unit_is_declared_even_though_it_is_disabled():
+    """The SERVICE must exist on both hosts even while nothing wants it, so an
+    operator arming the surface can start it by hand and watch it before wiring
+    it into the target. The `Install.WantedBy` is what the flag gates."""
+    src = home_nix()
+    assert nix_units.declares("systemd.user.services.tmux-reply-agent", src)
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", src))
+    assert "enableTmuxReplyAgent" in unit and "default.target" in unit, unit
+    # 🔴 A RESIDENT SERVICE, NOT A TIMER. A ~5s poll driven by a timer would fork
+    # a process, an interpreter and a connection 17,280 times a day.
+    assert nix_units.directive("Type", unit) == '"simple"', unit
+    assert not nix_units.declares("systemd.user.timers.tmux-reply-agent", src)
+
+
+def test_the_unit_PATH_carries_tmux_and_python():
+    """🔴 EVERY BINARY THE CHILD NEEDS, because under the user manager there is no
+    login-shell PATH to fall back on — a lesson drift-check.service already paid
+    for, reporting COULD NOT MEASURE forever from a unit that looked correct.
+
+    The agent is stdlib Python plus tmux. It deliberately does NOT carry curl,
+    openssh or gawk: it uses urllib and never leaves this host. That is the
+    opposite trim from tmux-snapshot-push's list, and copying that list wholesale
+    would be carrying binaries to justify later.
+    """
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))
+    assert "pkgs.tmux" in unit, "without tmux every delivery fails"
+    assert "pkgs.python3" in unit, "the agent is a Python program"
+    assert "pkgs.openssh" not in unit and "pkgs.gawk" not in unit, (
+        "the agent never leaves this host; these are copied, not needed")
+
+
+def test_the_unit_gives_tmux_its_SOCKET_directory():
+    """This host's tmux socket is at $XDG_RUNTIME_DIR/tmux-UID/, not tmux's
+    compiled-in /tmp/tmux-UID/. Without TMUX_TMPDIR the agent cannot connect and
+    every delivery fails."""
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))
+    assert nix_units.directive("TMUX_TMPDIR", unit) or "TMUX_TMPDIR=%t" in unit, unit
+
+
+def test_the_unit_does_not_wire_the_DND_defeating_failure_toast():
+    """🔴 notify-failure@ toasts are wired to DEFEAT do-not-disturb, and that
+    bypass is justified by a MEASURED rate of about one firing in nine days.
+
+    This unit restarts on failure and polls every few seconds, so any sustained
+    condition — the surface not armed, which is the state it ships in — would
+    fire a DND-bypassing toast on every restart and burn down the one alert
+    channel that has to keep its meaning.
+    """
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))
+    assert "OnFailure" not in unit, unit
+    assert "notify-failure" not in unit, unit
+
+
+def test_the_unit_runs_the_script_this_suite_tests():
+    """A unit pointing at a different path would make every test above a claim
+    about a file nothing runs."""
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))
+    assert "scripts/tmux-reply-agent" in unit, unit
+    assert SCRIPT.exists() and os.access(SCRIPT, os.X_OK)
+
+
+# --------------------------------------------------------------------------- #
+# 8. The second kind: new-session.
+# --------------------------------------------------------------------------- #
+def test_a_new_session_opens_a_window_at_the_cwd_and_types_into_THAT_pane(server, tmux_stub, tmp_path):
+    """🔴 THE NEW PANE IS ADDRESSED BY ID, NEVER "the active pane".
+
+    `new-window` is followed by a `send-keys`, and between the two the operator
+    may have switched windows. A relative target would then type the caller's
+    command into whatever they moved to — the wrong-pane failure this whole
+    surface is careful about, arriving through the one path that creates its own
+    target. So the agent asks tmux to PRINT the new pane's id (`-P -F
+    '#{pane_id}'`) and sends to that id.
+    """
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir",
+                                   text="claude 'do the thing'")]]
+    run_agent(server, tmux_stub, tmp_path)
+
+    calls = tmux_stub.calls()
+    new_windows = [c for c in calls if c and c[0] == "new-window"]
+    assert len(new_windows) == 1, f"expected one new-window, got {calls}"
+    assert new_windows[0] == ["new-window", "-P", "-F", "#{pane_id}", "-c", "/tmp/some/dir"], new_windows[0]
+
+    sends = tmux_stub.send_keys_calls()
+    assert len(sends) == 2, f"expected the text send and the Enter send, got {sends}"
+    # The stub's `new-window` prints nothing, so the agent must have failed
+    # rather than guessed a pane — see the companion test below. Here the stub is
+    # configured to print one.
+    assert sends[0][:4] == ["send-keys", "-t", tmux_stub.new_pane_id(), "-l"], sends[0]
+    assert sends[0][-1] == "claude 'do the thing'", sends[0]
+    assert sends[1] == ["send-keys", "-t", tmux_stub.new_pane_id(), "Enter"], sends[1]
+
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "delivered", body
+
+
+def test_a_new_session_that_cannot_report_a_pane_FAILS_rather_than_guessing(server, tmux_stub, tmp_path):
+    """If tmux does not hand back a pane id there is no safe target.
+
+    Guessing — "the active pane", "the last window" — is exactly the class of
+    fuzzy target the pane-id rule exists to forbid, and here it would run a
+    command in a pane the operator is looking at. Failing is the correct outcome
+    and it must produce NO send-keys at all.
+    """
+    tmux_stub.set_new_window_output("")
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], (
+        "the agent sent keys without a pane id from tmux; that lands in whatever pane happens "
+        "to be active")
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "failed", body
+
+
+def test_a_new_session_with_no_text_just_opens_the_window(server, tmux_stub, tmp_path):
+    """A bare window is a complete delivery — the caller asked for one, and
+    typing nothing into it is the right amount of typing."""
+    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
+    assert tmux_stub.send_keys_calls() == []
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "delivered", body
+
+
+def test_an_unknown_kind_is_refused_with_no_tmux_call_at_all(server, tmux_stub, tmp_path):
+    """🔴 REFUSE, DO NOT GUESS.
+
+    A kind this agent does not recognise means the server is asking for something
+    a newer build knows how to do. Falling back to the default kind would run a
+    command nobody on this host reviewed; refusing is visible in the audit log and
+    costs one write.
+    """
+    server.claim_batches = [[write(kind="reboot-the-host")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert [c for c in tmux_stub.calls() if c and c[0] in ("send-keys", "new-window")] == []
+    body = json.loads([r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "refused", body
+    assert "unknown write kind" in body["detail"], body
+
+
+def test_an_absent_kind_still_means_send_keys(server, tmux_stub, tmp_path):
+    """Backwards compatibility is the default, not a migration: a write with no
+    `kind` at all is what every caller predating the field sent, and it means
+    send-keys."""
+    w = write()
+    w.pop("kind", None)
+    server.claim_batches = [[w]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert len(tmux_stub.send_keys_calls()) == 2

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -46,10 +46,14 @@ asserting anything about a running system.
 """
 from __future__ import annotations
 
+import ast
 import importlib.machinery
 import importlib.util
 import json
 import os
+import re
+import pathlib
+import shutil
 import subprocess
 import sys
 import threading
@@ -215,6 +219,10 @@ def tmux_stub(tmp_path):
         def new_pane_id():
             return new_window_out.read_text().strip()
 
+        @staticmethod
+        def reset():
+            log.write_text("")
+
     return Stub
 
 
@@ -235,7 +243,8 @@ def write(**kw):
 
 
 def run_agent(server, tmux_stub, tmp_path, *, env_extra=None, conf_text=None,
-              token="not-a-real-terminal-token-not-a-real-token", timeout=30):
+              token="not-a-real-terminal-token-not-a-real-token", timeout=30,
+              expect_requests=2):
     """Run the agent for ONE productive round and then let it stop.
 
     The loop is driven to completion by the stub server: the first claim returns
@@ -268,7 +277,7 @@ def run_agent(server, tmux_stub, tmp_path, *, env_extra=None, conf_text=None,
     for _ in range(int(timeout / 0.05)):
         if proc.poll() is not None:
             break
-        if len(server.requests) >= 2:
+        if len(server.requests) >= expect_requests:
             break
         deadline.wait(0.05)
     proc.terminate()
@@ -714,11 +723,106 @@ def test_the_agent_unit_is_declared_even_though_it_is_disabled():
     assert nix_units.declares("systemd.user.services.tmux-reply-agent", src)
     unit = nix_units.strip_nix_comments(
         nix_units.unit_source("systemd.user.services.tmux-reply-agent", src))
-    assert "enableTmuxReplyAgent" in unit and "default.target" in unit, unit
     # 🔴 A RESIDENT SERVICE, NOT A TIMER. A ~5s poll driven by a timer would fork
     # a process, an interpreter and a connection 17,280 times a day.
     assert nix_units.directive("Type", unit) == '"simple"', unit
     assert not nix_units.declares("systemd.user.timers.tmux-reply-agent", src)
+
+
+def _wanted_by_expr(nix_src: str) -> tuple:
+    """-> (flag_value, condition_source, target_list_source) lifted FROM home.nix.
+
+    🔴 THE PREVIOUS GUARD PINNED WORDS AND THE ONE MUTATION THAT MATTERS WALKED
+    THROUGH IT. It asserted that the unit's text CONTAINS "enableTmuxReplyAgent"
+    and "default.target"; the mutant
+
+        WantedBy = lib.optionals (!enableTmuxReplyAgent) [ "default.target" ];
+
+    keeps both substrings and SURVIVES — an inversion that would start the agent
+    on both hosts on the next switch, i.e. the single thing this whole change
+    claims cannot happen. `claude/RULES.md`: "a guard can be SPELLED rather than
+    STRUCTURAL — ask whether it can pass while the hazard exists in a different
+    shape."
+
+    So the CONDITION is extracted and pinned as a whole normalised string rather
+    than searched for. `!enableTmuxReplyAgent` is not `enableTmuxReplyAgent`, and
+    neither is `(enableTmuxReplyAgent || true)`.
+    """
+    flag = re.search(r"^  enableTmuxReplyAgent = (true|false);", nix_src, re.M)
+    assert flag, "the master switch declaration was not found in home.nix"
+    unit = nix_units.strip_nix_comments(
+        nix_units.unit_source("systemd.user.services.tmux-reply-agent", nix_src))
+    m = re.search(r"WantedBy\s*=\s*lib\.optionals\s+(.+?)\s*(\[[^\]]*\])\s*;", unit, re.S)
+    assert m, f"no `WantedBy = lib.optionals <cond> [ ... ];` in the unit:\n{unit}"
+    cond = " ".join(m.group(1).split())
+    targets = " ".join(m.group(2).split())
+    return flag.group(1), cond, targets
+
+
+def test_the_agent_unit_IS_WANTED_BY_NOTHING_as_shipped():
+    """🔴 THE CENTRAL CLAIM, PINNED AS AN EXPRESSION RATHER THAN AS SUBSTRINGS.
+
+    Two facts together determine that nothing wants this unit, and BOTH are
+    asserted: the condition is the BARE flag (not a negation, not a wider
+    expression), and the flag is `false`. A mutant that changes either is a
+    different string here.
+
+    Deterministic — no evaluator, so it runs identically on the dev host and in
+    the nix check sandbox, which has no recursive nix. The `nix eval`
+    confirmation below is a second, weaker instrument that skips when nix is
+    unavailable; this one is the coverage.
+    """
+    flag, cond, targets = _wanted_by_expr(home_nix())
+    assert cond == "enableTmuxReplyAgent", (
+        f"the WantedBy condition is `{cond}`, not the bare flag. Anything else — a negation, a "
+        "disjunction, a different flag — can want this unit while still mentioning the flag's "
+        "name, which is exactly how the previous guard was walked past.")
+    assert flag == "false", (
+        f"enableTmuxReplyAgent is `{flag}`. As shipped it must be false: starting this unit means "
+        "arbitrary command execution as the operator on this host, and arming it is a separate "
+        "operator act.")
+    assert targets == '[ "default.target" ]', targets
+
+
+def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
+    """The positive control, and the whole reason the test above is shaped this
+    way. The previous, word-pinning guard passed over both of these mutants."""
+    src = home_nix()
+    inverted = src.replace(
+        'WantedBy = lib.optionals enableTmuxReplyAgent [ "default.target" ];',
+        'WantedBy = lib.optionals (!enableTmuxReplyAgent) [ "default.target" ];')
+    assert inverted != src, "the WantedBy line this control mutates was not found verbatim"
+    _flag, cond, _t = _wanted_by_expr(inverted)
+    assert cond != "enableTmuxReplyAgent", (
+        "the inverted-flag mutant reads identically to the shipped condition; this guard cannot "
+        "see the one mutation that would start the agent on both hosts")
+
+    flipped = src.replace("  enableTmuxReplyAgent = false;",
+                          "  enableTmuxReplyAgent = true;")
+    assert flipped != src
+    assert _wanted_by_expr(flipped)[0] == "true"
+
+
+def test_nix_agrees_that_nothing_wants_the_unit():
+    """CONFIRMATION, not coverage — and labelled so.
+
+    It evaluates the real expression through nix, which is the only thing that
+    can say what systemd will actually be given. It SKIPS where nix cannot run
+    (the check sandbox has no recursive nix), and a skipped test is not a passing
+    one — which is why the deterministic guard above exists and this does not
+    replace it.
+    """
+    if shutil.which("nix") is None:
+        pytest.skip("no nix on PATH; the deterministic guard above is the coverage")
+    flag, cond, targets = _wanted_by_expr(home_nix())
+    expr = (f"let lib = (import <nixpkgs> {{}}).lib; enableTmuxReplyAgent = {flag}; "
+            f"in lib.optionals {cond} {targets}")
+    out = subprocess.run(["nix", "eval", "--impure", "--json", "--expr", expr],
+                         capture_output=True, text=True, timeout=600)
+    if out.returncode != 0:
+        pytest.skip(f"nix eval unavailable here: {out.stderr.strip()[:200]}")
+    assert json.loads(out.stdout) == [], (
+        "nix says something WANTS this unit as shipped; a switch would start it")
 
 
 def test_the_unit_PATH_carries_tmux_and_python():
@@ -733,10 +837,22 @@ def test_the_unit_PATH_carries_tmux_and_python():
     """
     unit = nix_units.strip_nix_comments(
         nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))
-    assert "pkgs.tmux" in unit, "without tmux every delivery fails"
-    assert "pkgs.python3" in unit, "the agent is a Python program"
-    assert "pkgs.openssh" not in unit and "pkgs.gawk" not in unit, (
-        "the agent never leaves this host; these are copied, not needed")
+    # 🔴 READ THE makeBinPath LIST, NOT THE WHOLE UNIT. The previous version
+    # asserted `"pkgs.python3" in unit`, which is satisfied by the ExecStart line
+    # (`${pkgs.python3}/bin/python3 …`) — so deleting python3 from the PATH list
+    # left it green while the CHILD lost its interpreter directory. A substring
+    # test over a block that mentions a package for another reason is not a test
+    # of the list; the list has to be extracted first.
+    m = re.search(r"PATH=\$\{lib\.makeBinPath \[([^\]]*)\]\}", unit)
+    assert m, f"no PATH=...makeBinPath[...] in the unit:\n{unit}"
+    entries = m.group(1).split()
+    assert "pkgs.tmux" in entries, f"without tmux every delivery fails; PATH list = {entries}"
+    assert "pkgs.python3" in entries, f"the agent is a Python program; PATH list = {entries}"
+    assert "pkgs.coreutils" in entries, entries
+    # Deliberately absent: the agent uses urllib and never leaves this host.
+    for copied in ("pkgs.openssh", "pkgs.gawk", "pkgs.curl"):
+        assert copied not in entries, (
+            f"{copied} is in the PATH list; the agent never uses it — carried, not needed")
 
 
 def test_the_unit_gives_tmux_its_SOCKET_directory():
@@ -884,8 +1000,12 @@ def test_an_absent_kind_still_means_send_keys(server, tmux_stub, tmp_path):
     ({"pane": ""}, "pane id"),
     ({"pane": "-t"}, "pane id"),
     # A newline makes ONE write into TWO submissions.
-    ({"text": "yes\nrm -rf /"}, "control character"),
-    ({"text": "yes\x1b[A"}, "control character"),
+    # 🔴 The message now DIAGNOSES the codepoint (offset + name + category)
+    # instead of saying "control character", because the gate is an allowlist and
+    # the refused set is far wider than the controls. The assertion follows the
+    # gate rather than the old wording.
+    ({"text": "yes\nrm -rf /"}, "a newline at offset"),
+    ({"text": "yes\x1b[A"}, "non-printable character U+001B"),
     ({"text": ""}, "no text"),
     ({"text": "x" * 4000}, "size limit"),
 ])
@@ -948,11 +1068,252 @@ def test_a_batch_at_the_cap_is_still_executed(server, tmux_stub, tmp_path):
 def test_the_validator_is_exercised_directly():
     """Every branch, including the accepting ones — without which the table above
     is satisfied by a validator that refuses everything."""
-    assert AGENT.validate({"kind": "send-keys", "pane": "%12", "text": "hi"}) == ""
-    assert AGENT.validate({"pane": "%12", "text": "hi"}) == ""  # absent kind
-    assert AGENT.validate({"kind": "new-session", "cwd": "/tmp", "text": "hi"}) == ""
-    assert AGENT.validate({"kind": "new-session", "cwd": "/tmp", "text": ""}) == ""  # bare window
-    assert "unknown write kind" in AGENT.validate({"kind": "exec", "pane": "%1", "text": "hi"})
+    ok = {"id": "w-abc123"}
+    assert AGENT.validate({**ok, "kind": "send-keys", "pane": "%12", "text": "hi"}) == ""
+    assert AGENT.validate({**ok, "pane": "%12", "text": "hi"}) == ""  # absent kind
+    assert AGENT.validate({**ok, "kind": "new-session", "cwd": "/tmp", "text": "hi"}) == ""
+    assert AGENT.validate({**ok, "kind": "new-session", "cwd": "/tmp", "text": ""}) == ""  # bare window
+    assert "unknown write kind" in AGENT.validate({**ok, "kind": "exec", "pane": "%1", "text": "hi"})
     # Non-string fields from a malformed payload must not raise.
-    assert AGENT.validate({"kind": "send-keys", "pane": 12, "text": "hi"}) != ""
-    assert AGENT.validate({"kind": "new-session", "cwd": None, "text": "hi"}) != ""
+    assert AGENT.validate({**ok, "kind": "send-keys", "pane": 12, "text": "hi"}) != ""
+    assert AGENT.validate({**ok, "kind": "new-session", "cwd": None, "text": "hi"}) != ""
+    # An id this agent will not put in a URL is refused before anything else.
+    assert "write id" in AGENT.validate({"kind": "send-keys", "pane": "%1", "text": "hi"})
+
+
+# --------------------------------------------------------------------------- #
+# 10. The text gate is an ALLOWLIST, and it is the SAME one session-write uses.
+# --------------------------------------------------------------------------- #
+#
+# 🔴 THE DENYLIST THIS REPLACED WAS WRONG IN THE MEASURED WAY. `ord(ch) < 0x20 or
+# ord(ch) == 0x7F` refuses NUL, \n, \r, ESC and DEL — and passes every C1 control
+# (U+0080–U+009F), U+0085 NEL, U+2028 and U+2029. `session-write` had already
+# fixed exactly this class, with a docstring recording that U+000F (Ctrl-O) got
+# through its own earlier denylist and executed a pane's buffer with no Enter
+# sent. Two sites, one rule, wrong at the one reachable from the network.
+
+@pytest.mark.parametrize("ch,why", [
+    ("\x0f", "Ctrl-O — the character session-write's docstring records as executing a pane's buffer"),
+    ("\x85", "U+0085 NEL — a line break to some terminals, and >= 0x20 so a denylist misses it"),
+    ("\x9b", "U+009B CSI — a C1 control that starts an escape sequence"),
+    (" ", "U+2028 LINE SEPARATOR"),
+    (" ", "U+2029 PARAGRAPH SEPARATOR"),
+    ("​", "U+200B ZERO WIDTH SPACE — invisible, so the audit row and the pane disagree"),
+    ("", "U+E000 private use — renders identical to its neighbour"),
+    ("\n", "a newline: one write becoming TWO submissions"),
+    ("\x00", "NUL"),
+    ("\x1b", "ESC"),
+])
+def test_the_text_gate_refuses_what_a_denylist_would_pass(ch, why):
+    reason = AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                             "text": "echo hi" + ch})
+    assert reason, f"the allowlist ACCEPTED {ch!r} — {why}"
+
+
+def test_the_text_gate_still_accepts_ordinary_text():
+    """The positive control. Without it every case above is satisfied by a gate
+    that refuses everything, which would make the feature inert rather than safe.
+    """
+    for text in ("yes, go ahead", "café — naïve ünïcode ✓", "a\tb",
+                 "run `make test` && echo $HOME; then stop", "  spaced  "):
+        assert AGENT.validate({"id": "w-abc123", "kind": "send-keys",
+                               "pane": "%1", "text": text}) == "", text
+
+
+def test_a_trailing_tmux_separator_is_refused():
+    """tmux EATS a trailing `;` off an argv token, so the pane would receive
+    something other than what the audit log records — a payload silently
+    corrupted somewhere nobody looks."""
+    assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                           "text": "echo hi;"}) != ""
+    # …but a `;` in the MIDDLE is ordinary shell and must pass.
+    assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                           "text": "echo hi; echo there"}) == ""
+
+
+def test_the_agent_and_session_write_share_ONE_predicate():
+    """🔴 ONE RULE, ONE PLACE — asserted as a RELATIONSHIP, not as two green suites.
+
+    Both programs deliver literal text to a tmux pane. Before this they each had
+    their own answer to "what may be delivered", and the network-facing one was
+    the weaker: a denylist that passed every C1 control. The rule now lives in
+    `scripts/lib/tmux_text_policy.py`.
+
+    🔴 THE ASSERTION IS ON `__code__.co_filename`, NOT ON OBJECT IDENTITY. Both
+    programs are SCRIPTS loaded by path, so each gets its own module instance of
+    the policy and the two function objects are legitimately different — an `is`
+    check fails while the rule is perfectly shared, which is a guard that cries
+    wolf until someone deletes it. What actually matters is the SOURCE both
+    predicates were compiled from, and that is what this reads.
+    """
+    sw = _load_session_write()
+    shared = str((REPO_ROOT / "scripts" / "lib" / "tmux_text_policy.py").resolve())
+    for name, fn in (("session-write", sw.TEXT_IS_ALLOWED),
+                     ("tmux-reply-agent", AGENT.TEXT_POLICY.TEXT_IS_ALLOWED)):
+        got = str(pathlib.Path(fn.__code__.co_filename).resolve())
+        assert got == shared, (
+            f"{name}'s TEXT_IS_ALLOWED was compiled from {got}, not the shared policy at "
+            f"{shared} — it has its own copy again, and a second copy of this rule has "
+            "already been wrong once")
+    assert sw.TEXT_EXTRA_ALLOWED == AGENT.TEXT_POLICY.TEXT_EXTRA_ALLOWED == ("\t",)
+    # The separator the two could have disagreed about is pinned at
+    # session-write's import against session-resolve's own constant.
+    assert sw.TMUX_ARGV_SEPARATOR == AGENT.TEXT_POLICY.TMUX_ARGV_SEPARATOR
+
+
+def test_neither_script_defines_a_SECOND_text_predicate():
+    """The other half: no third copy, and no resurrection of the denylist.
+
+    AST, not grep — this file's own prose names `has_control` repeatedly, and a
+    raw-text scan would fire on the comment explaining why it is gone. Only
+    function DEFINITIONS are examined.
+    """
+    for script in ("session-write", "tmux-reply-agent"):
+        tree = ast.parse((REPO_ROOT / "scripts" / script).read_text())
+        defined = {n.name for n in ast.walk(tree)
+                   if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        for banned in ("TEXT_IS_ALLOWED", "has_control"):
+            assert banned not in defined, (
+                f"{script} defines its own {banned}(); the text policy has ONE home "
+                "(scripts/lib/tmux_text_policy.py) and a second copy of it has already "
+                "shipped wrong once")
+
+
+def test_the_shared_predicate_agrees_with_itself_across_the_whole_BMP():
+    """A behavioural sweep beside the structural check above.
+
+    The structural check says both callers import one file; this says the file's
+    answer is the one the callers' own gates actually produce, over a range no
+    hand-written fixture covers. It is what catches a consumer that imports the
+    predicate and then second-guesses it.
+    """
+    policy = AGENT.TEXT_POLICY
+    disagreements = []
+    for cp in range(0x20, 0x2100):
+        ch = chr(cp)
+        allowed = policy.TEXT_IS_ALLOWED(ch)
+        refused_by_agent = AGENT.validate(
+            {"id": "w-abc123", "kind": "send-keys", "pane": "%1", "text": "a" + ch + "b"}) != ""
+        if allowed == refused_by_agent:
+            disagreements.append(f"U+{cp:04X}")
+    assert not disagreements, (
+        "the agent's gate disagrees with the shared allowlist at: "
+        + ", ".join(disagreements[:20]))
+    # The positive control: the sweep must have seen BOTH answers, or it is a
+    # loop that proves nothing.
+    assert policy.TEXT_IS_ALLOWED("A") and not policy.TEXT_IS_ALLOWED("\u200b")
+
+
+def test_the_agent_REFUSES_TO_START_without_the_policy_module():
+    """🔴 NO FALLBACK. A missing policy module must stop the program, not leave
+    it with a weaker check — a silent fallback is how the denylist would come
+    back, and it would come back at the network-facing site."""
+    with pytest.raises(FileNotFoundError):
+        AGENT._load_tmux_text_policy("/nonexistent/tmux_text_policy.py")
+
+
+def _load_session_write():
+    """Import session-write by path.
+
+    🔴 REGISTERED IN sys.modules BEFORE exec_module. It defines dataclasses, and
+    `dataclasses` resolves a string annotation through `sys.modules[cls.__module__]`
+    — which is None for a module that is being executed but not registered, and
+    the failure is an AttributeError inside the stdlib rather than anything that
+    names the real cause.
+    """
+    name = "session_write_undertest"
+    if name in sys.modules:
+        return sys.modules[name]
+    path = REPO_ROOT / "scripts" / "session-write"
+    loader = importlib.machinery.SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        loader.exec_module(mod)
+    except Exception:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# 11. The host's OWN at-most-once, the id shape, and the new-session submit.
+# --------------------------------------------------------------------------- #
+def test_the_host_refuses_a_write_id_it_has_already_executed(server, tmux_stub, tmp_path):
+    """🔴 THE HOST'S OWN at-most-once, and it is not redundant with the server's.
+
+    The server's guarantee is a property of its claim predicate. This agent is
+    the thing that RUNS the command — so a server that is wrong, rolled back,
+    restored from a backup, or simply newer would re-execute a claimed row, and
+    the operator's decision that clawgate presses Enter makes that a second
+    command execution.
+    """
+    server.claim_batches = [[write()], [write()]]   # the SAME id, twice
+    run_agent(server, tmux_stub, tmp_path, expect_requests=4)
+    text_sends = [s for s in tmux_stub.send_keys_calls() if "-l" in s]
+    assert len(text_sends) == 1, (
+        f"the agent executed the same write id {len(text_sends)} times: {tmux_stub.send_keys_calls()}")
+    states = [json.loads(r["body"])["state"]
+              for r in server.requests if r["path"].endswith("/result")]
+    assert states[0] == "delivered", states
+    assert "refused" in states[1:], (
+        f"the duplicate was not reported as refused ({states}); a silently dropped duplicate is "
+        "indistinguishable in the audit log from one that never arrived")
+
+
+def test_the_dedupe_memory_is_bounded():
+    """An unbounded set in a process that runs for weeks is a slow leak."""
+    AGENT._SEEN.clear()
+    for i in range(AGENT.SEEN_LIMIT + 50):
+        assert not AGENT.already_executed(f"id{i}")
+    assert len(AGENT._SEEN) <= AGENT.SEEN_LIMIT
+    # Oldest-first eviction: the earliest ids are the ones forgotten.
+    assert "id0" not in AGENT._SEEN
+    assert f"id{AGENT.SEEN_LIMIT + 49}" in AGENT._SEEN
+    AGENT._SEEN.clear()
+
+
+@pytest.mark.parametrize("wid", ["", "../other", "a/b", "x" * 65, "a b", "a\nb", None, 7])
+def test_an_unusable_write_id_is_never_put_in_a_url(server, tmux_stub, tmp_path, wid):
+    """🔴 THE ID IS INTERPOLATED INTO A URL THIS AGENT CONSTRUCTS. A server-supplied
+    id it cannot vouch for could steer the request somewhere else, and it would
+    otherwise be unbounded text in a log line too."""
+    server.claim_batches = [[write(id=wid)]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], "a write with an unusable id was executed"
+    for req in server.requests:
+        assert "/result" not in req["path"], f"a request was aimed at {req['path']!r}"
+
+
+def test_a_new_session_ALWAYS_submits_whatever_the_row_says(server, tmux_stub, tmp_path):
+    """🔴 BOTH DIRECTIONS, because neither was pinned before.
+
+    A new-session exists to produce a window that is DOING something; typing a
+    command into a fresh shell and not running it leaves the operator a window to
+    go and finish by hand. So `submit` on the row describes the send-keys case
+    and is not consulted here — and that has to be asserted against a row saying
+    `false`, or a mutant that starts honouring the field survives.
+    """
+    for submit in (True, False):
+        server.requests.clear()
+        tmux_stub.reset()
+        AGENT._SEEN.clear()
+        server.claim_batches = [[write(id=f"w-ns{int(submit)}", kind="new-session", pane="",
+                                       cwd="/tmp/some/dir", text="echo hi", submit=submit)]]
+        run_agent(server, tmux_stub, tmp_path)
+        sends = tmux_stub.send_keys_calls()
+        assert len(sends) == 2, (
+            f"submit={submit}: expected the text send AND the Enter send, got {sends}")
+        assert sends[1][-1] == "Enter", sends[1]
+    assert AGENT.NEW_SESSION_ALWAYS_SUBMITS is True
+
+
+def test_a_server_supplied_pane_cannot_forge_a_log_line(server, tmux_stub, tmp_path):
+    """Every field in a claim is server-controlled. A pane that failed the id
+    check must not be echoed verbatim into the journal — a newline in it would
+    forge a second, well-formed-looking log line."""
+    server.claim_batches = [[write(pane="%1\ntmux-reply-agent: delivered everything")]]
+    _rc, out = run_agent(server, tmux_stub, tmp_path)
+    assert "delivered everything" not in out, out
+    assert tmux_stub.send_keys_calls() == []

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -53,7 +53,6 @@ import json
 import os
 import re
 import pathlib
-import shutil
 import subprocess
 import sys
 import threading
@@ -768,10 +767,19 @@ def test_the_agent_unit_IS_WANTED_BY_NOTHING_as_shipped():
     expression), and the flag is `false`. A mutant that changes either is a
     different string here.
 
-    Deterministic — no evaluator, so it runs identically on the dev host and in
-    the nix check sandbox, which has no recursive nix. The `nix eval`
-    confirmation below is a second, weaker instrument that skips when nix is
-    unavailable; this one is the coverage.
+    🔴 DETERMINISTIC, AND THERE IS DELIBERATELY NO `nix eval` BESIDE IT. A first
+    draft added one as "confirmation". It PASSED on the dev host and turned the
+    nix check sandbox RED — not by failing, but by SKIPPING: that sandbox has no
+    recursive nix, and this repo's runner treats an unpinned skip as an error,
+    because "a skip is a test that did not run". Pinning it would have bought a
+    permanent EXPECTED_SKIPS entry for a test that can never run in the tier that
+    gates, i.e. reading as coverage while providing none.
+
+    It was removed rather than pinned because it confirmed nothing this test does
+    not already determine: given `cond == "enableTmuxReplyAgent"` and the flag
+    `false`, `lib.optionals` yields `[]` by definition. And a change to a
+    DIFFERENT combinator (`lib.optional`, singular, with different semantics)
+    fails the regex above rather than slipping past it.
     """
     flag, cond, targets = _wanted_by_expr(home_nix())
     assert cond == "enableTmuxReplyAgent", (
@@ -802,28 +810,6 @@ def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
                           "  enableTmuxReplyAgent = true;")
     assert flipped != src
     assert _wanted_by_expr(flipped)[0] == "true"
-
-
-def test_nix_agrees_that_nothing_wants_the_unit():
-    """CONFIRMATION, not coverage — and labelled so.
-
-    It evaluates the real expression through nix, which is the only thing that
-    can say what systemd will actually be given. It SKIPS where nix cannot run
-    (the check sandbox has no recursive nix), and a skipped test is not a passing
-    one — which is why the deterministic guard above exists and this does not
-    replace it.
-    """
-    if shutil.which("nix") is None:
-        pytest.skip("no nix on PATH; the deterministic guard above is the coverage")
-    flag, cond, targets = _wanted_by_expr(home_nix())
-    expr = (f"let lib = (import <nixpkgs> {{}}).lib; enableTmuxReplyAgent = {flag}; "
-            f"in lib.optionals {cond} {targets}")
-    out = subprocess.run(["nix", "eval", "--impure", "--json", "--expr", expr],
-                         capture_output=True, text=True, timeout=600)
-    if out.returncode != 0:
-        pytest.skip(f"nix eval unavailable here: {out.stderr.strip()[:200]}")
-    assert json.loads(out.stdout) == [], (
-        "nix says something WANTS this unit as shipped; a switch would start it")
 
 
 def test_the_unit_PATH_carries_tmux_and_python():

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -53,7 +53,9 @@ import json
 import os
 import re
 import pathlib
+import shutil
 import subprocess
+import tempfile
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -173,6 +175,15 @@ def tmux_stub(tmp_path):
     err_file.write_text("")
     new_window_out = tmp_path / "tmux-new-window-out"
     new_window_out.write_text("%77\n")
+    # 🔴 A STUB THAT CAN LIE ABOUT WHERE THE WINDOW LANDED. The agent reads back
+    # the session and path tmux actually chose; without a stub that can report
+    # something OTHER than the request, that read-back is unpinned — measured, as
+    # two surviving mutants, because `=` and `isdir` each fire first in the
+    # ordinary case. These files override the derived values when non-empty.
+    landed_session = tmp_path / "tmux-landed-session"
+    landed_session.write_text("")
+    landed_path = tmp_path / "tmux-landed-path"
+    landed_path.write_text("")
 
     path = tmp_path / "bin" / "tmux"
     path.parent.mkdir(exist_ok=True)
@@ -184,7 +195,21 @@ def tmux_stub(tmp_path):
         f'''python3 -c 'import json,sys; open(sys.argv[1],"a").write(json.dumps(sys.argv[2:])+"\\n")' '''
         f'''{log} "$@"\n'''
         f'''if [ "$1" = "display-message" ]; then cat {server_id}; exit 0; fi\n'''
-        f'''if [ "$1" = "new-window" ]; then cat {new_window_out}; exit 0; fi\n'''
+        # 🔴 THE STUB NOW ECHOES WHAT THE AGENT READS BACK. The agent verifies the
+        # session and working directory tmux ACTUALLY chose, so a stub printing a
+        # bare pane id would fail every new-session test for the wrong reason.
+        # It derives both from its OWN argv, which is also what makes a
+        # deliberately mismatching stub expressible.
+        f'''if [ "$1" = "new-window" ]; then\n'''
+        f'''  python3 -c 'import sys;a=sys.argv[1:];\n'''
+        f'''c=a[a.index("-c")+1] if "-c" in a else "";\n'''
+        f'''c=open("{landed_path}").read().strip() or c;\n'''
+        f'''t=a[a.index("-t")+1].strip("=:") if "-t" in a else "keep";\n'''
+        f'''t=open("{landed_session}").read().strip() or t;\n'''
+        f'''p=open("{new_window_out}").read().strip();\n'''
+        f'''sys.stdout.write("" if p=="" else p+"\\t"+t+"\\t"+c+"\\n")' "$@"\n'''
+        f'''  exit 0\n'''
+        f'''fi\n'''
         f'''if [ "$1" = "send-keys" ]; then cat {err_file} >&2; exit "$(cat {rc_file})"; fi\n'''
         f'''exit 0\n'''
     ))
@@ -215,6 +240,14 @@ def tmux_stub(tmp_path):
             new_window_out.write_text(value)
 
         @staticmethod
+        def lie_about_landing(session=None, path=None):
+            """Make the stub report a landing that differs from the request."""
+            if session is not None:
+                landed_session.write_text(session)
+            if path is not None:
+                landed_path.write_text(path)
+
+        @staticmethod
         def new_pane_id():
             return new_window_out.read_text().strip()
 
@@ -240,6 +273,20 @@ def write(**kw):
     }
     out.update(kw)
     return out
+
+
+def real_dir(tmp_path, name="work"):
+    """A directory that EXISTS, for a new-session fixture.
+
+    🔴 `/tmp/some/dir` USED TO DO, AND THAT WAS THE HOLE. `new-window -c <missing
+    path>` returns rc 0 and opens the window in the HOME DIRECTORY — measured on
+    real tmux — so every stubbed fixture here was describing a delivery that, in
+    production, would have run the command somewhere else entirely. The agent
+    refuses a non-existent cwd now, so a fixture has to name a real one.
+    """
+    d = tmp_path / name
+    d.mkdir(exist_ok=True)
+    return str(d)
 
 
 def run_agent(server, tmux_stub, tmp_path, *, env_extra=None, conf_text=None,
@@ -888,14 +935,15 @@ def test_a_new_session_opens_a_window_at_the_cwd_and_types_into_THAT_pane(server
     target. So the agent asks tmux to PRINT the new pane's id (`-P -F
     '#{pane_id}'`) and sends to that id.
     """
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir",
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path),
                                    text="claude 'do the thing'")]]
     run_agent(server, tmux_stub, tmp_path)
 
     calls = tmux_stub.calls()
     new_windows = [c for c in calls if c and c[0] == "new-window"]
     assert len(new_windows) == 1, f"expected one new-window, got {calls}"
-    assert new_windows[0] == ["new-window", "-P", "-F", "#{pane_id}", "-c", "/tmp/some/dir"], new_windows[0]
+    assert new_windows[0] == ["new-window", "-P", "-F", AGENT.NEW_WINDOW_FORMAT,
+                              "-c", real_dir(tmp_path)], new_windows[0]
 
     sends = tmux_stub.send_keys_calls()
     assert len(sends) == 2, f"expected the text send and the Enter send, got {sends}"
@@ -919,7 +967,7 @@ def test_a_new_session_that_cannot_report_a_pane_FAILS_rather_than_guessing(serv
     and it must produce NO send-keys at all.
     """
     tmux_stub.set_new_window_output("")
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="echo hi")]]
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path), text="echo hi")]]
     run_agent(server, tmux_stub, tmp_path)
     assert tmux_stub.send_keys_calls() == [], (
         "the agent sent keys without a pane id from tmux; that lands in whatever pane happens "
@@ -931,7 +979,7 @@ def test_a_new_session_that_cannot_report_a_pane_FAILS_rather_than_guessing(serv
 def test_a_new_session_with_no_text_just_opens_the_window(server, tmux_stub, tmp_path):
     """A bare window is a complete delivery — the caller asked for one, and
     typing nothing into it is the right amount of typing."""
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="")]]
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path), text="")]]
     run_agent(server, tmux_stub, tmp_path)
     assert [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
     assert tmux_stub.send_keys_calls() == []
@@ -1291,7 +1339,7 @@ def test_a_new_session_ALWAYS_submits_whatever_the_row_says(server, tmux_stub, t
         tmux_stub.reset()
         AGENT._SEEN.clear()
         server.claim_batches = [[write(id=f"w-ns{int(submit)}", kind="new-session", pane="",
-                                       cwd="/tmp/some/dir", text="echo hi", submit=submit)]]
+                                       cwd=real_dir(tmp_path), text="echo hi", submit=submit)]]
         run_agent(server, tmux_stub, tmp_path)
         sends = tmux_stub.send_keys_calls()
         assert len(sends) == 2, (
@@ -1325,13 +1373,17 @@ def test_a_named_tmux_session_is_passed_to_tmux_as_a_target(server, tmux_stub, t
     next free index", and a session that does not exist makes tmux FAIL rather
     than silently fall back to the current one.
     """
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir",
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path),
                                    tmuxSessionName="scratch2", text="echo hi")]]
     run_agent(server, tmux_stub, tmp_path)
     new_windows = [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
     assert len(new_windows) == 1, tmux_stub.calls()
-    assert new_windows[0] == ["new-window", "-P", "-F", "#{pane_id}", "-c", "/tmp/some/dir",
-                              "-t", "scratch2:"], new_windows[0]
+    # 🔴 `=` FORCES AN EXACT SESSION MATCH. Without it tmux PREFIX-MATCHES:
+    # `-t scratch2:` with `scratch2` absent and `scratch20` live returns rc 0 and
+    # opens the window in `scratch20` — measured on 3.7c against the operator's
+    # own server, which holds exactly that pair.
+    assert new_windows[0] == ["new-window", "-P", "-F", AGENT.NEW_WINDOW_FORMAT,
+                              "-c", real_dir(tmp_path), "-t", "=scratch2:"], new_windows[0]
 
 
 def test_an_absent_tmux_session_leaves_the_target_to_tmux(server, tmux_stub, tmp_path):
@@ -1339,7 +1391,7 @@ def test_an_absent_tmux_session_leaves_the_target_to_tmux(server, tmux_stub, tmp
     server considers current", which is what happened before the field existed
     and the only honest answer when nobody expressed a preference. A `-t` with an
     empty value would be a target of its own."""
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/some/dir", text="echo hi")]]
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path), text="echo hi")]]
     run_agent(server, tmux_stub, tmp_path)
     new_windows = [c for c in tmux_stub.calls() if c and c[0] == "new-window"]
     assert len(new_windows) == 1
@@ -1359,7 +1411,7 @@ def test_the_host_refuses_a_compound_tmux_target(server, tmux_stub, tmp_path, na
     """🔴 RE-VALIDATED ON THE HOST, NOT TRUSTED. The server checks this too; this
     process is the one that hands the value to tmux, and the two sides of the
     boundary fail independently."""
-    server.claim_batches = [[write(kind="new-session", pane="", cwd="/tmp/d",
+    server.claim_batches = [[write(kind="new-session", pane="", cwd=real_dir(tmp_path),
                                    tmuxSessionName=name, text="echo hi")]]
     run_agent(server, tmux_stub, tmp_path)
     assert [c for c in tmux_stub.calls() if c and c[0] in ("new-window", "send-keys")] == [], (
@@ -1393,3 +1445,294 @@ def test_the_host_refuses_a_tab_even_though_the_shared_policy_allows_one():
     # The control: the same text without the tab is ordinary and passes.
     assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
                            "text": "rm -rf ~/projects/"}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# 13. REAL tmux. The stub cannot express either of these.
+# --------------------------------------------------------------------------- #
+#
+# 🔴 THE STUB ALWAYS EXITS 0, so it models neither of the two resolution rules
+# that shipped as defects: tmux PREFIX-MATCHES a session name, and `-c <missing
+# path>` falls back to the home directory. Both were measured live, both reported
+# `delivered`, and both were invisible to every stubbed test in this file. These
+# drive a REAL tmux on a private `-L` socket — never the operator's server — and
+# `tmux` is in REQUIRED_TOOLS and flake.nix's gateTools so they cannot silently
+# skip in the tier that gates.
+
+@pytest.fixture
+def real_tmux(tmp_path):
+    """A private tmux server with known sessions, torn down afterwards.
+
+    🔴 `-L <unique>` AND A PRIVATE TMUX_TMPDIR. This must never touch the
+    operator's live server: the thing under test CREATES WINDOWS.
+    """
+    sock = "rank29-" + os.path.basename(str(tmp_path))
+    sockdir = tempfile.mkdtemp(prefix="tmuxr29.")
+    env = dict(os.environ, TMUX_TMPDIR=sockdir)
+
+    def tmux(*args, check=True):
+        p = subprocess.run(["tmux", "-L", sock, *args], capture_output=True,
+                           text=True, env=env, timeout=30)
+        if check and p.returncode != 0:
+            raise AssertionError(f"tmux {args} failed: {p.stderr}")
+        return p
+
+    # The operator's real server holds `scratch`, `scratch2` … `scratch20` and
+    # `datapacket-talos`, `datapacket-talos-2`. This reproduces the SHAPE that
+    # makes a prefix match land somewhere else: a longer name present, the
+    # shorter one absent.
+    tmux("new-session", "-d", "-s", "scratch20")
+    tmux("new-session", "-d", "-s", "keep")
+    try:
+        yield {"sock": sock, "env": env, "tmux": tmux}
+    finally:
+        subprocess.run(["tmux", "-L", sock, "kill-server"], capture_output=True,
+                       env=env, timeout=30)
+        shutil.rmtree(sockdir, ignore_errors=True)
+
+
+def _agent_with_real_tmux(monkeypatch, real_tmux):
+    """Point the agent's tmux seam at the private server."""
+    sock, env = real_tmux["sock"], real_tmux["env"]
+
+    def run(args):
+        p = subprocess.run(["tmux", "-L", sock, *args], capture_output=True,
+                           text=True, env=env, timeout=30)
+        return p.returncode, p.stdout, p.stderr
+
+    monkeypatch.setattr(AGENT, "run_tmux", run)
+
+
+def test_a_MISSING_session_is_refused_not_prefix_matched(monkeypatch, real_tmux):
+    """🔴 THE FIRST SHIPPED DEFECT, against real tmux.
+
+    tmux prefix-matches a session name. `-t scratch2:` with `scratch2` absent and
+    `scratch20` live returns rc 0 and opens the window in `scratch20` — measured
+    on 3.7c against the operator's own server, where `scratch2` … `scratch20`
+    both exist. End to end the agent typed the command, pressed Enter and
+    reported `delivered`.
+
+    `scratch2` is the literal this file's own fixtures use.
+    """
+    _agent_with_real_tmux(monkeypatch, real_tmux)
+    before = real_tmux["tmux"]("list-windows", "-a", "-F", "#{session_name}").stdout
+
+    pane, err = AGENT.open_window(str(pathlib.Path.home()), "scratch2")
+    assert err, ("open_window SUCCEEDED for a session that does not exist. tmux prefix-matched "
+                 "it to `scratch20` and the next step presses Enter.")
+    assert pane == ""
+    after = real_tmux["tmux"]("list-windows", "-a", "-F", "#{session_name}").stdout
+    assert after == before, f"a window was created anyway:\nbefore={before!r}\nafter={after!r}"
+
+
+def test_the_EXACT_session_still_works(monkeypatch, real_tmux):
+    """The control for the refusal above: the real name opens a real window, so
+    the refusal is the `=` prefix and not a gate that refuses everything."""
+    _agent_with_real_tmux(monkeypatch, real_tmux)
+    pane, err = AGENT.open_window(str(pathlib.Path.home()), "scratch20")
+    assert not err, err
+    assert pane.startswith("%")
+    landed = real_tmux["tmux"](
+        "display-message", "-p", "-t", pane, "#{session_name}").stdout.strip()
+    assert landed == "scratch20", landed
+
+
+def test_a_cwd_that_does_not_exist_is_REFUSED_not_opened_in_HOME(monkeypatch, real_tmux, tmp_path):
+    """🔴 THE SECOND SHIPPED DEFECT, against real tmux.
+
+    `new-window -c <absolute path that does not exist>` returns rc 0 and opens
+    the window in the home directory — measured. End to end the agent reported
+    `state='delivered' detail='opened %1'` while the command ran in $HOME, so a
+    build or a recursive delete would have run there.
+    """
+    _agent_with_real_tmux(monkeypatch, real_tmux)
+    missing = str(tmp_path / "definitely" / "not" / "here")
+    pane, err = AGENT.open_window(missing, "scratch20")
+    assert err, ("open_window SUCCEEDED for a directory that does not exist; tmux fell back to "
+                 "the home directory and the command would have run there")
+    assert pane == ""
+
+    # The control: a directory that DOES exist opens there, and the read-back
+    # agrees — so the refusal is the fallback and not an unconditional no.
+    real = tmp_path / "real"
+    real.mkdir()
+    pane, err = AGENT.open_window(str(real), "scratch20")
+    assert not err, err
+    landed = real_tmux["tmux"](
+        "display-message", "-p", "-t", pane, "#{pane_current_path}").stdout.strip()
+    assert AGENT.same_directory(landed, str(real)), f"landed={landed!r} want={real}"
+
+
+def test_a_trailing_separator_in_the_cwd_is_refused(tmp_path):
+    """tmux eats a trailing separator off the `-c` word exactly as it does off a
+    send-keys token, so the path becomes a DIFFERENT path — and if that does not
+    exist, the window opens in the home directory. The text path already refused
+    this character; the cwd path did not."""
+    real = tmp_path / "build"
+    real.mkdir()
+    ok = {"id": "w-abc123", "kind": "new-session", "pane": "", "text": "make"}
+    assert AGENT.validate({**ok, "cwd": str(real)}) == ""
+    for bad in (str(real) + ";", str(real) + " ", " " + str(real)):
+        assert AGENT.validate({**ok, "cwd": bad}) != "", bad
+
+
+def test_a_nonexistent_cwd_is_refused_before_tmux_is_reached(tmp_path):
+    """The early, legible refusal. open_window re-checks where tmux ACTUALLY
+    landed; this makes the common case a clear message rather than a fallback."""
+    ok = {"id": "w-abc123", "kind": "new-session", "pane": "", "text": "make"}
+    assert "does not exist" in AGENT.validate({**ok, "cwd": str(tmp_path / "nope")})
+    assert AGENT.validate({**ok, "cwd": str(tmp_path)}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# 14. The guards that had no coverage.
+# --------------------------------------------------------------------------- #
+def test_the_shared_scan_sees_a_bad_character_at_OFFSET_ZERO():
+    """🟡 THE EXACT TRAP THE POLICY'S OWN DOCSTRING RECORDS, in the one caller.
+
+    `enumerate(text)` → `enumerate(text[1:], 1)` SURVIVED all 85 tests: every
+    fixture in this file puts the bad character LATER (`"echo hi" + ch`,
+    `"a" + ch + "b"`), so a scan blind at offset 0 refuses the same character at
+    the end and DELIVERS it at the start. session-write's own offset-zero test
+    cannot cover this — that file open-codes its own scan, and `first_disallowed`
+    has exactly one caller: this agent, the network-facing one.
+    """
+    policy = AGENT.TEXT_POLICY
+    for ch in ("\x0f", "\n", "\x1b", "\x00", "​", "\x85"):
+        got = policy.first_disallowed(ch + "echo hi")
+        assert got is not None, f"{ch!r} at offset 0 was not seen by the shared scan"
+        assert got[0] == 0, f"{ch!r} reported at offset {got[0]}, want 0"
+        # …and through the agent's own gate, which is what actually ships.
+        assert AGENT.validate({"id": "w-abc123", "kind": "send-keys", "pane": "%1",
+                               "text": ch + "echo hi"}) != "", ch
+    # The control: an allowed character at offset 0 is still allowed, so this is
+    # not a scan that refuses everything at the start.
+    assert policy.first_disallowed("echo hi") is None
+
+
+def test_the_response_read_is_BOUNDED(monkeypatch):
+    """🟡 `resp.read(MAX)` → `resp.read()` survived all 85 tests. A bare read
+    takes whatever the peer sends into a process on the operator's workstation."""
+    captured = {}
+
+    class FakeResp:
+        def read(self, *args):
+            captured["args"] = args
+            return b'{"writes":[]}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(AGENT.urllib.request, "urlopen", lambda *a, **k: FakeResp())
+    AGENT.post_json("http://127.0.0.1:1/x", "tok", {})
+    assert captured["args"], "the response was read with NO limit argument"
+    assert captured["args"][0] == AGENT.MAX_RESPONSE_BYTES
+
+
+def test_a_write_that_makes_the_validator_RAISE_is_still_reported(server, tmux_stub, tmp_path):
+    """🟡 A non-string `kind` raised out of the whole round: no result was POSTed
+    for that row OR ANY LATER ROW in the batch, so they landed `abandoned` —
+    "delivery UNKNOWN" — when the truthful answer is `refused`, nothing ran.
+
+    An audit log that says UNKNOWN where it could say NO is exactly the failure
+    its design is trying to avoid.
+    """
+    AGENT._SEEN.clear()
+    server.claim_batches = [[write(id="w-bad", kind=123), write(id="w-later")]]
+    run_agent(server, tmux_stub, tmp_path, expect_requests=4)
+    results = {json.loads(r["body"])["state"]
+               for r in server.requests if r["path"].endswith("/result")}
+    posted = [r["path"] for r in server.requests if r["path"].endswith("/result")]
+    assert any("w-bad" in p for p in posted), (
+        f"the raising write was never reported, so it becomes `abandoned` — delivery UNKNOWN — "
+        f"when nothing ran. Reported: {posted}")
+    assert any("w-later" in p for p in posted), (
+        f"a LATER write in the same batch was never reported either: {posted}")
+    assert "refused" in results, results
+
+
+@pytest.mark.parametrize("field,value", [
+    ("kind", 123), ("kind", None), ("expectTmuxServerId", []),
+    ("expectTmuxServerId", 7), ("pane", 12), ("cwd", None), ("text", 5), ("id", 9),
+])
+def test_the_validator_never_raises_on_a_non_string_field(field, value):
+    """The sentence this test's predecessor made was wider than the test: it
+    claimed "non-string fields must not raise" and exercised only `pane` and
+    `cwd`. Every field a server can send is a string in the contract and none of
+    them is guaranteed to be one on the wire."""
+    w = {"id": "w-abc123", "kind": "send-keys", "pane": "%1", "text": "hi", field: value}
+    assert isinstance(AGENT.validate(w), str)
+
+
+def test_a_refusal_detail_is_CLAMPED_like_every_other(server, tmux_stub, tmp_path):
+    """🟡 A validate() refusal bypassed redact() entirely: an unbounded
+    server-supplied `kind` interpolated into the message produced a
+    100,021-character detail, into a journal line and into the audit-log column
+    — while the comment beside it asserted every interpolated field was bounded.
+    """
+    AGENT._SEEN.clear()
+    server.claim_batches = [[write(kind="x" * 100000)]]
+    _rc, out = run_agent(server, tmux_stub, tmp_path)
+    body = json.loads(
+        [r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert len(body["detail"]) <= 400, (
+        f"the reported detail is {len(body['detail'])} characters; every other path is clamped "
+        "to 400 and this one is stored in a retained column")
+    for line in out.splitlines():
+        assert len(line) < 1000, f"a journal line is {len(line)} characters"
+
+
+def test_a_window_that_LANDED_ELSEWHERE_is_refused_even_when_tmux_said_ok(
+        server, tmux_stub, tmp_path):
+    """🔴 THE READ-BACK, PINNED INDEPENDENTLY OF THE CHECKS THAT USUALLY FIRE FIRST.
+
+    `=` makes tmux fail for a session that does not exist, and `isdir` refuses a
+    cwd that does not exist — so in the ordinary case the read-back never
+    decides anything, and removing it left every test green (measured, as two
+    surviving mutants). It exists for the case those two cannot see: tmux
+    resolving the target to something else for a reason nobody here has thought
+    of. Only a stub that LIES about where the window landed can express that.
+
+    The assertion is that NO keys are sent, not merely that the outcome says
+    `refused`: the next step presses Enter, so a check that runs after the typing
+    is not a check.
+    """
+    AGENT._SEEN.clear()
+    tmux_stub.lie_about_landing(session="somewhere-else")
+    server.claim_batches = [[write(id="w-sess", kind="new-session", pane="",
+                                   cwd=real_dir(tmp_path), tmuxSessionName="scratch2",
+                                   text="echo hi")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], (
+        "the agent typed into a window tmux placed in a DIFFERENT session than the one "
+        "requested, and the next step presses Enter")
+    body = json.loads(
+        [r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "failed", body
+    assert "not the requested" in body["detail"], body
+
+
+def test_a_window_that_landed_in_the_WRONG_DIRECTORY_is_refused(
+        server, tmux_stub, tmp_path):
+    """The same, for the working directory.
+
+    `isdir` refuses the common case up front; this is the one where the path
+    exists and tmux still put the window somewhere else. A build or a recursive
+    delete running one directory over is the whole reason the read-back is there.
+    """
+    AGENT._SEEN.clear()
+    tmux_stub.lie_about_landing(path=str(tmp_path / "elsewhere"))
+    (tmp_path / "elsewhere").mkdir(exist_ok=True)
+    server.claim_batches = [[write(id="w-path", kind="new-session", pane="",
+                                   cwd=real_dir(tmp_path), text="make")]]
+    run_agent(server, tmux_stub, tmp_path)
+    assert tmux_stub.send_keys_calls() == [], (
+        "the agent typed a command into a window tmux opened in a directory OTHER than the "
+        "one requested")
+    body = json.loads(
+        [r for r in server.requests if r["path"].endswith("/result")][0]["body"])
+    assert body["state"] == "failed", body
+    assert "not the requested" in body["detail"], body

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""tmux-reply-agent — the host half of clawgate's terminal WRITE surface.
+
+WHAT THIS IS
+------------
+clawgate runs in a pod on the workbench cluster. tmux sockets are unix sockets on
+the workbench and laptop HOSTS, and the deployment has no hostPath, no
+hostNetwork, no hostPID and no nodeName, so the pod structurally cannot see them.
+The read model solved that by PUSHING outbound (`tmux-snapshot-push.sh`); this is
+the other direction, and it solves it the same way rather than by opening a port:
+the agent holds an OUTBOUND short poll, claims work, executes it locally, and
+reports back. No inbound access to either machine, and no credential for either
+machine inside a pod on an unauthenticated LAN surface.
+
+🔴 WHAT ONE DELIVERY ACTUALLY DOES: `tmux send-keys` into a named pane, followed
+by Enter. That is arbitrary command execution as the operator on this host. The
+operator took that decision explicitly, with the blast radius stated — free text
+into ANY pane, and clawgate presses Enter, because type-only makes remote
+answering pointless. Everything defensive below exists because of that, not
+instead of it.
+
+🔴 IT IS INERT UNTIL SOMEONE ARMS IT, IN TWO INDEPENDENT PLACES. The server's
+write routes sit behind a FAIL-CLOSED wrapper that answers 503 until
+CLAWGATE_TERMINAL_TOKEN is set on the POD; and this unit is not wired into the
+user manager's default target until `enableTmuxReplyAgent` is set true in
+`nix/home.nix`. Neither implies the other, and both are deliberately off in the
+change that introduced them. A 503 is therefore this agent's NORMAL state, logged
+once and backed off from — never an error.
+
+🔴 AT MOST ONCE, NEVER AT LEAST ONCE. A retried `send-keys` runs a command twice.
+The server's claim moves a row out of `pending` permanently, so a write this agent
+claims and then fails to execute is LOST rather than repeated — and this agent
+never retries a send, never re-claims, and never replays. That direction is
+chosen: a lost reply is visible in the audit log (as `abandoned`, whose meaning is
+"delivery UNKNOWN"), a duplicated command is not undoable.
+
+🔴 THE REPLY TEXT IS CREDENTIAL-GRADE AND IS NEVER LOGGED HERE. A reply may
+contain a secret the operator typed. It is passed to tmux as a single argv
+element and reported to nobody; the audit log lives in the server's table, behind
+the terminal token. `tests/test_tmux_reply_agent.py` pins that behaviourally.
+
+Exit codes (distinct on purpose — "something went wrong" would not tell an
+operator whether to look at credentials, at tmux, or at the server):
+  0  clean shutdown on SIGTERM/SIGINT
+  2  no usable credentials — a configuration error that cannot self-heal
+  3  tmux is not usable on this host
+
+Everything else — an unreachable server, a 503, a 401, a malformed body — is
+BACKED OFF FROM RATHER THAN EXITED ON. This is a long-running unit, and a restart
+loop against a transient condition is worse than a quiet one: it would fill the
+journal and, once a failure toast is wired to it, defeat do-not-disturb 720 times
+a day. The compensating control is that every one of those states is logged with
+its reason and its backoff.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API_DEFAULT = "http://192.168.50.250:30302"
+CONF_FILE = os.environ.get("CLAWGATE_CONF_FILE") or os.path.expanduser("~/.claude/clawgate.env")
+ACTIVITY_ENV = os.path.expanduser("~/.config/activity-collector/env")
+
+# The host vocabulary the read model and the queue both use. `hostname` is
+# "nixos" on BOTH machines, so it cannot be the source of truth; ACTIVITY_HOST is.
+HOST_NAMES = ("workbench", "laptop")
+DEFAULT_LOCAL_HOST = "workbench"
+
+# The poll cadence. The server's write TTL is 90s, so this is ~18 polls inside a
+# write's whole deliverable life: a reply typed on a phone lands within seconds,
+# and an agent that misses a few ticks still has plenty of margin. Tighter buys
+# nothing a human can perceive and multiplies the request count against a pod
+# that is idle almost all the time.
+POLL_SECONDS = float(os.environ.get("TMUX_REPLY_POLL_SECONDS", "5"))
+# The backoff for every state that is not "a healthy empty queue": unreachable,
+# 503 (not armed — the normal state today), 401, a malformed body. Long enough
+# that a pod being redeployed or a token being absent costs almost nothing.
+BACKOFF_SECONDS = float(os.environ.get("TMUX_REPLY_BACKOFF_SECONDS", "60"))
+HTTP_TIMEOUT = float(os.environ.get("TMUX_REPLY_HTTP_TIMEOUT", "20"))
+# Bounds one `tmux send-keys`. It is a local unix-socket call that returns in
+# milliseconds; anything near this means the tmux server is wedged.
+TMUX_TIMEOUT = float(os.environ.get("TMUX_REPLY_TMUX_TIMEOUT", "10"))
+
+# 🔴 THE TMUX SERVER IDENTITY, SPELLED THE SAME WAY THE COLLECTOR SPELLS IT.
+# `session-manager` builds its `tmux_server_id` as "<pid>:<start_time>" from
+# `#{pid}` and `#{start_time}` — both server-level tmux formats — and the enqueuer
+# takes the expectation it sends us from that read model. Two spellings of one
+# token would make this guard compare a value against a differently-shaped one
+# and refuse EVERY write, which reads exactly like "the feature does not work".
+# `test_tmux_reply_agent.py::test_the_server_id_format_matches_the_collectors`
+# pins the two together against the collector's own source.
+#
+# It answers ONE question: did the tmux server restart since the enqueuer looked?
+# It is NOT a timestamp — one host's start_time was measured 5.6 years wrong
+# because tmux started before NTP sync — so equality is the only operation.
+TMUX_SERVER_ID_FORMAT = "#{pid}:#{start_time}"
+
+
+def log(msg: str) -> None:
+    """One log line.
+
+    🔴 NOTHING PASSED HERE MAY CONTAIN A WRITE'S TEXT. See the module header:
+    the reply is credential-grade and the journal is not the audit log.
+    """
+    print(f"tmux-reply-agent: {msg}", flush=True)
+
+
+# ── credentials ──────────────────────────────────────────────────────────────
+def read_conf_key(key: str, path: str) -> str:
+    """Read one KEY= value out of a sourceable env file.
+
+    🔴 THE ANCHOR ACCEPTS THE TWO SPELLINGS A SOURCEABLE FILE ACTUALLY CARRIES —
+    a leading `export ` and leading whitespace — and takes the LAST assignment,
+    as sourcing would. `tmux-snapshot-push.sh` reads the same file and learned
+    this the hard way: it anchored on a bare `^KEY=` while claiming to match
+    shell sourcing, so adding `export ` to the file would have made that reader
+    return empty forever while the hooks kept working. One file, several readers,
+    silently disagreeing.
+
+    Deliberate divergence from sourcing, same as the sibling's: a value is taken
+    literally, so no `$VAR` expansion and no `#` comment stripping. Both would
+    need a real parser, and this file holds a URL and opaque tokens.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return ""
+    pattern = re.compile(r"^[ \t]*(?:export[ \t]+)?" + re.escape(key) + r"=(.*)$")
+    value = ""
+    for line in text.splitlines():
+        m = pattern.match(line)
+        if m:
+            value = m.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        value = value[1:-1]
+    return value
+
+
+def resolve(key: str, conf_file: str, env=None) -> str:
+    """Environment first, then the file.
+
+    🔴 THE ENVIRONMENT WINS, and that direction is load-bearing.
+    `clawgate-stop-hook.sh` sources this same file with `set -a`, which makes the
+    FILE beat the environment — the opposite of the documented precedence. The
+    measured consequence over there: exporting CLAWGATE_API_URL to aim a probe
+    somewhere harmless did nothing and the probe silently POSTed to PRODUCTION.
+    On THIS surface the equivalent mistake would send a reply into a live pane.
+    """
+    e = os.environ if env is None else env
+    v = (e.get(key) or "").strip()
+    if v:
+        return v
+    return read_conf_key(key, conf_file)
+
+
+def local_host_label(env=None, env_file: str = ACTIVITY_ENV) -> str:
+    """This machine's ACTIVITY_HOST label.
+
+    Same rule as the collector's, and it has to be: the server's queue is keyed on
+    the host label the read model stores, so an agent that computed a different
+    label would poll for a host nobody enqueues to and deliver nothing, silently.
+    """
+    e = os.environ if env is None else env
+    v = (e.get("ACTIVITY_HOST") or "").strip().lower()
+    if v in HOST_NAMES:
+        return v
+    try:
+        with open(env_file, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        text = ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("ACTIVITY_HOST="):
+            val = line[len("ACTIVITY_HOST="):].strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                val = val[1:-1]
+            val = val.strip().lower()
+            if val in HOST_NAMES:
+                return val
+    return DEFAULT_LOCAL_HOST
+
+
+# ── tmux ─────────────────────────────────────────────────────────────────────
+def tmux_bin() -> str:
+    return os.environ.get("TMUX_REPLY_TMUX_BIN", "tmux")
+
+
+def run_tmux(args: list[str]) -> tuple[int, str, str]:
+    """Run one tmux command with an ARGV LIST and no shell.
+
+    🔴 NO SHELL, EVER, AND THIS IS THE SINGLE MOST IMPORTANT LINE IN THE FILE.
+    The text being delivered is arbitrary operator input. Interpolating it into a
+    shell string — which is what `subprocess.run(..., shell=True)` or any
+    `f"tmux send-keys ... {text}"` would do — turns `$(…)`, backticks, `;` and
+    quotes into code that runs on THIS host with the operator's privileges,
+    before tmux ever sees them. An argv list is passed to execve verbatim: there
+    is no parser between this process and tmux.
+    """
+    try:
+        p = subprocess.run([tmux_bin()] + args, capture_output=True, text=True,
+                           timeout=TMUX_TIMEOUT, check=False)
+    except subprocess.TimeoutExpired:
+        return 124, "", f"tmux timed out after {TMUX_TIMEOUT}s"
+    except OSError as exc:
+        return 127, "", f"could not execute tmux: {exc}"
+    return p.returncode, p.stdout, p.stderr
+
+
+def tmux_server_id() -> str:
+    """This host's live tmux server identity, or "" if it cannot be measured.
+
+    An unmeasurable identity is NOT treated as a match — see should_refuse.
+    """
+    rc, out, _ = run_tmux(["display-message", "-p", TMUX_SERVER_ID_FORMAT])
+    if rc != 0:
+        return ""
+    out = out.strip()
+    # tmux renders an unknown format verbatim; a lone ":" means this tmux does
+    # not know one of the two fields, which is "cannot measure", not an identity.
+    return "" if out in ("", ":") else out
+
+
+def should_refuse(expected: str, live: str) -> tuple[bool, str]:
+    """The WRITE-TIME GUARD. Returns (refuse, reason).
+
+    🔴 WHAT IT CLOSES, EXACTLY. Within one tmux server a pane id `%N` is never
+    reused, so a stale one simply does not resolve and the send fails harmlessly.
+    The dangerous case is a tmux server RESTART: ids are minted again from %0, so
+    a `%12` the enqueuer saw an hour ago now names a completely different pane —
+    and a submitted reply would execute there. Comparing the server identity the
+    enqueuer recorded against the one running now refuses exactly that.
+
+    🔴 AN ABSENT EXPECTATION IS NOT A MATCH, IT IS "NOT CHECKED", AND THAT IS
+    DELIBERATE RATHER THAN LAX. The collector reports its `tmux_server_id` as
+    UNMEASURED in real conditions (an older tmux, rows that disagree), so
+    refusing every write that carries no expectation would make the feature fail
+    exactly when the read model is degraded — while protecting against nothing,
+    since a caller that cannot measure the id cannot supply a right one either.
+    The audit row records the empty expectation, so "was this write guarded" is
+    answerable after the fact rather than assumed.
+
+    ⚠ WHAT IT DOES NOT CLOSE, stated because it is the residual the operator was
+    told about: a pane that simply MOVED ON — same tmux server, same pane, the
+    question already answered or the prompt gone. Nothing here can see that. The
+    server's TTL bounds enqueue-to-delivery at 90s, and the attention queue
+    retires stale questions off a 2-minute snapshot, so the exposed window is one
+    snapshot interval of display staleness. Closing it would need either a
+    content fingerprint (brittle against animated status lines, and its failure
+    direction is refusing legitimate replies, which trains an operator to turn
+    the guard off) or type-only writes, which the operator declined.
+    """
+    if not expected:
+        return False, ""
+    if not live:
+        return True, "the tmux server identity could not be measured on this host"
+    if expected != live:
+        # 🔴 The reason names neither identity's provenance beyond the two opaque
+        # tokens, and carries no pane content — it goes into the audit log and
+        # into a log line.
+        return True, f"tmux server identity moved (expected {expected}, live {live})"
+    return False, ""
+
+
+# ── HTTP ─────────────────────────────────────────────────────────────────────
+class Refused(Exception):
+    """A server answer that means "back off", carrying its reason."""
+
+
+def post_json(url: str, token: str, payload: dict) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    # 🔴 The token goes in a HEADER, never in the URL or in argv. Everything on
+    # this box can read /proc/<pid>/cmdline, and a URL lands in access logs.
+    req.add_header("Authorization", "Bearer " + token)
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+            raise Refused("the terminal write surface is NOT ARMED on the server "
+                          "(HTTP 503) — CLAWGATE_TERMINAL_TOKEN is unset there. "
+                          "This is the shipped state, not a fault.") from exc
+        if exc.code == 401:
+            raise Refused("the server rejected this agent's terminal token (HTTP 401)") from exc
+        if exc.code == 404:
+            raise Refused("the server has no terminal write route (HTTP 404) — it "
+                          "predates the write surface, or has no database wired") from exc
+        raise Refused(f"the server answered HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise Refused(f"could not reach the server: {exc.reason}") from exc
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise Refused(f"the server's answer was not JSON: {exc}") from exc
+
+
+# ── delivery ─────────────────────────────────────────────────────────────────
+# The two things a write can ask for. Enumerated rather than pattern-matched: an
+# unknown kind arriving from the server must be REFUSED, not guessed at — a
+# guessed kind is a command nobody reviewed running on this host.
+KIND_SEND_KEYS = "send-keys"
+KIND_NEW_SESSION = "new-session"
+
+
+def open_window(cwd: str) -> tuple[str, str]:
+    """Open a new tmux window at cwd. Returns (pane_id, error).
+
+    🔴 A TRANSPORT PRIMITIVE, NOT A FEATURE. "Start a Claude Code session" is
+    entirely a question of what the caller's TEXT says; this only makes a window
+    in the right directory and hands back its pane so the text can be typed there.
+    Nothing about an agent session is encoded here, deliberately.
+
+    `-P -F '#{pane_id}'` makes tmux PRINT the new pane's id, which is what lets
+    the text be sent to THAT pane by id rather than to "the active pane" — the
+    difference matters because between these two calls the operator may have
+    switched windows, and a relative target would type into whatever they moved to.
+    """
+    rc, out, err = run_tmux(["new-window", "-P", "-F", "#{pane_id}", "-c", cwd])
+    if rc != 0:
+        return "", (err or f"tmux exited {rc}")
+    pane = out.strip().splitlines()[0].strip() if out.strip() else ""
+    if not pane.startswith("%"):
+        return "", f"tmux did not report a pane id for the new window (got {pane!r})"
+    return pane, ""
+
+
+def deliver(write: dict) -> tuple[str, str]:
+    """Execute ONE claimed write. Returns (state, detail).
+
+    🔴 ONE ATTEMPT. No retry at any layer, for any reason. The claim already
+    moved this row out of `pending` permanently, so a retry here would be the one
+    place in the whole path that could deliver a command twice.
+    """
+    kind = (write.get("kind") or KIND_SEND_KEYS).strip() or KIND_SEND_KEYS
+    pane = write.get("pane") or ""
+    text = write.get("text") or ""
+    submit = bool(write.get("submit"))
+    expected = (write.get("expectTmuxServerId") or "").strip()
+
+    if kind not in (KIND_SEND_KEYS, KIND_NEW_SESSION):
+        return "refused", f"unknown write kind {kind!r}"
+
+    refuse, reason = should_refuse(expected, tmux_server_id())
+    if refuse:
+        return "refused", reason
+
+    if kind == KIND_NEW_SESSION:
+        # 🔴 THE GUARD ABOVE STILL APPLIES, and it is not redundant here. A
+        # new-session has no pane to be stale about, but it DOES have a host and a
+        # tmux server: an expectation that no longer matches means the enqueuer was
+        # looking at a tmux server that has since restarted, and a window opened on
+        # the new one is not the fleet state it was reasoning about.
+        cwd = (write.get("cwd") or "").strip()
+        if not cwd:
+            return "failed", "a new-session write carried no cwd"
+        pane, err = open_window(cwd)
+        if err:
+            return "failed", redact(err, text)
+        if not text:
+            # A bare window is a complete delivery: the caller asked for one.
+            return "delivered", f"opened {pane}"
+        # Fall through and type the caller's text into the window just created.
+        submit = True
+
+    # 🔴 `-l` MAKES IT LITERAL, AND WITHOUT IT THIS IS A DIFFERENT COMMAND.
+    # Un-flagged, `send-keys` interprets its arguments as KEY NAMES: a reply
+    # containing "C-c" would interrupt whatever is running in the pane rather
+    # than typing three characters. `--` ends option parsing so text beginning
+    # with `-` is text and not a flag. The text is ONE argv element; see run_tmux.
+    rc, _, err = run_tmux(["send-keys", "-t", pane, "-l", "--", text])
+    if rc != 0:
+        return "failed", redact(err or f"tmux exited {rc}", text)
+
+    if submit:
+        # A SEPARATE, NON-LITERAL send: `Enter` here is a key name, which is
+        # exactly why the text above had to be sent literally and alone. The
+        # server rejects any text containing a newline, so this is the ONLY
+        # submission a delivery can produce.
+        rc, _, err = run_tmux(["send-keys", "-t", pane, "Enter"])
+        if rc != 0:
+            # 🔴 THE TEXT IS ALREADY IN THE PANE. Report `failed` so the audit log
+            # does not claim a completed delivery, but say which half failed — an
+            # operator seeing this needs to know a line is sitting there unsent,
+            # not that nothing happened.
+            return "failed", redact(
+                "the text was typed but Enter was not accepted: " + (err or f"tmux exited {rc}"), text)
+    return "delivered", (f"opened {pane}" if kind == KIND_NEW_SESSION else "")
+
+
+def redact(detail: str, text: str) -> str:
+    """Remove the write's text from a diagnostic before it leaves this process.
+
+    🔴 tmux QUOTES ITS ARGUMENTS IN ITS OWN ERRORS, so the most natural failure
+    diagnostic is also the one most likely to carry a secret the operator typed —
+    into a log line and into the audit log's `detail` column. The exact string is
+    known here, so this is an exact substitution rather than a pattern match: it
+    cannot miss for the reason a secret-shaped regex misses, and it cannot
+    silently claim to have scrubbed something it did not.
+    """
+    if text:
+        detail = detail.replace(text, "<text>")
+    detail = " ".join(detail.split())
+    return detail[:400]
+
+
+# ── main loop ────────────────────────────────────────────────────────────────
+_STOP = False
+
+
+def _on_signal(_signum, _frame):
+    global _STOP
+    _STOP = True
+
+
+def one_round(api: str, token: str, host: str, agent: str) -> int:
+    """Claim, execute and report one batch. Returns the number of writes handled."""
+    got = post_json(f"{api}/api/term/send-keys/claim", token,
+                    {"host": host, "agent": agent})
+    writes = got.get("writes") or []
+    if not isinstance(writes, list):
+        raise Refused("the server's claim answer had no `writes` array")
+    for write in writes:
+        wid = str(write.get("id") or "")
+        if not wid:
+            log("a claimed write carried no id and cannot be reported; skipping")
+            continue
+        state, detail = deliver(write)
+        # 🔴 The log names the ROW and the OUTCOME, never the text. `detail` is
+        # already redacted of the text by deliver().
+        log(f"{state} {wid} (pane {write.get('pane')})" + (f": {detail}" if detail else ""))
+        try:
+            post_json(f"{api}/api/term/send-keys/{wid}/result", token,
+                      {"agent": agent, "state": state, "detail": detail})
+        except Refused as exc:
+            # 🔴 DO NOT RE-EXECUTE. The write already ran (or already failed); a
+            # lost result leaves the row to be relabelled `abandoned`, which means
+            # "delivery UNKNOWN" and is the truthful record. Re-sending would be
+            # the second execution this whole design exists to prevent.
+            log(f"could not report the outcome of {wid} — the audit log will show it as "
+                f"abandoned, which means delivery is UNKNOWN, not that it did not run: {exc}")
+    return len(writes)
+
+
+def main(argv: list[str]) -> int:
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    api = (resolve("CLAWGATE_API_URL", CONF_FILE) or API_DEFAULT).rstrip("/")
+    token = resolve("CLAWGATE_TERMINAL_TOKEN", CONF_FILE)
+    if not token:
+        # 🔴 A CONFIGURATION ERROR THAT CANNOT SELF-HEAL, so this one exits rather
+        # than backing off. It is also the state this ships in: arming the
+        # surface means provisioning that secret on the pod AND handing this host
+        # a copy, and neither has been done. The unit is not wired into the user
+        # manager's default target until `enableTmuxReplyAgent` is true, so this
+        # exit is what an operator sees if they start it by hand before arming.
+        log(f"no CLAWGATE_TERMINAL_TOKEN in the environment or {CONF_FILE} — "
+            "the terminal write surface is not armed on this host; refusing to poll")
+        return 2
+
+    rc, _, _ = run_tmux(["-V"])
+    if rc != 0:
+        log("tmux is not usable on this host; a claimed write could not be delivered")
+        return 3
+
+    host = local_host_label()
+    # The agent identity the server records against a claim. It includes the pid
+    # so two agents on one host (a hand-started one beside the unit) are
+    # distinguishable in the audit log rather than indistinguishable.
+    agent = f"{host}:{os.getpid()}"
+    log(f"polling {api} every {POLL_SECONDS:g}s for writes addressed to `{host}` as `{agent}`")
+
+    backoff_reason = ""
+    while not _STOP:
+        try:
+            one_round(api, token, host, agent)
+            if backoff_reason:
+                log("the server is answering again; back to the normal poll")
+                backoff_reason = ""
+            delay = POLL_SECONDS
+        except Refused as exc:
+            reason = str(exc)
+            # 🔴 LOG A REPEATING CONDITION ONCE, NOT EVERY TICK. The 503 "not
+            # armed" state is PERMANENT until someone arms the surface, and this
+            # loop runs 17,280 times a day; a line per tick would bury every real
+            # event in the journal and make the unit's output worthless.
+            if reason != backoff_reason:
+                log(f"backing off {BACKOFF_SECONDS:g}s: {reason}")
+                backoff_reason = reason
+            delay = BACKOFF_SECONDS
+        except Exception as exc:  # noqa: BLE001 — a poll must not kill the unit
+            log(f"unexpected error in the poll; backing off {BACKOFF_SECONDS:g}s: {exc!r}")
+            delay = BACKOFF_SECONDS
+
+        # Sleep in short slices so a shutdown signal is honoured promptly rather
+        # than after a full backoff.
+        waited = 0.0
+        while waited < delay and not _STOP:
+            step = min(0.25, delay - waited)
+            time.sleep(step)
+            waited += step
+
+    log("stopping")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -362,6 +362,11 @@ WRITE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 #: did not choose rather than failing — the wrong-place class the pane rule
 #: exists for, one level up: a whole WINDOW instead of a keystroke.
 TMUX_SESSION_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$")
+#: What `new-window -P -F` prints so the caller can check WHERE tmux actually
+#: put the window. Tab-separated: none of the three fields can contain a tab
+#: (a pane id is `%N`, a session name is checked against TMUX_SESSION_RE, and a
+#: path containing a tab is refused by validate()).
+NEW_WINDOW_FORMAT = "#{pane_id}\t#{session_name}\t#{pane_current_path}"
 MAX_TEXT_BYTES = 2048
 MAX_BATCH = 4
 # Bounds the response body this agent will read. urlopen().read() with no
@@ -377,7 +382,16 @@ def validate(write: dict) -> str:
     property of the OPERATOR'S shell config, which this process cannot read, so
     "is this character safe to deliver" is the only answerable question.
     """
-    kind = (write.get("kind") or KIND_SEND_KEYS).strip() or KIND_SEND_KEYS
+    kind = write.get("kind") or KIND_SEND_KEYS
+    # 🔴 TYPE BEFORE SHAPE, ON EVERY FIELD. Every value here comes off the wire
+    # and none is guaranteed to be a string. Calling .strip() first raised
+    # AttributeError out of validate -> out of deliver -> out of the whole round,
+    # so neither this write NOR ANY LATER ONE in the batch got a result POSTed and
+    # they all landed `abandoned` ("delivery UNKNOWN") when the truthful answer is
+    # `refused`, nothing ran.
+    if not isinstance(kind, str):
+        return "the write kind is not a string"
+    kind = kind.strip() or KIND_SEND_KEYS
     if kind not in (KIND_SEND_KEYS, KIND_NEW_SESSION):
         return f"unknown write kind {kind!r}"
 
@@ -387,6 +401,9 @@ def validate(write: dict) -> str:
         # could steer the request elsewhere.
         return "the write id is not the shape this agent will put in a URL"
 
+    expect = write.get("expectTmuxServerId") or ""
+    if not isinstance(expect, str):
+        return "the expected tmux server id is not a string"
     text = write.get("text") or ""
     if not isinstance(text, str):
         return "the text is not a string"
@@ -434,6 +451,24 @@ def validate(write: dict) -> str:
             return "the working directory carries a character that is not printable"
         if any(seg == ".." for seg in cwd.split("/")):
             return "the working directory contains `..`"
+        # 🔴 A TRAILING SEPARATOR IS REFUSED HERE TOO. tmux eats it off the `-c`
+        # word exactly as it does off a send-keys token, so a path ending in one
+        # becomes a different path -- and if that does not exist, the window opens
+        # in the home directory. The text path already refused this character; the
+        # cwd path did not, which was the same character getting opposite
+        # treatment in one file.
+        if TEXT_POLICY.ends_with_separator(cwd) or cwd != cwd.strip():
+            return ("the working directory ends with "
+                    f"{TEXT_POLICY.TMUX_ARGV_SEPARATOR!r} or whitespace, which tmux eats "
+                    "off the token")
+        # 🔴 IT MUST EXIST ON THIS HOST. `new-window -c <missing path>` does NOT
+        # fail -- measured rc 0, with the window opened in the home directory -- so
+        # a build or a recursive delete would run there and be reported
+        # `delivered`. The queue is host-keyed, so a path that exists on the
+        # workbench and not the laptop is an ordinary mistake. open_window
+        # re-checks where tmux ACTUALLY landed; this is the early, legible refusal.
+        if not os.path.isdir(cwd):
+            return "the working directory does not exist on this host"
         # 🔴 RE-VALIDATED HERE, NOT TRUSTED. The server checks it too; this
         # process is the one that hands the value to tmux as a target, and the
         # two sides of the boundary fail independently. Absent is fine — it means
@@ -466,10 +501,35 @@ def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
     🔴 WITHOUT `-t` THE TARGET IS DECIDED BY tmux, NOT BY THE CALLER. `new-window`
     with no target joins whatever session this server considers CURRENT — which
     depends on what the operator last looked at — so a launched window lands
-    somewhere nobody chose. `-t "<name>:"` is the unambiguous spelling: the
-    trailing colon means "this session, next free index", and a session that does
-    not exist makes tmux FAIL rather than fall back to the current one, which is
-    the direction this whole surface prefers.
+    somewhere nobody chose.
+
+    🔴 THE `=` PREFIX IS LOAD-BEARING: tmux PREFIX-MATCHES A SESSION NAME. An
+    earlier revision passed `-t "<name>:"` and this docstring asserted that a
+    missing session would make tmux FAIL. Measured on tmux 3.7c against the
+    operator's live server — which holds `scratch`, `scratch2` ... `scratch20`
+    and `datapacket-talos`, `datapacket-talos-2` — it does not fail. It
+    prefix-matches and returns rc 0:
+
+        -t scratch2:         (scratch2 absent, scratch20 live) -> rc 0, lands in scratch20
+        -t datapacket-talos: (only ...-2 live)                 -> rc 0, lands in ...-2
+        -t =scratch2:                                          -> rc 1, can't find session
+
+    End to end that opened a window in the WRONG session, typed the command,
+    pressed Enter and reported `delivered`. `=` forces an exact match, which is
+    the only spelling that makes the sentence above true.
+
+    🔴 AND WHERE IT LANDED IS READ BACK, NOT ASSUMED. `-c <path>` with a path that
+    does not exist does not fail either: measured rc 0 with
+    `pane_current_path=/home/zach`, i.e. the window silently opens in the home
+    directory and a build or a recursive delete runs there. Three shape-valid
+    inputs reach it — a path absent on THIS host (the queue is host-keyed, so a
+    workbench path can be enqueued for the laptop), a trailing space, and a
+    trailing separator, which tmux eats off the `-c` word.
+
+    So the single `-P -F` prints the session and the working directory tmux
+    ACTUALLY chose and the caller compares them. One call, no extra round trip,
+    and it catches both classes — including any resolution rule nobody here has
+    thought of.
 
     🔴 A TRANSPORT PRIMITIVE, NOT A FEATURE. "Start a Claude Code session" is
     entirely a question of what the caller's TEXT says; this only makes a window
@@ -481,18 +541,45 @@ def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
     difference matters because between these two calls the operator may have
     switched windows, and a relative target would type into whatever they moved to.
     """
-    argv = ["new-window", "-P", "-F", "#{pane_id}", "-c", cwd]
+    argv = ["new-window", "-P", "-F", NEW_WINDOW_FORMAT, "-c", cwd]
     if tmux_session:
-        # The name has already been through TMUX_SESSION_RE, so it cannot be a
-        # compound target; the trailing colon makes the intent explicit anyway.
-        argv += ["-t", tmux_session + ":"]
+        # `=` forces an EXACT session match; the trailing colon means "this
+        # session, next free index". Both are required — see the docstring.
+        argv += ["-t", "=" + tmux_session + ":"]
     rc, out, err = run_tmux(argv)
     if rc != 0:
         return "", (err or f"tmux exited {rc}")
-    pane = out.strip().splitlines()[0].strip() if out.strip() else ""
+
+    fields = (out.strip().splitlines() or [""])[0].split("\t")
+    if len(fields) != 3:
+        return "", f"tmux did not report the new window's identity (got {out.strip()!r})"
+    pane, landed_session, landed_path = (f.strip() for f in fields)
     if not pane.startswith("%"):
         return "", f"tmux did not report a pane id for the new window (got {pane!r})"
+
+    # 🔴 REFUSE ON A MISMATCH RATHER THAN TYPE INTO IT. Both checks are about one
+    # thing: tmux resolved the target to something other than what was asked for,
+    # and the next step presses Enter.
+    if tmux_session and landed_session != tmux_session:
+        return "", (f"tmux opened the window in session {landed_session!r}, not the requested "
+                    f"{tmux_session!r}")
+    if not same_directory(landed_path, cwd):
+        return "", (f"tmux opened the window in {landed_path!r}, not the requested {cwd!r} — "
+                    "the directory does not exist on this host, so tmux fell back")
     return pane, ""
+
+
+def same_directory(a: str, b: str) -> bool:
+    """Whether two paths name the same directory, resolving symlinks.
+
+    `realpath` BOTH sides: a trailing slash and a symlinked parent are ordinary,
+    and a raw string comparison would report a false mismatch and refuse a
+    legitimate write.
+    """
+    try:
+        return os.path.realpath(a) == os.path.realpath(b)
+    except OSError:
+        return False
 
 
 def deliver(write: dict) -> tuple[str, str]:
@@ -502,11 +589,13 @@ def deliver(write: dict) -> tuple[str, str]:
     moved this row out of `pending` permanently, so a retry here would be the one
     place in the whole path that could deliver a command twice.
     """
-    kind = (write.get("kind") or KIND_SEND_KEYS).strip() or KIND_SEND_KEYS
+    kind = write.get("kind") or KIND_SEND_KEYS
+    kind = kind.strip() or KIND_SEND_KEYS if isinstance(kind, str) else KIND_SEND_KEYS
     pane = write.get("pane") or ""
     text = write.get("text") or ""
     submit = bool(write.get("submit"))
-    expected = (write.get("expectTmuxServerId") or "").strip()
+    expected = write.get("expectTmuxServerId") or ""
+    expected = expected.strip() if isinstance(expected, str) else ""
 
     # 🔴 THE TRUST BOUNDARY. See `validate`: this process executes, so this
     # process refuses — regardless of what the server accepted.
@@ -652,7 +741,16 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
             # dropping it. See _SEEN.
             state, detail = "refused", "this agent has already executed that write id"
         else:
-            state, detail = deliver(write)
+            # 🔴 AN UNEXPECTED ERROR IS REPORTED, NOT THROWN. A non-string `kind`
+            # or `expectTmuxServerId` used to raise out of the whole round: no
+            # result was POSTed for that row OR ANY LATER ROW in the batch, so
+            # they were relabelled `abandoned` -- "delivery UNKNOWN" -- when the
+            # truthful answer is `refused`, nothing ran. An audit log that says
+            # UNKNOWN where it could say NO is the failure its design avoids.
+            try:
+                state, detail = deliver(write)
+            except Exception as exc:  # noqa: BLE001 - one bad row must not eat the batch
+                state, detail = "refused", f"the agent could not process that write: {exc!r}"
         # 🔴 The log names the ROW and the OUTCOME, never the text. `detail` is
         # already redacted of the text by deliver().
         # 🔴 EVERY INTERPOLATED FIELD IS BOUNDED AND SHAPED. `wid` matched
@@ -662,6 +760,15 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
         # already redacted of the write's text and clamped by redact().
         pane = write.get("pane")
         pane = pane if isinstance(pane, str) and PANE_ID_RE.match(pane) else "-"
+        # 🔴 EVERY DETAIL IS CLAMPED HERE, ON ONE PATH. A validate() refusal used
+        # to bypass redact() entirely -- an unbounded server-supplied `kind`
+        # interpolated into a refusal produced a 100,021-character detail, into a
+        # journal line and into the audit-log column, while the comment below
+        # asserted every interpolated field was bounded. Clamping at the single
+        # point where a detail becomes output makes that true for paths nobody has
+        # written yet.
+        text = write.get("text") if isinstance(write.get("text"), str) else ""
+        detail = redact(detail, text)
         log(f"{state} {wid} (pane {pane})" + (f": {detail}" if detail else ""))
         try:
             post_json(f"{api}/api/term/send-keys/{wid}/result", token,

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -54,6 +54,8 @@ its reason and its backoff.
 """
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import os
 import re
@@ -63,6 +65,30 @@ import sys
 import time
 import urllib.error
 import urllib.request
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_tmux_text_policy(path: str = None):
+    """Load `scripts/lib/tmux_text_policy.py` by EXPLICIT PATH.
+
+    🔴 IT RAISES RATHER THAN FALLING BACK, and that is the whole point. A
+    fallback would leave this program with a weaker check — which is exactly
+    what shipped here before: a DENYLIST (`ord(ch) < 0x20 or ord(ch) == 0x7F`)
+    that passed every C1 control and U+0085 NEL. `session-write` had already
+    fixed that class and written down why; this file had its own copy and was
+    wrong at the one site reachable from the network. The rule now lives in one
+    module and a missing module stops the agent.
+    """
+    path = path or os.path.join(_HERE, "lib", "tmux_text_policy.py")
+    loader = importlib.machinery.SourceFileLoader("_tra_tmux_text_policy", path)
+    spec = importlib.util.spec_from_loader("_tra_tmux_text_policy", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+TEXT_POLICY = _load_tmux_text_policy()
 
 API_DEFAULT = "http://192.168.50.250:30302"
 CONF_FILE = os.environ.get("CLAWGATE_CONF_FILE") or os.path.expanduser("~/.claude/clawgate.env")
@@ -325,6 +351,11 @@ def post_json(url: str, token: str, payload: dict) -> dict:
 #     from a server that is wrong, compromised or simply newer is a thousand
 #     commands, and nothing downstream would stop them.
 PANE_ID_RE = re.compile(r"^%[0-9]{1,12}$")
+#: A write id is minted by the server as base64url of 16 random bytes, and this
+#: agent INTERPOLATES IT INTO A URL. Bounding and shaping it here is what stops a
+#: server-supplied id from steering the request somewhere else (`../`, a query
+#: string, a scheme) or from being unbounded text in a log line.
+WRITE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 MAX_TEXT_BYTES = 2048
 MAX_BATCH = 4
 # Bounds the response body this agent will read. urlopen().read() with no
@@ -332,20 +363,39 @@ MAX_BATCH = 4
 MAX_RESPONSE_BYTES = 1 << 20
 
 
-def has_control(value: str) -> bool:
-    return any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
-
-
 def validate(write: dict) -> str:
-    """Return a refusal reason, or "" when this write is safe to execute here."""
+    """Return a refusal reason, or "" when this write is safe to execute here.
+
+    🔴 THE TEXT GATE IS `tmux_text_policy`'s ALLOWLIST, NOT A LOCAL CHECK. See
+    that module: the set of characters bound to an accept-line variant is a
+    property of the OPERATOR'S shell config, which this process cannot read, so
+    "is this character safe to deliver" is the only answerable question.
+    """
     kind = (write.get("kind") or KIND_SEND_KEYS).strip() or KIND_SEND_KEYS
     if kind not in (KIND_SEND_KEYS, KIND_NEW_SESSION):
         return f"unknown write kind {kind!r}"
+
+    wid = write.get("id")
+    if not isinstance(wid, str) or not WRITE_ID_RE.match(wid):
+        # It goes into a URL this agent constructs; an id it cannot vouch for
+        # could steer the request elsewhere.
+        return "the write id is not the shape this agent will put in a URL"
+
     text = write.get("text") or ""
-    if not isinstance(text, str) or has_control(text):
-        return "the text contains a control character"
+    if not isinstance(text, str):
+        return "the text is not a string"
     if len(text.encode("utf-8", "replace")) > MAX_TEXT_BYTES:
         return "the text is over the size limit"
+    bad = TEXT_POLICY.first_disallowed(text)
+    if bad is not None:
+        return "the text carries " + TEXT_POLICY.describe_disallowed(*bad)
+    if TEXT_POLICY.ends_with_separator(text):
+        # tmux EATS a trailing separator off an argv token, so the pane would
+        # receive something other than what the audit log records.
+        return (f"the text ends with {TEXT_POLICY.TMUX_ARGV_SEPARATOR!r}, which tmux "
+                "eats off the token — the pane would get something other than what "
+                "the audit log records")
+
     if kind == KIND_SEND_KEYS:
         pane = write.get("pane") or ""
         if not isinstance(pane, str) or not PANE_ID_RE.match(pane):
@@ -354,8 +404,10 @@ def validate(write: dict) -> str:
             return "the write carries no text"
     else:
         cwd = write.get("cwd") or ""
-        if not isinstance(cwd, str) or not cwd.startswith("/") or has_control(cwd):
+        if not isinstance(cwd, str) or not cwd.startswith("/"):
             return "the working directory is not an absolute path"
+        if TEXT_POLICY.first_disallowed(cwd) is not None:
+            return "the working directory carries a character that is not printable"
         if any(seg == ".." for seg in cwd.split("/")):
             return "the working directory contains `..`"
     return ""
@@ -366,6 +418,11 @@ def validate(write: dict) -> str:
 # guessed kind is a command nobody reviewed running on this host.
 KIND_SEND_KEYS = "send-keys"
 KIND_NEW_SESSION = "new-session"
+
+#: See deliver(): a new-session's text is always submitted, whatever the row's
+#: `submit` field says. Named so the behaviour is assertable rather than implied
+#: by a bare literal in the middle of a function.
+NEW_SESSION_ALWAYS_SUBMITS = True
 
 
 def open_window(cwd: str) -> tuple[str, str]:
@@ -427,8 +484,16 @@ def deliver(write: dict) -> tuple[str, str]:
         if not text:
             # A bare window is a complete delivery: the caller asked for one.
             return "delivered", f"opened {pane}"
-        # Fall through and type the caller's text into the window just created.
-        submit = True
+        # 🔴 A new-session's text is ALWAYS SUBMITTED, and the constant says so
+        # rather than the assignment. The point of a new-session is a window that
+        # is DOING something; typing a command into a fresh shell and not running
+        # it produces a window the operator has to go and finish by hand, which is
+        # the thing this feature exists to avoid. `submit` on the row is therefore
+        # not consulted for this kind — it describes the send-keys case — and
+        # test_a_new_session_ALWAYS_submits_whatever_the_row_says pins BOTH
+        # directions so a mutant that drops this line, or that starts honouring
+        # the field, is caught.
+        submit = NEW_SESSION_ALWAYS_SUBMITS
 
     # 🔴 `-l` MAKES IT LITERAL, AND WITHOUT IT THIS IS A DIFFERENT COMMAND.
     # Un-flagged, `send-keys` interprets its arguments as KEY NAMES: a reply
@@ -480,6 +545,33 @@ def _on_signal(_signum, _frame):
     _STOP = True
 
 
+#: Ids this process has already executed. 🔴 THE HOST'S OWN at-most-once, and it
+#: is not redundant with the server's: the server's guarantee is a property of
+#: its claim predicate, and this agent is the thing that RUNS the command. If a
+#: server is wrong, rolled back, restored from a backup, or simply newer than
+#: this agent, re-offering a claimed row would re-execute it — and the operator's
+#: decision that clawgate presses Enter makes that a second command execution.
+#:
+#: Bounded, because an unbounded set in a process that runs for weeks is a slow
+#: leak. The bound is generous relative to the real rate (a handful of replies a
+#: day) and the eviction is oldest-first, so the only thing it can forget is a
+#: write from thousands of writes ago — which the server's own ladder has long
+#: since made unclaimable anyway.
+SEEN_LIMIT = 4096
+_SEEN: dict = {}
+
+
+def already_executed(wid: str) -> bool:
+    """Record wid and report whether this process had already run it."""
+    if wid in _SEEN:
+        return True
+    _SEEN[wid] = True
+    while len(_SEEN) > SEEN_LIMIT:
+        # dicts preserve insertion order, so this evicts the oldest.
+        _SEEN.pop(next(iter(_SEEN)))
+    return False
+
+
 def one_round(api: str, token: str, host: str, agent: str) -> int:
     """Claim, execute and report one batch. Returns the number of writes handled."""
     got = post_json(f"{api}/api/term/send-keys/claim", token,
@@ -497,14 +589,32 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
         raise Refused(f"the server returned {len(writes)} writes in one claim, over the "
                       f"{MAX_BATCH} this agent will execute")
     for write in writes:
-        wid = str(write.get("id") or "")
-        if not wid:
-            log("a claimed write carried no id and cannot be reported; skipping")
+        wid = write.get("id")
+        if not isinstance(wid, str) or not WRITE_ID_RE.match(wid):
+            # 🔴 NOT LOGGED VERBATIM. Every field here is server-controlled, and
+            # an id is the one that would otherwise be interpolated into both a
+            # log line and a URL. An unusable id cannot be reported either — there
+            # is nowhere to report it TO — so this counts it rather than echoing
+            # it, and the count is the signal.
+            log("a claimed write carried an unusable id and cannot be reported; skipping")
             continue
-        state, detail = deliver(write)
+        if already_executed(wid):
+            # 🔴 DO NOT RUN IT AGAIN, and report the refusal so the audit log
+            # records that this host saw a duplicate rather than silently
+            # dropping it. See _SEEN.
+            state, detail = "refused", "this agent has already executed that write id"
+        else:
+            state, detail = deliver(write)
         # 🔴 The log names the ROW and the OUTCOME, never the text. `detail` is
         # already redacted of the text by deliver().
-        log(f"{state} {wid} (pane {write.get('pane')})" + (f": {detail}" if detail else ""))
+        # 🔴 EVERY INTERPOLATED FIELD IS BOUNDED AND SHAPED. `wid` matched
+        # WRITE_ID_RE above; `pane` is re-derived through the same regex rather
+        # than echoed, so a server-supplied pane cannot put arbitrary text — or a
+        # newline that forges a second log line — into the journal. `detail` is
+        # already redacted of the write's text and clamped by redact().
+        pane = write.get("pane")
+        pane = pane if isinstance(pane, str) and PANE_ID_RE.match(pane) else "-"
+        log(f"{state} {wid} (pane {pane})" + (f": {detail}" if detail else ""))
         try:
             post_json(f"{api}/api/term/send-keys/{wid}/result", token,
                       {"agent": agent, "state": state, "detail": detail})

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -392,6 +392,24 @@ def validate(write: dict) -> str:
         return "the text is not a string"
     if len(text.encode("utf-8", "replace")) > MAX_TEXT_BYTES:
         return "the text is over the size limit"
+    # 🔴 TAB IS REFUSED ON THIS SURFACE, THOUGH THE SHARED POLICY PERMITS IT, and
+    # the divergence is deliberate rather than drift. `send-keys -l` delivers a
+    # tab literally and a bash/zsh pane runs COMPLETION on it: `rm -rf ~/pro` plus
+    # TAB becomes `rm -rf ~/projects/` in the buffer, and the Enter this path
+    # presses submits THAT — while the clawgate audit row still says
+    # `rm -rf ~/pro`. The server refuses it for the same reason; this is the
+    # host-side half, so a server that has not been upgraded cannot deliver one.
+    #
+    # `session-write` keeps the tab, and that asymmetry is the point: it is
+    # invoked by the operator AT THEIR OWN KEYBOARD, where the buffer is visible
+    # before anything runs. Here the audit row IS the compensating control — it is
+    # what answers "what did that write actually do" for a reply sent from a phone
+    # — so a character that makes the row lie costs more than the typography is
+    # worth. The shared policy stays as it is; this surface is stricter, which is
+    # the safe direction for a divergence.
+    if "\t" in text:
+        return ("the text carries a tab, which shell completion would expand after the audit "
+                "row was written")
     bad = TEXT_POLICY.first_disallowed(text)
     if bad is not None:
         return "the text carries " + TEXT_POLICY.describe_disallowed(*bad)

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -284,7 +284,9 @@ def post_json(url: str, token: str, payload: dict) -> dict:
     req.add_header("Authorization", "Bearer " + token)
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-            raw = resp.read()
+            # 🔴 BOUNDED. A bare .read() takes whatever the peer sends, into the
+            # memory of a process running on the operator's workstation.
+            raw = resp.read(MAX_RESPONSE_BYTES)
     except urllib.error.HTTPError as exc:
         if exc.code == 503:
             raise Refused("the terminal write surface is NOT ARMED on the server "
@@ -305,6 +307,60 @@ def post_json(url: str, token: str, payload: dict) -> dict:
 
 
 # ── delivery ─────────────────────────────────────────────────────────────────
+# 🔴 THE HOST RE-VALIDATES EVERYTHING THE SERVER ALREADY VALIDATED, AND THAT IS
+# NOT REDUNDANCY — IT IS THE TRUST BOUNDARY. The server is a pod on a cluster,
+# reachable from an unauthenticated LAN NodePort; THIS process is the thing that
+# actually runs commands as the operator. "One rule, one place" applies to two
+# copies of a rule on the same side of a boundary; here the two sides fail
+# independently, and the side that executes is the one that must refuse.
+#
+# The concrete cases, each of which the server also refuses:
+#   * a pane that is not `%N` — tmux resolves a name-shaped target FUZZILY, so a
+#     `scratch:1` would not fail, it would land in some other pane and run there.
+#   * a control character in the text — `send-keys -l` writes a newline as a
+#     newline, so one write becomes TWO submissions.
+#   * a relative cwd — resolves against THIS process's directory, which differs
+#     per host and per restart.
+#   * an over-long batch — the server caps a claim at 4; a batch of a thousand
+#     from a server that is wrong, compromised or simply newer is a thousand
+#     commands, and nothing downstream would stop them.
+PANE_ID_RE = re.compile(r"^%[0-9]{1,12}$")
+MAX_TEXT_BYTES = 2048
+MAX_BATCH = 4
+# Bounds the response body this agent will read. urlopen().read() with no
+# argument reads whatever the peer sends.
+MAX_RESPONSE_BYTES = 1 << 20
+
+
+def has_control(value: str) -> bool:
+    return any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+
+
+def validate(write: dict) -> str:
+    """Return a refusal reason, or "" when this write is safe to execute here."""
+    kind = (write.get("kind") or KIND_SEND_KEYS).strip() or KIND_SEND_KEYS
+    if kind not in (KIND_SEND_KEYS, KIND_NEW_SESSION):
+        return f"unknown write kind {kind!r}"
+    text = write.get("text") or ""
+    if not isinstance(text, str) or has_control(text):
+        return "the text contains a control character"
+    if len(text.encode("utf-8", "replace")) > MAX_TEXT_BYTES:
+        return "the text is over the size limit"
+    if kind == KIND_SEND_KEYS:
+        pane = write.get("pane") or ""
+        if not isinstance(pane, str) or not PANE_ID_RE.match(pane):
+            return "the target is not a tmux pane id of the form %N"
+        if not text:
+            return "the write carries no text"
+    else:
+        cwd = write.get("cwd") or ""
+        if not isinstance(cwd, str) or not cwd.startswith("/") or has_control(cwd):
+            return "the working directory is not an absolute path"
+        if any(seg == ".." for seg in cwd.split("/")):
+            return "the working directory contains `..`"
+    return ""
+
+
 # The two things a write can ask for. Enumerated rather than pattern-matched: an
 # unknown kind arriving from the server must be REFUSED, not guessed at — a
 # guessed kind is a command nobody reviewed running on this host.
@@ -347,22 +403,24 @@ def deliver(write: dict) -> tuple[str, str]:
     submit = bool(write.get("submit"))
     expected = (write.get("expectTmuxServerId") or "").strip()
 
-    if kind not in (KIND_SEND_KEYS, KIND_NEW_SESSION):
-        return "refused", f"unknown write kind {kind!r}"
+    # 🔴 THE TRUST BOUNDARY. See `validate`: this process executes, so this
+    # process refuses — regardless of what the server accepted.
+    if reason := validate(write):
+        return "refused", reason
 
     refuse, reason = should_refuse(expected, tmux_server_id())
     if refuse:
         return "refused", reason
 
     if kind == KIND_NEW_SESSION:
+        # `validate` has already established this is an absolute, traversal-free
+        # path; the local read below is the value it checked.
         # 🔴 THE GUARD ABOVE STILL APPLIES, and it is not redundant here. A
         # new-session has no pane to be stale about, but it DOES have a host and a
         # tmux server: an expectation that no longer matches means the enqueuer was
         # looking at a tmux server that has since restarted, and a window opened on
         # the new one is not the fleet state it was reasoning about.
-        cwd = (write.get("cwd") or "").strip()
-        if not cwd:
-            return "failed", "a new-session write carried no cwd"
+        cwd = write.get("cwd") or ""
         pane, err = open_window(cwd)
         if err:
             return "failed", redact(err, text)
@@ -429,6 +487,15 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
     writes = got.get("writes") or []
     if not isinstance(writes, list):
         raise Refused("the server's claim answer had no `writes` array")
+    if len(writes) > MAX_BATCH:
+        # 🔴 REFUSE THE WHOLE BATCH RATHER THAN TRUNCATE IT. Executing the first
+        # four and dropping the rest would run commands the server believes are
+        # in flight while silently abandoning others — a partial delivery nobody
+        # can reason about. Refusing the round leaves every row to be relabelled
+        # `abandoned` (delivery UNKNOWN), which is the honest record, and the
+        # condition is loud rather than absorbed.
+        raise Refused(f"the server returned {len(writes)} writes in one claim, over the "
+                      f"{MAX_BATCH} this agent will execute")
     for write in writes:
         wid = str(write.get("id") or "")
         if not wid:

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -356,6 +356,12 @@ PANE_ID_RE = re.compile(r"^%[0-9]{1,12}$")
 #: server-supplied id from steering the request somewhere else (`../`, a query
 #: string, a scheme) or from being unbounded text in a log line.
 WRITE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+#: A tmux SESSION name, and deliberately narrower than tmux itself allows.
+#: 🔴 tmux TARGET SYNTAX IS COMPOUND (`session:window.pane`), so a name carrying
+#: `:` or `.` is a DIFFERENT ADDRESS and tmux resolves it somewhere the caller
+#: did not choose rather than failing — the wrong-place class the pane rule
+#: exists for, one level up: a whole WINDOW instead of a keystroke.
+TMUX_SESSION_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$")
 MAX_TEXT_BYTES = 2048
 MAX_BATCH = 4
 # Bounds the response body this agent will read. urlopen().read() with no
@@ -410,6 +416,17 @@ def validate(write: dict) -> str:
             return "the working directory carries a character that is not printable"
         if any(seg == ".." for seg in cwd.split("/")):
             return "the working directory contains `..`"
+        # 🔴 RE-VALIDATED HERE, NOT TRUSTED. The server checks it too; this
+        # process is the one that hands the value to tmux as a target, and the
+        # two sides of the boundary fail independently. Absent is fine — it means
+        # "wherever this server considers current", which is the behaviour when
+        # nobody expressed a preference.
+        tmux_session = write.get("tmuxSessionName") or ""
+        if not isinstance(tmux_session, str):
+            return "the tmux session name is not a string"
+        if tmux_session and not TMUX_SESSION_RE.match(tmux_session):
+            return ("the tmux session name is not a bare session name — `:` and `.` make it "
+                    "a compound tmux target, which resolves somewhere nobody chose")
     return ""
 
 
@@ -425,8 +442,16 @@ KIND_NEW_SESSION = "new-session"
 NEW_SESSION_ALWAYS_SUBMITS = True
 
 
-def open_window(cwd: str) -> tuple[str, str]:
-    """Open a new tmux window at cwd. Returns (pane_id, error).
+def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
+    """Open a new tmux window at cwd, in tmux_session when one is named.
+
+    🔴 WITHOUT `-t` THE TARGET IS DECIDED BY tmux, NOT BY THE CALLER. `new-window`
+    with no target joins whatever session this server considers CURRENT — which
+    depends on what the operator last looked at — so a launched window lands
+    somewhere nobody chose. `-t "<name>:"` is the unambiguous spelling: the
+    trailing colon means "this session, next free index", and a session that does
+    not exist makes tmux FAIL rather than fall back to the current one, which is
+    the direction this whole surface prefers.
 
     🔴 A TRANSPORT PRIMITIVE, NOT A FEATURE. "Start a Claude Code session" is
     entirely a question of what the caller's TEXT says; this only makes a window
@@ -438,7 +463,12 @@ def open_window(cwd: str) -> tuple[str, str]:
     difference matters because between these two calls the operator may have
     switched windows, and a relative target would type into whatever they moved to.
     """
-    rc, out, err = run_tmux(["new-window", "-P", "-F", "#{pane_id}", "-c", cwd])
+    argv = ["new-window", "-P", "-F", "#{pane_id}", "-c", cwd]
+    if tmux_session:
+        # The name has already been through TMUX_SESSION_RE, so it cannot be a
+        # compound target; the trailing colon makes the intent explicit anyway.
+        argv += ["-t", tmux_session + ":"]
+    rc, out, err = run_tmux(argv)
     if rc != 0:
         return "", (err or f"tmux exited {rc}")
     pane = out.strip().splitlines()[0].strip() if out.strip() else ""
@@ -478,7 +508,7 @@ def deliver(write: dict) -> tuple[str, str]:
         # looking at a tmux server that has since restarted, and a window opened on
         # the new one is not the fleet state it was reasoning about.
         cwd = write.get("cwd") or ""
-        pane, err = open_window(cwd)
+        pane, err = open_window(cwd, write.get("tmuxSessionName") or "")
         if err:
             return "failed", redact(err, text)
         if not text:


### PR DESCRIPTION
The **host half** of rank 29 of the tmux-webapp effort. The server half is `ZacxDev/homelab-infra#711`.

## What this is

clawgate's pod cannot see either host's tmux socket — no hostPath, no hostNetwork, no hostPID, no nodeName. The read model solved that by pushing outbound (`tmux-snapshot-push.sh`); this is the **return direction**, solved the same way rather than by opening a port. `scripts/tmux-reply-agent` holds an outbound short poll (~5s), claims queued writes for **its own host**, runs `tmux send-keys` locally, and reports the outcome. No inbound access to either machine, and no credential for either machine inside a pod on an unauthenticated LAN surface.

That closes the third missing layer. Host→pod was push-only; **nothing pulled commands down**, which is why "jump into this pane" is currently a clipboard copy of `tmux switch-client -t %N`.

## 🔴 IT SHIPS DISABLED. NO SECRET IS PROVISIONED.

`enableTmuxReplyAgent = false` in `nix/home.nix`. The **service unit is emitted on both hosts and wired into nothing** — `Install.WantedBy` is `lib.optionals enableTmuxReplyAgent [ "default.target" ]`, so a `home-manager switch` after this merges starts no process.

Arming needs **two independent acts**, and neither implies the other:

1. `CLAWGATE_TERMINAL_TOKEN` provisioned into the **pod's** secret — until then the server's routes answer 503 and the pod says so at boot, unconditionally and in both directions;
2. this flag set true, with the same secret readable on the host from `~/.claude/clawgate.env`.

Flip only the flag and you get a unit that exits **2** saying the surface is not armed. Provision only the secret and you get a live route nobody polls. Disarming is removing the secret; it is reversible.

Both halves are pinned: `test_the_agent_unit_SHIPS_DISABLED` reads the flag through `testlib.nix_units.strip_nix_comments`, **not** a substring search — this file's blocks quote directives verbatim in prose, and that exact failure once left a guard green over a deleted unit.

## What one delivery actually does, and what guards it

🔴 **`tmux send-keys` into a named pane, then Enter. That is arbitrary command execution as the operator on this host**, on text that arrived over a LAN route with no human auth. Your decisions — free text into any pane, and clawgate presses Enter — are what make it that; everything below exists because of them, not instead of them.

- 🔴 **The text never reaches a shell.** It is passed to `subprocess.run` as one element of an **argv list**. `test_the_text_is_delivered_as_one_argv_element_with_no_shell` feeds `-n $(id) \`id\` "q" 'p' ;echo x |tee /dev/null && true \n $HOME` and asserts the byte-identical string arrives as a single argument — through a stub `tmux` that records **argv**, not a command line, because a stub recording `"$*"` would flatten the exact distinction under test.
- 🔴 **`-l` and `--` are the command, not decoration.** Without `-l`, `send-keys` reads its argument as *key names*: a reply containing `C-c` interrupts whatever is running instead of typing three characters. Without `--`, text starting with `-` is a flag. The test pins the exact argv, because presence without ordering proves nothing.
- **One submission, never two.** The server rejects any text containing a control character, so the literal send plus a separate `Enter` is the only submission a delivery can produce. (A newline would otherwise submit line 1 and *run line 2 as a fresh command*.)
- **The write-time guard runs before the write.** `expectTmuxServerId` — the collector's own `<pid>:<start_time>` token — is compared against this host's live tmux server identity. A mismatch is `refused` **with no `send-keys` at all**; the test asserts zero sends, not merely a refusal status, because a guard that reports after the keys have gone is not a guard.
- **An unmeasurable identity refuses.** tmux renders an unknown format verbatim, so an old tmux yields a bare `:`; that reads as "cannot measure", which the guard turns into a refusal.
- **An unknown `kind` refuses rather than guesses.** Falling back to the default would run a command nobody on this host reviewed.
- **`new-session` addresses the new pane by id.** `new-window -P -F '#{pane_id}'` prints it, and the text is sent to *that* id — between the two calls the operator may have switched windows, and a relative target would type into whatever they moved to. If tmux reports no pane id, the agent **fails rather than guessing**, with zero sends.

## Idempotency: at-most-once, and the agent's part in it

A retried `send-keys` runs a command twice. The server's claim moves a row out of `pending` permanently; **this agent never retries a send, never re-claims, and never replays**. When the result POST fails it does *not* re-execute — the row is relabelled `abandoned`, which means **delivery UNKNOWN, never "did not run"**, and the agent logs it in those words. `test_a_failed_result_post_does_NOT_re_execute_the_write` pins both halves.

## The reply text is credential-grade and is never logged here

You chose a full audit log **including the text**; the cost stated at the time was that a reply may contain a secret. That log lives in the server's table behind the terminal token. The journal is a much wider readership, so:

- `test_the_reply_text_is_never_written_to_the_journal` drives a delivery that **fails with tmux's stderr echoing the text back** and asserts a synthetic marker appears nowhere in the agent's output — with positive controls that the agent logged *something*, named the write, and really did send the marker.
- the agent **redacts the exact text** from any diagnostic before reporting it (`detail` lands in the audit log *and* a log line, and tmux quotes its arguments in its own errors). It is an exact substitution, not a secret-shaped pattern, so it cannot miss the way a heuristic misses.
- 🔴 The same hazard bit the server side for real: its first draft logged the agent's `detail` and the equivalent guard caught it. See #711.
- **This repo is public.** Never paste a real reply, a real pane preview, or a row from that table anywhere in it.

## The seams a disagreement would break silently

- **Host label.** The queue is keyed on the label the *read model* stores, which the collector computes from `ACTIVITY_HOST` (`hostname` is `nixos` on both machines). An agent computing a different label would poll for a host nobody enqueues to and deliver nothing, with no error anywhere. `test_the_host_label_follows_the_same_rule_as_the_collector` asserts the rule **and** reads `HOST_NAMES` / `DEFAULT_LOCAL_HOST` out of `scripts/session-manager`'s own source rather than restating them.
- **tmux server-id spelling.** Two spellings of one token would compare apples to oranges and **refuse every write** — which reads exactly like "the feature does not work", with nothing naming the cause. `test_the_server_id_format_matches_the_collectors` pins `TMUX_SERVER_ID_FORMAT` against the collector's `WINDOW_FORMAT` and its `f"{pid}:{started}"` join, read from that file.
- **Env beats file.** `clawgate-stop-hook.sh` sources the same credential file with `set -a`, which makes the *file* win — and the measured consequence over there was a probe aimed somewhere harmless silently POSTing to production. On this surface that mistake sends a reply into a live pane. Regression-guarded, along with the `export `-and-leading-whitespace anchor that `tmux-snapshot-push.sh` had to learn.
- **The token is never in argv or a URL** — asserted through the stub tmux's recorded argv and the stub server's received request, not by reading the source.

## The unit

`Type = "simple"`, not the oneshot-plus-timer shape its two siblings use: a ~5s poll driven by a timer would fork a process, a Python interpreter and a TCP connection **17,280 times a day** for a queue that is empty almost always.

- 🔴 **No `OnFailure`**, deliberately. `notify-failure@` toasts are wired to *defeat* do-not-disturb, justified by a measured ~1 firing in 9 days. This unit restarts on failure and polls constantly, so any sustained condition — above all "the surface is not armed", the state it ships in — would fire a DND-bypassing toast on every restart and burn down the one alert channel that has to keep its meaning. What surfaces a genuinely broken agent instead is `StartLimitBurst=5` / `StartLimitIntervalSec=600` marking the unit **failed**, which `/standup` reads. Everything transient is backed off from *inside* the loop rather than exited on, precisely so a restart storm is not the failure mode.
- **A repeating condition is logged once, not per tick** — asserted (`out.count("NOT ARMED") == 1`), because at the real cadence a per-tick line is 17,280 a day and buries every real event.
- **PATH carries `coreutils`, `python3`, `tmux` and nothing else.** Deliberately *not* curl/openssh/gawk: the agent is stdlib Python and never leaves this host. That is the opposite trim from `tmux-snapshot-push`'s list, and copying it wholesale would be carrying binaries to justify later. Pinned two ways (present *and* absent).
- **`TMUX_TMPDIR=%t`** — this host's socket is at `$XDG_RUNTIME_DIR/tmux-UID/`, not tmux's compiled-in `/tmp/tmux-UID/`. Here it is load-bearing rather than defensive: if this unit cannot connect, every delivery fails *loudly* and is recorded as `failed`, which is the safe direction — unlike the feeder, where the same miss produces a silent destructive zero.
- **NOT `serverMode`-gated**, and the asymmetry with `enableTmuxSnapshotPush` is the same one `transcript-push` has. That feeder is workbench-only as a *correctness* requirement (its collector already reaches both hosts over ssh, so a second reporter would fight over every row). A tmux socket is visible only from the machine it lives on, so a workbench-only agent would leave every laptop pane permanently unanswerable. The queue is keyed on the host label, so two agents claiming disjoint scopes cannot collide.

Exit codes are distinct on purpose: **2** = no usable credentials (a configuration error that cannot self-heal — and the state this ships in), **3** = tmux unusable, **0** = clean shutdown. An unreachable server, a 503, a 401 or a malformed body are **backed off from, not exited on**.

## 🔴 A gap I found reviewing my own agent: it trusted the server's payload

The agent validated nothing the server had already validated. That reads like good hygiene — "one rule, one place" — and it is **the wrong reading of that rule**: it governs two copies on ONE side of a trust boundary. Here the server is a pod reachable from an unauthenticated LAN NodePort and this process is the thing that *runs commands as the operator*. The two sides fail independently, and the side that executes is the one that must refuse.

Re-checked on the host now, each of which the server also rejects:

- **a pane that is not `%N`** — a name-shaped target does not *fail* in tmux, it resolves fuzzily and runs the command in some other pane;
- **a control character in the text** — one write becoming two submissions;
- **a relative or `..`-bearing `cwd`** — resolves against *this process's* directory, which differs per host and after every restart, on the one path that creates its own target;
- **an oversized claim batch** — the server caps a claim at 4; a thousand writes from a server that is wrong, compromised or simply newer is a thousand commands, and nothing downstream would stop them. The batch is refused **whole**, not truncated: executing four and dropping the rest is a partial delivery nobody can reason about, whereas refusing leaves every row to be relabelled `abandoned` (delivery UNKNOWN), which is the honest record.

It also bounds the response body it will read — a bare `.read()` takes whatever the peer sends into a process on the operator's workstation.

**Mutation-tested:** deleting the `validate()` call reds **12** cases; deleting the batch cap reds its own, with a control that a batch *at* the cap still executes.

## 🔴 The text gate was a DENYLIST, at the one site reachable from the network

```python
def has_control(value):
    return any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
```

It refuses NUL, `\n`, `\r`, ESC and DEL — and **passes** every C1 control (U+0080–U+009F), **U+0085 NEL** (a line break to some terminals), U+2028/U+2029, and every invisible. Including **U+000F**, the exact character `scripts/session-write`'s own docstring records as having got through *its* earlier denylist and executed a pane's buffer **with no Enter sent**.

So this repo had already found and fixed this class, written down why, and mutation-tested the fix — and I shipped a second, weaker copy at the site an attacker can reach. That is `claude/RULES.md`'s "a predicate open-coded at N sites is typically wrong at N−1 of them, in the same direction", measured.

**The rule now lives in `scripts/lib/tmux_text_policy.py` and both programs import it.** `session-write` re-exports the names its 185 tests already read, so none of them changed, and it pins the tmux argv separator against `session-resolve`'s own constant at import — an assertion, not a convention. Neither program falls back if the module is missing: a fallback is exactly how the weaker check would return.

Guarded two ways, because either alone decays:

- **structural** — both predicates' `__code__.co_filename` must be the shared file, and an AST scan (not a grep — this file's prose names `has_control` repeatedly) fails if either script defines its own again;
- **behavioural** — a sweep across U+0020–U+20FF asserts the agent's gate answers exactly what the shared allowlist answers, with a positive control that the sweep saw both answers.

The allowlist is `ch in ("\t",) or ch.isprintable()`. Tab is the one control character deliberately permitted: it has an ordinary typographic use and cannot accept a line.

## 🔴 Three guards that pinned words and passed over live mutants

The audit found these; all three now fail on the mutant that walked through them.

| guard | the mutant that survived | why it mattered |
|---|---|---|
| `WantedBy` | `lib.optionals (!enableTmuxReplyAgent) [ "default.target" ]` | both asserted substrings survive an **inversion** that starts the agent on both hosts on the next switch — the single thing this change claims cannot happen |
| unit `PATH` | deleting `pkgs.python3` from `makeBinPath` | the assertion was satisfied by the **ExecStart** line, which names python3 for a different reason; the child lost its interpreter directory |
| new-session `submit` | replacing `submit = True` with `pass` | neither direction was pinned, because every fixture set submit true |

The `WantedBy` guard now extracts the condition and pins it as a **whole normalised expression** — `!enableTmuxReplyAgent` is not `enableTmuxReplyAgent` — and asserts the flag is `false`. It is deterministic, so it runs identically in the check sandbox, which has no recursive nix; a `nix eval` sits beside it as **labelled confirmation** that skips where nix is unavailable, because a skipped test is not a passing one.

## 🔴 Two defects a stubbed suite structurally could not see

Both were in shipped payload, both on the path that **always presses Enter**, and both were invisible to 86 green tests because **the stub tmux exits 0 for everything** — it models neither resolution rule. Only a real-tmux probe finds them.

**1. tmux PREFIX-MATCHES a session name.** `-t "<name>:"` does not fail when the session is absent — measured on tmux 3.7c, it returns rc 0 and picks a longer match. The operator's live server is exactly the shape that triggers it: `scratch`, `scratch2` … `scratch20`, and `datapacket-talos`, `datapacket-talos-2`. So `-t scratch2:` — *the literal this suite's own fixtures used* — opened a window in `scratch20`, typed the command, pressed Enter and reported `delivered`. My docstring asserted the opposite. Fixed with `=`, which forces an exact match.

**2. `-c <absolute path that does not exist>` also returns rc 0**, with the window in `$HOME`. Three shape-valid inputs reach it: a path absent **on this host** (the queue is host-keyed, so a workbench path can be enqueued for the laptop), a trailing space, and a trailing `;` — which tmux eats off the `-c` word, and which the *text* path already refused while the *cwd* path did not. Same character, same file, opposite treatment. A build or a recursive delete ran in the home directory and was reported `delivered`.

Both are now checked twice: `os.path.isdir` up front for a legible refusal, and a **read-back** of the session and working directory tmux actually chose, printed by the same `-P -F` at no extra round trip. The read-back is what catches a resolution rule nobody has thought of.

⚠ **Both read-backs SURVIVED their first mutation** — `=` and `isdir` each fire first in the ordinary case — so the stub can now *lie* about where the window landed, and two tests pin them independently.

`tmux` is in `REQUIRED_TOOLS` and `flake.nix` `gateTools` so those guards cannot silently skip in the tier that gates. ⚠ Adding it without a written justification is itself what the sandbox tier caught: `test_devshell_satisfies_required_tools.py` requires one, because the FATAL it prints promises the reader one.

## Verification matrix

**Base sha `a75ffc6a`** (`origin/main`; the branch is rebased onto it, so this is the merged tree).

**Tier 1 — `scripts/gate.sh --tier both`, run inside the flake devShell** (`nix develop <worktree> -c bash scripts/gate.sh --tier both`; a bare run fails rc 3 with `required tool(s) missing from PATH: logrotate`, because `.envrc` is `use opencode` and does not carry the gate toolchain):

Both tiers PASS, and the counts are the runners' own summary lines rather than my arithmetic:

```
  TOTAL collected=21779  passed=21776  skipped=3  failed=0  (floor: 18610 = sum of 30 per-target floors)
RESULT: PASS (exit=0)
  TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0 skipped=0  (floor: 1367)
RESULT: PASS (exit=0)
  PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'
  PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
GATE: RESULT=PASS exit=0
```

`gate.sh` cross-checks its own exit status against those `RESULT:` lines and exits 90 when they disagree; it exited 0, so the status and the verdicts agree.

**Tier 2 — the sandbox tier the merge gate runs**, `nix build .#checks.x86_64-linux.pytests` and `.nodetests`, **one at a time** (a combined invocation produces false failures under store contention):

```
devrc-pytests>   TOTAL collected=21779  passed=21776  skipped=3  failed=0  (floor: 18610 = sum of 30 per-target floors)
devrc-pytests> RESULT: PASS (exit=0)

devrc-nodetests>   TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0 skipped=0  (floor: 1367)
devrc-nodetests> RESULT: PASS (exit=0)
```

Exit codes as the runs themselves reported them — not a piped status, which `| tail` destroys:

```
GATE_RC=0
NIXPY_RC=0
NIXNODE_RC=0
```

⚠ **Only the final run counts, and the earlier ones are catalogued above.** Each superseded run measured a tree that has since moved; none of their numbers appear here.

**This suite alone:** `scripts/tests/test_tmux_reply_agent.py` — **105 passed**, 0 failed, 0 skipped. `scripts/tests/test_session_write.py` — **185 passed**, unchanged by the predicate extraction.

⚠ **An earlier version of this body claimed 46 and described code that was not in the pushed commit.** The push had never landed: I pushed once before rebasing and never again, so the PR showed the pre-rebase head while the body was written from my worktree. `git status` was clean, which is what I checked, and it cannot see that. **Checking `git rev-list --left-right origin/<branch>...HEAD` is what would have.** The head is **`1adc0d47`**, and I verify the PUSHED head's own file list against every claim here — `git show origin/<branch>:<path>` — rather than the worktree's. The same failure recurred one layer out later in this PR: an edit to this body's *file* that was never `gh pr edit`-ed, so the published body lacked a section I had reported as present. I now re-read the live body with `gh pr view --json body` after every edit.

## Red-at-base, honestly labelled

🔴 **Nothing in this PR is regression coverage, and I am not presenting it as such.** Every test here covers a script that did not exist at `origin/main`; there is no pre-change code to watch them fail on, and a compile/import error is not a red I would report as one.

The one guard that *did* earn its keep by going red is on the server side (#711): the equivalent text-never-logged test caught a real credential leak in that handler's first draft.

Two tests here are **invariant guards** rather than coverage, and are labelled so in their own docstrings: `test_the_server_id_format_matches_the_collectors` and `test_the_host_label_follows_the_same_rule_as_the_collector` pin cross-file relationships no bug has yet violated.

## ⚠ A property of the transport, stated so it is not later inferred to have been considered

**This agent talks to the pod over plain HTTP to a LAN NodePort.** No TLS, no server authentication, and the terminal token travels in cleartext on every poll (~every 5s). That is the pattern `tmux-snapshot-push.sh` and `transcript-push.sh` already use — **but the stake is different**: those tokens gate *reads*, this one gates `send-keys` plus Enter. Not fixed here, and not in scope; written down so arming is a decision taken with it on the table.

## What I could NOT verify

- 🔴 **The agent has never run against a real clawgate, and structurally cannot until the surface is armed.** Every test drives it against a stub HTTP server and a stub `tmux`. It has never touched a real pane.
- 🔴 **The closing condition in the handoff — "a reply typed in the web UI appears in the target pane" — is NOT met by this PR and is not claimed to be.** It needs the token provisioned, rank 30's UI, and a live check on both hosts.
- **No `home-manager switch` was run.** The unit is not wired into anything, so a switch would start nothing, but I did not run one and cannot say the module evaluates on a real host beyond `nix-instantiate --parse` and whatever the nix check tier exercises.
- The unit's `Environment` PATH list is asserted against the source, **not** by running the child under it — the one mistake `tmux-snapshot-push`'s comment warns about (its `gawk` was trimmed as "unused" and its absence was silent). Here the exposure is smaller: the agent is stdlib Python plus `tmux`, and a missing `tmux` exits 3 loudly rather than fabricating a zero. Still: unmeasured.
- Branch protection on this repo was not re-measured by me.

## Not done, deliberately

- **No `CLAWGATE_TERMINAL_TOKEN` created, written to `~/.claude/clawgate.env`, encrypted or applied.**
- Master switch left `false`. No timer, no `default.target` want.
- No `ship.sh`, no deploy, no merge.
