### PR TITLE
docs(proposal): session capture attached to cairn entries

### DIFF
--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -59,10 +59,25 @@ It is nonetheless **the wrong instrument here, and the reasons are structural, n
 will hold two answers to "which sessions matter", and those answers will drift — the exact
 shape `claude/RULES.md` calls out as regenerating the same bug at every site. The mitigation
 is not to merge them (their triggers genuinely differ) but to **share the parts that are one
-rule**: transcript discovery and `project_of`. **Not the byte-boundary logic** — it exists to
-drop the leading partial JSON record from a *tail*, and decision 1 ships whole files, so the
-new shipper has no caller for it. Extracting it would move dead surface for one of the two
-callers.
+rule**. **Not the byte-boundary logic** — it exists to drop the leading partial JSON record
+from a *tail*, and decision 1 ships whole files, so the new shipper has no caller for it.
+
+🔴 **AND TRANSCRIPT DISCOVERY IS ALREADY SHARED — REUSING IT IS A DECISION, NOT A FREEBIE,
+AND IT ANSWERS §9.6 IN THE OPPOSITE DIRECTION.** `scripts/lib/transcript_search.py` already
+exposes `iter_transcripts` / `is_corpus_member`; the existing feeder imports it, and
+`test_transcript_search.py`'s two-way site ledger scans the tree so a fourth hand-rolled walk
+cannot pass unseen — i.e. the repo actively rewards reuse. But that module carries
+`EXCLUDED_DIR_NAMES = ("subagents",)` and `is_corpus_member` rejects anything beneath it.
+Measured 2026-09-05: the exclusion and the `agent-*` prefix **coincide exactly** — 4,955 of
+4,955 `agent-*` files are under a `subagents/` directory and 0 of 913 real-session files are.
+
+So an implementer who takes "share discovery" at face value, reuses `iter_transcripts` — the
+correct-looking move, and the one the ledger test pushes toward — **silently ships parent
+transcripts only**, which is precisely the "drops most of the evidence this proposal exists to
+preserve, while looking complete" outcome §5.0 names. The ledger test stays green throughout,
+because reusing the shared walk is what it exists to reward. **If §9.6 resolves to "ship the
+set", the shared walk must be widened or deliberately bypassed, and that is a change to a
+module with an enforced site ledger — not a free adoption.**
 
 ## 4. Volume — measured, not estimated
 
@@ -80,28 +95,40 @@ Measured on the workbench, 2026-09-05. All three populations, because they diffe
 |---|---|---|---|---|---|
 | all `.jsonl` — **NOT what ships** | 5,864 | 0.74 MB | 2.53 MB | 23.48 MB | 6.73 GB |
 | real sessions (excluding `agent-*`) | 913 | **2.62 MB** | 4.97 MB | 23.48 MB | 2.45 GB |
-| **sessions that produced a handoff** — what decision 2 selects | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
+| **sessions that produced a handoff** — what decision 2 selects, **parent file only** | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
+| the same 37 sessions, **parent + their subagent transcripts** | 37 | **8.68 MB** | — | 31.00 MB | 375 MB |
 
-The third row is the population decision 2 actually selects. It was derived from the
+Rows 3 and 4 are the population decision 2 selects, counted two ways — see the next
+paragraph but one for which of them to size off. Both were derived from the
 `Claude-Session-Id` trailer on commits touching `claudedocs/handoff-*.md` since 2026-07-01:
 37 distinct ids, **all 37** resolving to a transcript on disk, none of them an `agent-*`
 file.
 
 🔴 **The selection effect runs the WRONG WAY, and that is the point of the row.** Sessions
 that produce a handoff are the long ones, so the per-handoff filter picks the **large tail**,
-not the median — 3.82 MB against 2.62 MB against 0.74 MB. `SessionEnd` re-ship makes it
-larger still, so **3.82 MB is a floor, not an estimate.** Anyone sizing a bucket, a PUT
-timeout or a per-handoff cost must use that row.
+not the median — 3.82 MB against 2.62 MB against 0.74 MB.
+
+🔴 **AND THE ROW YOU SIZE OFF DEPENDS ON AN ANSWER §9.6 HAS NOT GIVEN YET.** Row 3 is the
+parent transcript alone. If §5.0 resolves to "ship the set", row 4 is the real unit: **2.3×
+the median and 2.5× the total**, with a largest single session of **31.00 MB** — which
+*exceeds* the 23 MB figure §5.2 uses as its worked example of a payload too big for the pod.
+33 of the 37 sessions have subagent bytes at all; the worst measured is a 3.79 MB parent with
+60 subagent files totalling 43.20 MB, where shipping one object captures **8%** of the
+session. Two further reasons both rows are floors: `SessionEnd` re-ship only grows them, and
+the sample below is partial.
+
+**So: size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
+§9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
+more than 2×.
 
 ⚠ **Scope of the 37-session sample, stated rather than buried:** devrc handoffs only, and
 only commits carrying the trailer. Handoffs in other repos are not counted, so the true
 population is larger and the totals are floors.
 
-| | |
-|---|---|
-| opencode session data | **2.4 GB** — a SQLite DB plus `storage/`, `snapshot/`, `tool-output/` |
+**opencode**, for scale only: **2.4 GB** — a SQLite DB plus `storage/`, `snapshot/` and
+`tool-output/`. Not comparable to the rows above and not summed with them.
 
-⚠ The `6.73 GB` above is the `.jsonl` population summed in decimal bytes. A `du -sh` of the
+⚠ The `6.73 GB` in row 1 is the `.jsonl` population summed in decimal bytes. A `du -sh` of the
 directory reads `6.6 GB` because it is GiB and includes ~7,000 non-`.jsonl` files. Two
 different measurements; do not pair them.
 
@@ -127,7 +154,8 @@ work at all."* For an `agent-*.jsonl` the stem is `agent-<hash>`, which is **not
 id. Sampled 6 subagent transcripts: in every one the stem is absent from the `sessionId`
 values inside the file, and the single `sessionId` present is the **parent's**.
 
-So "keyed on session id" (§5.1) has two readings and neither is safe by default:
+So keying the object "on session id" — which is what §5.1 said before it was rewritten to
+defer to this section — has two readings, and neither is safe by default:
 
 - key on the **in-record `sessionId`** → parent and all N subagent files collide on one
   object key, each push overwriting the last. §8 control 4 ("assert the sha256 changed")
@@ -179,8 +207,9 @@ imply "over the mesh" — an implementer who accepts only the capacity argument 
 MinIO through a public ingress satisfies it completely while putting unredacted multi-client
 transcripts through a third party. **Name the rule when writing this down.**
 
-The capacity point is true and secondary: the pod is single-replica, `Recreate`, PVC-backed
-and designed to render markdown (all three verified), so a 23 MB PUT through it is a category
+The capacity point is true and secondary: the pod is single-replica, `Recreate` and
+PVC-backed (all three verified) and is designed to render markdown, so a 23 MB PUT — or a
+31 MB one, per §4 row 4 — through it is a category
 change. But that is a reason not to use the pod — it is not the reason the route must stay on
 the mesh.
 
@@ -192,9 +221,16 @@ Front-matter on each touched entry gains a session reference carrying `id`, `sha
 🔴 **THE FIELD SHAPE IS CONSTRAINED, AND THE OBVIOUS SPELLING IS SILENTLY DESTRUCTIVE.**
 Cairn front matter is parsed by `parse_front_matter` in `lib/subsystem_resolver.py`, which is
 hand-rolled and **line-based**. It handles `key: value`, an inline flow list `key: [a, b, c]`,
-and a block list of one-line `- item`s. **There is no case for a nested mapping**, and its own
-docstring records the measured result of feeding it one: the key comes back empty and every
-child is promoted to a phantom top-level key by its own internal colon.
+and a block list of one-line `- item`s. **There is no case for a nested mapping**: the key
+comes back empty and every child is promoted to a phantom top-level key by its own internal
+colon.
+
+⚠ **Do not read the parser's docstring as documenting this** — an earlier revision of this
+paragraph cited it, and the citation was wrong in a way that would close the case for a reader
+who checked it. The docstring records the same corruption for a **block list**, under the
+heading *"THE BLOCK FORM IS PARSED BECAUSE NOT PARSING IT CORRUPTED THE MAPPING"* — i.e. that
+shape was **fixed**. The nested-mapping case is unfixed and undocumented there; the evidence
+for it is the reproduction below and nothing else.
 
 Reproduced against the live parser while writing this, with the exact five fields above under
 a `session:` key:
@@ -281,15 +317,19 @@ depth now rests on storage. Concretely, the implementation must:
   write-capable key whose secret exists nowhere — the exact window #683 closed. The
   stdout half matters too (these scripts are run by agents, so a printed secret lands in a
   transcript), and with decision 8 it would land there **permanently**;
-- carry **no anonymous access policy** — see §8 control 6 for how to prove that, which is
-  harder than it looks;
+- carry **no anonymous access policy**, proven by probing it rather than by reading the
+  policy JSON — and see §8 control 6, because probing it correctly is harder than it looks;
 - keep the **cairn read token unable to reach the bucket**, and vice versa — pinned by a
   test, not asserted by a comment. ⚠ Note the limit stated in §5.3: this separates
   credentials, not the host they both sit on.
 - 🔴 **register the credential in `SECRETS.md` with a rotation coupling, in the same change
   that mints it.** That file exists to make a new-host bootstrap deterministic instead of
-  manual archaeology, and every comparable entry carries one. A credential minted outside it
-  is invisible at bootstrap and at rotation.
+  manual archaeology. ⚠ **Naming the population, since this document's own §4 is about not
+  doing that:** of `SECRETS.md`'s 8 host-file rows, 6 bear a secret and **2 of those 6** carry
+  a rotation-coupling clause — both of them hosted-service bearer tokens with a k8s source of
+  truth, which is exactly what this credential would be. So the precedent is strong for this
+  shape and is *not* a universal convention. A credential minted outside that file is
+  invisible at bootstrap and at rotation either way.
 
 🔴 **The bucket has NO tenancy boundary, and the store it attaches to does.** Under
 `plan-cairn-integration.md` the store's future is multi-tenant with sharing gated on
@@ -372,9 +412,10 @@ invariant the bug never violated is an invariant guard and must be labelled as o
 3. **Which entries count as "touched"?** The handoff run knows what it wrote; whether that
    set is the right one, or too wide, has not been measured.
 4. **opencode** — schedule, or park indefinitely.
-5. **Does the shared-module extraction in §3 happen now or later?** Later is defensible;
-   never is how the two shippers drift. Scope it to discovery and `project_of` — not the
-   byte-boundary logic.
+5. **What does the new shipper do about `transcript_search`?** Not "does the extraction
+   happen" — discovery is **already** a shared module with an enforced site ledger. The
+   question is narrower and sharper: reuse it and inherit its `subagents/` exclusion, widen
+   it, or bypass it deliberately. §3. This is downstream of question 6, not independent of it.
 6. 🔴 **Does a session ship as ONE object or a SET?** §5.0. This is the largest open
    question, it decides the object key, and the goal in §1 depends on the answer — 64% of the
    bytes are in subagent transcripts, and one-object-per-session drops them.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -50,7 +50,8 @@ and a distinct exit code per failure condition.
 
 It is nonetheless **the wrong instrument here, and the reasons are structural, not stylistic**:
 
-- it ships a **192 KiB tail**; decision 1 wants whole files up to 23 MB;
+- it ships a **192 KiB tail**; decision 1 wants whole files, up to 23.48 MB — §4 row 1's max,
+  i.e. the largest single transcript FILE on the host;
 - it is **ambient and periodic**; decision 2 wants an explicit per-session act;
 - it posts the payload **inline in JSON** to an HTTP endpoint; decision 3 wants bytes in
   object storage and only a pointer in the API.
@@ -59,8 +60,20 @@ It is nonetheless **the wrong instrument here, and the reasons are structural, n
 will hold two answers to "which sessions matter", and those answers will drift — the exact
 shape `claude/RULES.md` calls out as regenerating the same bug at every site. The mitigation
 is not to merge them (their triggers genuinely differ) but to **share the parts that are one
-rule**. **Not the byte-boundary logic** — it exists to drop the leading partial JSON record
-from a *tail*, and decision 1 ships whole files, so the new shipper has no caller for it.
+rule**.
+
+**The one clearly-shareable surface is `project_of`** (`build_transcript_push.py`), which maps
+a transcript to its project label. It exists at exactly one site, is **not** in the shared
+discovery module, and its own docstring warns that it is *"a LABEL, NOT AN IDENTIFIER"* that
+must not be un-slugified. A second shipper needing a project label for object metadata or a
+key prefix would hand-roll it in four lines, and the two copies would disagree the first time
+a directory name contains a literal `-`. ⚠ An earlier revision of this section deleted this
+sentence as collateral while rewriting the paragraph below, leaving the section with no
+positive advice at all — which reads as "nothing is safe to share" and is the opposite of what
+was found.
+
+**Not the byte-boundary logic** — it exists to drop the leading partial JSON record from a
+*tail*, and decision 1 ships whole files, so the new shipper has no caller for it.
 
 🔴 **AND TRANSCRIPT DISCOVERY IS ALREADY SHARED — REUSING IT IS A DECISION, NOT A FREEBIE,
 AND IT ANSWERS §9.6 IN THE OPPOSITE DIRECTION.** `scripts/lib/transcript_search.py` already
@@ -89,14 +102,19 @@ was right; the population was wrong. Kept here rather than silently corrected, b
 error is the instructive part: **a percentile is a claim about a population, so name the
 population or the number means nothing.**
 
-Measured on the workbench, 2026-09-05. All three populations, because they differ by 5×:
+Measured on the workbench, 2026-09-05. Four populations, because the answer spans ~12×
+between them — and which one applies is decided by a question §9 has not closed:
 
 | population | files | median | p90 | max | total |
 |---|---|---|---|---|---|
 | all `.jsonl` — **NOT what ships** | 5,864 | 0.74 MB | 2.53 MB | 23.48 MB | 6.73 GB |
 | real sessions (excluding `agent-*`) | 913 | **2.62 MB** | 4.97 MB | 23.48 MB | 2.45 GB |
 | **sessions that produced a handoff** — what decision 2 selects, **parent file only** | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
-| the same 37 sessions, **parent + their subagent transcripts** | 37 | **8.68 MB** | — | 31.00 MB | 375 MB |
+| the same 37 sessions, **parent + their subagent transcripts** | 288 files / 37 sessions | **8.68 MB** *(per session)* | 20.23 MB | 31.00 MB *(per session)* | 375 MB |
+
+⚠ Every percentile in this table uses one convention — the sorted value at `int(n × 0.9)`,
+no interpolation. Stated because a different convention gives a visibly different p90 for
+row 4 (16.65 MB rather than 20.23 MB) and nothing in the table would show which was used.
 
 Rows 3 and 4 are the population decision 2 selects, counted two ways — see the next
 paragraph but one for which of them to size off. Both were derived from the
@@ -109,13 +127,27 @@ that produce a handoff are the long ones, so the per-handoff filter picks the **
 not the median — 3.82 MB against 2.62 MB against 0.74 MB.
 
 🔴 **AND THE ROW YOU SIZE OFF DEPENDS ON AN ANSWER §9.6 HAS NOT GIVEN YET.** Row 3 is the
-parent transcript alone. If §5.0 resolves to "ship the set", row 4 is the real unit: **2.3×
-the median and 2.5× the total**, with a largest single session of **31.00 MB** — which
-*exceeds* the 23 MB figure §5.2 uses as its worked example of a payload too big for the pod.
-33 of the 37 sessions have subagent bytes at all; the worst measured is a 3.79 MB parent with
-60 subagent files totalling 43.20 MB, where shipping one object captures **8%** of the
-session. Two further reasons both rows are floors: `SessionEnd` re-ship only grows them, and
-the sample below is partial.
+parent transcript alone. If §9.6 resolves to "ship the set" (§5.0 frames it), row 4 is the
+real unit: **2.3×
+the median and 2.5× the total**, with a largest single session of **31.00 MB**.
+⚠ **That 31.00 MB is a SESSION TOTAL, not an object size** — under "ship the set" it
+arrives as many PUTs (the 37 sessions hold 288 files, mean object ~1.3 MB), and the largest
+single *file* on the host is 23.48 MB, row 1's max. So it does not describe a bigger PUT
+than §5.2's worked example; it describes more of them. Size a per-object limit off row 1's
+max and a per-handoff cost off row 4's total, and do not cross the two.
+33 of the 37 sessions have subagent bytes at all, and the worst **within those 37** is a
+3.82 MB parent with 19 subagent files totalling 26.56 MB — a 30.39 MB session of which
+shipping one object captures **12.6%**. Two further reasons both rows are floors:
+`SessionEnd` re-ship only grows them, and the sample caveat below is real.
+
+⚠ **An earlier revision quoted a worse-looking example here — a 3.79 MB parent with 60
+subagent files, 8% captured — and that session is NOT one of the 37.** It is from the
+913-session population, and its 46.99 MB total contradicted the 31.00 MB row-4 max stated
+three lines above it. Recorded rather than quietly swapped, because the mistake is this
+section's own thesis: **a figure imported from a different population is wrong even when the
+figure itself is exact.** For scale, the largest sessions on the whole host do reach ~47 MB
+including subagents — but they are not what decision 2 selects, and they are not what row 4
+measures.
 
 **So: size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
 §9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
@@ -146,6 +178,11 @@ open. **Name the front-matter field so it does not assume jsonl.**
 On this host a session writes **several** transcripts: the parent `<session-id>.jsonl` plus
 one `agent-<hash>.jsonl` per dispatched subagent. Measured: **4,951 of 5,864** files are
 `agent-*`, holding **4.28 GB of 6.73 GB — 64% of the bytes**.
+
+⚠ **These counts are a SNAPSHOT of a live corpus and they drift within a session** — §3
+quotes 4,955 and this section 4,951, taken minutes apart on the same day, and a later
+reading gave 4,957. The durable claims are the **ratio** (~85% of files, ~64% of bytes) and
+the **exact coincidence** in §3; the absolute counts are not, and nothing pins them.
 
 Those files are not addressable the way the parent is. `build_transcript_push.py` states the
 convention the whole join rests on — *"The session id IS the filename stem … the same id the
@@ -208,8 +245,9 @@ MinIO through a public ingress satisfies it completely while putting unredacted 
 transcripts through a third party. **Name the rule when writing this down.**
 
 The capacity point is true and secondary: the pod is single-replica, `Recreate` and
-PVC-backed (all three verified) and is designed to render markdown, so a 23 MB PUT — or a
-31 MB one, per §4 row 4 — through it is a category
+PVC-backed (all three verified) and is designed to render markdown, so a 23.48 MB PUT — §4
+row 1's max, the largest single transcript FILE, which is the right population here because
+§5.1 ships one object per transcript — through it is a category
 change. But that is a reason not to use the pod — it is not the reason the route must stay on
 the mesh.
 
@@ -373,7 +411,7 @@ does nothing:
 4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
    session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
    not duplicate. **Name the host it ran on** — §5.1: the hook is wired on one host today.
-   ⚠ If §5.0 resolves to one-object-per-session, this control passes trivially for the wrong
+   ⚠ If §9.6 resolves to one-object-per-session, this control passes trivially for the wrong
    reason whenever subagent files collide on the key; it is only meaningful once the key is
    decided.
 5. **A crash path attaches the floor.** Kill a session without `SessionEnd`; the
@@ -412,10 +450,12 @@ invariant the bug never violated is an invariant guard and must be labelled as o
 3. **Which entries count as "touched"?** The handoff run knows what it wrote; whether that
    set is the right one, or too wide, has not been measured.
 4. **opencode** — schedule, or park indefinitely.
-5. **What does the new shipper do about `transcript_search`?** Not "does the extraction
-   happen" — discovery is **already** a shared module with an enforced site ledger. The
-   question is narrower and sharper: reuse it and inherit its `subagents/` exclusion, widen
-   it, or bypass it deliberately. §3. This is downstream of question 6, not independent of it.
+5. **What does the new shipper do about `transcript_search`, and does it share `project_of`?**
+   Not "does the extraction happen" — discovery is **already** a shared module with an
+   enforced site ledger, so the question is narrower: reuse it and inherit its `subagents/`
+   exclusion, widen it, or bypass it deliberately. That half is downstream of question 6.
+   `project_of` is the separate, unconditional half: it is one-site today and the second
+   shipper will want it. §3.
 6. 🔴 **Does a session ship as ONE object or a SET?** §5.0. This is the largest open
    question, it decides the object key, and the goal in §1 depends on the answer — 64% of the
    bytes are in subagent transcripts, and one-object-per-session drops them.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -105,26 +105,39 @@ population or the number means nothing.**
 Measured on the workbench, 2026-09-05. Four populations, because the answer spans ~12×
 between them — and which one applies is decided by a question §9 has not closed:
 
-| population | files | median | p90 | max | total |
-|---|---|---|---|---|---|
-| all `.jsonl` — **NOT what ships** | 5,864 | 0.74 MB | 2.53 MB | 23.48 MB | 6.73 GB |
-| real sessions (excluding `agent-*`) | 913 | **2.62 MB** | 4.97 MB | 23.48 MB | 2.45 GB |
-| **sessions that produced a handoff** — what decision 2 selects, **parent file only** | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
-| the same 37 sessions, **parent + their subagent transcripts** | 288 files / 37 sessions | **8.68 MB** *(per session)* | 20.23 MB | 31.00 MB *(per session)* | 375 MB |
+| row | population | files | median | p90 | max | total |
+|---|---|---|---|---|---|---|
+| **1** | all `.jsonl` — **NOT what ships** | 5,864 | 0.74 MB | 2.53 MB | 23.48 MB | 6.73 GB |
+| **2** | real sessions (excluding `agent-*`) | 913 | **2.62 MB** | 4.97 MB | 23.48 MB | 2.45 GB |
+| **3** | **sessions that produced a handoff** — what decision 2 selects, **parent file only** | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
+| **4** | the same 37 sessions, **parent + their subagent transcripts** | 288 files / 37 sessions | **8.68 MB** *(per session)* | 20.23 MB | 31.00 MB *(per session)* | 375 MB |
+
+🔴 **The row numbers are IN the table on purpose.** Fourteen places in this document say
+"row 1"…"row 4"; without a number column each of those is an unwritten ordinal that a
+future inserted row silently falsifies — including THE SIZING DIRECTIVE itself, which would
+then point at the wrong population. Numbering them makes each reference an identifier that
+an insertion cannot move. If you add a row, append it; do not renumber.
 
 ⚠ Every percentile in this table uses one convention — the sorted value at `int(n × 0.9)`,
 no interpolation. Stated because a different convention gives a visibly different p90 for
 row 4 (16.65 MB rather than 20.23 MB) and nothing in the table would show which was used.
 
-Rows 3 and 4 are the population decision 2 selects, counted two ways; **THE SIZING
-DIRECTIVE** below says which to use. Both were derived by this exact command, stated in
+Rows 3 and 4 are the population decision 2 selects, counted two ways.
+**THE SIZING DIRECTIVE** below says which to use. Both were derived by this exact command, stated in
 full because two independent re-derivations from a prose description of it disagreed with
 each other and with this table:
 
 ```bash
 git log origin/main --since=2026-07-01 \
-  --format='%(trailers:key=Claude-Session-Id,valueonly)' -- 'claudedocs/handoff-*.md'
+  --format='%(trailers:key=Claude-Session-Id,valueonly)' -- 'claudedocs/handoff-*.md' \
+  | grep . | sort -u | wc -l
 ```
+
+🔴 **The `grep . | sort -u` is not decoration.** Raw it prints 407 lines; `sort -u` alone
+gives **38**, because commits without the trailer emit an empty line and the blank counts
+as a value. A re-derivation that drops the blank filter disagrees with this table by one
+and re-opens a question that is closed — which is why the counting half is in the block
+rather than in the prose around it.
 
 **37** distinct ids, **all 37** resolving to a transcript on disk, none of them an
 `agent-*` file. Reproduced at four refs (`origin/main` `4d249c0c`, `c4e76a10`, this
@@ -179,8 +192,9 @@ in the sentence retracting it — as a whole-host maximum. **Retracting a number
 as not using it.**
 
 🔴 **AND THE LESSON FOR THIS DOCUMENT'S OWN RECORDS: name things, do not count or locate
-them.** An earlier revision of these records carried a paragraph COUNT and a paragraph
-DISTANCE. 🔴 **Both were wrong AT THE REVISION THAT INTRODUCED THEM** — not falsified
+them.** An earlier revision of these records counted its own REVISIONS ("three separate
+revisions … in three different places" — it was two) and located a block by DISTANCE
+("two paragraphs below" — it was five). 🔴 **Both were wrong AT THE REVISION THAT INTRODUCED THEM** — not falsified
 later by an insertion, which is what an earlier draft of this very paragraph claimed and
 is the more comfortable story, because it blames drift rather than the writing. Nobody
 counts paragraphs before writing "two paragraphs below". **A NAME can be checked at the
@@ -195,11 +209,9 @@ caveat §5.0 carries for the corpus counts — every new handoff adds a session 
 coverage caveat below was stated originally, and coverage and time are different limits.
 Re-measured 2026-09-05 after a day's work: still **37**, so no drift was observed — but the
 method is time-dependent by construction, and a later re-derivation returning a different `n`
-means the table is **stale, not wrong**. ⚠ An audit reading reported 43. That is now **explained, not merely non-reproducing**:
-43 is what the trailer yields when the **pathspec is dropped** and every commit in the window
-is counted. The method must therefore name its ref as well — these figures are from
-`origin/main`; `--all` gives a larger number that varies by clone, so it is not a
-measurement of anything shared.
+means the table is **stale, not wrong**. ⚠ Two audit readings of this population disagreed with each other and with the table. Both
+are accounted for by the command block above — that is what the block is for, and the
+figures are not restated here so there is only ever one place to correct.
 
 ⚠ **THE COVERAGE CAVEAT — scope of the 37-session sample, stated rather than buried:**
 devrc handoffs only, and
@@ -456,8 +468,12 @@ does nothing:
    count move from 0 to 1 and report the pair, never the zero alone.
 2. **Negative control.** Point it at an unreachable endpoint and watch it warn and exit
    non-zero rather than reporting a successful no-op.
-3. **Idempotency, measured.** Two handoff runs in one session → **one** object, **one**
-   pointer per entry. Assert the set does not grow.
+3. **Idempotency, measured.** Two handoff runs in one session must not GROW either set:
+   the object count stays whatever one run produces, and the pointer count per entry stays
+   one. ⚠ **Do not write this as "one object"** — that is only true under parent-only.
+   Under "ship the set" one session yields many objects (288 files across 37 sessions,
+   §4 row 4), so an assertion of `len(objects) == 1` fails a correct implementation.
+   Assert NO GROWTH between runs, which is true under both branches of §9.6.
 4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
    session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
    not duplicate. **Name the host it ran on** — §5.1: the hook is wired on one host today.
@@ -509,8 +525,16 @@ invariant the bug never violated is an invariant guard and must be labelled as o
 6. 🔴 **Does a session ship as ONE object or a SET?** §5.0. This is the largest open
    question, it decides the object key, and the goal in §1 depends on the answer — 64% of the
    bytes are in subagent transcripts, and one-object-per-session drops them.
-7. **Is there a retraction path when a secret is found in a shipped object?** §6. Deleting
+7. 🔴 **What happens when the fan-out PARTIALLY succeeds?** Decision 6 writes a pointer to
+   every touched entry, so the write is N-way and can land on 3 of 5. §5.5's fail-open
+   covers the PUSH and §6 covers deletion; nothing covers a half-written fan-out. §5.4's
+   digest ledger cannot detect it either — it validates a pointer that EXISTS, and the
+   failure here is entries that silently have none, which is indistinguishable from
+   entries the session never touched. Nothing records the expected fan-out set, so
+   nothing can compare against it. Either record that set or accept silent partial
+   attachment, but choose deliberately.
+8. **Is there a retraction path when a secret is found in a shipped object?** §6. Deleting
    the object leaves N pointers dangling and nothing sweeps them. Under decision 8 this is
    permanent, so "no path" is an answer — but it should be a chosen one.
-8. **Who wires `SessionEnd` on the second host, and what detects that it is missing?**
+9. **Who wires `SessionEnd` on the second host, and what detects that it is missing?**
    §5.1. It is unmanaged per-host state that `drift-check.sh` does not currently see.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -31,7 +31,7 @@ Settled by the operator across two rounds of questions on 2026-09-05:
 | 2 | **Cairn-owned shipper, triggered per session** at handoff time — not the 5-minute timer | the operator controls what ships; volume collapses to sessions that produced a handoff |
 | 3 | **Pointer in cairn, bytes in the homelab MinIO tenant** | entries stay small and renderable; the store's third-party rule is satisfied |
 | 4 | **Ship raw** — no redaction; the storage boundary is the control | every credential ever echoed in a captured session lands in the bucket |
-| 5 | **Handoff ships, `SessionEnd` re-ships** | the only arrangement under which "always the whole transcript" is literally true |
+| 5 | **Handoff ships, `SessionEnd` re-ships** | the whole transcript on every CLEAN exit; the handoff-time floor on a crash or kill — see §5.1, and note `SessionEnd` is a PER-HOST operator act that is not wired on both hosts today |
 | 6 | **Pointer on every cairn entry the session touched** | one session fans out across N entries and M scopes |
 | 7 | **Push failure warns; handoff still succeeds** | a handoff can exist with no session attached, and must say so |
 | 8 | **Indefinite retention** | the bucket accumulates unredacted content permanently |
@@ -56,28 +56,54 @@ It is nonetheless **the wrong instrument here, and the reasons are structural, n
   object storage and only a pointer in the API.
 
 🔴 **This is a real duplication and it should be named rather than hidden.** Two shippers
-will hold two answers to "which sessions matter, and how much of each", and those answers
-will drift — the exact shape `claude/RULES.md` calls out as regenerating the same bug at
-every site. The mitigation is not to merge them (their triggers genuinely differ) but to
-**share the parts that are one rule**: transcript discovery, `project_of`, and the
-byte-boundary logic belong in one module both call. If that extraction is not done, expect
-the two to disagree about which file belongs to which project within a few months.
+will hold two answers to "which sessions matter", and those answers will drift — the exact
+shape `claude/RULES.md` calls out as regenerating the same bug at every site. The mitigation
+is not to merge them (their triggers genuinely differ) but to **share the parts that are one
+rule**: transcript discovery and `project_of`. **Not the byte-boundary logic** — it exists to
+drop the leading partial JSON record from a *tail*, and decision 1 ships whole files, so the
+new shipper has no caller for it. Extracting it would move dead surface for one of the two
+callers.
 
 ## 4. Volume — measured, not estimated
 
-Measured on the workbench, 2026-09-05:
+🔴 **AN EARLIER REVISION OF THIS SECTION MEASURED THE WRONG POPULATION AND ITS CONCLUSION
+WAS WRONG BY ~5×.** It reported a median of 739 KB and concluded "well under a megabyte per
+handoff". That median is real but it is the median of **all** `.jsonl` files, and **84% of
+those are `agent-*.jsonl` subagent transcripts** this design does not ship. The arithmetic
+was right; the population was wrong. Kept here rather than silently corrected, because the
+error is the instructive part: **a percentile is a claim about a population, so name the
+population or the number means nothing.**
+
+Measured on the workbench, 2026-09-05. All three populations, because they differ by 5×:
+
+| population | files | median | p90 | max | total |
+|---|---|---|---|---|---|
+| all `.jsonl` — **NOT what ships** | 5,864 | 0.74 MB | 2.53 MB | 23.48 MB | 6.73 GB |
+| real sessions (excluding `agent-*`) | 913 | **2.62 MB** | 4.97 MB | 23.48 MB | 2.45 GB |
+| **sessions that produced a handoff** — what decision 2 selects | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
+
+The third row is the population decision 2 actually selects. It was derived from the
+`Claude-Session-Id` trailer on commits touching `claudedocs/handoff-*.md` since 2026-07-01:
+37 distinct ids, **all 37** resolving to a transcript on disk, none of them an `agent-*`
+file.
+
+🔴 **The selection effect runs the WRONG WAY, and that is the point of the row.** Sessions
+that produce a handoff are the long ones, so the per-handoff filter picks the **large tail**,
+not the median — 3.82 MB against 2.62 MB against 0.74 MB. `SessionEnd` re-ship makes it
+larger still, so **3.82 MB is a floor, not an estimate.** Anyone sizing a bucket, a PUT
+timeout or a per-handoff cost must use that row.
+
+⚠ **Scope of the 37-session sample, stated rather than buried:** devrc handoffs only, and
+only commits carrying the trailer. Handoffs in other repos are not counted, so the true
+population is larger and the totals are floors.
 
 | | |
 |---|---|
-| Claude Code transcripts | **6.6 GB**, **5,840** `.jsonl` files |
-| median file | **739 KB** |
-| p90 | **2.5 MB** |
-| largest single file | **23 MB** |
 | opencode session data | **2.4 GB** — a SQLite DB plus `storage/`, `snapshot/`, `tool-output/` |
 
-The per-handoff trigger is what makes decision 1 affordable: the population that ships is
-sessions-that-produced-a-handoff, not all 5,840. At the median that is well under a
-megabyte per handoff.
+⚠ The `6.73 GB` above is the `.jsonl` population summed in decimal bytes. A `du -sh` of the
+directory reads `6.6 GB` because it is GiB and includes ~7,000 non-`.jsonl` files. Two
+different measurements; do not pair them.
 
 🔴 **opencode is a separate project, not a flag on this one.** It has no `.jsonl` — "the
 whole session" there means an exporter with its own fidelity question (which tables, what
@@ -86,45 +112,135 @@ open. **Name the front-matter field so it does not assume jsonl.**
 
 ## 5. The design
 
-### 5.1 Two triggers, one object
+### 5.0 🔴 "A session's transcript" is a SET, not a file — and this is OPEN
+
+**This is the first thing an implementer needs and the proposal does not yet answer it.**
+
+On this host a session writes **several** transcripts: the parent `<session-id>.jsonl` plus
+one `agent-<hash>.jsonl` per dispatched subagent. Measured: **4,951 of 5,864** files are
+`agent-*`, holding **4.28 GB of 6.73 GB — 64% of the bytes**.
+
+Those files are not addressable the way the parent is. `build_transcript_push.py` states the
+convention the whole join rests on — *"The session id IS the filename stem … the same id the
+attention queue and session-manager's `claude_session_id` carry, which is what makes the join
+work at all."* For an `agent-*.jsonl` the stem is `agent-<hash>`, which is **not** a session
+id. Sampled 6 subagent transcripts: in every one the stem is absent from the `sessionId`
+values inside the file, and the single `sessionId` present is the **parent's**.
+
+So "keyed on session id" (§5.1) has two readings and neither is safe by default:
+
+- key on the **in-record `sessionId`** → parent and all N subagent files collide on one
+  object key, each push overwriting the last. §8 control 4 ("assert the sha256 changed")
+  would pass while the object is simply the last writer;
+- key on the **filename stem** → subagent objects are keyed `agent-<hash>`, joinable to no
+  cairn entry, no attention-queue row and no `session-manager` view.
+
+🔴 **And this is where the goal in §1 is won or lost.** `CLAUDE.md` records that the operator
+works **entirely via agents**. The receipts — the tool calls, the files read, the commands
+run — are in the subagent transcripts. The parent carries only each subagent's final report.
+Shipping "the session's transcript" as one file therefore drops most of the evidence this
+proposal exists to preserve, while looking complete.
+
+**Decide before implementing (§9.6):** does a session ship as one object or a set; and if a
+set, what is the key that keeps the subagent objects joinable to the parent.
+
+### 5.1 Two triggers, one object per transcript
 
 Handoff ships the transcript as it stands. A `SessionEnd` hook overwrites it with the final
-bytes. (`SessionEnd` is already a wired hook event on this host — verified, not assumed.)
+bytes.
 
 - The handoff-time object is the **floor**. `SessionEnd` does not fire on a crash or a
-  kill, so without it a crashed session would attach nothing at all.
+  kill, so without it a crashed session would attach nothing at all. **So decision 5 buys
+  "the whole transcript on a clean exit", not "always"** — §2 records it that way.
 - The object is therefore **at least as complete as the handoff moment**. Write that down
   where a reader will see it: a short object is not corruption.
-- **Overwrite must be idempotent**, keyed on session id. Handoff can run several times in
-  one session — the skill's own docs warn that re-running appends findings twice — and each
-  run must land on the same key.
+- **Overwrite must be idempotent**, on whatever key §5.0 resolves to. Handoff can run
+  several times in one session — the skill's own docs warn that re-running appends findings
+  twice — and each run must land on the same key.
+
+🔴 **`SessionEnd` is a PER-HOST OPERATOR ACT, and it is wired on ONE host today.** Measured
+2026-09-05: the workbench's `~/.claude/settings.json` registers `SessionEnd`; the laptop's
+does not (`PermissionRequest`, `PostToolUse`, `PreToolUse`, `SessionStart`, `Stop`,
+`SubagentStop`, `UserPromptSubmit` — no `SessionEnd`). That file is per-host and **unmanaged
+by nix** by design, and `drift-check.sh` rc 15 compares only top-level key *names*, so this
+does not surface as drift. Consequence: on a host without the hook, **every** session attaches
+only the handoff-time floor, permanently and silently. Wiring it is an operator act per host,
+not a change this proposal can ship, and §8 control 4 must name the host it ran on.
 
 ### 5.2 Transport
 
-Host → object storage **directly over the mesh**. Not through the cairn pod: it is
-single-replica, `Recreate`, PVC-backed, and designed to render markdown. A 23 MB PUT
-through it is a category change, not a feature.
+Host → object storage **directly over the mesh**.
 
-### 5.3 What cairn holds — and the one change I recommend against the letter of decision 6
+🔴 **The binding constraint is the store's third-party rule, NOT the pod's capacity.** The
+store README: content *"must never transit a third party … A git remote, a sync target or an
+API endpoint is permitted only on infrastructure Zach owns and reaches over the nebula
+mesh."* Cairn's own public API already fronts through a CDN, so "not the pod" does **not**
+imply "over the mesh" — an implementer who accepts only the capacity argument and reaches
+MinIO through a public ingress satisfies it completely while putting unredacted multi-client
+transcripts through a third party. **Name the rule when writing this down.**
+
+The capacity point is true and secondary: the pod is single-replica, `Recreate`, PVC-backed
+and designed to render markdown (all three verified), so a 23 MB PUT through it is a category
+change. But that is a reason not to use the pod — it is not the reason the route must stay on
+the mesh.
+
+### 5.3 What cairn holds — and one recommendation no recorded decision covers
 
 Front-matter on each touched entry gains a session reference carrying `id`, `sha256`,
 `bytes`, `captured_at`, `host`.
 
-🔴 **RECOMMENDATION: the pointer is an OPAQUE ID, never a resolvable URL** — no bucket, no
-path, no endpoint in the entry. Resolving it requires the transcript credential, which is
-separate from the cairn read token by construction (decision 3 already put them apart).
+🔴 **THE FIELD SHAPE IS CONSTRAINED, AND THE OBVIOUS SPELLING IS SILENTLY DESTRUCTIVE.**
+Cairn front matter is parsed by `parse_front_matter` in `lib/subsystem_resolver.py`, which is
+hand-rolled and **line-based**. It handles `key: value`, an inline flow list `key: [a, b, c]`,
+and a block list of one-line `- item`s. **There is no case for a nested mapping**, and its own
+docstring records the measured result of feeding it one: the key comes back empty and every
+child is promoted to a phantom top-level key by its own internal colon.
 
-The reason is decision 6 meeting a decision the programme already took.
-`plan-cairn-integration.md` decision 5 reads: *"Cross-tenant reads — opt-in sharing per
-scope or entry — makes tenancy a security boundary, not a cache key."* A session routinely
-touches this repo's scope and a client scope in the same run. Fanning the pointer out means
-a `sensitivity: client-confidential` entry carries a reference to an object that also holds
-that session's work on **other** clients, retained forever. The moment entry-level sharing
-exists, sharing that entry shares that reference.
+Reproduced against the live parser while writing this, with the exact five fields above under
+a `session:` key:
+
+```
+{'service': …, 'scope': …, 'session': '',
+ 'id': '…', 'sha256': '…', 'bytes': '…', 'captured_at': '…', 'host': '…'}
+```
+
+The pointer is **gone**, `cairn recall` renders the entry as clean, and §5.4's digest ledger —
+the thing meant to make a bad pointer visible — was never written to be checked. So the field
+must be a **single scalar or an inline flow list**, or the parser must be widened first.
+⚠ Widening it is a **two-repo change**: `parse_front_matter` sits in `ZacxDev/cairn` too, at
+the same line, and §7 puts that repo out of scope. ⚠ Also unmeasured: the same docstring
+records that block-list lines are currently **zero across the live store** and says to re-take
+that count before relying on the shape. This field would be its first user.
+
+🔴 **RECOMMENDATION: the pointer is an OPAQUE ID, never a resolvable URL** — no bucket, no
+path, no endpoint in the entry.
+
+⚠ **This contradicts no recorded decision.** Decision 6 is *"pointer on every cairn entry the
+session touched"* and says nothing about the pointer's form, so this is a gap being filled,
+not a dissent. An earlier revision of this section called it "against the letter of decision
+6", which sent the reader looking for a conflict that does not exist — and inviting deference
+to a decision nobody made is a good way to lose a cheap recommendation.
+
+**The hazard, stated in the direction it actually runs.** `plan-cairn-integration.md`
+decision 11 already gates sharing on `sensitivity:` — *client-confidential can never be
+shared* — so the obvious scenario (a client entry leaking a pointer) **cannot fire**, and an
+earlier revision of this section argued exactly that already-closed case. What survives
+decision 11 is the mirror image, and it is worse: a **shareable** entry — this repo's own
+scope, marked `internal` — carries a pointer into an object that contains that same session's
+**client-confidential** work, because one session routinely touches both. Sharing the
+innocuous entry hands over a reference into multi-client content.
 
 An opaque id keeps decision 6 exactly as chosen while making the shared artifact an
-**identifier, not content**. It costs nothing and it is reversible; a URL baked into N
-entries is not.
+**identifier, not content**. It costs nothing and it is reversible; a URL baked into N entries
+is not.
+
+⚠ **What "separate credential" does and does not buy.** Resolving an id requires the
+transcript credential. That is **not** separation "by construction": decision 3 separates the
+*data*, not the *credentials*, and both would live in the same user's `~/.config`
+neighbourhood on the same box, readable by any process running as that user — including a
+shipper that holds one while running inside a session that holds the other. The separation is
+real only against an adversary holding exactly one credential and no host access. Say that,
+rather than implying more.
 
 🔴 **An unauthorized resolve must render as NOT AUTHORIZED, never as missing.** Those two
 are the same observable otherwise, and an empty result cannot distinguish two mechanisms —
@@ -156,14 +272,37 @@ depth now rests on storage. Concretely, the implementation must:
 
 - use its **own bucket and its own credential** — not the archive tenant's backup
   credential, which exists for a different blast radius;
-- **never print the credential.** Write it to a `0600` file and print the *path*.
-  `ZacxDev/homelab-infra#683` fixed exactly this defect in the sibling provisioning script:
-  it printed the secret to stdout, and it is run by agents, so every run re-staged a
-  transcript-capture incident that had already forced one rotation;
-- carry **no anonymous access policy**, proven by an **unauthenticated GET as a control**
-  rather than by reading the policy JSON;
-- keep the **cairn read token unable to reach the bucket**, and vice versa. Decision 3 puts
-  them apart; a test should pin it rather than a comment asserting it.
+- 🔴 **write the credential to a `0600` file BEFORE anything can create the user** — not
+  after, and never to stdout. Both halves are load-bearing and an earlier revision of this
+  bullet kept only the second. `ZacxDev/homelab-infra#683`'s own heading is *"the reordering
+  is not the fix"*: what closes the class is the secret existing on disk **before** the
+  provisioning step, because the fallible steps after user-creation are host-side and no
+  ordering inside the pod can reach them. Write-after-create leaves an orphaned live
+  write-capable key whose secret exists nowhere — the exact window #683 closed. The
+  stdout half matters too (these scripts are run by agents, so a printed secret lands in a
+  transcript), and with decision 8 it would land there **permanently**;
+- carry **no anonymous access policy** — see §8 control 6 for how to prove that, which is
+  harder than it looks;
+- keep the **cairn read token unable to reach the bucket**, and vice versa — pinned by a
+  test, not asserted by a comment. ⚠ Note the limit stated in §5.3: this separates
+  credentials, not the host they both sit on.
+- 🔴 **register the credential in `SECRETS.md` with a rotation coupling, in the same change
+  that mints it.** That file exists to make a new-host bootstrap deterministic instead of
+  manual archaeology, and every comparable entry carries one. A credential minted outside it
+  is invisible at bootstrap and at rotation.
+
+🔴 **The bucket has NO tenancy boundary, and the store it attaches to does.** Under
+`plan-cairn-integration.md` the store's future is multi-tenant with sharing gated on
+`sensitivity:`. This bucket is single-tenant by credential and multi-client by content, held
+forever — so the transcript credential is an **all-clients-at-once** credential. Nothing in
+this design changes that, and it should be understood before the credential is minted rather
+than discovered when the store gains a second tenant.
+
+⚠ **There is no retraction story, and decision 8 makes that permanent.** If a secret is found
+in a shipped object, deleting the object leaves the N fanned-out pointers dangling. §5.4 makes
+a dangling pointer *detectable*; nothing here makes it *retractable*, and nothing sweeps the
+entries that reference it. That is a real gap, not an oversight being papered over — it is
+listed in §9.
 
 🔴 **You currently have NO detector for a credential landing in a transcript.** Redaction
 was declined and that is settled — but a **report-only** scan over the bytes being shipped
@@ -176,7 +315,7 @@ v1; recommended as the first follow-on.**
 - **opencode capture** — §4. Different extraction, different fidelity question.
 - **Redaction of any kind** — decision 4.
 - **Anything in `ZacxDev/cairn`.** The OSS extraction deliberately removed `cairn who`
-  because session forensics on named hosts *"is not an operation on a store"*. Whole-session
+  because session forensics on named hosts is *"not an operation on a store"*. Whole-session
   capture sits further across that same line. This is devrc-side, private, and stays there.
 - **Retiring the clawgate feeder.** It serves a different consumer and keeps running.
 
@@ -193,26 +332,54 @@ does nothing:
    pointer per entry. Assert the set does not grow.
 4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
    session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
-   not duplicate.
+   not duplicate. **Name the host it ran on** — §5.1: the hook is wired on one host today.
+   ⚠ If §5.0 resolves to one-object-per-session, this control passes trivially for the wrong
+   reason whenever subagent files collide on the key; it is only meaningful once the key is
+   decided.
 5. **A crash path attaches the floor.** Kill a session without `SessionEnd`; the
    handoff-time object must still be there and its digest must match what was shipped.
-6. **Anonymous GET against the bucket → denied.** The control for §6, run against the real
-   bucket, not a fixture.
-7. **The cross-credential separation**, both directions.
+6. **Anonymous access denied — and the control must distinguish DENIED from ABSENT.**
+   🔴 The obvious version passes on a publicly-readable bucket: GET a key that was never
+   uploaded and an anonymous-download bucket answers `404 NoSuchKey` while a locked one
+   answers `403 AccessDenied`. Both are "not 200". So: **GET a key that EXISTS, and assert
+   `403` specifically** — not "denied", not "not 200". This is §5.3's own rule turned back on
+   §8: an empty result cannot distinguish two mechanisms. Cover anonymous **LIST** and **PUT**
+   as well; a public-read policy grants list alongside read, and a denied GET says nothing
+   about either. Run against the real bucket, not a fixture.
+7. **Cross-credential separation, both directions, each with a named observable:** the cairn
+   read token against a bucket key → `403`; the transcript credential against a cairn read
+   route → `401`. An earlier revision named neither operation nor expected result, which any
+   test satisfies — including one that type-checks past a wrong argument.
+8. **Decision 7's actual behaviour, which no earlier control covered.** Make the push fail
+   (unreachable endpoint) and assert **handoff exits 0** *and* the doc carries the
+   no-session-attached line. Control 2 asserts the *shipper* exits non-zero, which is the
+   opposite-signed observable and is equally satisfied by a handoff that fails hard — the
+   precise failure decision 7 exists to forbid.
 
 🔴 Every one of these must be watched to FAIL before it is trusted. A guard pinning an
 invariant the bug never violated is an invariant guard and must be labelled as one.
 
 ## 9. Open — decide before building
 
-1. **Does the pointer-shape recommendation in §5.3 stand?** It is the one place this
-   proposal argues against the letter of a settled decision, and it is cheap to accept and
-   expensive to retrofit.
-2. **What is the front-matter field called**, and does the subsystem-index skill or the
-   handoff tool own writing it? The handoff doc already carries `clawgate-task:` as
-   precedent for a linkage field.
+1. **Does the pointer-shape recommendation in §5.3 stand?** No recorded decision covers the
+   pointer's form, so this fills a gap rather than dissenting. Cheap to accept, expensive to
+   retrofit.
+2. **What is the front-matter field called and SHAPED?** Constrained by §5.3: a scalar or an
+   inline flow list, or `parse_front_matter` gets widened first in **two** repos. Also: does
+   the subsystem-index skill or the handoff tool own writing it? (`clawgate-task:` is
+   precedent for the *idea* of a linkage field, though it is a handoff-doc field rather than
+   a cairn-entry one.)
 3. **Which entries count as "touched"?** The handoff run knows what it wrote; whether that
    set is the right one, or too wide, has not been measured.
 4. **opencode** — schedule, or park indefinitely.
 5. **Does the shared-module extraction in §3 happen now or later?** Later is defensible;
-   never is how the two shippers drift.
+   never is how the two shippers drift. Scope it to discovery and `project_of` — not the
+   byte-boundary logic.
+6. 🔴 **Does a session ship as ONE object or a SET?** §5.0. This is the largest open
+   question, it decides the object key, and the goal in §1 depends on the answer — 64% of the
+   bytes are in subagent transcripts, and one-object-per-session drops them.
+7. **Is there a retraction path when a secret is found in a shipped object?** §6. Deleting
+   the object leaves N pointers dangling and nothing sweeps them. Under decision 8 this is
+   permanent, so "no path" is an answer — but it should be a chosen one.
+8. **Who wires `SessionEnd` on the second host, and what detects that it is missing?**
+   §5.1. It is unmanaged per-host state that `drift-check.sh` does not currently see.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -116,11 +116,21 @@ between them — and which one applies is decided by a question §9 has not clos
 no interpolation. Stated because a different convention gives a visibly different p90 for
 row 4 (16.65 MB rather than 20.23 MB) and nothing in the table would show which was used.
 
-Rows 3 and 4 are the population decision 2 selects, counted two ways — see the next
-paragraph but one for which of them to size off. Both were derived from the
-`Claude-Session-Id` trailer on commits touching `claudedocs/handoff-*.md` since 2026-07-01:
-37 distinct ids, **all 37** resolving to a transcript on disk, none of them an `agent-*`
-file.
+Rows 3 and 4 are the population decision 2 selects, counted two ways; **THE SIZING
+DIRECTIVE** below says which to use. Both were derived by this exact command, stated in
+full because two independent re-derivations from a prose description of it disagreed with
+each other and with this table:
+
+```bash
+git log origin/main --since=2026-07-01 \
+  --format='%(trailers:key=Claude-Session-Id,valueonly)' -- 'claudedocs/handoff-*.md'
+```
+
+**37** distinct ids, **all 37** resolving to a transcript on disk, none of them an
+`agent-*` file. Reproduced at four refs (`origin/main` `4d249c0c`, `c4e76a10`, this
+branch's head, and the base clone's HEAD) and with the pathspec both quoted and
+shell-expanded — the same 37 every time. Dropping the pathspec gives 42-43; `--all` gives
+a clone-dependent number that measures nothing shared.
 
 🔴 **The selection effect runs the WRONG WAY, and that is the point of the row.** Sessions
 that produce a handoff are the long ones, so the per-handoff filter picks the **large tail**,
@@ -147,8 +157,7 @@ and do not cross the two — but do not claim 23.48 MB is what ships today, beca
 33 of the 37 sessions have subagent bytes at all, and the worst **within those 37** is a
 3.82 MB parent with 19 subagent files totalling 26.56 MB — a 30.39 MB session of which
 shipping one object captures **12.6%**. Two further reasons both rows are floors:
-`SessionEnd` re-ship only grows them, and the **COVERAGE CAVEAT** below (the ⚠ block headed
-*Scope of the 37-session sample*) is real.
+`SessionEnd` re-ship only grows them, and **THE COVERAGE CAVEAT** below is real.
 
 ⚠ **An earlier revision quoted a worse-looking example here — a 3.79 MB parent with 60
 subagent files, 8% captured — and that session is NOT one of the 37.** It is from the
@@ -170,12 +179,14 @@ in the sentence retracting it — as a whole-host maximum. **Retracting a number
 as not using it.**
 
 🔴 **AND THE LESSON FOR THIS DOCUMENT'S OWN RECORDS: name things, do not count or locate
-them.** Two earlier revisions of these retraction records carried a paragraph COUNT and a
-paragraph DISTANCE; both were falsified by the next edit that inserted a block, and a wrong
-pointer sends a reader to the wrong population — the exact hazard §4 exists to prevent. A
-NAME survives insertion; an ordinal does not.
+them.** An earlier revision of these records carried a paragraph COUNT and a paragraph
+DISTANCE. 🔴 **Both were wrong AT THE REVISION THAT INTRODUCED THEM** — not falsified
+later by an insertion, which is what an earlier draft of this very paragraph claimed and
+is the more comfortable story, because it blames drift rather than the writing. Nobody
+counts paragraphs before writing "two paragraphs below". **A NAME can be checked at the
+moment it is written; an ordinal is a measurement nobody takes.**
 
-**So: size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
+**THE SIZING DIRECTIVE — size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
 §9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
 more than 2×.
 

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -1,0 +1,218 @@
+# Proposal: session capture attached to cairn entries — 2026-09-05
+
+**Status: PROPOSED, NOTHING BUILT.** No code, no bucket, no credential, no front-matter
+field. This is the argument and the shape; the decisions in §2 are settled and are not to
+be re-litigated, and everything in §9 is still open.
+
+🔴 **This repo is PUBLIC and the store is client-confidential.** No scope name, entry name,
+bucket name, endpoint or credential appears below. Scopes are referred to by role. The
+implementation prints real names at run time on the operator's terminal — deliberately the
+only place they appear. This follows `plan-cairn-phase1-cutover.md`, which set the
+precedent.
+
+---
+
+## 1. What this is
+
+When a session produces a handoff, ship that session's transcript to object storage and
+attach it to the cairn entries the session touched, so a future reader of an entry can
+reach the receipts behind a bullet rather than re-deriving them.
+
+The job cairn does is **per-person agent re-entry**. Today an entry carries the conclusion;
+the evidence that produced it dies with the session. This closes that.
+
+## 2. Decisions already taken — do not re-litigate
+
+Settled by the operator across two rounds of questions on 2026-09-05:
+
+| # | decision | consequence accepted |
+|---|---|---|
+| 1 | **Full forensic record** — the whole transcript, not a tail | real object storage, not an inline JSON field |
+| 2 | **Cairn-owned shipper, triggered per session** at handoff time — not the 5-minute timer | the operator controls what ships; volume collapses to sessions that produced a handoff |
+| 3 | **Pointer in cairn, bytes in the homelab MinIO tenant** | entries stay small and renderable; the store's third-party rule is satisfied |
+| 4 | **Ship raw** — no redaction; the storage boundary is the control | every credential ever echoed in a captured session lands in the bucket |
+| 5 | **Handoff ships, `SessionEnd` re-ships** | the only arrangement under which "always the whole transcript" is literally true |
+| 6 | **Pointer on every cairn entry the session touched** | one session fans out across N entries and M scopes |
+| 7 | **Push failure warns; handoff still succeeds** | a handoff can exist with no session attached, and must say so |
+| 8 | **Indefinite retention** | the bucket accumulates unredacted content permanently |
+
+Decisions 4 and 8 compound: the bucket is a permanent, unredacted secrets-grade asset.
+That is the operator's call, made explicitly. What follows from it is §6 — the boundary
+has to be built like it is the only control, because it is.
+
+## 3. Why not the shipper that already exists
+
+`scripts/transcript-push.sh` + `scripts/lib/build_transcript_push.py` (#1310, rank 25) push
+Claude Code transcripts to clawgate on a 5-minute timer. It is good code and it solved the
+hard parts — a byte-boundary-safe tail with the leading partial JSON line dropped,
+`truncated` as a first-class field, a sha256 digest so unchanged sessions are not re-sent,
+and a distinct exit code per failure condition.
+
+It is nonetheless **the wrong instrument here, and the reasons are structural, not stylistic**:
+
+- it ships a **192 KiB tail**; decision 1 wants whole files up to 23 MB;
+- it is **ambient and periodic**; decision 2 wants an explicit per-session act;
+- it posts the payload **inline in JSON** to an HTTP endpoint; decision 3 wants bytes in
+  object storage and only a pointer in the API.
+
+🔴 **This is a real duplication and it should be named rather than hidden.** Two shippers
+will hold two answers to "which sessions matter, and how much of each", and those answers
+will drift — the exact shape `claude/RULES.md` calls out as regenerating the same bug at
+every site. The mitigation is not to merge them (their triggers genuinely differ) but to
+**share the parts that are one rule**: transcript discovery, `project_of`, and the
+byte-boundary logic belong in one module both call. If that extraction is not done, expect
+the two to disagree about which file belongs to which project within a few months.
+
+## 4. Volume — measured, not estimated
+
+Measured on the workbench, 2026-09-05:
+
+| | |
+|---|---|
+| Claude Code transcripts | **6.6 GB**, **5,840** `.jsonl` files |
+| median file | **739 KB** |
+| p90 | **2.5 MB** |
+| largest single file | **23 MB** |
+| opencode session data | **2.4 GB** — a SQLite DB plus `storage/`, `snapshot/`, `tool-output/` |
+
+The per-handoff trigger is what makes decision 1 affordable: the population that ships is
+sessions-that-produced-a-handoff, not all 5,840. At the median that is well under a
+megabyte per handoff.
+
+🔴 **opencode is a separate project, not a flag on this one.** It has no `.jsonl` — "the
+whole session" there means an exporter with its own fidelity question (which tables, what
+about `tool-output/`, is a DB snapshot a session). Ship Claude first; §9 keeps opencode
+open. **Name the front-matter field so it does not assume jsonl.**
+
+## 5. The design
+
+### 5.1 Two triggers, one object
+
+Handoff ships the transcript as it stands. A `SessionEnd` hook overwrites it with the final
+bytes. (`SessionEnd` is already a wired hook event on this host — verified, not assumed.)
+
+- The handoff-time object is the **floor**. `SessionEnd` does not fire on a crash or a
+  kill, so without it a crashed session would attach nothing at all.
+- The object is therefore **at least as complete as the handoff moment**. Write that down
+  where a reader will see it: a short object is not corruption.
+- **Overwrite must be idempotent**, keyed on session id. Handoff can run several times in
+  one session — the skill's own docs warn that re-running appends findings twice — and each
+  run must land on the same key.
+
+### 5.2 Transport
+
+Host → object storage **directly over the mesh**. Not through the cairn pod: it is
+single-replica, `Recreate`, PVC-backed, and designed to render markdown. A 23 MB PUT
+through it is a category change, not a feature.
+
+### 5.3 What cairn holds — and the one change I recommend against the letter of decision 6
+
+Front-matter on each touched entry gains a session reference carrying `id`, `sha256`,
+`bytes`, `captured_at`, `host`.
+
+🔴 **RECOMMENDATION: the pointer is an OPAQUE ID, never a resolvable URL** — no bucket, no
+path, no endpoint in the entry. Resolving it requires the transcript credential, which is
+separate from the cairn read token by construction (decision 3 already put them apart).
+
+The reason is decision 6 meeting a decision the programme already took.
+`plan-cairn-integration.md` decision 5 reads: *"Cross-tenant reads — opt-in sharing per
+scope or entry — makes tenancy a security boundary, not a cache key."* A session routinely
+touches this repo's scope and a client scope in the same run. Fanning the pointer out means
+a `sensitivity: client-confidential` entry carries a reference to an object that also holds
+that session's work on **other** clients, retained forever. The moment entry-level sharing
+exists, sharing that entry shares that reference.
+
+An opaque id keeps decision 6 exactly as chosen while making the shared artifact an
+**identifier, not content**. It costs nothing and it is reversible; a URL baked into N
+entries is not.
+
+🔴 **An unauthorized resolve must render as NOT AUTHORIZED, never as missing.** Those two
+are the same observable otherwise, and an empty result cannot distinguish two mechanisms —
+a reader would read "this session was never captured" off a permission error.
+
+### 5.4 The digest ledger is not optional
+
+`bytes` + `sha256` + `captured_at` + `host` alongside the id. Without them a pointer to a
+missing, truncated or superseded object reads **identically** to a healthy one. It is also
+the shipper's own positive control: a run that shipped and a run that shipped nothing must
+be distinguishable in its output, and a reassuring zero is otherwise indistinguishable from
+a shipper wired to nothing.
+
+### 5.5 Failure semantics
+
+Fail **open**. A failed push prints the reason and the exact re-push command; the handoff
+still succeeds and the doc records that no session was attached. Handoff's job is the doc
+and the entries — the transcript is an attachment, and a heavily-used skill must not become
+dependent on the mesh being up.
+
+🔴 **"Warns" is a claim about the WRITE, and the write is not where this fails.** The
+failure to design for is the silent one: a push that reports success while writing nothing,
+or writing to the wrong key. That is what §8 exists for.
+
+## 6. The boundary is the only control, so build it like one
+
+Decision 4 removed redaction from the design. Everything that would have been defence in
+depth now rests on storage. Concretely, the implementation must:
+
+- use its **own bucket and its own credential** — not the archive tenant's backup
+  credential, which exists for a different blast radius;
+- **never print the credential.** Write it to a `0600` file and print the *path*.
+  `ZacxDev/homelab-infra#683` fixed exactly this defect in the sibling provisioning script:
+  it printed the secret to stdout, and it is run by agents, so every run re-staged a
+  transcript-capture incident that had already forced one rotation;
+- carry **no anonymous access policy**, proven by an **unauthenticated GET as a control**
+  rather than by reading the policy JSON;
+- keep the **cairn read token unable to reach the bucket**, and vice versa. Decision 3 puts
+  them apart; a test should pin it rather than a comment asserting it.
+
+🔴 **You currently have NO detector for a credential landing in a transcript.** Redaction
+was declined and that is settled — but a **report-only** scan over the bytes being shipped
+blocks nothing, costs one pass over data already being read, and turns an invisible event
+into a number. With indefinite retention, a secret that lands there is there forever. **Not
+v1; recommended as the first follow-on.**
+
+## 7. Explicitly out of scope
+
+- **opencode capture** — §4. Different extraction, different fidelity question.
+- **Redaction of any kind** — decision 4.
+- **Anything in `ZacxDev/cairn`.** The OSS extraction deliberately removed `cairn who`
+  because session forensics on named hosts *"is not an operation on a store"*. Whole-session
+  capture sits further across that same line. This is devrc-side, private, and stays there.
+- **Retiring the clawgate feeder.** It serves a different consumer and keeps running.
+
+## 8. How the implementation must prove itself
+
+Not "the tests pass" — these specific controls, because each names a way this silently
+does nothing:
+
+1. **Positive control on the shipper.** A session that MUST produce an object: watch the
+   count move from 0 to 1 and report the pair, never the zero alone.
+2. **Negative control.** Point it at an unreachable endpoint and watch it warn and exit
+   non-zero rather than reporting a successful no-op.
+3. **Idempotency, measured.** Two handoff runs in one session → **one** object, **one**
+   pointer per entry. Assert the set does not grow.
+4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
+   session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
+   not duplicate.
+5. **A crash path attaches the floor.** Kill a session without `SessionEnd`; the
+   handoff-time object must still be there and its digest must match what was shipped.
+6. **Anonymous GET against the bucket → denied.** The control for §6, run against the real
+   bucket, not a fixture.
+7. **The cross-credential separation**, both directions.
+
+🔴 Every one of these must be watched to FAIL before it is trusted. A guard pinning an
+invariant the bug never violated is an invariant guard and must be labelled as one.
+
+## 9. Open — decide before building
+
+1. **Does the pointer-shape recommendation in §5.3 stand?** It is the one place this
+   proposal argues against the letter of a settled decision, and it is cheap to accept and
+   expensive to retrofit.
+2. **What is the front-matter field called**, and does the subsystem-index skill or the
+   handoff tool own writing it? The handoff doc already carries `clawgate-task:` as
+   precedent for a linkage field.
+3. **Which entries count as "touched"?** The handoff run knows what it wrote; whether that
+   set is the right one, or too wide, has not been measured.
+4. **opencode** — schedule, or park indefinitely.
+5. **Does the shared-module extraction in §3 happen now or later?** Later is defensible;
+   never is how the two shippers drift.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -2,7 +2,8 @@
 
 **Status: PROPOSED, NOTHING BUILT.** No code, no bucket, no credential, no front-matter
 field. This is the argument and the shape; the decisions in §2 are settled and are not to
-be re-litigated, and everything in §9 is still open.
+be re-litigated. **Eight of §9's nine questions were answered on 2026-09-05 and are now
+in §2 as decisions 9-16;** only opencode remains open.
 
 🔴 **This repo is PUBLIC and the store is client-confidential.** No scope name, entry name,
 bucket name, endpoint or credential appears below. Scopes are referred to by role. The
@@ -35,6 +36,26 @@ Settled by the operator across two rounds of questions on 2026-09-05:
 | 6 | **Pointer on every cairn entry the session touched** | one session fans out across N entries and M scopes |
 | 7 | **Push failure warns; handoff still succeeds** | a handoff can exist with no session attached, and must say so |
 | 8 | **Indefinite retention** | the bucket accumulates unredacted content permanently |
+
+### Round 2 — answered 2026-09-05, after the audit ladder measured the consequences
+
+| # | decision | consequence accepted |
+|---|---|---|
+| 9 | **A session ships as a SET** — one object per transcript file, parent + subagents | ~7.8 objects per session and 2.3x the bytes (row 4, not row 3); forces decision 13 |
+| 10 | **The pointer is an OPAQUE ID**, never a resolvable URL | a reader needs the transcript credential to resolve anything; a shared entry leaks an identifier, not content |
+| 11 | **The expected fan-out set is RECORDED** | a partial N-way pointer write becomes detectable instead of indistinguishable from "not touched" |
+| 12 | **Front matter is a BLOCK LIST of ids**; digest/size/host live as object metadata | ships against today's parser with no change to either repo; checking a pointer costs a HEAD request |
+| 13 | **`transcript_search` is widened with an OPT-IN flag** | the existing feeder keeps its behaviour by default, and must be pinned by a test before the module is touched |
+| 14 | 🔴 **NO retraction path — rotate the leaked credential instead** | the bucket is append-only **by policy**; a secret's bytes persist deliberately and forever |
+| 15 | **`SessionEnd` wired per host, and `drift-check` extended to detect its absence** | the wiring stays an operator act; the gap stops being invisible |
+| 16 | **"Touched" = entries the handoff run WROTE or UPDATED** | mechanical, no inference; an entry only read deeply attaches no receipts |
+
+🔴 **Decision 14 is the one that diverged from the recommendation, and it changes what the
+other machinery is for.** With no deletion, a dangling pointer cannot arise from retraction —
+so §5.4's digest ledger is no longer a retraction-detector, it is purely an integrity check.
+And the report-only scan §6 suggests becomes *the* control rather than a nice-to-have: if the
+only response to a leaked credential is rotation, then **knowing** is the whole of the
+response, and nothing else in this design will tell you.
 
 Decisions 4 and 8 compound: the bucket is a permanent, unredacted secrets-grade asset.
 That is the operator's call, made explicitly. What follows from it is §6 — the boundary
@@ -76,7 +97,7 @@ was found.
 *tail*, and decision 1 ships whole files, so the new shipper has no caller for it.
 
 🔴 **AND TRANSCRIPT DISCOVERY IS ALREADY SHARED — REUSING IT IS A DECISION, NOT A FREEBIE,
-AND IT ANSWERS §9.6 IN THE OPPOSITE DIRECTION.** `scripts/lib/transcript_search.py` already
+AND IT ANSWERED WHAT IS NOW DECISION 9 IN THE OPPOSITE DIRECTION.** `scripts/lib/transcript_search.py` already
 exposes `iter_transcripts` / `is_corpus_member`; the existing feeder imports it, and
 `test_transcript_search.py`'s two-way site ledger scans the tree so a fourth hand-rolled walk
 cannot pass unseen — i.e. the repo actively rewards reuse. But that module carries
@@ -88,9 +109,14 @@ So an implementer who takes "share discovery" at face value, reuses `iter_transc
 correct-looking move, and the one the ledger test pushes toward — **silently ships parent
 transcripts only**, which is precisely the "drops most of the evidence this proposal exists to
 preserve, while looking complete" outcome §5.0 names. The ledger test stays green throughout,
-because reusing the shared walk is what it exists to reward. **If §9.6 resolves to "ship the
-set", the shared walk must be widened or deliberately bypassed, and that is a change to a
-module with an enforced site ledger — not a free adoption.**
+because reusing the shared walk is what it exists to reward.
+
+✅ **DECIDED (decisions 9 and 13): the set ships, so the walk is WIDENED with an opt-in
+flag** — not bypassed, which would add the fourth hand-rolled walk the site ledger exists to
+prevent, and not widened unconditionally, which would silently change what the live 5-minute
+feeder ships. 🔴 **Pin the existing feeder's behaviour with a test BEFORE touching the
+module**: it is a working pipeline with its own consumer, and the default path must be shown
+unchanged rather than assumed unchanged.
 
 ## 4. Volume — measured, not estimated
 
@@ -103,7 +129,8 @@ error is the instructive part: **a percentile is a claim about a population, so 
 population or the number means nothing.**
 
 Measured on the workbench, 2026-09-05. Four populations, because the answer spans ~12×
-between them — and which one applies is decided by a question §9 has not closed:
+between them. **Decision 9 selects row 4**; the others are kept because the retraction
+records below only mean something against the population they were wrong about:
 
 | row | population | files | median | p90 | max | total |
 |---|---|---|---|---|---|---|
@@ -149,10 +176,9 @@ a clone-dependent number that measures nothing shared.
 that produce a handoff are the long ones, so the per-handoff filter picks the **large tail**,
 not the median — 3.82 MB (row 3) against 2.62 MB (row 2) against 0.74 MB (row 1).
 
-🔴 **AND THE ROW YOU SIZE OFF DEPENDS ON AN ANSWER §9.6 HAS NOT GIVEN YET.** Row 3 is the
-parent transcript alone. If §9.6 resolves to "ship the set" (§5.0 frames it), row 4 is the
-real unit — **2.3× the median and 2.5× the total**, with a largest single session of
-**31.00 MB**.
+🔴 **DECISION 9 MAKES ROW 4 THE UNIT.** Row 3 is the parent transcript alone and is no
+longer what ships. Row 4 is **2.3× the median and 2.5× the total**, with a largest single
+session of **31.00 MB**.
 
 ⚠ **That 31.00 MB is a SESSION TOTAL, not an object size** — under "ship the set" it
 arrives as many PUTs (the 37 sessions hold 288 files, mean object ~1.3 MB), and the largest
@@ -200,9 +226,8 @@ is the more comfortable story, because it blames drift rather than the writing. 
 counts paragraphs before writing "two paragraphs below". **A NAME can be checked at the
 moment it is written; an ordinal is a measurement nobody takes.**
 
-**THE SIZING DIRECTIVE — size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
-§9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
-more than 2×.
+**THE SIZING DIRECTIVE — size off row 4.** Decision 9 settled this; sizing off row 3 is how a
+bucket, a PUT timeout or a per-handoff cost estimate comes out low by more than 2×.
 
 ⚠ **This table is a SNAPSHOT of a population that GROWS AS THE SYSTEM IS USED**, the same
 caveat §5.0 carries for the corpus counts — every new handoff adds a session to it. Only the
@@ -269,8 +294,13 @@ run — are in the subagent transcripts. The parent carries only each subagent's
 Shipping "the session's transcript" as one file therefore drops most of the evidence this
 proposal exists to preserve, while looking complete.
 
-**Decide before implementing (§9.6):** does a session ship as one object or a set; and if a
-set, what is the key that keeps the subagent objects joinable to the parent.
+✅ **DECIDED — decision 9: a session ships as a SET, one object per transcript file.**
+So the key cannot be the session id alone. 🔴 **The remaining implementation constraint,
+which decision 9 does not settle:** the subagent objects must stay joinable to the parent, and
+an `agent-<hash>` stem joins to nothing. The parent id is available — it is the `sessionId`
+INSIDE each subagent file, verified present and singular on every file sampled — so key each
+object by **(parent session id, transcript filename)** and neither collision nor an
+unjoinable object can arise.
 
 ### 5.1 Two triggers, one object per transcript
 
@@ -292,8 +322,12 @@ does not (`PermissionRequest`, `PostToolUse`, `PreToolUse`, `SessionStart`, `Sto
 `SubagentStop`, `UserPromptSubmit` — no `SessionEnd`). That file is per-host and **unmanaged
 by nix** by design, and `drift-check.sh` rc 15 compares only top-level key *names*, so this
 does not surface as drift. Consequence: on a host without the hook, **every** session attaches
-only the handoff-time floor, permanently and silently. Wiring it is an operator act per host,
-not a change this proposal can ship, and §8 control 4 must name the host it ran on.
+only the handoff-time floor, permanently and silently. ✅ **DECIDED — decision 15: wire it per host, and extend `drift-check.sh` to detect its
+absence.** The wiring stays an operator act because that file is per-host by design; what
+changes is that the gap stops being invisible. The detector compares the **hook-event set**
+across hosts — the same shape as the `skillOverrides` arm rc 22 already implements, and it
+closes exactly the class that let this hide: rc 15 compares top-level key NAMES, so a missing
+nested event is structurally unseeable. §8 control 4 must still name the host it ran on.
 
 ### 5.2 Transport
 
@@ -315,8 +349,14 @@ the mesh.
 
 ### 5.3 What cairn holds — and one recommendation no recorded decision covers
 
-Front-matter on each touched entry gains a session reference carrying `id`, `sha256`,
-`bytes`, `captured_at`, `host`.
+Front-matter on each touched entry gains a session reference.
+
+✅ **"Touched" is DEFINED — decision 16: the entries the handoff run WROTE or UPDATED.**
+Mechanical, because the run already knows; no inference, and no rule to get wrong. The
+accepted narrowness: an entry a session read deeply but did not change attaches no receipts.
+🔴 **This definition is also what makes decision 11 meaningful** — a recorded fan-out set is
+only as good as the rule that produced it, and "what the run wrote" is the one rule that can
+be compared against afterwards without re-deriving a judgement.
 
 🔴 **THE FIELD SHAPE IS CONSTRAINED, AND THE OBVIOUS SPELLING IS SILENTLY DESTRUCTIVE.**
 Cairn front matter is parsed by `parse_front_matter` in `lib/subsystem_resolver.py`, which is
@@ -342,14 +382,18 @@ a `session:` key:
 
 The pointer is **gone**, `cairn recall` renders the entry as clean, and §5.4's digest ledger —
 the thing meant to make a bad pointer visible — was never written to be checked. So the field
-must be a **single scalar or an inline flow list**, or the parser must be widened first.
+must be a shape the parser already handles. ✅ **DECIDED — decision 12: a BLOCK LIST of ids**
+(`sessions:` then one `- <id>` per line), which the parser handles today and which uuids
+cannot trip, since promotion needs a colon inside the item. **The digest, size and host move
+to the object's own metadata** — so no parser change lands in either repo, and checking a
+pointer costs a HEAD request rather than an entry read.
 ⚠ Widening it is a **two-repo change**: `parse_front_matter` sits in `ZacxDev/cairn` too, at
 the same line, and §7 puts that repo out of scope. ⚠ Also unmeasured: the same docstring
 records that block-list lines are currently **zero across the live store** and says to re-take
 that count before relying on the shape. This field would be its first user.
 
-🔴 **RECOMMENDATION: the pointer is an OPAQUE ID, never a resolvable URL** — no bucket, no
-path, no endpoint in the entry.
+✅ **DECIDED — decision 10: the pointer is an OPAQUE ID, never a resolvable URL** — no bucket,
+no path, no endpoint in the entry.
 
 ⚠ **This contradicts no recorded decision.** Decision 6 is *"pointer on every cairn entry the
 session touched"* and says nothing about the pointer's form, so this is a gap being filled,
@@ -384,7 +428,11 @@ a reader would read "this session was never captured" off a permission error.
 
 ### 5.4 The digest ledger is not optional
 
-`bytes` + `sha256` + `captured_at` + `host` alongside the id. Without them a pointer to a
+`bytes` + `sha256` + `captured_at` + `host` — **on the OBJECT, not in the entry** (decision
+12), so the entry stays a list of ids and the ledger is one HEAD request away.
+⚠ **And under decision 14 its job narrowed:** with no deletion there is no retraction, so a
+dangling pointer can only mean corruption or a failed write. It is an integrity check now,
+not a retraction-detector. Without them a pointer to a
 missing, truncated or superseded object reads **identically** to a healthy one. It is also
 the shipper's own positive control: a run that shipped and a run that shipped nothing must
 be distinguishable in its output, and a reassuring zero is otherwise indistinguishable from
@@ -438,17 +486,26 @@ forever — so the transcript credential is an **all-clients-at-once** credentia
 this design changes that, and it should be understood before the credential is minted rather
 than discovered when the store gains a second tenant.
 
-⚠ **There is no retraction story, and decision 8 makes that permanent.** If a secret is found
-in a shipped object, deleting the object leaves the N fanned-out pointers dangling. §5.4 makes
-a dangling pointer *detectable*; nothing here makes it *retractable*, and nothing sweeps the
-entries that reference it. That is a real gap, not an oversight being papered over — it is
-listed in §9.
+🔴 **DECIDED — decision 14: THERE IS NO RETRACTION PATH, BY POLICY. The bucket is
+append-only and a leaked credential is answered by ROTATION, not by deletion.**
+This is deliberate and it is the one decision that diverged from the recommendation, so its
+consequences are stated rather than left to be discovered:
 
-🔴 **You currently have NO detector for a credential landing in a transcript.** Redaction
-was declined and that is settled — but a **report-only** scan over the bytes being shipped
-blocks nothing, costs one pass over data already being read, and turns an invisible event
-into a number. With indefinite retention, a secret that lands there is there forever. **Not
-v1; recommended as the first follow-on.**
+- a secret that reaches the bucket **stays there permanently**, and rotation makes it dead
+  rather than absent;
+- rotation only works on credentials that CAN be rotated — a client's secret, a token you do
+  not own, or personal data in a transcript has no rotation, and for those this policy is the
+  whole of the response;
+- 🔴 **the report-only scan below is therefore promoted from a nice-to-have to THE control.**
+  If the only answer to a leak is to rotate, then *knowing a leak happened* is the entire
+  response, and nothing else in this design will tell you. Without it the policy reads as
+  "accept leaks" rather than "detect and rotate".
+
+🔴 **THE REPORT-ONLY SCAN IS NOW LOAD-BEARING, NOT A FOLLOW-ON.** Redaction was declined
+(decision 4) and deletion was declined (decision 14), which leaves detection as the only
+remaining control in the chain. A scan over the bytes being shipped blocks nothing, costs one
+pass over data already being read, and turns an invisible event into a number you can act on
+while the credential is still worth rotating. **Ship it with v1, not after.**
 
 ## 7. Explicitly out of scope
 
@@ -473,13 +530,15 @@ does nothing:
    one. ⚠ **Do not write this as "one object"** — that is only true under parent-only.
    Under "ship the set" one session yields many objects (288 files across 37 sessions,
    §4 row 4), so an assertion of `len(objects) == 1` fails a correct implementation.
-   Assert NO GROWTH between runs, which is true under both branches of §9.6.
+   Assert NO GROWTH between runs. ⚠ Under decision 9 one session yields MANY objects
+   (288 files across 37 sessions), so an assertion of `len(objects) == 1` fails a correct
+   implementation.
 4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
    session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
    not duplicate. **Name the host it ran on** — §5.1: the hook is wired on one host today.
-   ⚠ If §9.6 resolves to one-object-per-session, this control passes trivially for the wrong
-   reason whenever subagent files collide on the key; it is only meaningful once the key is
-   decided.
+   ⚠ Under decision 9 the key is (parent session id, filename), so this control must name
+   WHICH object it re-shipped — asserting "a sha256 changed" across a set is satisfied by any
+   one member moving.
 5. **A crash path attaches the floor.** Kill a session without `SessionEnd`; the
    handoff-time object must still be there and its digest must match what was shipped.
 6. **Anonymous access denied — and the control must distinguish DENIED from ABSENT.**
@@ -505,36 +564,28 @@ invariant the bug never violated is an invariant guard and must be labelled as o
 
 ## 9. Open — decide before building
 
-1. **Does the pointer-shape recommendation in §5.3 stand?** No recorded decision covers the
-   pointer's form, so this fills a gap rather than dissenting. Cheap to accept, expensive to
-   retrofit.
-2. **What is the front-matter field called and SHAPED?** Constrained by §5.3: a scalar or an
-   inline flow list, or `parse_front_matter` gets widened first in **two** repos. Also: does
-   the subsystem-index skill or the handoff tool own writing it? (`clawgate-task:` is
-   precedent for the *idea* of a linkage field, though it is a handoff-doc field rather than
-   a cairn-entry one.)
-3. **Which entries count as "touched"?** The handoff run knows what it wrote; whether that
-   set is the right one, or too wide, has not been measured.
-4. **opencode** — schedule, or park indefinitely.
-5. **What does the new shipper do about `transcript_search`, and does it share `project_of`?**
-   Not "does the extraction happen" — discovery is **already** a shared module with an
-   enforced site ledger, so the question is narrower: reuse it and inherit its `subagents/`
-   exclusion, widen it, or bypass it deliberately. That half is downstream of question 6.
-   `project_of` is the separate, unconditional half: it is one-site today and the second
-   shipper will want it. §3.
-6. 🔴 **Does a session ship as ONE object or a SET?** §5.0. This is the largest open
-   question, it decides the object key, and the goal in §1 depends on the answer — 64% of the
-   bytes are in subagent transcripts, and one-object-per-session drops them.
-7. 🔴 **What happens when the fan-out PARTIALLY succeeds?** Decision 6 writes a pointer to
-   every touched entry, so the write is N-way and can land on 3 of 5. §5.5's fail-open
-   covers the PUSH and §6 covers deletion; nothing covers a half-written fan-out. §5.4's
-   digest ledger cannot detect it either — it validates a pointer that EXISTS, and the
-   failure here is entries that silently have none, which is indistinguishable from
-   entries the session never touched. Nothing records the expected fan-out set, so
-   nothing can compare against it. Either record that set or accept silent partial
-   attachment, but choose deliberately.
-8. **Is there a retraction path when a secret is found in a shipped object?** §6. Deleting
-   the object leaves N pointers dangling and nothing sweeps them. Under decision 8 this is
-   permanent, so "no path" is an answer — but it should be a chosen one.
-9. **Who wires `SessionEnd` on the second host, and what detects that it is missing?**
-   §5.1. It is unmanaged per-host state that `drift-check.sh` does not currently see.
+🔴 **Eight of the nine questions this section carried were answered on 2026-09-05 and are now
+decisions 9-16 in §2.** They are not restated here; §2 is the single place they live, so there
+is one place to correct. What remains:
+
+1. **opencode.** Schedule, or park indefinitely. It has no `.jsonl` — 2.4 GB of SQLite plus
+   `storage/`, `snapshot/` and `tool-output/` — so "the whole session" means an exporter with
+   its own fidelity question (which tables; what about `tool-output/`; is a DB snapshot a
+   session). **Recommendation: park it.** Ship Claude capture first and let the front-matter
+   field name stay format-agnostic so opencode can join later without a migration.
+
+## 10. What implementation must decide that no decision above settles
+
+These are not open questions for the operator — they are the places an implementer will have
+to choose, called out so the choice is deliberate rather than accidental:
+
+- **The object key.** §5.0 fixes it as *(parent session id, transcript filename)*. Anything
+  keyed on the filename stem alone leaves `agent-<hash>` objects joinable to nothing.
+- **What "the expected fan-out set" is recorded IN** (decision 11) — object metadata or the
+  handoff doc. Either works; recording it nowhere is what decision 11 forbids.
+- **How a resolver renders an id it cannot resolve.** 🔴 It must read as NOT AUTHORISED or
+  NOT FOUND *distinctly* — never as one ambiguous failure — because under decision 14 nothing
+  is ever deleted, so "missing" now means something went wrong rather than something was
+  retracted.
+- **Whether the opt-in flag on `transcript_search` defaults to today's behaviour.** Decision 13
+  says it must; a test pinning the existing feeder's output is what proves it.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -336,7 +336,30 @@ reference is the ledger, not the other machine."* rc 15 is the cross-host arm, a
 one this paragraph already calls too narrow. **A cross-host diff inherits the exact failure
 decision 15 exists to end**: drop `SessionEnd` from both hosts — a bootstrap, an upgrade, or
 an operator "fixing" the diff by deleting it from the other side — and the sets agree while
-every session on every host silently attaches only the floor. §8 control 4 must still name the host it ran on.
+every session on every host silently attaches only the floor.
+
+🔴 **BUT THE LEDGER SHAPE DOES NOT CARRY ACROSS INTACT, AND THE PART THAT DOES NOT IS THE
+PART THAT MAKES rc 22 WORK.** `test_skill_tiers.py` pins that ledger **two-way** — every
+shipped skill has exactly one entry and every entry names a shipped skill — and its own
+docstring calls that *"THE ONE PROPERTY THAT MAKES IT SCALE … without it the mechanism
+silently stops covering the tree the moment a skill is added"*. That pin is possible because
+skills **exist as files**, so the expected set can be GENERATED. **Required hook events have
+no generator** — nothing in the tree enumerates them (the only hook-event list,
+`register-nudge-hook.py`'s `MATCHER_EVENTS`, says which events accept a matcher, not which
+must be registered). So this ledger is a hand-written policy list, and a two-way pin cannot
+be written for it.
+
+**Three consequences the implementer must handle, because the gate cannot:**
+1. 🔴 **Do not seed the ledger from a host.** Seeding from the laptop — the host being fixed,
+   or a fresh one — omits `SessionEnd`, after which both hosts match the ledger, no rc fires,
+   and the run prints a clean tiers-style line forever. Author each entry from the
+   requirement, not from an observation.
+2. **Each entry states WHY that event is required**, so a reader can check the list against
+   something. That is the only review the absent generator leaves available.
+3. **A missing or empty ledger is COULD NOT MEASURE, never clean** — `drift-check.sh` already
+   states this hazard for rc 22 in terms (*"an empty expectation would make every host look
+   compliant, in silence"*) and defends it that way; this arm inherits the hazard without
+   inheriting the test. §8 control 4 must still name the host it ran on.
 
 ### 5.2 Transport
 
@@ -399,7 +422,8 @@ list parses to a clean list member. Block-item promotion was FIXED, which is wha
 docstring quoted above is recording. The shape is safe because the parser handles it, not
 because uuids dodge a trap. **The digest, size and host move
 to the object's own metadata** — so no parser change lands in either repo, and checking a
-pointer costs a HEAD request rather than an entry read.
+pointer costs a LIST plus one HEAD per object — see §5.4, because decision 9 made this
+N-way — rather than an entry read.
 ⚠ Widening it is a **two-repo change**: `parse_front_matter` sits in `ZacxDev/cairn` too, at
 the same line, and §7 puts that repo out of scope. ⚠ Also unmeasured: the same docstring
 records that block-list lines are currently **zero across the live store** and says to re-take
@@ -552,8 +576,10 @@ while the credential is still worth rotating. **Ship it with v1, not after.**
 Not "the tests pass" — these specific controls, because each names a way this silently
 does nothing:
 
-1. **Positive control on the shipper.** A session that MUST produce an object: watch the
-   count move from 0 to 1 and report the pair, never the zero alone.
+1. **Positive control on the shipper.** A session that MUST produce objects: watch the count
+   move from zero to non-zero and report the pair, never the zero alone.
+   ⚠ **Not "0 to 1"** — control 3 forbids exactly that spelling, because under decision 9 a
+   session produces ~7.8 objects and an assertion of `== 1` fails a correct implementation.
 2. **Negative control.** Point it at an unreachable endpoint and watch it warn and exit
    non-zero rather than reporting a successful no-op.
 3. **Idempotency, measured.** Two handoff runs in one session must produce **no NEW key for a
@@ -583,12 +609,19 @@ does nothing:
    read token against a bucket key → `403`; the transcript credential against a cairn read
    route → `401`. An earlier revision named neither operation nor expected result, which any
    test satisfies — including one that type-checks past a wrong argument.
-8. **The report-only scan can actually SEE a credential** — the control decision 14 makes
-   load-bearing. Plant a synthetic credential in a fixture transcript, run the scan over the
-   bytes being shipped, and watch the count move **0 → 1**; report the pair, never the zero
-   alone. A scan wired to nothing reports `0 findings` and reads exactly like a clean run —
-   and under decision 14 that zero is the last thing standing between a leak and nobody
-   knowing.
+8. **The report-only scan can actually SEE a credential, ON THE PATH THAT SHIPS** — the
+   control decision 14 makes load-bearing, so it gets the same N-way treatment as control 4.
+   🔴 **Run the SHIPPER, not the scanner.** A scanner unit-tested against a fixture and never
+   invoked on the real path reports `0 findings` forever — verbatim the failure this control
+   exists to prevent, and the seam nobody owns.
+   🔴 **Plant the credential in a SUBAGENT transcript, not the parent.** Under decision 9 the
+   shipped unit is ~7.8 files and `agent-*` files hold **64% of the bytes** (§5.0). §3 shows
+   the correct-looking implementation — reusing `iter_transcripts`, which the site-ledger test
+   rewards — silently ships parents only; wire the scan the same way, plant in the parent, and
+   the count moves 0 → 1 while the majority of bytes are never scanned. **A parent-only plant
+   is a control that passes on the case that was never in doubt.**
+   Then report the pair — a non-zero count on the planted case beside the count under test —
+   never the zero alone.
 9. **Decision 7's actual behaviour, which no earlier control covered.** Make the push fail
    (unreachable endpoint) and assert **handoff exits 0** *and* the doc carries the
    no-session-attached line. Control 2 asserts the *shipper* exits non-zero, which is the
@@ -642,4 +675,8 @@ rather than absent.
 - A test pinning the existing feeder's output **before** `transcript_search` is touched
   (decision 13).
 - Wiring `SessionEnd` on the second host, and building the ledger-based detector §5.1 describes
-  (decision 15).
+  (decision 15). 🔴 **Including the three things §5.1 says the gate cannot do for you** — the
+  ledger is authored from the requirement rather than seeded from a host, each entry says why
+  its event is required, and a missing or empty ledger reports COULD NOT MEASURE rather than
+  clean. There is no generator for required hook events, so no two-way pin can be written and
+  those three are the whole of the review.

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -68,8 +68,8 @@ discovery module, and its own docstring warns that it is *"a LABEL, NOT AN IDENT
 must not be un-slugified. A second shipper needing a project label for object metadata or a
 key prefix would hand-roll it in four lines, and the two copies would disagree the first time
 a directory name contains a literal `-`. ⚠ An earlier revision of this section deleted this
-sentence as collateral while rewriting the paragraph below, leaving the section with no
-positive advice at all — which reads as "nothing is safe to share" and is the opposite of what
+sentence as collateral while rewriting the shared-discovery paragraph that follows, leaving
+the section with no positive advice at all — which reads as "nothing is safe to share" and is the opposite of what
 was found.
 
 **Not the byte-boundary logic** — it exists to drop the leading partial JSON record from a
@@ -130,6 +130,7 @@ not the median — 3.82 MB (row 3) against 2.62 MB (row 2) against 0.74 MB (row 
 parent transcript alone. If §9.6 resolves to "ship the set" (§5.0 frames it), row 4 is the
 real unit — **2.3× the median and 2.5× the total**, with a largest single session of
 **31.00 MB**.
+
 ⚠ **That 31.00 MB is a SESSION TOTAL, not an object size** — under "ship the set" it
 arrives as many PUTs (the 37 sessions hold 288 files, mean object ~1.3 MB), and the largest
 single *file* on the host is 23.48 MB, row 1's max. So it does not describe a bigger PUT
@@ -146,12 +147,13 @@ and do not cross the two — but do not claim 23.48 MB is what ships today, beca
 33 of the 37 sessions have subagent bytes at all, and the worst **within those 37** is a
 3.82 MB parent with 19 subagent files totalling 26.56 MB — a 30.39 MB session of which
 shipping one object captures **12.6%**. Two further reasons both rows are floors:
-`SessionEnd` re-ship only grows them, and the coverage caveat two paragraphs below is real.
+`SessionEnd` re-ship only grows them, and the **COVERAGE CAVEAT** below (the ⚠ block headed
+*Scope of the 37-session sample*) is real.
 
 ⚠ **An earlier revision quoted a worse-looking example here — a 3.79 MB parent with 60
 subagent files, 8% captured — and that session is NOT one of the 37.** It is from the
-913-session population, and its 46.99 MB total contradicted the 31.00 MB row-4 max stated
-three lines above it. Recorded rather than quietly swapped, because the mistake is this
+913-session population, and its 46.99 MB total contradicted row 4's own 31.00 MB max.
+Recorded rather than quietly swapped, because the mistake is this
 section's own thesis: **a figure imported from a different population is wrong even when the
 figure itself is exact.**
 
@@ -160,10 +162,18 @@ It closed with *"the largest sessions on the whole host do reach ~47 MB"* — wh
 the total of the session being retracted, promoted from "an example that does not belong here"
 to "the host maximum". Measured: the host maximum is **94.02 MB** (an 11.72 MB parent plus
 82.30 MB across 29 subagent transcripts) and **9 sessions exceed 47 MB**. A reader sizing for
-the widened population §4's own caveat anticipates would have been **2× low**, from a sentence
-written to warn against exactly that. Recorded because three separate revisions of this one
-paragraph made the same mistake in three different places: **retracting a number is not the
-same as not using it.**
+the widened population the coverage caveat anticipates would have been **2× low**, from a
+sentence written to warn against exactly that.
+
+The same figure was therefore wrong **twice**: once as a within-the-37 worst case, and once —
+in the sentence retracting it — as a whole-host maximum. **Retracting a number is not the same
+as not using it.**
+
+🔴 **AND THE LESSON FOR THIS DOCUMENT'S OWN RECORDS: name things, do not count or locate
+them.** Two earlier revisions of these retraction records carried a paragraph COUNT and a
+paragraph DISTANCE; both were falsified by the next edit that inserted a block, and a wrong
+pointer sends a reader to the wrong population — the exact hazard §4 exists to prevent. A
+NAME survives insertion; an ordinal does not.
 
 **So: size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
 §9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
@@ -174,10 +184,14 @@ caveat §5.0 carries for the corpus counts — every new handoff adds a session 
 coverage caveat below was stated originally, and coverage and time are different limits.
 Re-measured 2026-09-05 after a day's work: still **37**, so no drift was observed — but the
 method is time-dependent by construction, and a later re-derivation returning a different `n`
-means the table is **stale, not wrong**. ⚠ One audit reading of this reported 43; it did not
-reproduce here under the stated method, which is itself the reason to state the method.
+means the table is **stale, not wrong**. ⚠ An audit reading reported 43. That is now **explained, not merely non-reproducing**:
+43 is what the trailer yields when the **pathspec is dropped** and every commit in the window
+is counted. The method must therefore name its ref as well — these figures are from
+`origin/main`; `--all` gives a larger number that varies by clone, so it is not a
+measurement of anything shared.
 
-⚠ **Scope of the 37-session sample, stated rather than buried:** devrc handoffs only, and
+⚠ **THE COVERAGE CAVEAT — scope of the 37-session sample, stated rather than buried:**
+devrc handoffs only, and
 only commits carrying the trailer. Handoffs in other repos are not counted, so the true
 population is larger and the totals are floors.
 
@@ -205,10 +219,10 @@ one `agent-<hash>.jsonl` per dispatched subagent. Measured: **4,951 of 5,864** f
 
 ⚠ **These counts are a SNAPSHOT of a live corpus and they drift within a session** — §3
 quotes 4,955 and this section 4,951, taken minutes apart on the same day, and a later
-reading gave 4,957. The durable claims are the **ratio** (~85% of files, ~64% of bytes) and
+reading gave 4,957. The durable claims are the **ratio** (84.4% of files, ~64% of bytes) and
 the **exact coincidence** in §3; the absolute counts are not, and nothing pins them.
-(The ratio is 84.4% of files — quoted as "84%" above; do not read the two as different
-measurements.)
+The file ratio is **84.4%** — the single measurement behind both the "84%" quoted above and
+the "~85%" an earlier revision left standing here; they were never three readings.
 
 Those files are not addressable the way the parent is. `build_transcript_push.py` states the
 convention the whole join rests on — *"The session id IS the filename stem … the same id the

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -43,15 +43,16 @@ Settled by the operator across two rounds of questions on 2026-09-05:
 |---|---|---|
 | 9 | **A session ships as a SET** — one object per transcript file, parent + subagents | ~7.8 objects per session and 2.3x the bytes (row 4, not row 3); forces decision 13 |
 | 10 | **The pointer is an OPAQUE ID**, never a resolvable URL | a reader needs the transcript credential to resolve anything; a shared entry leaks an identifier, not content |
-| 11 | **The expected fan-out set is RECORDED** | a partial N-way pointer write becomes detectable instead of indistinguishable from "not touched" |
-| 12 | **Front matter is a BLOCK LIST of ids**; digest/size/host live as object metadata | ships against today's parser with no change to either repo; checking a pointer costs a HEAD request |
+| 11 | **The expected fan-out set is RECORDED** | a partial N-way write becomes **checkable** — recording is not detecting, so something must compare against it (§10) |
+| 12 | **Front matter is a BLOCK LIST of ids**; digest/size/host live as object metadata | ships against today's parser with no change to either repo; checking a pointer costs a LIST plus one HEAD per object (see §5.4 — decision 9 made this N-way) |
 | 13 | **`transcript_search` is widened with an OPT-IN flag** | the existing feeder keeps its behaviour by default, and must be pinned by a test before the module is touched |
 | 14 | 🔴 **NO retraction path — rotate the leaked credential instead** | the bucket is append-only **by policy**; a secret's bytes persist deliberately and forever |
 | 15 | **`SessionEnd` wired per host, and `drift-check` extended to detect its absence** | the wiring stays an operator act; the gap stops being invisible |
 | 16 | **"Touched" = entries the handoff run WROTE or UPDATED** | mechanical, no inference; an entry only read deeply attaches no receipts |
 
-🔴 **Decision 14 is the one that diverged from the recommendation, and it changes what the
-other machinery is for.** With no deletion, a dangling pointer cannot arise from retraction —
+🔴 **Decision 14 went against the recommendation made during the interview — which is NOT in
+this document, and is named here so nobody hunts for it — and it changes what the other
+machinery is for.** With no deletion, a dangling pointer cannot arise from retraction —
 so §5.4's digest ledger is no longer a retraction-detector, it is purely an integrity check.
 And the report-only scan §6 suggests becomes *the* control rather than a nice-to-have: if the
 only response to a leaked credential is rotation, then **knowing** is the whole of the
@@ -139,9 +140,9 @@ records below only mean something against the population they were wrong about:
 | **3** | **sessions that produced a handoff** — what decision 2 selects, **parent file only** | 37 | **3.82 MB** | 5.22 MB | 10.59 MB | 148 MB |
 | **4** | the same 37 sessions, **parent + their subagent transcripts** | 288 files / 37 sessions | **8.68 MB** *(per session)* | 20.23 MB | 31.00 MB *(per session)* | 375 MB |
 
-🔴 **The row numbers are IN the table on purpose.** Fourteen places in this document say
-"row 1"…"row 4"; without a number column each of those is an unwritten ordinal that a
-future inserted row silently falsifies — including THE SIZING DIRECTIVE itself, which would
+🔴 **The row numbers are IN the table on purpose.** This document refers to "row 1"…"row 4"
+throughout; without a number column each of those is an unwritten ordinal that a future
+inserted row silently falsifies — including THE SIZING DIRECTIVE itself, which would
 then point at the wrong population. Numbering them makes each reference an identifier that
 an insertion cannot move. If you add a row, append it; do not renumber.
 
@@ -257,9 +258,11 @@ open. **Name the front-matter field so it does not assume jsonl.**
 
 ## 5. The design
 
-### 5.0 🔴 "A session's transcript" is a SET, not a file — and this is OPEN
+### 5.0 🔴 "A session's transcript" is a SET, not a file — DECIDED (decision 9)
 
-**This is the first thing an implementer needs and the proposal does not yet answer it.**
+**This is the first thing an implementer needs, and decision 9 answers it: a SET.** The
+measurement below is why, and it is kept because the object key and the sizing both fall out
+of it.
 
 On this host a session writes **several** transcripts: the parent `<session-id>.jsonl` plus
 one `agent-<hash>.jsonl` per dispatched subagent. Measured: **4,951 of 5,864** files are
@@ -324,10 +327,16 @@ by nix** by design, and `drift-check.sh` rc 15 compares only top-level key *name
 does not surface as drift. Consequence: on a host without the hook, **every** session attaches
 only the handoff-time floor, permanently and silently. ✅ **DECIDED — decision 15: wire it per host, and extend `drift-check.sh` to detect its
 absence.** The wiring stays an operator act because that file is per-host by design; what
-changes is that the gap stops being invisible. The detector compares the **hook-event set**
-across hosts — the same shape as the `skillOverrides` arm rc 22 already implements, and it
-closes exactly the class that let this hide: rc 15 compares top-level key NAMES, so a missing
-nested event is structurally unseeable. §8 control 4 must still name the host it ran on.
+changes is that the gap stops being invisible. 🔴 **The detector must compare each host against a GIT-TRACKED LEDGER of required hook
+events — NOT the two hosts against each other.** An earlier revision of this paragraph
+prescribed a cross-host set diff and cited rc 22 as precedent. That is backwards: rc 22
+compares each host to `claude/skill-tiers.json`, and `drift-check.sh` says so in capitals —
+*"THIS IS NOT A CROSS-HOST COMPARISON. Both hosts can agree perfectly and both be wrong; the
+reference is the ledger, not the other machine."* rc 15 is the cross-host arm, and it is the
+one this paragraph already calls too narrow. **A cross-host diff inherits the exact failure
+decision 15 exists to end**: drop `SessionEnd` from both hosts — a bootstrap, an upgrade, or
+an operator "fixing" the diff by deleting it from the other side — and the sets agree while
+every session on every host silently attaches only the floor. §8 control 4 must still name the host it ran on.
 
 ### 5.2 Transport
 
@@ -347,7 +356,7 @@ row 1's max, the largest single transcript FILE on the host — through it is a 
 change. But that is a reason not to use the pod — it is not the reason the route must stay on
 the mesh.
 
-### 5.3 What cairn holds — and one recommendation no recorded decision covers
+### 5.3 What cairn holds
 
 Front-matter on each touched entry gains a session reference.
 
@@ -383,8 +392,12 @@ a `session:` key:
 The pointer is **gone**, `cairn recall` renders the entry as clean, and §5.4's digest ledger —
 the thing meant to make a bad pointer visible — was never written to be checked. So the field
 must be a shape the parser already handles. ✅ **DECIDED — decision 12: a BLOCK LIST of ids**
-(`sessions:` then one `- <id>` per line), which the parser handles today and which uuids
-cannot trip, since promotion needs a colon inside the item. **The digest, size and host move
+(`sessions:` then one `- <id>` per line), which the parser handles today.
+⚠ **Not because uuids carry no colon** — an earlier revision said that, and it is a hazard
+that no longer exists. Measured against the live parser: `- clickup:868abc123` in a block
+list parses to a clean list member. Block-item promotion was FIXED, which is what the
+docstring quoted above is recording. The shape is safe because the parser handles it, not
+because uuids dodge a trap. **The digest, size and host move
 to the object's own metadata** — so no parser change lands in either repo, and checking a
 pointer costs a HEAD request rather than an entry read.
 ⚠ Widening it is a **two-repo change**: `parse_front_matter` sits in `ZacxDev/cairn` too, at
@@ -404,8 +417,10 @@ to a decision nobody made is a good way to lose a cheap recommendation.
 **The hazard, stated in the direction it actually runs.** `plan-cairn-integration.md`
 decision 11 already gates sharing on `sensitivity:` — *client-confidential can never be
 shared* — so the obvious scenario (a client entry leaking a pointer) **cannot fire**, and an
-earlier revision of this section argued exactly that already-closed case. What survives
-decision 11 is the mirror image, and it is worse: a **shareable** entry — this repo's own
+earlier revision of this section argued exactly that already-closed case. ⚠ That is
+`plan-cairn-integration.md`'s decision 11, not this document's — the numbers collide, and
+every other decision reference in this section is local. What survives **that** decision 11
+is the mirror image, and it is worse: a **shareable** entry — this repo's own
 scope, marked `internal` — carries a pointer into an object that contains that same session's
 **client-confidential** work, because one session routinely touches both. Sharing the
 innocuous entry hands over a reference into multi-client content.
@@ -429,7 +444,16 @@ a reader would read "this session was never captured" off a permission error.
 ### 5.4 The digest ledger is not optional
 
 `bytes` + `sha256` + `captured_at` + `host` — **on the OBJECT, not in the entry** (decision
-12), so the entry stays a list of ids and the ledger is one HEAD request away.
+12), so the entry stays a list of ids.
+
+🔴 **DECISION 9 MADE THIS N-WAY, AND THE OBJECT SET HAS THE HOLE DECISION 11 CLOSES FOR
+ENTRIES.** A session is ~7.8 objects, not one, so checking a pointer costs a LIST plus a HEAD
+per object — and more seriously, **a member that never landed is undetectable**. A `sha256`
+proves every object that EXISTS is intact; it says nothing about one that does not, because
+nothing records how many objects a session should have. That is precisely the gap decision 11
+closes for the entry fan-out, left open for the object fan-out decision 9 created.
+**So record the expected OBJECT set alongside the expected entry set** — same mechanism, same
+reason, and §10 says who must read it.
 ⚠ **And under decision 14 its job narrowed:** with no deletion there is no retraction, so a
 dangling pointer can only mean corruption or a failed write. It is an integrity check now,
 not a retraction-detector. Without them a pointer to a
@@ -488,14 +512,19 @@ than discovered when the store gains a second tenant.
 
 🔴 **DECIDED — decision 14: THERE IS NO RETRACTION PATH, BY POLICY. The bucket is
 append-only and a leaked credential is answered by ROTATION, not by deletion.**
-This is deliberate and it is the one decision that diverged from the recommendation, so its
-consequences are stated rather than left to be discovered:
+Deliberate, and chosen against the interview's recommendation (not recorded here — the
+document's own earlier text called a missing retraction path "a real gap" and said "'no path'
+is an answer, but it should be a chosen one", which is what this is). Its consequences are
+stated rather than left to be discovered:
 
 - a secret that reaches the bucket **stays there permanently**, and rotation makes it dead
   rather than absent;
-- rotation only works on credentials that CAN be rotated — a client's secret, a token you do
-  not own, or personal data in a transcript has no rotation, and for those this policy is the
-  whole of the response;
+- 🔴 rotation only works on credentials that CAN be rotated. A client's secret, a token you
+  do not own, or personal data in a transcript has no rotation — and deletion is declined —
+  so for that class **the response is nothing, and the exposure is permanent with no
+  remedy**. Say it that way rather than "the policy is the whole of the response", which
+  reads as though a response exists. It also bounds the scan's value: detection buys a
+  rotation window only where something can be rotated;
 - 🔴 **the report-only scan below is therefore promoted from a nice-to-have to THE control.**
   If the only answer to a leak is to rotate, then *knowing a leak happened* is the entire
   response, and nothing else in this design will tell you. Without it the policy reads as
@@ -503,7 +532,9 @@ consequences are stated rather than left to be discovered:
 
 🔴 **THE REPORT-ONLY SCAN IS NOW LOAD-BEARING, NOT A FOLLOW-ON.** Redaction was declined
 (decision 4) and deletion was declined (decision 14), which leaves detection as the only
-remaining control in the chain. A scan over the bytes being shipped blocks nothing, costs one
+**response available once bytes are already in the bucket**. ⚠ Not "the only control" —
+the storage boundary is a control and is the subject of this whole section; the narrower
+statement is the one that holds, and the conclusion survives it intact. A scan over the bytes being shipped blocks nothing, costs one
 pass over data already being read, and turns an invisible event into a number you can act on
 while the credential is still worth rotating. **Ship it with v1, not after.**
 
@@ -525,14 +556,13 @@ does nothing:
    count move from 0 to 1 and report the pair, never the zero alone.
 2. **Negative control.** Point it at an unreachable endpoint and watch it warn and exit
    non-zero rather than reporting a successful no-op.
-3. **Idempotency, measured.** Two handoff runs in one session must not GROW either set:
-   the object count stays whatever one run produces, and the pointer count per entry stays
-   one. ⚠ **Do not write this as "one object"** — that is only true under parent-only.
-   Under "ship the set" one session yields many objects (288 files across 37 sessions,
-   §4 row 4), so an assertion of `len(objects) == 1` fails a correct implementation.
-   Assert NO GROWTH between runs. ⚠ Under decision 9 one session yields MANY objects
-   (288 files across 37 sessions), so an assertion of `len(objects) == 1` fails a correct
-   implementation.
+3. **Idempotency, measured.** Two handoff runs in one session must produce **no NEW key for a
+   transcript already shipped**, and the pointer count per entry stays one.
+   ⚠ **Do not write this as "one object"**, and do not write it as "the set does not grow"
+   either. Under decision 9 a session is many objects, so `len(objects) == 1` fails a correct
+   implementation — and the set legitimately GROWS if a subagent is dispatched between the two
+   runs, so a no-growth assertion fails one too. The property that holds regardless is
+   per-key: nothing already shipped acquires a second key.
 4. **The `SessionEnd` overwrite actually overwrites.** Ship at handoff, append to the
    session, fire `SessionEnd`, assert the stored `sha256` **changed** and the pointer did
    not duplicate. **Name the host it ran on** — §5.1: the hook is wired on one host today.
@@ -553,7 +583,13 @@ does nothing:
    read token against a bucket key → `403`; the transcript credential against a cairn read
    route → `401`. An earlier revision named neither operation nor expected result, which any
    test satisfies — including one that type-checks past a wrong argument.
-8. **Decision 7's actual behaviour, which no earlier control covered.** Make the push fail
+8. **The report-only scan can actually SEE a credential** — the control decision 14 makes
+   load-bearing. Plant a synthetic credential in a fixture transcript, run the scan over the
+   bytes being shipped, and watch the count move **0 → 1**; report the pair, never the zero
+   alone. A scan wired to nothing reports `0 findings` and reads exactly like a clean run —
+   and under decision 14 that zero is the last thing standing between a leak and nobody
+   knowing.
+9. **Decision 7's actual behaviour, which no earlier control covered.** Make the push fail
    (unreachable endpoint) and assert **handoff exits 0** *and* the doc carries the
    no-session-attached line. Control 2 asserts the *shipper* exits non-zero, which is the
    opposite-signed observable and is equally satisfied by a handoff that fails hard — the
@@ -574,18 +610,36 @@ is one place to correct. What remains:
    session). **Recommendation: park it.** Ship Claude capture first and let the front-matter
    field name stay format-agnostic so opencode can join later without a migration.
 
-## 10. What implementation must decide that no decision above settles
+## 10. Still to settle, and where each one lives
 
-These are not open questions for the operator — they are the places an implementer will have
-to choose, called out so the choice is deliberate rather than accidental:
+🔴 **An earlier revision of this section listed three things that decisions 1-16 DO settle** —
+the object key, the unresolvable-id rendering, and the `transcript_search` flag default — which
+made it a second site for rules §9 had just said live in exactly one place. They are constraints,
+not choices, and they are stated where they belong: §5.0, §5.3 and decision 13.
 
-- **The object key.** §5.0 fixes it as *(parent session id, transcript filename)*. Anything
-  keyed on the filename stem alone leaves `agent-<hash>` objects joinable to nothing.
-- **What "the expected fan-out set" is recorded IN** (decision 11) — object metadata or the
-  handoff doc. Either works; recording it nowhere is what decision 11 forbids.
-- **How a resolver renders an id it cannot resolve.** 🔴 It must read as NOT AUTHORISED or
-  NOT FOUND *distinctly* — never as one ambiguous failure — because under decision 14 nothing
-  is ever deleted, so "missing" now means something went wrong rather than something was
-  retracted.
-- **Whether the opt-in flag on `transcript_search` defaults to today's behaviour.** Decision 13
-  says it must; a test pinning the existing feeder's output is what proves it.
+### Genuinely undecided — an implementer must choose
+
+- **Where the expected fan-out sets are RECORDED** (decision 11, and the object set §5.4 adds) —
+  object metadata, or the handoff doc. Either works; recording them nowhere is what decision 11
+  forbids.
+- 🔴 **WHO READS THEM.** Decision 11's value is not in the recording — a recorded set that
+  nothing compares against detects nothing, which is the same shape as a digest nobody checks.
+  Name the reader, or the decision is inert.
+- **Who owns WRITING the front-matter field** — the `subsystem-index` skill or the handoff tool.
+  Decision 12 settles the field's *shape* and says nothing about its writer. (The handoff doc's
+  `clawgate-task:` is precedent for the idea of a linkage field, though it is a handoff-doc field
+  rather than a cairn-entry one.)
+- **Whether `project_of` is shared** (`build_transcript_push.py`). Decision 13 covers
+  `transcript_search` only. §3 records why this is the one unconditionally-shareable surface and
+  what breaks if it is hand-rolled twice; nothing has decided it.
+
+⚠ The last two were sub-clauses of questions whose *other* halves became decisions 12 and 13.
+They were dropped when those questions were closed, and are restored here so they read as open
+rather than absent.
+
+### Owed work that follows from a decision rather than choosing anything
+
+- A test pinning the existing feeder's output **before** `transcript_search` is touched
+  (decision 13).
+- Wiring `SessionEnd` on the second host, and building the ledger-based detector §5.1 describes
+  (decision 15).

--- a/claudedocs/proposal-cairn-session-capture.md
+++ b/claudedocs/proposal-cairn-session-capture.md
@@ -124,34 +124,58 @@ file.
 
 🔴 **The selection effect runs the WRONG WAY, and that is the point of the row.** Sessions
 that produce a handoff are the long ones, so the per-handoff filter picks the **large tail**,
-not the median — 3.82 MB against 2.62 MB against 0.74 MB.
+not the median — 3.82 MB (row 3) against 2.62 MB (row 2) against 0.74 MB (row 1).
 
 🔴 **AND THE ROW YOU SIZE OFF DEPENDS ON AN ANSWER §9.6 HAS NOT GIVEN YET.** Row 3 is the
 parent transcript alone. If §9.6 resolves to "ship the set" (§5.0 frames it), row 4 is the
-real unit: **2.3×
-the median and 2.5× the total**, with a largest single session of **31.00 MB**.
+real unit — **2.3× the median and 2.5× the total**, with a largest single session of
+**31.00 MB**.
 ⚠ **That 31.00 MB is a SESSION TOTAL, not an object size** — under "ship the set" it
 arrives as many PUTs (the 37 sessions hold 288 files, mean object ~1.3 MB), and the largest
 single *file* on the host is 23.48 MB, row 1's max. So it does not describe a bigger PUT
-than §5.2's worked example; it describes more of them. Size a per-object limit off row 1's
-max and a per-handoff cost off row 4's total, and do not cross the two.
+than §5.2's worked example; it describes more of them.
+
+⚠ **Per-object sizing: row 1's 23.48 MB is a deliberate OVER-estimate, and here is why it is
+not simply the wrong row.** The largest single file among the 37 selected sessions is
+**10.59 MB** — 2.2× smaller — so nothing shippable today approaches 23.48 MB, and row 1 is
+the row labelled *NOT what ships*. The reason to size above the selected maximum anyway is
+§4's own coverage caveat below: the selection is devrc-only and **the true population is
+larger**, so a session with a 23 MB parent can enter it without anything else changing. Size
+a per-object limit off row 1's max for that headroom, a per-handoff cost off row 4's total,
+and do not cross the two — but do not claim 23.48 MB is what ships today, because it is not.
 33 of the 37 sessions have subagent bytes at all, and the worst **within those 37** is a
 3.82 MB parent with 19 subagent files totalling 26.56 MB — a 30.39 MB session of which
 shipping one object captures **12.6%**. Two further reasons both rows are floors:
-`SessionEnd` re-ship only grows them, and the sample caveat below is real.
+`SessionEnd` re-ship only grows them, and the coverage caveat two paragraphs below is real.
 
 ⚠ **An earlier revision quoted a worse-looking example here — a 3.79 MB parent with 60
 subagent files, 8% captured — and that session is NOT one of the 37.** It is from the
 913-session population, and its 46.99 MB total contradicted the 31.00 MB row-4 max stated
 three lines above it. Recorded rather than quietly swapped, because the mistake is this
 section's own thesis: **a figure imported from a different population is wrong even when the
-figure itself is exact.** For scale, the largest sessions on the whole host do reach ~47 MB
-including subagents — but they are not what decision 2 selects, and they are not what row 4
-measures.
+figure itself is exact.**
+
+🔴 **AND THE FIRST DRAFT OF THIS VERY RETRACTION RE-IMPORTED THE SAME NUMBER, ONE LEVEL UP.**
+It closed with *"the largest sessions on the whole host do reach ~47 MB"* — which is 46.99 MB,
+the total of the session being retracted, promoted from "an example that does not belong here"
+to "the host maximum". Measured: the host maximum is **94.02 MB** (an 11.72 MB parent plus
+82.30 MB across 29 subagent transcripts) and **9 sessions exceed 47 MB**. A reader sizing for
+the widened population §4's own caveat anticipates would have been **2× low**, from a sentence
+written to warn against exactly that. Recorded because three separate revisions of this one
+paragraph made the same mistake in three different places: **retracting a number is not the
+same as not using it.**
 
 **So: size off row 4 unless and until §9.6 resolves to parent-only.** Sizing off row 3 while
 §9.6 is open is how a bucket, a PUT timeout or a per-handoff cost estimate comes out low by
 more than 2×.
+
+⚠ **This table is a SNAPSHOT of a population that GROWS AS THE SYSTEM IS USED**, the same
+caveat §5.0 carries for the corpus counts — every new handoff adds a session to it. Only the
+coverage caveat below was stated originally, and coverage and time are different limits.
+Re-measured 2026-09-05 after a day's work: still **37**, so no drift was observed — but the
+method is time-dependent by construction, and a later re-derivation returning a different `n`
+means the table is **stale, not wrong**. ⚠ One audit reading of this reported 43; it did not
+reproduce here under the stated method, which is itself the reason to state the method.
 
 ⚠ **Scope of the 37-session sample, stated rather than buried:** devrc handoffs only, and
 only commits carrying the trailer. Handoffs in other repos are not counted, so the true
@@ -183,6 +207,8 @@ one `agent-<hash>.jsonl` per dispatched subagent. Measured: **4,951 of 5,864** f
 quotes 4,955 and this section 4,951, taken minutes apart on the same day, and a later
 reading gave 4,957. The durable claims are the **ratio** (~85% of files, ~64% of bytes) and
 the **exact coincidence** in §3; the absolute counts are not, and nothing pins them.
+(The ratio is 84.4% of files — quoted as "84%" above; do not read the two as different
+measurements.)
 
 Those files are not addressable the way the parent is. `build_transcript_push.py` states the
 convention the whole join rests on — *"The session id IS the filename stem … the same id the
@@ -246,8 +272,7 @@ transcripts through a third party. **Name the rule when writing this down.**
 
 The capacity point is true and secondary: the pod is single-replica, `Recreate` and
 PVC-backed (all three verified) and is designed to render markdown, so a 23.48 MB PUT — §4
-row 1's max, the largest single transcript FILE, which is the right population here because
-§5.1 ships one object per transcript — through it is a category
+row 1's max, the largest single transcript FILE on the host — through it is a category
 change. But that is a reason not to use the pod — it is not the reason the route must stay on
 the mesh.
 


### PR DESCRIPTION
Proposes shipping a session's whole transcript to object storage at handoff time and attaching it to the cairn entries that session touched, so a future reader of an entry can reach the receipts instead of re-deriving them.

**Nothing is built.** No code, no bucket, no credential, no front-matter field. This is the argument and the shape.

## What's in it

**Eight settled decisions (§2)**, each recorded with the consequence it accepts so they are not re-litigated: whole file not tail · per-session trigger not the 5-minute timer · pointer in cairn, bytes in MinIO · ship raw with the storage boundary as the control · handoff ships + `SessionEnd` re-ships · pointer on every touched entry · fail-open on push failure · indefinite retention.

Decisions 4 and 8 compound into a permanent unredacted asset. §6 therefore builds the boundary like it is the only control — because it is.

**It argues against the letter of one decision, once, and says so.** The pointer should be an **opaque id, not a resolvable URL**. Fanning a URL across every touched entry puts a reference to a multi-client object inside a `client-confidential` entry, colliding with the already-taken decision that *tenancy is a security boundary, not a cache key*. An id keeps the fan-out exactly as chosen while making the shared artifact an identifier rather than content. Cheap to accept, expensive to retrofit.

**Why not the shipper that already exists.** `#1310`'s clawgate feeder is good code and the wrong instrument here — structurally, not stylistically: 192 KiB tail vs whole file, ambient timer vs explicit act, inline JSON vs object storage. The duplication is named rather than hidden, with the specific parts that should become shared.

## Measured, not estimated

| | |
|---|---|
| transcripts | 6.6 GB, 5,840 files |
| median / p90 / max | 739 KB / 2.5 MB / 23 MB |
| opencode | 2.4 GB of SQLite, **no jsonl** — separate project |

`SessionEnd` was verified to be a wired hook event on this host rather than assumed, since one option depended on it.

## Seven controls the implementation must be watched to FAIL

Positive and negative controls on the shipper · idempotency across two handoff runs in one session · a `SessionEnd` overwrite that actually changes the digest · the crash path still attaching the handoff-time floor · anonymous GET denied against the **real** bucket · cross-credential separation, both directions.

## Still open

Five questions in §9, led by the pointer-shape recommendation above.

---

No scope, entry, bucket or endpoint name appears, per the precedent `plan-cairn-phase1-cutover.md` set for this public repo.

**Gate:** content + skill-listing gates, 294 passed. Docs-only; other tiers not run and not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wTuXEuj8Hs89X6H8xYpjq