### PR TITLE
perf(mention-open): delete the GitHub-wide search; offer the picker instead of refusing

### DIFF
--- a/claudedocs/handoff-mention-system-repos.md
+++ b/claudedocs/handoff-mention-system-repos.md
@@ -53,17 +53,27 @@ diagnosis in progress.)
 1. **Exercise the real Alacritty click path** — STILL the one thing never done end-to-end,
    and now more valuable than before because #1313 changed it. Plain left-click (the hint is
    `mouse.enabled = true` with no mods; `Ctrl+Shift+M` is the keyboard route):
-   `talos-infra#1065` (opens), `dashboard#12` (rofi picker), `#282828` (underlines, opens
-   nothing). 🔴 **The widest-blast-radius change to check deliberately:** a bare `#N` clicked
+   `talos-infra#1065` (opens), `dashboard#12` (rofi picker, now with an explanatory line
+   above the list naming the clicked text, the row count and the mapping's age), `#282828`
+   (underlines; since #1328 it opens NO picker and shows a named toast saying it looks like a
+   colour literal). 🔴 **The widest-blast-radius change to check deliberately:** a bare `#N` clicked
    in a pane with NO resolvable repo now shows a ~370-row fuzzy picker with the clawgate task
    first, where it previously opened the clawgate task directly. Type to narrow. If that is
    wrong in practice it is a one-line ordering change.
    🔴 NEEDS A HUMAN — clicking raises windows, a `pkill`-class action for an agent.
    forcing: none
-2. **Add a staleness signal for `~/.config/mention-open/known_repos.json`** (devrc;
-   `scripts/regen-known-repos.py` + a test, or a systemd-user timer in `nix/home.nix`).
-   Re-measured 2026-09-04: still zero timers reference it (`present-regen.timer` belongs to
-   the `present` skill and is unrelated). Degrades to the API fallback rather than breaking.
+2. ~~**Add a staleness signal for `~/.config/mention-open/known_repos.json`**~~ — **DONE** in
+   PR #1328. `mention-open.py` now measures the mapping's age (`mapping_age_days`) and
+   surfaces it in BOTH places the operator can see it: the note above the fuzzy picker
+   (`universe_note`) and the refusal body (`staleness_note`, past `STALE_MAPPING_DAYS = 7`).
+   🔴 **A SIGNAL, NOT A REPAIR, AND THAT WAS THE CHOICE.** A systemd-user timer was the other
+   option and was rejected: `regen-known-repos.py` shells out to `gh api user/repos` and
+   REFUSES below its 25-repo floor with exit 3, so a host without `gh auth` would take a
+   failing unit plus a failure toast on every fire — a permanently-red timer, which trains
+   everyone to ignore it. The signal instead fires at the exact moment the staleness bites:
+   the click that did not resolve. Re-measured 2026-09-05: still zero timers reference the
+   generator. Pinned at four ages (0, 6, 8, 90 days) by `test_the_mapping_age_is_measured_at_
+   FOUR_points`, and mutation-verified (K32).
    forcing: none
 3. **Commit the workbench's `save_to_clipboard` WIP** in
    `nix/programs/alacritty/default.nix`. Now the ONLY substantive difference between the two
@@ -89,9 +99,9 @@ diagnosis in progress.)
 
 ## Gotchas / decisions / dead-ends
 - `--no-discovery` flag intentionally skips the static mapping (Pass 2 only). This is by design: the flag means "resolve only what the text itself carries."
-- `clawgate#50` does NOT resolve — `clawgate` is a container inside `homelab-talos`, not a standalone GitHub repo. The `GITHUB_RE` scanner treats it as a repo name, finds no match, and the API fallback also finds nothing. This is correct behavior.
+- `clawgate#50` does NOT auto-resolve — `clawgate` is a container inside `homelab-talos`, not a standalone GitHub repo. The `GITHUB_RE` scanner treats it as a repo name and finds no match. Since #1328 that is not a refusal: it opens the fuzzy repo picker over the local universe, with a note above the list naming the clicked text.
 - Case normalization was necessary: GitHub repo names are case-insensitive (`ComfyUI` vs `comfyui`), so all keys in `KNOWN_REPOS` are lowercased. Local checkout overlays also add lowercase entries.
-- The API fallback (`_gh_api_repo_search`) only fires for explicit `repo#N`, not bare `#N`. A bare `#N` needs context (tmux pane) to know which repo, and the API can't provide that.
+- 🔴 **THE API FALLBACK IS DELETED — do not reason from it.** `_gh_api_repo_search` / `gh api search/repositories` was removed in PR #1328: measured at **4.3s through `--print` and ~10s through the real hint path**, essentially all network wait, answering `dashboard#12` with strangers' repositories. `mention-open.py`'s docstring carries the full record. THE CLICK PATH NOW MAKES NO NETWORK CALL, pinned by a two-way ledger of every command the resolution path may spawn (`test_the_resolution_path_spawns_ONLY_these_local_commands`) — keyed on the VERB PATH, `("git", "remote", "get-url")`, because a two-word key admitted `git remote update`, which fetches.
 - `known_repos.py` does NOT need nix deployment — `session-tailer.py` (the telemetry consumer) calls `scan_mention_spans(text)` without repos (detection only, no resolution), so it doesn't need the mapping.
 
 - 🔴 **`gh api user/repos` RETURNS PRIVATE REPOS.** That one fact is the whole incident: a
@@ -153,12 +163,16 @@ diagnosis in progress.)
   a mutation test that removes a hint literal and watches a reachability test go red.
 - 🔴 **A git-sha pattern is catastrophic and was rejected outright** — a `[0-9a-f]{7,12}`
   probe returned **520,256** hits. Recorded so nobody re-proposes it.
-- **The click path has THREE distinct dead-ends, not one** (`mention-open.py` ~lines 430-465),
-  and decision 4 lands on each differently: (a) `len(matches) > PASS3_MAX_CHOICES` (8) refuses
-  outright — its comment argues "a 100-row list is not a choice, it is a wall", which is
-  exactly what fuzzy typing dissolves, so the cap moves AND that comment must move with it;
-  (b) search ran, found nothing — fuzzy over the ~370-entry universe rescues typos;
-  (c) bare `#N` with no `default_repo`.
+- ~~**The click path has THREE distinct dead-ends**~~ — **ALL THREE CLOSED in #1328, and the
+  furniture this bullet described is GONE.** `PASS3_MAX_CHOICES` (the cap of 8) no longer
+  exists: `pick()` runs rofi with `-matching fuzzy`, which turns the wall into a narrowing,
+  and the comment arguing for the cap was replaced by one forbidding its return. The
+  namesake SEARCH no longer exists either (see the API-fallback bullet above), so "search
+  ran, found nothing" is not a state. What remains: (a) an unresolvable `repo#N` → the fuzzy
+  universe picker with an explanatory note; (b) a bare `#N` with no `default_repo` → clawgate
+  FIRST with the universe appended below it; (c) a SIX-DIGIT `#N` → a named toast, not a
+  picker, because on this host six digits is always a colour literal and every offered row
+  would 404.
 - 🔴 **The fuzzy universe is `known_repos.json` — THE FILE FROM THE #1283 DISCLOSURE.** It
   holds private repo names. Displaying them in rofi on the operator's own screen is fine;
   they must never reach a log, a test fixture, an `activity.events` payload or a debug dump,
@@ -223,16 +237,26 @@ diagnosis in progress.)
   failing when a NEW private name appears; that churns nothing and closes the actual hazard,
   which is the next bulk dump rather than the names already present. ⚠ The scan's positive
   control held (private list non-empty, 233/149); its negative control was near-vacuous.
-- **`--print` above the retired namesake cap now prints every namesake and exits 0** where it
-  used to refuse — declared intended, argued in code and body, pinned at nine rows. Nothing
-  in the repo consumes `--print`.
+- 🔴 **`--print` NOW REFUSES an unresolvable reference, and that reverses the line this bullet
+  used to carry.** It read "`--print` above the retired namesake cap now prints every namesake
+  and exits 0"; #1328 deleted the namesake search, so there are no namesakes to print.
+  `--print dashboard#12` exits 1 with a named reason instead of exit 0 carrying strangers'
+  repository URLs — a wrong answer dressed as an answer. `--print` never offers the picker
+  (it is non-interactive, and printing several hundred private repo names to stdout would be
+  a disclosure), and its refusal now names BOTH causes: the flag AND the mapping's state,
+  because only the second is actionable. `--print` still prints every candidate for real
+  ambiguity. Nothing in the repo consumes `--print`.
 
 ## How to verify
 ```bash
 # The 2026-09-03 resolver work, on the deployed artifact (not a checkout)
 python3 ~/workspace/devrc/scripts/mention-open.py --print 'talos-infra#1065'   # civitai/talos-infra
-python3 ~/workspace/devrc/scripts/mention-open.py --print 'kubernetes#1'       # refuses: "at least N repositories are named"
-python3 ~/workspace/devrc/scripts/mention-open.py --print 'zzz-no-such-repo#1' # refuses, names the reason
+# 🔴 Since #1328 there is no namesake search, so an unresolvable name REFUSES (exit 1) and
+# names BOTH causes — the flag, and the mapping's state — rather than printing candidates.
+python3 ~/workspace/devrc/scripts/mention-open.py --print 'kubernetes#1'       # exit 1, named reason
+python3 ~/workspace/devrc/scripts/mention-open.py --print 'zzz-no-such-repo#1' # exit 1, named reason
+# The six-digit branch: a colour literal is answered, not asked about (exit 1, named toast).
+python3 ~/workspace/devrc/scripts/mention-open.py '#282828'
 
 # The premise correction — this MUST resolve, it is not a gap
 python3 ~/workspace/devrc/scripts/mention-open.py --print 'innovation-upstream/devrc#1291'

--- a/nix/programs/alacritty/default.nix
+++ b/nix/programs/alacritty/default.nix
@@ -13,14 +13,27 @@ let
   # `pkgs.rofi` in would install a second, independently-versioned copy whose
   # theme could drift from the launcher's. The picker must look like every other
   # picker on this desktop.
+  # 🔴 THE LIST BELOW IS PINNED AGAINST THE HANDLER'S OWN AST by
+  # `scripts/tests/test_mention_open.py::test_the_alacritty_wrapper_PATH_covers_
+  # every_executable_the_handler_spawns`. Adding a spawn to `mention-open.py`
+  # without adding its package here produces a `FileNotFoundError` that the
+  # handler catches as `OSError` and answers with "" — inert in production,
+  # green in every suite. That test is what makes this list a claim rather than
+  # a hope, and it fails in BOTH directions, so a package nobody spawns is a
+  # finding too.
+  #
+  # ⚠ `pkgs.gh` USED TO BE HERE and is REMOVED. Its comment justified it as
+  # "PASS 3's only tool" — PASS 3 was the GitHub-wide namesake search, which is
+  # deleted (see `mention-open.py`'s docstring for the 4.3s it cost), and the
+  # passes were renumbered when it went, so the old comment pointed a reader at
+  # the fuzzy universe, which spawns nothing at all. Do not re-add it without a
+  # spawn to justify it.
   mentionOpen = pkgs.writeShellScript "alacritty-mention-open" ''
     export PATH=${lib.makeBinPath [
-      # `gh` is PASS 3's only tool, and its absence is SILENT: FileNotFoundError
-      # is caught as OSError and the search returns {}, so the fallback would be
-      # inert in production with a fully green suite. `~/.nix-profile` is also
-      # blanked for ~1s during every home-manager switch, so relying on the
-      # inherited PATH is not enough.
-      pkgs.python312 pkgs.git pkgs.tmux pkgs.xdg-utils pkgs.libnotify pkgs.gh
+      # `~/.nix-profile` is blanked for ~1s during every home-manager switch, so
+      # relying on the inherited PATH is not enough: a click landing in that
+      # window would find none of these by bare name.
+      pkgs.python312 pkgs.git pkgs.tmux pkgs.xdg-utils pkgs.libnotify
     ]}:$PATH
     exec ${pkgs.python312}/bin/python3 \
       ${config.home.homeDirectory}/workspace/devrc/scripts/mention-open.py "$@"

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -360,7 +360,8 @@ def _fan_out(paths: list[Path]) -> list[str]:
     `~/workspace/devrc` would answer `devrc#1291` with issue 1291 of some other
     organisation's repository. That is the confident-wrong-page failure this
     whole module is anchored against, and it is invisible to any fixture holding
-    one checkout. Pinned by `test_the_fan_out_pairs_every_checkout_with_its_OWN`.
+    one checkout. Pinned by
+    `test_mention_open.py::test_the_fan_out_pairs_every_checkout_with_its_OWN_owner`.
 
     The measurement it parallelises is ~100% waiting on a child process, which
     is why threads are the right tool and the GIL is not in the way: 100

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -19,8 +19,11 @@ RESOLUTION
   1 openable candidate   -> xdg-open it.
   2+ (a bare `#N`)       -> rofi picker, one row per platform, showing the URL.
   0                      -> the FUZZY repo picker over the LOCAL universe, and
-                            only if that cannot be shown, a notification saying
-                            WHICH empty this is.
+                            only if that cannot or should not be shown, a
+                            notification saying WHICH empty this is.
+  0, and six digits      -> a NAMED toast. A six-digit `#N` is always a colour
+                            literal here, so every row a picker could offer
+                            would 404. See `colour_literal_offer`.
 
 🔴 THE CLICK PATH MAKES NO NETWORK CALL. This is a hard property, not a target,
 and it is pinned by `test_the_resolution_path_spawns_ONLY_these_local_commands`.
@@ -58,23 +61,30 @@ only from a source that names THIS repo unambiguously, in this order:
 
 🔴 AND WHEN NONE OF THEM ANSWERS, THE OPERATOR CHOOSES — THE HANDLER DOES NOT
 REFUSE. Every repository this host knows about goes into a rofi picker with
-`-matching fuzzy`, so `talos-inf#12` is four keystrokes from `talos-infra`, and
-`#282828` — which the strict scanner rejects, and which used to produce the
-toast `no mention in the clicked text` — opens a picker instead. That toast read
-as a failure when it was the guard working, and a guard that reads as a bug gets
-deleted by the next maintainer.
+`-matching fuzzy`, so `talos-inf#12` is four keystrokes from `talos-infra`. The
+old toast `no mention in the clicked text` read as a failure when it was the
+guard working, and a guard that reads as a bug gets deleted by the next
+maintainer — so every unresolvable shape now becomes a CHOICE.
+
+⚠ EVERY SHAPE EXCEPT ONE. A SIX-DIGIT `#N` gets a named toast rather than a
+picker, because on this host it is always a colour literal and every row a
+picker could offer names an issue no repository has. That is not the old dead
+end returning: the toast SAYS what it saw. See `colour_literal_offer`.
 
 🔴 THIS IS NOT A RELAXATION OF THE NO-GUESSING RULE, IT IS ITS EXTENSION. A
 picker is a CHOICE the operator makes; a guess is one this script makes for
 them. Nothing below ever opens a URL the operator did not select, and dismissing
-the picker still opens NOTHING. In particular a six-digit number is OFFERED and
-never AUTO-OPENED — see `offer_number` and `offered_universe`.
+the picker still opens NOTHING — a universe row is never auto-opened even when
+it is the only one, see `offered_universe`.
 
-⚠ IT DEGRADES, IT DOES NOT DISAPPEAR. A toast is correct in exactly one case:
-the picker cannot be shown. That is the universe being missing, unreadable or
-empty, or `--print`/`--no-discovery` barring it by contract — and the toast
-still names WHICH of those it is, because each needs a different next move. A
-silent empty picker would be the same silent zero one layer up.
+⚠ IT DEGRADES, IT DOES NOT DISAPPEAR. A toast is correct in exactly two cases:
+the picker cannot be shown, or it SHOULD not be. The first is the universe being
+missing, unreadable or empty, or `--print`/`--no-discovery` barring it by
+contract. The second is a SIX-DIGIT `#N`, which is always a false positive here
+(nothing this host references numbers past five digits) and whose every offered
+row would name an issue no repository has — see `colour_literal_offer`. Either
+way the toast names WHICH of those it is, because each needs a different next
+move. A silent empty picker would be the same silent zero one layer up.
 
 🔴 THE UNIVERSE NAMES PRIVATE REPOSITORIES. It is built from
 `known_repos.json`, the file whose committed ancestor disclosed 232 private
@@ -91,6 +101,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # 🔴 `concurrent.futures` IS IMPORTED LAZILY, INSIDE `discover_repos`, AND THAT
@@ -125,6 +136,27 @@ KNOWN_REPOS_PATH = Path(
     os.environ.get("MENTION_OPEN_KNOWN_REPOS")
     or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
     / "mention-open" / "known_repos.json")
+
+# 🔴 THE MAPPING IS HAND-REGENERATED ONLY, AND NOTHING CONVERGES IT. There is no
+# timer anywhere in `nix/` that runs `scripts/regen-known-repos.py`, so a
+# repository created after the last run is INVISIBLE to every resolution path —
+# and the symptom is the picker appearing for a name that ought to have resolved,
+# which reads as "the picker is noisy" rather than as "my mapping is old".
+#
+# So the age is MEASURED and SURFACED, at both places the operator can see it:
+# the note above the picker (`universe_note`) and the refusal body
+# (`staleness_note`). It is a SIGNAL, not a repair — deliberately, and the
+# alternative was weighed: a systemd-user timer would run `gh api user/repos`
+# on a schedule, and `regen-known-repos.py` REFUSES below its 25-repo floor and
+# exits 3, so a host without `gh auth` would take a failing unit and a failure
+# toast on every fire. A permanently-red timer is worse than no timer. The
+# signal fires at the exact moment the staleness bites, which is the click that
+# did not resolve.
+#
+# Seven days is a week of repo-creating, not a tuned constant; it is pinned at
+# two points (fresh and stale) rather than at a boundary, and it is not
+# env-overridable because a run must not be able to excuse itself.
+STALE_MAPPING_DAYS = 7
 
 # rofi theme — the same one nix/i3/config.nix already uses for the app launcher,
 # so the picker looks like every other picker on this desktop.
@@ -220,9 +252,17 @@ def offer_number(text: str) -> str:
     toast `no mention in the clicked text`, which reads as the handler being
     broken rather than as the guard doing its job.
 
-    So a number recovered here reaches the picker and nowhere else. It is never
-    handed to `resolve()`, never used to build a candidate that could satisfy the
-    single-candidate auto-open, and never counted as a mention.
+    So a number recovered here reaches the picker or a NAMED toast, and nowhere
+    else. It is never handed to `resolve()`, never used to build a candidate
+    that could satisfy the single-candidate auto-open, and never counted as a
+    mention.
+
+    ⚠ IT STILL RETURNS SIX DIGITS, AND THAT IS ON PURPOSE. `colour_literal_offer`
+    is the caller that reads six digits as "a colour, not a reference" and routes
+    it to a toast instead of a picker — the classification lives THERE, at one
+    site, not in this recogniser. Narrowing this bound to `{1,5}` would break the
+    seam it is pinned against (the Alacritty hint's own `{1,6}`) and leave the
+    six-digit case with no number to name in its message.
 
     ⚠ IT RETURNS "" FOR TEXT WITH NO `#N` AT ALL, and that case cannot arrive
     from a click: the Alacritty hint regex requires `#[0-9]{1,6}` or a ClickUp
@@ -311,6 +351,28 @@ def repo_of_checkout(path: Path) -> str:
     return parse_owner_repo(_git(["remote", "get-url", "origin"], cwd=str(path)))
 
 
+def _fan_out(paths: list[Path]) -> list[str]:
+    """`repo_of_checkout` for every path, IN THE SAME ORDER, across a thread pool.
+
+    🔴 ORDER IS THE CONTRACT, not an implementation detail. The caller re-pairs
+    this list with `paths` positionally, so a result list that is reordered,
+    reversed or short by one maps every checkout onto its NEIGHBOUR's owner —
+    `~/workspace/devrc` would answer `devrc#1291` with issue 1291 of some other
+    organisation's repository. That is the confident-wrong-page failure this
+    whole module is anchored against, and it is invisible to any fixture holding
+    one checkout. Pinned by `test_the_fan_out_pairs_every_checkout_with_its_OWN`.
+
+    The measurement it parallelises is ~100% waiting on a child process, which
+    is why threads are the right tool and the GIL is not in the way: 100
+    checkouts cost 0.149-0.184s serially and 0.026s across 16 threads.
+    """
+    from concurrent.futures import ThreadPoolExecutor  # see the import block
+    with ThreadPoolExecutor(max_workers=_DISCOVERY_WORKERS) as pool:
+        # `list(...)` INSIDE the `with`: `pool.map` is lazy, so returning the
+        # iterator would hand the caller a generator over a shut-down pool.
+        return list(pool.map(repo_of_checkout, paths))
+
+
 def load_known_repos(path: Path | None = None) -> dict[str, str]:
     """{name: "owner/repo"} from the operator's generated mapping, or {}.
 
@@ -378,11 +440,28 @@ def discover_repos(workspace: Path | None = None) -> dict:
     # submodule gitdirs, `include`/`includeIf` and `url.<base>.insteadOf` to keep
     # agreeing. 26ms is already far inside the budget; reimplementing a slice of
     # git to save 18ms buys a whole class of divergence bugs for nothing.
-    from concurrent.futures import ThreadPoolExecutor  # see the import block
-    with ThreadPoolExecutor(max_workers=_DISCOVERY_WORKERS) as pool:
-        for entry, full in zip(entries, pool.map(repo_of_checkout, entries)):
-            if full:
-                out[entry.name] = full
+    #
+    # 🔴 AND IT DEGRADES TO SERIAL RATHER THAN VANISHING. `ThreadPoolExecutor`
+    # raises `RuntimeError: can't start new thread` when the process or the box
+    # is at its thread limit — this host routinely runs 100+ concurrent agent
+    # worktrees — and the lazy import can raise `ImportError` on a broken
+    # interpreter. Either one used to propagate out of `main()` into a DETACHED
+    # process with no terminal, so the click did nothing at all: no toast, no
+    # visible stderr, indistinguishable from a hint that was never wired up.
+    # Serially, 100 checkouts cost ~0.18s — slower, and an answer.
+    try:
+        resolved = _fan_out(entries)
+    except (ImportError, OSError, RuntimeError):
+        resolved = [repo_of_checkout(p) for p in entries]
+    for entry, full in zip(entries, resolved):
+        # 🔴 `if full:` IS A GUARD, NOT A TIDY-UP. `repo_of_checkout` answers ""
+        # for a checkout whose `git remote` failed or timed out; writing that ""
+        # over `out[entry.name]` would DELETE a good row the generated mapping
+        # had already supplied, silently un-resolving a name the host could
+        # answer a moment ago. Pinned by
+        # `test_an_UNREADABLE_checkout_does_not_ERASE_the_mappings_answer`.
+        if full:
+            out[entry.name] = full
     return out
 
 
@@ -423,10 +502,22 @@ def notify(summary: str, body: str = "") -> None:
     """Best-effort desktop notification. A handler that fails SILENTLY is
     indistinguishable from one that was never wired up, which is exactly the
     silent-zero shape this repo keeps paying for — so a refusal is always
-    announced somewhere."""
+    announced somewhere.
+
+    🔴 `--` IS LOAD-BEARING AND WAS MISSING. Several refusal bodies begin with a
+    flag NAME — "--print cannot show the repository picker", "--no-discovery
+    resolves only what the text itself carries" — because naming the operator's
+    own lever is the point. `notify-send` uses GNU getopt, which PERMUTES: an
+    argument starting with `--` is parsed as an option wherever it sits.
+    MEASURED with notify-send 0.8.8: `notify-send -a mention-open SUMMARY
+    "--no-discovery …"` prints `Unknown option` and exits 1 with NO toast, while
+    the same call with `--` exits 0 and shows one. And `check=False` swallows
+    that exit code, so the failure is silent — a refusal that shows nothing is
+    worse than the refusal it replaced. Pinned by
+    `test_notify_send_is_given_a_double_dash_before_the_MESSAGE`."""
     print(f"mention-open: {summary} {body}".strip(), file=sys.stderr)
     try:
-        subprocess.run(["notify-send", "-a", "mention-open", summary, body],
+        subprocess.run(["notify-send", "-a", "mention-open", "--", summary, body],
                        timeout=5, check=False)
     except (OSError, subprocess.SubprocessError):
         pass
@@ -442,9 +533,20 @@ def open_url(url: str) -> int:
     return 0
 
 
-def pick(candidates: list[dict]) -> str:
+def pick(candidates: list[dict], mesg: str = "") -> str:
     """Ask rofi which candidate to open. Returns the chosen URL, or "" if the
     operator dismissed the picker (which must open NOTHING).
+
+    🔴 `mesg` IS WHERE THE DIAGNOSIS GOES, AND THE REASON IS THAT ROFI CANNOT
+    TELL THE TWO EXITS APART. With `-no-custom` a name that matches nothing
+    cannot be submitted, so "I typed `kubectl-neat` and the list went empty" and
+    "I changed my mind" BOTH arrive back here as rofi exiting non-zero with no
+    selection. There is no signal that separates them — not the exit code, not
+    stdout — so a toast fired after a dismissal would fire after every dismissal,
+    which is the noise this handler must not make. The diagnosis therefore goes
+    where it costs nothing and is read BEFORE the choice: a line above the list,
+    on the operator's own screen, which is the one surface the universe may
+    already reach. See `universe_note` for what it may say.
 
     🔴 `-matching fuzzy` IS LOAD-BEARING, not a nicety. It is the entire reason
     the namesake cap could be removed and the reason a hundred-row universe is a
@@ -457,11 +559,25 @@ def pick(candidates: list[dict]) -> str:
     `row_to_url` would then fail to match — dismissal-shaped, but by accident.
     """
     rows = picker_rows(candidates)
+    # `-mesg` renders as PANGO MARKUP, and the note embeds the clicked text. A
+    # stray `<` or `&` there would break the whole line's rendering, so the three
+    # markup-significant characters are escaped. Rows are NOT markup (there is no
+    # `-markup-rows`), so they need no such treatment.
+    #
+    # 🔴 SPLICED WITH `*`, NEVER CONCATENATED ONTO A NAME. The argv must stay a
+    # LIST LITERAL whose first element is the constant `"rofi"`, because
+    # `test_mention_open.py`'s AST ledger of spawnable executables reads exactly
+    # that; handing `subprocess.run` a variable reports `<computed>` and the
+    # ledger — the guard that stops a network call being re-added — goes red for
+    # a reason that has nothing to do with what is being spawned.
+    mesg_argv = ["-mesg", (mesg.replace("&", "&amp;")
+                               .replace("<", "&lt;")
+                               .replace(">", "&gt;"))] if mesg else []
     try:
         r = subprocess.run(
             ["rofi", "-dmenu", "-i", "-matching", "fuzzy",
              "-p", "mention", "-theme", ROFI_THEME,
-             "-format", "s", "-no-custom"],
+             "-format", "s", "-no-custom", *mesg_argv],
             input="\n".join(rows), capture_output=True, text=True, timeout=120)
     except (OSError, subprocess.SubprocessError) as exc:
         notify("could not show the mention picker",
@@ -558,6 +674,101 @@ def universe_reason(path: Path | None = None) -> str:
     return ""
 
 
+def mapping_age_days(path: Path | None = None) -> float | None:
+    """How long ago the repo mapping was written, in days, or None.
+
+    🔴 ONE MEASUREMENT, TWO READERS. `staleness_note` puts it in a refusal body
+    and `universe_note` puts it above the picker; open-coding `st_mtime` at both
+    would be the same predicate at two sites, wrong at one of them. None means
+    "could not be measured" — absent, or a stat that failed — and every caller
+    must treat that as UNKNOWN, never as fresh.
+    """
+    path = path or KNOWN_REPOS_PATH
+    try:
+        return max(0.0, (time.time() - path.stat().st_mtime) / 86400.0)
+    except OSError:
+        return None
+
+
+def staleness_note(path: Path | None = None) -> str:
+    """"the repo mapping is N days old — …" when it is, else "".
+
+    🔴 IT IS A SIGNAL FOR A FILE NOTHING CONVERGES. See `STALE_MAPPING_DAYS`.
+    A repository created since the last `regen-known-repos.py` run cannot be
+    resolved by ANY path here, and the only symptom is a picker appearing where
+    a resolution used to — so the refusal says how old the mapping is and what
+    to run. It names a COUNT and a CONSTANT PATH, never a row.
+    """
+    age = mapping_age_days(path)
+    if age is None or age < STALE_MAPPING_DAYS:
+        return ""
+    return (f"the repo mapping is {age:.0f} days old and nothing regenerates it "
+            f"— a repository created since then cannot resolve; run "
+            f"scripts/regen-known-repos.py")
+
+
+def universe_note(subject: str, offered: int, path: Path | None = None) -> str:
+    """The line shown ABOVE the fuzzy picker when the universe is the last resort.
+
+    🔴 IT EXISTS BECAUSE A DISMISSED PICKER CANNOT BE READ. `pick()` explains
+    why: rofi with `-no-custom` reports "nothing matched what I typed" and "I
+    changed my mind" identically, so the only honest place to say "this host has
+    no repository called `kubectl-neat`" is BEFORE the choice, not after it. A
+    real dismissal still opens nothing and still says nothing.
+
+    🔴 IT NAMES THE CLICKED TEXT, A COUNT AND A DATE — NEVER A ROW. `subject` is
+    what the OPERATOR typed or clicked, which they already have; `offered` is a
+    cardinality; the date is the mapping file's mtime. None of the three is a
+    repository name from the universe, and this string reaches rofi only — it is
+    never handed to `notify()`, which would put it on stderr.
+    """
+    age = mapping_age_days(path)
+    if age is None:
+        when = "no mapping file on this host"
+    else:
+        # Derived from the SAME reading as the age, not a second `stat()`: the
+        # file can be regenerated between two calls, and a date that disagreed
+        # with the age beside it would read as a bug in the note.
+        stamp = time.strftime("%Y-%m-%d", time.localtime(time.time() - age * 86400))
+        when = f"mapping generated {stamp} ({age:.0f}d ago)"
+    return (f"nothing here knows {subject} — pick a repository, or dismiss. "
+            f"{offered} offered · {when} · refresh with "
+            f"scripts/regen-known-repos.py")
+
+
+def colour_literal_offer(span: dict | None, text: str) -> str:
+    """The SIX-DIGIT number in `text` that is a colour literal, not a reference —
+    or "" for everything else.
+
+    🔴 SIX DIGITS IS ALWAYS A FALSE POSITIVE ON THIS HOST, AND THAT IS A
+    MEASUREMENT RATHER THAN A HUNCH. `mention_scan`'s `_NUM` is `\\d{1,5}`
+    exactly because nothing here — no clawgate task, no GitHub issue in any repo
+    the operator touches — reaches six digits; devrc itself is in the 1300s. So
+    a six-digit `#N` that the scanner refused cannot be a reference, and every
+    row a universe picker would offer for it names an issue NO repository has.
+    Raising a several-hundred-row window to choose between hundreds of URLs that
+    all 404 is not a choice, it is a wall with no door.
+
+    ⚠ AND THE ORIGINAL CASE IS THE PROOF. `#282828` is the operator's own gruvbox
+    background literal — it is written in `nix/programs/alacritty/default.nix`,
+    the very file that configures this hint. The right answer to clicking it is
+    "that is a colour", said once, not a picker.
+
+    🔴 THIS DOES NOT WEAKEN THE AUTO-OPEN RULE, IT MAKES IT UNREACHABLE. Six
+    digits could never auto-open (`offered_universe` suppresses the shortcut for
+    every universe row, and that guard is UNCHANGED); now it is not offered at
+    all. Every OTHER unresolvable shape keeps the picker — `kubectl-neat#1`,
+    `talos-inf#12`, a bare `#N` nothing attributes. This is the six-digit case
+    and nothing else.
+
+    ⚠ IT ASKS FOR `span is None` FIRST. A number the scanner ACCEPTED is a
+    reference by definition, whatever its length, and must not be second-guessed
+    here.
+    """
+    num = offer_number(text) if span is None else ""
+    return num if len(num) == 6 else ""
+
+
 def refuse(span: dict | None, text: str, args: argparse.Namespace) -> int:
     """The last resort, and the ONLY case a toast is still correct in: the picker
     could not be shown. Always returns 1.
@@ -580,15 +791,44 @@ def refuse(span: dict | None, text: str, args: argparse.Namespace) -> int:
         notify("no mention in the clicked text", repr(text))
         return 1
     subject = span["raw"] if span is not None else repr(text)
+    colour = colour_literal_offer(span, text)
     if args.no_discovery:
+        # The flag is the whole cause and the operator's own lever. The mapping
+        # is never even READ under it, so blaming the mapping would send them to
+        # regenerate a file that was not involved.
         why = "--no-discovery resolves only what the text itself carries"
-    elif args.print_only:
-        # 🔴 A DECIDED CONTRACT, not an oversight. `--print` is non-interactive;
-        # the answer to "which of your 369 repositories did you mean?" is a
-        # question, and printing all of them is not an answer either.
-        why = "--print cannot show the repository picker — there is nobody to ask"
+    elif colour:
+        # 🔴 SIX DIGITS — see `colour_literal_offer`. This is a NAMED answer, not
+        # a dead end, and it is the reason the picker is not raised.
+        why = (f"#{colour} is six digits — that looks like a colour literal, "
+               f"not a reference; nothing here numbers past five digits")
+        advice = "if you did mean a reference, write it as owner/repo#N"
     else:
-        why = universe_reason() or "no repository owner is known for it"
+        # 🔴 BOTH CAUSES, NOT WHICHEVER ONE IS CHECKED FIRST. `--print` bars the
+        # picker by contract AND the mapping may be absent, and the flag used to
+        # win purely by being tested first — so `--print zzz#12` on a host with
+        # no mapping at all blamed the flag and never mentioned
+        # `regen-known-repos.py`. Both are true; only one is ACTIONABLE, and
+        # that is the one that was being dropped. In a handler whose stated
+        # discipline is "say WHICH empty this is", reporting the un-actionable
+        # half alone is the silent zero wearing a name.
+        reason = universe_reason()
+        if args.print_only:
+            # 🔴 A DECIDED CONTRACT, not an oversight. `--print` is
+            # non-interactive; the answer to "which of your 369 repositories did
+            # you mean?" is a question, and printing all of them is not an
+            # answer either.
+            why = ("--print cannot show the repository picker — there is nobody "
+                   "to ask")
+            if extra := (reason or staleness_note()):
+                why = f"{why}; also {extra}"
+        else:
+            why = reason or "no repository owner is known for it"
+            # A mapping that PARSED and holds rows can still be months old, and
+            # that is a different, ADDITIVE fact — appended, never substituted
+            # for the primary one, for the same reason the advice is.
+            if not reason and (stale := staleness_note()):
+                why = f"{why}; {stale}"
     notify(f"cannot resolve {subject}", f"{why} — {advice}")
     return 1
 
@@ -604,25 +844,44 @@ def main(argv: list[str] | None = None) -> int:
     span, candidates = resolve(text, default_repo=args.default_repo or None)
 
     # 🔴 THE NUMBER A PICKER COULD OFFER, computed from the RAW TEXT and kept
-    # strictly apart from anything `resolve()` produced. For `#282828` the
-    # scanner returns no span at all and this returns "282828" — which is what
-    # turns the old `no mention in the clicked text` toast into a choice. It is
+    # strictly apart from anything `resolve()` produced. For a text the scanner
+    # refuses outright — `&#123;`, `##370` — it recovers the number so the
+    # operator gets a choice instead of `no mention in the clicked text`. It is
     # never merged into `span` and never satisfies the auto-open below.
     offer_num = offer_number(text)
+
+    # 🔴 SIX DIGITS IS ANSWERED, NOT ASKED ABOUT — see `colour_literal_offer`.
+    # It is computed HERE, once, and read by both the measurement guard below
+    # and by `refuse()`, because a predicate open-coded at two sites is wrong at
+    # one of them. Skipping the measurement is the point as well as the window:
+    # building a several-hundred-row universe that will not be shown is latency
+    # the operator pays on a click that already has its answer.
+    colour = colour_literal_offer(span, text)
 
     # PASS 2 — the LOCAL measurement, only when the text did not answer it.
     # Discovery costs a concurrent `git remote` fan-out plus a tmux round-trip
     # (~30ms here), and paying that before opening a link that needed neither is
     # latency the operator feels on every single click.
     #
-    # 🔴 IT NOW RUNS FOR `span is None` TOO. It used to short-circuit straight to
-    # a refusal there, which is exactly why `#282828` dead-ended: the universe
-    # the picker needs is built by this pass. Guarded on `offer_num` so a text
-    # carrying no number at all — impossible from a click, see `offer_number` —
-    # still costs nothing.
+    # 🔴 IT RUNS FOR `span is None` TOO. It used to short-circuit straight to a
+    # refusal there, and the universe the picker needs is built by this pass.
+    # Guarded on `offer_num` so a text carrying no number at all — impossible
+    # from a click, see `offer_number` — still costs nothing, and on `colour` so
+    # the one shape that has its own answer does not pay for a universe nobody
+    # will see.
+    #
+    # ⚠ SCOPE OF THE `span is None` ARM, STATED HONESTLY BECAUSE IT NARROWED.
+    # The scanner refuses a `#N` for two reasons: six or more digits, and a
+    # forbidden character immediately before the `#` (`&#123;` an HTML entity,
+    # `##370` a heading run). `colour` now takes the first, so this arm covers
+    # the second — which the Alacritty hint CANNOT produce, because it matches
+    # from the `#` and hands over `#123` rather than `&#123;`. So it is a
+    # command-line surface now, not a click one. It is kept because that surface
+    # is real and the alternative is a dead end on it.
     discovered: dict = {}
     unresolved = span is None or span["ambiguous"] or not candidates
-    if unresolved and not args.no_discovery and (span is not None or offer_num):
+    if (unresolved and not args.no_discovery and not colour
+            and (span is not None or offer_num)):
         default_repo = args.default_repo or tmux_pane_repo()
         # Kept, not recomputed: PASS 3 offers the SAME measurement as a fuzzy
         # universe, and calling `discover_repos()` twice would run the whole
@@ -655,14 +914,19 @@ def main(argv: list[str] | None = None) -> int:
     # candidate → just open it" shortcut below. Without it, a host that knows
     # exactly ONE repository would answer `trowelcast#77` by opening issue 77 in
     # that unrelated repository — a confident wrong page, which is precisely the
-    # failure this whole handler is anchored against. It is ALSO what keeps
-    # `#282828` offered-but-never-auto-opened: a number the scanner refused
-    # reaches `candidates` only as universe rows, and universe rows never
-    # auto-open. Measured during development: the first version of this pass did
-    # open it, and the test that caught it was the one asserting a picker
-    # appeared.
+    # failure this whole handler is anchored against. Measured during
+    # development: the first version of this pass did open it, and the test that
+    # caught it was the one asserting a picker appeared.
+    #
+    # ⚠ IT IS NOT WHAT HANDLES `#282828` ANY MORE, AND THAT NOTE IS KEPT BECAUSE
+    # THIS PARAGRAPH USED TO SAY IT WAS. A six-digit number never reaches here
+    # now — `colour` bars it above — so this guard covers the case that remains:
+    # a host whose universe holds exactly ONE repository answering an
+    # unresolvable `repo#N`. Do not delete it on the reasoning that the
+    # six-digit path no longer needs it.
     offered_universe = False
-    may_offer_universe = not args.print_only and not args.no_discovery
+    may_offer_universe = (not args.print_only and not args.no_discovery
+                          and not colour)
     num = span["id"] if (span is not None and span["id"].isdigit()) else offer_num
     universe = (universe_candidates(num, repo_universe(discovered))
                 if (may_offer_universe and num) else [])
@@ -698,9 +962,44 @@ def main(argv: list[str] | None = None) -> int:
     if len(candidates) == 1 and not offered_universe:
         return open_url(candidates[0]["url"])
 
-    url = pick(candidates)
+    # 🔴 THE NOTE IS ATTACHED ONLY WHEN THE UNIVERSE IS THE ANSWER. A picker
+    # over real candidates — the clawgate/GitHub pair for a bare `#N` — is not a
+    # dead end and needs no explanation; adding one there would put a line of
+    # apology above the single most common interaction in this handler.
+    mesg = (universe_note(span["raw"] if span is not None else text,
+                          len(candidates))
+            if offered_universe else "")
+    url = pick(candidates, mesg=mesg)
     return open_url(url) if url else 0
 
 
+def guarded_main(argv: list[str] | None = None) -> int:
+    """`main()` with a last-resort reporter around it. Always the entry point.
+
+    🔴 AN UNCAUGHT EXCEPTION HERE IS A SILENT CLICK. Alacritty spawns this
+    DETACHED: there is no terminal, so a traceback goes to a stderr nobody will
+    ever read, and the operator sees a click that did nothing — the exact shape
+    `notify()`'s docstring exists to prevent, arriving one level above it.
+
+    The case that is not hypothetical: `ThreadPoolExecutor` raises
+    `RuntimeError: can't start new thread` when the box is at its thread limit,
+    and this host routinely runs 100+ concurrent agent worktrees.
+    `discover_repos` degrades to a serial fan-out for exactly that, but a guard
+    that only covers the failure somebody imagined is not a guard — argparse,
+    a malformed `known_repos.json` racing a regeneration, a `Path` that vanishes
+    mid-`stat`, all land here too.
+
+    ⚠ `except Exception`, DELIBERATELY BROAD AND DELIBERATELY NOT BARE:
+    `KeyboardInterrupt` and `SystemExit` derive from `BaseException` and must
+    still terminate. This returns 1 rather than re-raising, because a non-zero
+    exit that ALSO said something is the whole difference being closed here.
+    """
+    try:
+        return main(argv)
+    except Exception as exc:  # noqa: BLE001 — see the docstring
+        notify("mention-open failed", f"{type(exc).__name__}: {exc}")
+        return 1
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(guarded_main())

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -18,41 +18,63 @@ RESOLUTION
 ----------
   1 openable candidate   -> xdg-open it.
   2+ (a bare `#N`)       -> rofi picker, one row per platform, showing the URL.
-  0                      -> the FUZZY repo picker (below), and only if that
-                            cannot run, a desktop notification saying why.
+  0                      -> the FUZZY repo picker over the LOCAL universe, and
+                            only if that cannot be shown, a notification saying
+                            WHICH empty this is.
+
+🔴 THE CLICK PATH MAKES NO NETWORK CALL. This is a hard property, not a target,
+and it is pinned by `test_the_resolution_path_spawns_ONLY_these_local_commands`.
+
+🔴 THE CANDIDATE UNIVERSE IS THE REPOS THE OPERATOR CONTRIBUTES TO — NEVER ALL
+OF GITHUB, AND A GITHUB-WIDE NAMESAKE SEARCH USED TO LIVE HERE. `gh api
+search/repositories` was consulted for a `repo#N` the local sources could not
+name. MEASURED on the deployed copy: `dashboard#12` took **4.3s through
+`--print` and ~10s through the real hint path, at 6% CPU** — essentially all of
+it network wait — and what came back was `vzhong/dashboard`,
+`yorkie-team/dashboard`, `zce/dashboard`: strangers' repositories, none of which
+the operator would ever pick. It was not slow AND useful; it was slow BECAUSE it
+searched a corpus that structurally cannot contain the answer. The same click
+with discovery disabled returned in 0.046s.
+
+So it is DELETED, not deferred or cached. The correct universe was local the
+whole time: `~/.config/mention-open/known_repos.json` is built by
+`scripts/regen-known-repos.py` from `gh api user/repos --paginate` — owner,
+collaborator and organization_member — plus the local checkouts. That IS "the
+repos the operator contributes to", it is already on disk, and reading it costs
+under a millisecond.
 
 🔴 NOTHING IS GUESSED. A GitHub reference needs an owner, and an owner that is
 wrong points confidently at a real-but-unrelated issue. An owner is accepted
-only from a source that names THIS repo unambiguously:
+only from a source that names THIS repo unambiguously, in this order:
 
-  1. an explicit `owner/repo` in the clicked text itself;
-  2. `~/.config/mention-open/known_repos.json`, if the operator has generated it
-     (`scripts/regen-known-repos.py`). It is per-host and OUTSIDE every checkout
-     — it names private repositories, and this repo is public;
+  1. an explicit `owner/repo` in the clicked text itself — the strongest signal
+     there is, and the only one that costs no I/O at all;
+  2. an exact hit in `~/.config/mention-open/known_repos.json`. It is per-host
+     and OUTSIDE every checkout — it names private repositories, and this repo
+     is public;
   3. the git remote of a real local checkout under `~/workspace` (MEASURED, and
      it OVERRIDES 2 — the checkout is authoritative about its own owner);
-  4. last resort, a GitHub search restricted to an EXACT name match.
+  4. the tmux pane the operator was most recently in.
 
-🔴 WHEN SEVERAL OWNERS ANSWER, THE OPERATOR CHOOSES: a name like `dashboard` or
-`cli` exists under dozens of owners, so an exact-name search hit is not the same
-as an unambiguous one. Several matches means a picker, never the first row —
-that is the same rule as "no owner means no URL", applied to the other end of
-the range.
+🔴 AND WHEN NONE OF THEM ANSWERS, THE OPERATOR CHOOSES — THE HANDLER DOES NOT
+REFUSE. Every repository this host knows about goes into a rofi picker with
+`-matching fuzzy`, so `talos-inf#12` is four keystrokes from `talos-infra`, and
+`#282828` — which the strict scanner rejects, and which used to produce the
+toast `no mention in the clicked text` — opens a picker instead. That toast read
+as a failure when it was the guard working, and a guard that reads as a bug gets
+deleted by the next maintainer.
 
-🔴 AND WHEN NONE OF THEM ANSWERS, THE OPERATOR STILL CHOOSES — the handler does
-not dead-end. Every repository this host knows about goes into the same rofi
-picker with `-matching fuzzy`, so `talos-inf#12` is four keystrokes from
-`talos-infra` and `kubernetes#1` is a typed narrowing rather than a refusal.
 🔴 THIS IS NOT A RELAXATION OF THE NO-GUESSING RULE, IT IS ITS EXTENSION. A
 picker is a CHOICE the operator makes; a guess is one this script makes for
 them. Nothing below ever opens a URL the operator did not select, and dismissing
-the picker still opens NOTHING.
+the picker still opens NOTHING. In particular a six-digit number is OFFERED and
+never AUTO-OPENED — see `offer_number` and `offered_universe`.
 
-⚠ IT DEGRADES, IT DOES NOT DISAPPEAR. When the universe cannot be read at all —
-the mapping absent, unreadable or empty, or `--no-discovery` in force — the
-handler falls back to the ORIGINAL refusal, which still names WHICH empty this
-is ("gh is not on PATH" and "no repo by that name" need opposite next moves).
-A silent empty picker would be the same silent zero one layer up.
+⚠ IT DEGRADES, IT DOES NOT DISAPPEAR. A toast is correct in exactly one case:
+the picker cannot be shown. That is the universe being missing, unreadable or
+empty, or `--print`/`--no-discovery` barring it by contract — and the toast
+still names WHICH of those it is, because each needs a different next move. A
+silent empty picker would be the same silent zero one layer up.
 
 🔴 THE UNIVERSE NAMES PRIVATE REPOSITORIES. It is built from
 `known_repos.json`, the file whose committed ancestor disclosed 232 private
@@ -70,6 +92,15 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+# 🔴 `concurrent.futures` IS IMPORTED LAZILY, INSIDE `discover_repos`, AND THAT
+# IS MEASURED RATHER THAN STYLISTIC. At the top of the file it costs ~5ms of
+# interpreter startup — it drags in `threading`, `queue` and `weakref` — and that
+# 5ms lands on EVERY click, including `owner/repo#N` and a bare `#N`, which are
+# the common cases and never reach the fan-out at all. Measured here, interleaved
+# against the pre-change file: 29.6ms -> 35.1ms for an explicit `owner/repo#N`
+# with the import at the top, and back to 30.0ms with it moved. A 5ms tax on the
+# fast path to save nothing on the slow one is a straight loss.
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "collector"))
 
@@ -99,6 +130,12 @@ KNOWN_REPOS_PATH = Path(
 # so the picker looks like every other picker on this desktop.
 ROFI_THEME = "gruvbox-dark-hard"
 
+# How many `git remote get-url` children run at once during discovery. 16 was
+# measured as the knee on this host (8/16/32/64 -> 24/26/28/32 ms for 100
+# checkouts); the curve is flat enough either side that the exact value is not
+# load-bearing, which is why no test pins it.
+_DISCOVERY_WORKERS = 16
+
 PLATFORM_LABEL = {
     PLATFORM_CLAWGATE: "clawgate task",
     PLATFORM_GITHUB: "github",
@@ -112,27 +149,38 @@ PLATFORM_LABEL = {
 _SSH_REMOTE = re.compile(r"^(?:ssh://)?git@[^:/]+[:/](?P<path>.+?)(?:\.git)?/?$")
 _HTTP_REMOTE = re.compile(r"^https?://[^/]+/(?P<path>.+?)(?:\.git)?/?$")
 
-# PASS 3's subject: a bare `repo#N` and NOTHING else. 🔴 It deliberately does not
-# admit `owner/repo#N` — an owner in the text is source 1, the strongest there
-# is, so searching by name there could only ever REPLACE a stated owner with a
-# guessed one. Anchored at both ends so a partial match cannot slice a name out
-# of a longer string.
-_PASS3_REPO_RE = re.compile(r"^(?P<repo>[A-Za-z0-9][A-Za-z0-9._-]*)#(?P<num>\d+)$")
+# 🔴 THE NUMBER A PICKER MAY OFFER — WHICH IS NOT A REFERENCE THE HANDLER MAY
+# OPEN. `mention_scan`'s `_NUM` is `\d{1,5}` precisely so a six-digit hex colour
+# cannot become a reference; that guard is UNCHANGED and still decides what
+# auto-opens. This pattern is a strictly weaker thing: given text the scanner
+# REFUSED, it recovers a number so the operator can be offered a choice instead
+# of a dead end.
+#
+# 🔴 THE TWO MUST NOT BE CONFLATED, AND THE CODE KEEPS THEM APART STRUCTURALLY,
+# not by convention: a number that arrives through here can only ever become a
+# UNIVERSE row, and `offered_universe` in `main()` unconditionally suppresses the
+# "exactly one candidate → just open it" shortcut for universe rows. So there is
+# no path on which `#282828` opens anything without the operator selecting it.
+#
+# The `{1,6}` bound is not arbitrary — it MIRRORS the Alacritty hint regex in
+# `nix/programs/alacritty/default.nix`, which is the click surface. Offering a
+# number the terminal could never underline would be offering something no click
+# can produce. The two bounds are pinned to each other by
+# `test_alacritty_hints.py::test_the_handlers_OFFER_bound_matches_the_hints_own`.
+_OFFER_NUM_RE = re.compile(r"#(?P<num>[0-9]{1,6})")
 
-# 🔴 THERE IS NO LONGER A CAP ON HOW MANY NAMESAKES REACH THE PICKER, AND THIS
-# PARAGRAPH REPLACES ONE THAT ARGUED FOR IT. The old rule refused above 8, on the
-# reasoning that "a 100-row list of URLs differing only by owner is not a choice,
-# it is a wall". That reasoning was correct about a list you can only SCROLL and
-# wrong about one you can TYPE AT: `-matching fuzzy` turns the wall into a
-# narrowing, so `kubernetes#1` — which used to refuse outright, naming 65
-# namesakes — is now four keystrokes from the right owner.
+# 🔴 THERE IS NO CAP ON HOW MANY REPOS REACH THE PICKER, AND THIS PARAGRAPH
+# REPLACES ONE THAT ARGUED FOR IT. The old rule refused above 8, on the reasoning
+# that "a 100-row list of URLs differing only by owner is not a choice, it is a
+# wall". That reasoning was correct about a list you can only SCROLL and wrong
+# about one you can TYPE AT: `-matching fuzzy` turns the wall into a narrowing.
 #
 # 🔴 DO NOT RE-ADD THE CAP WITHOUT ALSO REMOVING THE FUZZY MATCHER. A comment
 # left asserting a hazard the code has closed is exactly how the refusal would
 # come back: the next maintainer reads "not a choice, it is a wall", believes it,
 # and restores a limit that now only removes the operator's ability to choose.
-# The residual cost, stated rather than hidden: the picker can be long, and one
-# page of search results is still one page (see `gh_api_repo_search`).
+# The residual cost, stated rather than hidden: the picker can be several hundred
+# rows on a host with many checkouts.
 
 # `_OWNER_REPO_RE` is IMPORTED, not re-declared — see the import block. It used
 # to be a second copy of `mention_scan`'s rule, which is exactly the shape that
@@ -160,6 +208,29 @@ def parse_owner_repo(remote_url: str) -> str:
     if len(parts) != 2:
         return ""
     return f"{parts[0]}/{parts[1]}"
+
+
+def offer_number(text: str) -> str:
+    """The first `#N` in `text` as a bare digit string, or "".
+
+    🔴 THIS IS AN OFFER, NOT A RESOLUTION, AND THE DISTINCTION IS THE WHOLE
+    POINT. `mention_scan` refuses `#282828` because a six-digit run is far more
+    likely a hex colour than task 282828, and that refusal is correct about what
+    may be OPENED. It was wrong about what may be SHOWN: the operator got the
+    toast `no mention in the clicked text`, which reads as the handler being
+    broken rather than as the guard doing its job.
+
+    So a number recovered here reaches the picker and nowhere else. It is never
+    handed to `resolve()`, never used to build a candidate that could satisfy the
+    single-candidate auto-open, and never counted as a mention.
+
+    ⚠ IT RETURNS "" FOR TEXT WITH NO `#N` AT ALL, and that case cannot arrive
+    from a click: the Alacritty hint regex requires `#[0-9]{1,6}` or a ClickUp
+    id, so nothing digitless is ever underlined. It is reachable only from the
+    command line, and it is the one place the old refusal survives verbatim.
+    """
+    m = _OFFER_NUM_RE.search(text or "")
+    return m.group("num") if m else ""
 
 
 def openable(span: dict) -> list[dict]:
@@ -240,9 +311,6 @@ def repo_of_checkout(path: Path) -> str:
     return parse_owner_repo(_git(["remote", "get-url", "origin"], cwd=str(path)))
 
 
-_GITHUB_API_CACHE: dict[str, dict[str, str]] = {}
-
-
 def load_known_repos(path: Path | None = None) -> dict[str, str]:
     """{name: "owner/repo"} from the operator's generated mapping, or {}.
 
@@ -276,8 +344,11 @@ def discover_repos(workspace: Path | None = None) -> dict:
 
     A local checkout WINS: it is a measurement of this disk, so it is the
     authority on its own owner and it settles a name the mapping had to drop as
-    ambiguous. This does not perform the API fallback — that is PASS 3 in
-    `main()`, which only runs when everything here came back empty.
+    ambiguous.
+
+    🔴 EVERY SOURCE HERE IS LOCAL. There is no network fallback below this
+    function and none above it; a name this cannot answer becomes a PICKER, not
+    a search. See the module docstring for the 4.3s this replaced.
     """
     # 🔴 RESOLVED AT CALL TIME — the same defect as `load_known_repos`' old
     # default, and the reason this is a CLASS sweep rather than one fix: a
@@ -289,71 +360,30 @@ def discover_repos(workspace: Path | None = None) -> dict:
     workspace = workspace or WORKSPACE
     out: dict = dict(load_known_repos())
     try:
-        entries = sorted(p for p in workspace.iterdir() if p.is_dir())
+        entries = sorted(p for p in workspace.iterdir()
+                         if p.is_dir() and (p / ".git").exists())
     except OSError:
         return out
-    for entry in entries:
-        if not (entry / ".git").exists():
-            continue
-        full = repo_of_checkout(entry)
-        if full:
-            out[entry.name] = full
+    # 🔴 CONCURRENT, AND THAT IS A LATENCY FIX RATHER THAN A FEATURE. This is a
+    # fan-out of one `git remote get-url origin` per checkout, and it lands on
+    # the operator on every click that needs discovery. MEASURED on this host,
+    # 100 checkouts: 0.149-0.184s serially, 0.026s across 16 threads — the work
+    # is ~100% waiting on a child process, so threads are the right tool and the
+    # GIL is not in the way.
+    #
+    # 🔴 `git remote get-url` IS KEPT RATHER THAN PARSING `.git/config`
+    # DIRECTLY, and that was a real choice: a hand-rolled reader measured 0.008s
+    # and agreed with git on all 100 checkouts here (56 of them linked
+    # worktrees), but it would have to re-implement `commondir` resolution,
+    # submodule gitdirs, `include`/`includeIf` and `url.<base>.insteadOf` to keep
+    # agreeing. 26ms is already far inside the budget; reimplementing a slice of
+    # git to save 18ms buys a whole class of divergence bugs for nothing.
+    from concurrent.futures import ThreadPoolExecutor  # see the import block
+    with ThreadPoolExecutor(max_workers=_DISCOVERY_WORKERS) as pool:
+        for entry, full in zip(entries, pool.map(repo_of_checkout, entries)):
+            if full:
+                out[entry.name] = full
     return out
-
-
-def gh_api_repo_search(name: str) -> tuple[dict[str, str], str]:
-    """({"owner/repo": "owner/repo"} for every repo on the FIRST PAGE whose name
-    equals `name` case-insensitively, "") — or ({}, reason) when the search
-    could not run. An empty dict with an empty reason means it ran and matched
-    nothing.
-
-    🔴 THE NAME MATCH IS DONE HERE, NOT IN THE jq PROGRAM. `gh api --jq` takes
-    no `--arg`, so a name written into the filter can only be a string literal —
-    which is how an earlier filter came to compare `.name` against the literal
-    text `"$name"` and match NOTHING, ever, for any input, while every test that
-    stubbed `gh` passed. The jq program is now a constant with no interpolation.
-
-    🔴 EVERY exact match ON THE PAGE is returned, not the first. The search is
-    relevance-ordered, so the first row for `dashboard` is whichever repo GitHub
-    ranks highest — measured, a click on `dashboard#12` opened a retired
-    Kubernetes repo. Returning them all is what puts the choice in the picker.
-
-    ⚠ ONE PAGE, AND THE CAVEAT IS REAL. `dashboard` matches 1.2M repos; this
-    reads the first 100 and no more. For a common name the intended repo may
-    not be among them, so a refusal here means "not on page 1", never "does not
-    exist" — which is why `main()` says so in the refusal.
-
-    Returns (matches, reason). `reason` is "" when the search RAN, whether or
-    not it matched; otherwise it names why it could not, because an empty
-    result cannot distinguish "no such repo" from "gh is missing", "not
-    authenticated", "rate-limited" (search allows 30/min) or "timed out" — and
-    the operator gets a different next move for each.
-    """
-    if name in _GITHUB_API_CACHE:
-        return dict(_GITHUB_API_CACHE[name]), ""
-    try:
-        r = subprocess.run(
-            ["gh", "api", "search/repositories", "--method", "GET",
-             "-f", f"q={name} in:name", "-f", "per_page=100",
-             "--jq", ".items[].full_name"],
-            capture_output=True, text=True, timeout=5)
-    except FileNotFoundError:
-        return {}, "gh is not on PATH"
-    except subprocess.TimeoutExpired:
-        return {}, "the GitHub search timed out"
-    except (OSError, subprocess.SubprocessError) as exc:
-        return {}, f"the GitHub search could not run ({type(exc).__name__})"
-    if r.returncode != 0:
-        detail = (r.stderr or "").strip().splitlines()
-        return {}, f"gh exited {r.returncode}: {detail[0][:80] if detail else 'no detail'}"
-    want = name.lower()
-    out: dict[str, str] = {}
-    for line in r.stdout.splitlines():
-        full = line.strip()
-        if "/" in full and full.rsplit("/", 1)[-1].lower() == want:
-            out[full] = full
-    _GITHUB_API_CACHE[name] = dict(out)
-    return out, ""
 
 
 def tmux_pane_repo() -> str:
@@ -450,7 +480,10 @@ def build_parser() -> argparse.ArgumentParser:
         description="Resolve and open a clawgate / GitHub / ClickUp mention.")
     p.add_argument("--print", dest="print_only", action="store_true",
                    help="print the resolved URL instead of opening it (and "
-                        "print every candidate when ambiguous)")
+                        "print every candidate when ambiguous). Never offers "
+                        "the repository picker: it is non-interactive, so an "
+                        "unresolvable reference exits 1 with a named reason "
+                        "rather than listing every repo on the host")
     p.add_argument("--no-discovery", action="store_true",
                    help="do not read git remotes or ask tmux — resolve only "
                         "what the text itself carries")
@@ -488,6 +521,78 @@ def resolve(text: str, *, repos: dict | None = None,
     return (span, openable(span))
 
 
+def universe_reason(path: Path | None = None) -> str:
+    """WHICH empty the repo universe is — absent, unreadable, or holding no
+    usable row — as one operator-facing sentence. "" when the mapping is fine.
+
+    🔴 IT NAMES THE FILE AND THE REGENERATOR, NEVER A ROW. This string is handed
+    to `notify()`, which writes to stderr AND to `notify-send`; a row from the
+    mapping reaching either would disclose a private repository name. The path is
+    not a row — it is a constant already spelled in this public file.
+
+    🔴 AND IT SEPARATES THREE STATES THAT ALL PRODUCE THE SAME EMPTY DICT,
+    because they need three different next moves: "no mapping yet" wants
+    `regen-known-repos.py` run; "unreadable" wants the file looked at BEFORE it
+    is regenerated over the top; "ran but produced nothing usable" is a `gh auth`
+    problem rather than a mention-open one. Collapsing them into "the universe is
+    empty" is the silent zero this handler is written against — it is the same
+    mistake as the deleted search's empty result, which could not tell "no such
+    repo" from "gh is missing".
+
+    ⚠ IT RE-READS THE FILE. `load_known_repos()` already read it, but it answers
+    every failure with `{}` on purpose (see its docstring), so the reason is not
+    recoverable from its return value. This runs on the refusal path only, never
+    on the hot path.
+    """
+    path = path or KNOWN_REPOS_PATH
+    hint = "run scripts/regen-known-repos.py"
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return f"this host has no repo mapping at {path} — {hint}"
+    except (OSError, ValueError):
+        return (f"the repo mapping at {path} could not be read — "
+                f"look at it before you {hint}")
+    if not clean_repo_map(raw):
+        return f"the repo mapping at {path} holds no usable rows — {hint}"
+    return ""
+
+
+def refuse(span: dict | None, text: str, args: argparse.Namespace) -> int:
+    """The last resort, and the ONLY case a toast is still correct in: the picker
+    could not be shown. Always returns 1.
+
+    🔴 THE REASON IS NAMED, NEVER GENERIC, and the ADVICE IS APPENDED RATHER THAN
+    SUBSTITUTED. The case that names a cause is exactly the case where writing
+    `owner/repo#N` is the workaround, so dropping the advice there is backwards —
+    it was dropped once already.
+
+    🔴 IT NAMES THE CLICKED TEXT AND NOTHING ELSE. `discovered` is in scope at
+    every call site and holds the whole universe; adding "did you mean one of
+    these?" here is a natural-looking improvement that would leak every private
+    repository name to stderr and to `notify-send`.
+    """
+    advice = "open the repo in a tmux pane, or write it as owner/repo#N"
+    if span is None and not offer_number(text):
+        # No mention AND no number to offer. Unreachable from a click — the
+        # Alacritty hint regex requires `#[0-9]{1,6}` or a ClickUp id — so this
+        # is the command line, and the original refusal is still the right one.
+        notify("no mention in the clicked text", repr(text))
+        return 1
+    subject = span["raw"] if span is not None else repr(text)
+    if args.no_discovery:
+        why = "--no-discovery resolves only what the text itself carries"
+    elif args.print_only:
+        # 🔴 A DECIDED CONTRACT, not an oversight. `--print` is non-interactive;
+        # the answer to "which of your 369 repositories did you mean?" is a
+        # question, and printing all of them is not an answer either.
+        why = "--print cannot show the repository picker — there is nobody to ask"
+    else:
+        why = universe_reason() or "no repository owner is known for it"
+    notify(f"cannot resolve {subject}", f"{why} — {advice}")
+    return 1
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     # 🔴 THE ALACRITTY CONTRACT: the matched text is the LAST argument. Taking
@@ -498,131 +603,98 @@ def main(argv: list[str] | None = None) -> int:
     # question, and most clicks are one of those.
     span, candidates = resolve(text, default_repo=args.default_repo or None)
 
-    # PASS 2 — only when the text did NOT answer it. Discovery costs a fan-out
-    # of `git remote` calls plus a tmux round-trip, and paying that before
-    # opening a link that needed neither is latency the operator feels on every
-    # single click.
+    # 🔴 THE NUMBER A PICKER COULD OFFER, computed from the RAW TEXT and kept
+    # strictly apart from anything `resolve()` produced. For `#282828` the
+    # scanner returns no span at all and this returns "282828" — which is what
+    # turns the old `no mention in the clicked text` toast into a choice. It is
+    # never merged into `span` and never satisfies the auto-open below.
+    offer_num = offer_number(text)
+
+    # PASS 2 — the LOCAL measurement, only when the text did not answer it.
+    # Discovery costs a concurrent `git remote` fan-out plus a tmux round-trip
+    # (~30ms here), and paying that before opening a link that needed neither is
+    # latency the operator feels on every single click.
+    #
+    # 🔴 IT NOW RUNS FOR `span is None` TOO. It used to short-circuit straight to
+    # a refusal there, which is exactly why `#282828` dead-ended: the universe
+    # the picker needs is built by this pass. Guarded on `offer_num` so a text
+    # carrying no number at all — impossible from a click, see `offer_number` —
+    # still costs nothing.
     discovered: dict = {}
-    needs_measuring = span is not None and (span["ambiguous"] or not candidates)
-    if needs_measuring and not args.no_discovery:
+    unresolved = span is None or span["ambiguous"] or not candidates
+    if unresolved and not args.no_discovery and (span is not None or offer_num):
         default_repo = args.default_repo or tmux_pane_repo()
-        # Kept, not recomputed: PASS 4 offers the SAME measurement as a fuzzy
+        # Kept, not recomputed: PASS 3 offers the SAME measurement as a fuzzy
         # universe, and calling `discover_repos()` twice would run the whole
         # `git remote` fan-out again for an answer already in hand.
         discovered = discover_repos()
         span, candidates = resolve(text, repos=discovered,
                                    default_repo=default_repo or None)
 
-    if span is None:
-        notify("no mention in the clicked text", repr(text))
-        return 1
-
-    # PASS 3 — the GitHub API, for a repo in neither the mapping nor a checkout.
-    # Only for an explicit `repo#N`: a bare `#N` names no repo, so there is
-    # nothing to search for, and `--no-discovery` means "resolve only what the
-    # text itself carries", which excludes this too.
-    why = ""
-    if not candidates and not args.no_discovery:
-        m = _PASS3_REPO_RE.match(span["raw"])
-        if m:
-            matches, why = gh_api_repo_search(m.group("repo"))
-            # 🔴 EVERY match goes to the picker — there is no cap any more. See
-            # the note where `PASS3_MAX_CHOICES` used to be: a list you can type
-            # at is a choice, so refusing above an arbitrary count now removes
-            # the operator's ability to choose rather than protecting them from
-            # a wall.
-            #
-            # 🔴 AND THIS PASS IS REACHED IN `--print` MODE TOO — DELIBERATE, and
-            # stated because removing the cap CHANGED IT. `--print widget#12`
-            # with nine namesakes used to exit 1 with a named refusal ("more than
-            # 8 owners"); it now prints nine URLs and exits 0. That is the
-            # documented contract of the flag — "print every candidate when
-            # ambiguous" — and a namesake set IS ambiguity of exactly the kind
-            # the picker exists for: every row is an EXACT-name search hit, i.e.
-            # evidence about the name the operator typed. It is not the PASS 4
-            # universe, which is evidence about nothing and stays barred from
-            # `--print`. A consumer wanting a single answer must write
-            # `owner/repo#N`; one line of output was never promised here.
-            # Pinned by `test_print_mode_prints_EVERY_namesake_rather_than_
-            # refusing_above_a_cap`.
-            candidates = [
-                {"platform": PLATFORM_GITHUB, "id": m.group("num"),
-                 "url": GITHUB_ISSUE_URL.format(repo=full, id=m.group("num")),
-                 "raw": span["raw"]}
-                for full in sorted(matches)
-            ]
-
-    # PASS 4 — THE FUZZY UNIVERSE. Everything above has failed to name a
-    # repository, and the old behaviour here was a refusal. Offer every repo the
-    # host knows about instead and let the operator type at it.
+    # PASS 3 — THE FUZZY LOCAL UNIVERSE. Everything above has failed to name a
+    # repository, and the old behaviour here was a refusal — first a toast, and
+    # before that a 4.3s GitHub-wide search that answered with strangers' repos.
+    # Offer every repo THIS HOST knows about and let the operator type at it.
     #
     # 🔴 NOT IN `--print` MODE, and not under `--no-discovery`. `--print` exists
-    # so a script can read the resolved URL; answering it with several hundred
-    # is not an answer, and `--no-discovery` means "resolve only what the text
-    # itself carries", which a host-wide mapping is not.
+    # so a script can read the resolved URL; answering it with several hundred is
+    # not an answer, printing them would write PRIVATE repository names to
+    # stdout, and a picker is interactive while `--print` has no operator to ask.
+    # `--no-discovery` means "resolve only what the text itself carries", which a
+    # host-wide mapping is not.
     #
-    # ⚠ IT NEEDS A NUMBER. Only a numeric reference can be turned into an issue
-    # URL under a chosen repo; there is no such thing as "this ClickUp id, but in
-    # that repository". A ClickUp span always resolves anyway, so this is a guard
-    # rather than a branch anyone reaches.
+    # ⚠ IT NEEDS A NUMBER, from one of two places that must not be confused:
+    # `span["id"]` when the scanner ACCEPTED the text (already bounded to
+    # `\d{1,5}`), or `offer_num` when it REFUSED it. Only a numeric reference can
+    # become an issue URL under a chosen repo — there is no such thing as "this
+    # ClickUp id, but in that repository" — and a ClickUp span always resolves
+    # anyway, so the non-digit branch is a guard rather than one anyone reaches.
     #
     # 🔴 A UNIVERSE ROW IS NEVER OPENED WITHOUT A SELECTION, EVEN WHEN IT IS THE
     # ONLY ONE. `offered_universe` exists solely to suppress the "exactly one
     # candidate → just open it" shortcut below. Without it, a host that knows
     # exactly ONE repository would answer `trowelcast#77` by opening issue 77 in
     # that unrelated repository — a confident wrong page, which is precisely the
-    # failure this whole handler is anchored against. A search hit is evidence
-    # ABOUT THE NAME; a universe row is not evidence about anything, only an
-    # option. Measured during development: the first version of PASS 4 did open
-    # it, and the test that caught it was the one asserting a picker appeared.
+    # failure this whole handler is anchored against. It is ALSO what keeps
+    # `#282828` offered-but-never-auto-opened: a number the scanner refused
+    # reaches `candidates` only as universe rows, and universe rows never
+    # auto-open. Measured during development: the first version of this pass did
+    # open it, and the test that caught it was the one asserting a picker
+    # appeared.
     offered_universe = False
     may_offer_universe = not args.print_only and not args.no_discovery
-    if may_offer_universe and span["id"].isdigit():
-        universe = universe_candidates(span["id"], repo_universe(discovered))
-        if not candidates and universe:
-            offered_universe = True
-            # Dead end 1 and 2 — a namesake wall, or a search that matched
-            # nothing. Either way the operator now gets a choice.
-            #
-            # 🔴 THE PICKER DOES NOT SWALLOW `why`. A search that could not RUN
-            # ("gh is not on PATH", rate-limited, timed out) is a fact about the
-            # operator's tooling that the picker cannot express, and the whole
-            # "say WHICH empty this is" discipline would be lost if offering a
-            # choice silently replaced it. So the cause is announced AND the
-            # choice is offered — they are answers to different questions.
-            if why:
-                notify("the repository search could not run", why)
-            candidates = universe
-        elif span["ambiguous"] and not any(
-                c["platform"] == PLATFORM_GITHUB for c in candidates):
-            # Dead end 3 — a bare `#N` nothing could attribute. The clawgate
-            # candidate STAYS FIRST so the common case is still one Enter away;
-            # the universe is appended as the way to say "no, GitHub, this repo".
-            candidates = candidates + universe
+    num = span["id"] if (span is not None and span["id"].isdigit()) else offer_num
+    universe = (universe_candidates(num, repo_universe(discovered))
+                if (may_offer_universe and num) else [])
+    if not candidates and universe:
+        # Dead end 1 — an unresolvable `repo#N`, or text the scanner refused
+        # outright. Either way the operator now gets a choice instead of a toast.
+        offered_universe = True
+        candidates = universe
+    elif (span is not None and span["ambiguous"] and universe
+            and not any(c["platform"] == PLATFORM_GITHUB for c in candidates)):
+        # Dead end 2 — a bare `#N` nothing could attribute. The clawgate
+        # candidate STAYS FIRST so the common case is still one Enter away; the
+        # universe is appended as the way to say "no, GitHub, this repo".
+        candidates = candidates + universe
 
     if not candidates:
-        # 🔴 SAY WHICH EMPTY THIS IS. "gh is not on PATH" and "no repo by that
-        # name" produce the same empty result and need opposite next moves, and
-        # a search that ran only saw the first page.
-        advice = ("open the repo in a tmux pane, or write it as owner/repo#N")
-        # 🔴 The reason is PREPENDED, never substituted: the case where the
-        # search could not run is exactly the case where writing `owner/repo#N`
-        # is the workaround, so dropping the advice there is backwards.
-        detail = (f"{why} — so this is not a claim that no such repo exists. {advice}"
-                  if why else f"no repository owner is known for it — {advice}")
-        notify(f"cannot resolve {span['raw']}", detail)
-        return 1
+        # 🔴 SAY WHICH EMPTY THIS IS. A toast is now correct in exactly one
+        # situation — the picker could not be SHOWN — and the three ways that
+        # happens need three different next moves. Reporting them as one empty
+        # is the silent-zero shape one layer up.
+        return refuse(span, text, args)
 
     if args.print_only:
         for c in candidates:
             print(c["url"])
         return 0
 
-    # 🔴 `and not offered_universe`: see PASS 4. One candidate is enough to open
+    # 🔴 `and not offered_universe`: see PASS 3. One candidate is enough to open
     # only when that candidate is EVIDENCE about the reference — an explicit
-    # owner, a measured checkout, an exact-name search hit. A universe row is an
-    # OPTION, and a host that happens to know exactly one repository must not
-    # have that option opened for it.
+    # owner, a measured checkout, a mapping hit, the pane's repo. A universe row
+    # is an OPTION, and a host that happens to know exactly one repository must
+    # not have that option opened for it.
     if len(candidates) == 1 and not offered_universe:
         return open_url(candidates[0]["url"])
 

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -19,7 +19,9 @@ the reader cannot run is a claim, not evidence. This makes it evidence.
 The defect class it exists for is a SEAM: `mention_scan.py` decides what may be
 detected, `session-tailer.py` decides what is recorded, and `mention-open.py`
 decides what is clicked — and every round-1 survivor lived at one of those joins,
-not inside one file. So `TARGETS` names a file per mutant and
+not inside one file. A FOURTH surface, `nix/programs/alacritty/default.nix`, is
+not mutated but its suite IS collected: it decides what the terminal underlines,
+and the handler's offer bound mirrors it. So `TARGETS` names a file per mutant and
 `scripts/tests/test_mutation_battery_anchors.py` (which IS collected) reads it,
 so a row whose anchor stops occurring exactly once fails the push rather than
 scoring a silent SURVIVED for whoever next runs this by hand.
@@ -74,6 +76,14 @@ SUITES = (
     "scripts/tests/test_mention_scan.py",
     "scripts/tests/test_mention_open.py",
     "scripts/collector/claude/tests/test_session_tailer.py",
+    # 🔴 NOT A MUTATION TARGET — A SUITE, and it is here because a guard was
+    # scored KILLED-WRONG-REASON without it. The seam between the Alacritty hint
+    # regex's digit bound and the handler's `_OFFER_NUM_RE` is asserted in THIS
+    # file, so widening `_OFFER_NUM_RE` (K20) reddened only an incidental
+    # parametrized case while the test that names the hazard never ran. A battery
+    # that does not collect a guard's own suite reports on mutations that guard
+    # cannot see.
+    "scripts/tests/test_alacritty_hints.py",
 )
 
 # (id, shape, description, old, new[, expected]) — `old` must occur EXACTLY once
@@ -141,16 +151,16 @@ MUTANTS: list[tuple] = [
      "reached the CLICK surface"),
 
     # ---- F4: the disclosure guard's two blind paths -------------------------
-    ("K11", "disclosure", "the REFUSAL notify offers the universe as a hint — "
-                          "the path `--print` reaches and PASS 4 does not",
-     "        notify(f\"cannot resolve {span['raw']}\", detail)\n",
-     "        notify(f\"cannot resolve {span['raw']}\",\n"
-     '               detail + " known: " + ", ".join(repo_universe(discovered)))\n',
+    ("K11", "disclosure", "the REFUSAL path offers the universe as a hint — the "
+                          "path `--print` reaches and the picker does not",
+     "        return refuse(span, text, args)\n",
+     '        notify("cannot resolve it", ", ".join(repo_universe(discovered)))\n'
+     "        return refuse(span, text, args)\n",
      "REFUSAL-PATH DISCLOSURE"),
     ("K12", "disclosure", "the picker path logs the universe to stdout",
-     "            candidates = universe\n",
-     '            print("universe:", repo_universe(discovered))\n'
-     "            candidates = universe\n",
+     "        candidates = universe\n",
+     '        print("universe:", repo_universe(discovered))\n'
+     "        candidates = universe\n",
      "PICKER-PATH DISCLOSURE"),
     ("K13", "disclosure", "the emit line ships the WHOLE mapping beside the one "
                           "repo the mention was attributed to",
@@ -188,6 +198,60 @@ MUTANTS: list[tuple] = [
      'TASK_ANCHOR_RE = re.compile(rf"(?<![&#])#task-(?P<num>{_NUM})" + _NUM_END)\n',
      'TASK_ANCHOR_RE = re.compile(rf"#task-(?P<num>{_NUM})" + _NUM_END)\n',
      "the legacy-anchor left guard is gone"),
+
+    # ---- F5: the click path must make NO NETWORK CALL ----------------------
+    #
+    # 🔴 The rows below exist because a GitHub-WIDE namesake search used to live
+    # in this handler and cost 4.3s per click, answering with strangers' repos.
+    # It is deleted; these are what stop it — or any replacement — coming back.
+    ("K17", "widening", "a network call is re-added to the resolution path: the "
+                        "deleted GitHub-wide namesake search, verbatim",
+     "        discovered = discover_repos()\n",
+     '        subprocess.run(["gh", "api", "search/repositories", "--method",\n'
+     '                        "GET", "-f", "q=x in:name"],\n'
+     "                       capture_output=True, text=True, timeout=5)\n"
+     "        discovered = discover_repos()\n",
+     "the resolution path's command ledger MOVED"),
+    ("K18", "widening", "the same call wearing a DIFFERENT name, which a ban on "
+                        "the word `gh` alone would not see",
+     "    discovered: dict = {}\n",
+     "    discovered: dict = {}\n"
+     '    subprocess.run(["git", "ls-remote", "https://github.com/x/y"],\n'
+     "                   capture_output=True, text=True, timeout=5)\n",
+     "the resolution path's command ledger MOVED"),
+
+    # ---- F6: OFFERED is not RESOLVED ---------------------------------------
+    ("K19", "deletion", "a universe row becomes auto-openable again, so a click "
+                        "on a hex colour opens an unrelated repo's issue",
+     "        offered_universe = True\n", "        offered_universe = False\n",
+     "bypassing the picker"),
+    ("K20", "widening", "`_OFFER_NUM_RE` loses its bound and drifts away from "
+                        "the Alacritty hint regex it mirrors",
+     '_OFFER_NUM_RE = re.compile(r"#(?P<num>[0-9]{1,6})")\n',
+     '_OFFER_NUM_RE = re.compile(r"#(?P<num>[0-9]{1,9})")\n',
+     "the handler offers up to"),
+    ("K21", "deletion", "the `span is None` arm of the measurement pass is "
+                        "reverted, so a six-digit click dead-ends again",
+     '    unresolved = span is None or span["ambiguous"] or not candidates\n',
+     '    unresolved = span is not None and (span["ambiguous"] or not candidates)\n',
+     "DEAD-ENDED instead of offering the picker"),
+    ("K22", "deletion", "`--print` is allowed to offer the universe, so a "
+                        "non-interactive consumer is answered with a question — "
+                        "and private repo names reach stdout",
+     "    may_offer_universe = not args.print_only and not args.no_discovery\n",
+     "    may_offer_universe = not args.no_discovery\n",
+     "a refusal must print no URL at all"),
+
+    # ---- F7: the refusal must say WHICH empty it is ------------------------
+    ("K23", "deletion", "`universe_reason` stops distinguishing a mapping that "
+                        "PARSED but holds nothing usable from one that is fine",
+     "    if not clean_repo_map(raw):\n", "    if False:\n",
+     "no usable rows"),
+    ("K24", "operand swap", "the refusal SUBSTITUTES the cause for the advice — "
+                            "exactly the regression that happened once before",
+     '    notify(f"cannot resolve {subject}", f"{why} — {advice}")\n',
+     '    notify(f"cannot resolve {subject}", why)\n',
+     "the actionable advice was dropped"),
 ]
 
 TARGETS: dict[str, pathlib.Path] = {
@@ -197,6 +261,8 @@ TARGETS: dict[str, pathlib.Path] = {
     "K7": SCAN, "K8": SCAN, "K9": SCAN, "K10": OPEN_,
     "K11": OPEN_, "K12": OPEN_, "K13": TAILER, "K14": TAILER,
     "K15": SCAN, "K16": SCAN,
+    "K17": OPEN_, "K18": OPEN_, "K19": OPEN_, "K20": OPEN_,
+    "K21": OPEN_, "K22": OPEN_, "K23": OPEN_, "K24": OPEN_,
 }
 
 

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -15,13 +15,14 @@ not imagined, including a `profile="telemetry"` mutant at the click surface that
 the whole 313-test suite tolerated. A mutation result quoted from an instrument
 the reader cannot run is a claim, not evidence. This makes it evidence.
 
-🔴 IT SPANS THREE FILES, which is what this battery adds over its two siblings.
+🔴 IT SPANS FOUR FILES, which is what this battery adds over its two siblings.
 The defect class it exists for is a SEAM: `mention_scan.py` decides what may be
-detected, `session-tailer.py` decides what is recorded, and `mention-open.py`
-decides what is clicked — and every round-1 survivor lived at one of those joins,
-not inside one file. A FOURTH surface, `nix/programs/alacritty/default.nix`, is
-not mutated but its suite IS collected: it decides what the terminal underlines,
-and the handler's offer bound mirrors it. So `TARGETS` names a file per mutant and
+detected, `session-tailer.py` decides what is recorded, `mention-open.py` decides
+what is clicked, and `nix/programs/alacritty/default.nix` decides what the
+terminal underlines AND what is on the handler's PATH — and every round-1
+survivor lived at one of those joins, not inside one file. The nix file used to
+be collected but not mutated; K36 mutates it, because "its suite is collected"
+was a claim nothing checked. So `TARGETS` names a file per mutant and
 `scripts/tests/test_mutation_battery_anchors.py` (which IS collected) reads it,
 so a row whose anchor stops occurring exactly once fails the push rather than
 scoring a silent SURVIVED for whoever next runs this by hand.
@@ -42,6 +43,15 @@ READ BEFORE TRUSTING A VERDICT:
   * A mutant whose pattern is NOT FOUND is reported as such and counted as a
     problem. Silent non-application is how a battery reports a clean sweep of
     mutations it never made.
+  * 🔴 A MUTANT THAT COLLECTED NOTHING CANNOT SCORE `SURVIVED`. This was a real
+    hole in this instrument: the `npass < 200` sanity check ran on the CONTROL
+    only, and the per-mutant verdict was `if not nfail: SURVIVED`. A mutant that
+    makes a module UNIMPORTABLE produces `0 failed, 0 passed` and a collection
+    ERROR — pytest's summary then says `N errors`, which the `(\\d+) failed`
+    regex does not see — so the row was reported as "no test can see this
+    change" when in truth no test RAN. `classify()` now answers `NOT-OBSERVED`
+    for that, counted with the problems, and the floor is derived from the
+    control's own reading rather than from a literal.
   * SURVIVED does not mean "the code is wrong". It means "no test can see this
     change" — usually a missing test, occasionally genuinely-equivalent code.
   * THREE KILL VERDICTS. `KILLED` is "the suite went red". A row carrying an
@@ -68,6 +78,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCAN = ROOT / "scripts/collector/mention_scan.py"
 TAILER = ROOT / "scripts/collector/claude/session-tailer.py"
 OPEN_ = ROOT / "scripts/mention-open.py"
+ALACRITTY = ROOT / "nix/programs/alacritty/default.nix"
 
 # The primary target, for the shared anchor checker's single-file affordances.
 SCRIPT = SCAN
@@ -238,8 +249,10 @@ MUTANTS: list[tuple] = [
     ("K22", "deletion", "`--print` is allowed to offer the universe, so a "
                         "non-interactive consumer is answered with a question — "
                         "and private repo names reach stdout",
-     "    may_offer_universe = not args.print_only and not args.no_discovery\n",
-     "    may_offer_universe = not args.no_discovery\n",
+     "    may_offer_universe = (not args.print_only and not args.no_discovery\n"
+     "                          and not colour)\n",
+     "    may_offer_universe = (not args.no_discovery\n"
+     "                          and not colour)\n",
      "a refusal must print no URL at all"),
 
     # ---- F7: the refusal must say WHICH empty it is ------------------------
@@ -252,6 +265,96 @@ MUTANTS: list[tuple] = [
      '    notify(f"cannot resolve {subject}", f"{why} — {advice}")\n',
      '    notify(f"cannot resolve {subject}", why)\n',
      "the actionable advice was dropped"),
+
+    # ---- F8: the 16-thread fan-out, which had ZERO coverage ----------------
+    #
+    # 🔴 EVERY WORKSPACE FIXTURE IN THE SUITE USED TO HOLD ONE CHECKOUT, so both
+    # rows below SURVIVED the whole 352-test suite: with a single entry,
+    # `zip(entries, results)` and `zip(entries, reversed(results))` are the same
+    # function, and there is no second row for an empty answer to overwrite.
+    ("K25", "operand swap", "the fan-out pairs each checkout with its NEIGHBOUR's"
+                            " owner — `~/workspace/devrc` then answers "
+                            "`devrc#1291` with another org's issue 1291",
+     "        resolved = _fan_out(entries)\n",
+     "        resolved = _fan_out(entries)[::-1]\n",
+     "paired a checkout with a NEIGHBOUR's owner"),
+    ("K26", "deletion", "a checkout whose `git remote` failed writes \"\" OVER a "
+                        "good row the mapping supplied, un-resolving a name the "
+                        "host could answer a moment ago",
+     "        if full:\n            out[entry.name] = full\n",
+     "        out[entry.name] = full\n",
+     "ERASED the mapping's answer"),
+    ("K33", "deletion", "the fan-out stops degrading to serial, so a box at its "
+                        "thread limit gets an exception out of a DETACHED "
+                        "process and a click that does nothing",
+     "    except (ImportError, OSError, RuntimeError):\n"
+     "        resolved = [repo_of_checkout(p) for p in entries]\n",
+     "    except (ImportError, OSError, RuntimeError):\n"
+     "        resolved = []\n",
+     "did not DEGRADE to a serial fan-out"),
+
+    # ---- F9: the no-network ledger was one word short of its own claim -----
+    ("K27", "widening", "a `git remote update` — a fetch per remote — is added "
+                        "to the measurement leg. Under the OLD two-word ledger "
+                        "this survived all 352 tests",
+     '    return parse_owner_repo(_git(["remote", "get-url", "origin"], cwd=str(path)))\n',
+     '    _git(["remote", "update"], cwd=str(path))\n'
+     '    return parse_owner_repo(_git(["remote", "get-url", "origin"], cwd=str(path)))\n',
+     "the resolution path's command ledger MOVED"),
+
+    # ---- F10: a refusal that shows nothing ---------------------------------
+    ("K28", "deletion", "`notify-send` loses its `--`, so every refusal body "
+                        "beginning with a flag name is parsed as an option and "
+                        "NO toast appears (exit 1, swallowed by check=False)",
+     '        subprocess.run(["notify-send", "-a", "mention-open", "--", summary, body],\n',
+     '        subprocess.run(["notify-send", "-a", "mention-open", summary, body],\n',
+     "notify-send got a body starting with `--`"),
+    ("K34", "deletion", "the entry point stops going through `guarded_main`, so "
+                        "an unexpected exception is a silent click again",
+     "    raise SystemExit(guarded_main())\n",
+     "    raise SystemExit(main())\n",
+     "does not call guarded_main()"),
+
+    # ---- F11: six digits is answered, not asked about ----------------------
+    ("K29", "deletion", "a six-digit colour literal raises the several-hundred-"
+                        "row picker again, every row of which 404s",
+     # Anchored with the following line: `refuse()` calls the same helper, and
+     # mutating THAT one changes only the refusal's wording, not whether the
+     # picker is raised — a different mutant under this row's name.
+     "    colour = colour_literal_offer(span, text)\n\n    # PASS 2",
+     '    colour = ""\n\n    # PASS 2',
+     "raised the repository picker for a colour literal"),
+    ("K30", "widening", "`colour_literal_offer` stops asking for `span is None`, "
+                        "so a six-digit number the SCANNER ACCEPTED — from a URL "
+                        "shape — would be dismissed as a colour",
+     '    num = offer_number(text) if span is None else ""\n',
+     "    num = offer_number(text)\n",
+     "a colour literal BESIDE a real reference suppressed the reference"),
+
+    # ---- F12: the picker must explain itself, the refusal must be actionable
+    ("K31", "deletion", "the fuzzy picker is raised with NO note, so a dismissal "
+                        "and a no-match are indistinguishable to the operator",
+     "    url = pick(candidates, mesg=mesg)\n",
+     "    url = pick(candidates)\n",
+     "raised with NO explanation"),
+    ("K32", "widening", "the staleness threshold is pushed past any real age, so "
+                        "a mapping nothing regenerates never reports as old",
+     "STALE_MAPPING_DAYS = 7\n", "STALE_MAPPING_DAYS = 99999\n",
+     "never named the mapping's age"),
+    ("K35", "deletion", "`--print` goes back to blaming the FLAG alone on a host "
+                        "with no mapping, dropping the only cause the operator "
+                        "can act on",
+     "            if extra := (reason or staleness_note()):\n"
+     '                why = f"{why}; also {extra}"\n',
+     "            pass\n",
+     "blamed the FLAG and never named the mapping"),
+    ("K36", "deletion", "the alacritty wrapper drops `pkgs.git` from the hint's "
+                        "PATH: `git` is then absent under the display manager's "
+                        "environment, FileNotFoundError is caught as OSError, "
+                        "and discovery is INERT in production",
+     "      pkgs.python312 pkgs.git pkgs.tmux pkgs.xdg-utils pkgs.libnotify\n",
+     "      pkgs.python312 pkgs.tmux pkgs.xdg-utils pkgs.libnotify\n",
+     "the wrapper's PATH is MISSING"),
 ]
 
 TARGETS: dict[str, pathlib.Path] = {
@@ -263,6 +366,16 @@ TARGETS: dict[str, pathlib.Path] = {
     "K15": SCAN, "K16": SCAN,
     "K17": OPEN_, "K18": OPEN_, "K19": OPEN_, "K20": OPEN_,
     "K21": OPEN_, "K22": OPEN_, "K23": OPEN_, "K24": OPEN_,
+    "K25": OPEN_, "K26": OPEN_, "K27": OPEN_, "K28": OPEN_,
+    "K29": OPEN_, "K30": OPEN_, "K31": OPEN_, "K32": OPEN_,
+    "K33": OPEN_, "K34": OPEN_, "K35": OPEN_,
+    # 🔴 A FOURTH FILE, AND A NIX ONE. The wrapper's PATH is a seam between two
+    # files in two languages that agree only by coincidence, and both directions
+    # of disagreement are silent — see the test named in K36's `expected`. It is
+    # mutated rather than merely collected because the header of this module
+    # called it "not a mutation target", and that sentence was true only for as
+    # long as nothing here read it.
+    "K36": ALACRITTY,
 }
 
 
@@ -270,8 +383,36 @@ def _digest(path: pathlib.Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
 
 
-def run_suite(messages: bool = False) -> tuple[int, int, list[str], str]:
-    """Run the three mention suites once. Returns (failed, passed, killers, msgs).
+def classify(nfail: int, npass: int, nerror: int, floor: int,
+             expected: str | None, msgs: str) -> str:
+    """The verdict for ONE mutant run. Pure, so it is unit-tested by
+    `test_mutation_battery_anchors.py` rather than only exercised by running the
+    whole battery for half an hour.
+
+    🔴 `NOT-OBSERVED` COMES FIRST, AND IT IS THE FIX FOR THIS INSTRUMENT'S OWN
+    BLIND SPOT. `SURVIVED` is a claim that every test RAN and none of them saw
+    the change; a run that collected nothing satisfies `nfail == 0` just as
+    well, and reports the strongest possible finding — "no test covers this" —
+    from a suite that never executed. A mutant that makes a module unimportable
+    is exactly that shape: pytest reports `N errors`, not `N failed`, and the
+    old code read the absence of failures as survival.
+
+    Two independent detectors, because either alone can be walked past: `nerror`
+    catches a collection error by name, and the FLOOR catches a run that
+    silently collected a fraction of the suite (a mutant inside a `conftest`, an
+    import that hangs a whole file) without pytest calling it an error.
+    """
+    if nerror or (npass + nfail) < floor:
+        return "NOT-OBSERVED"
+    if not nfail:
+        return "SURVIVED"
+    if expected is None:
+        return "KILLED"
+    return "KILLED(attributed)" if expected in msgs else "KILLED-WRONG-REASON"
+
+
+def run_suite(messages: bool = False) -> tuple[int, int, int, list[str], str]:
+    """Run the mention suites once. Returns (failed, passed, errors, killers, msgs).
 
     🔴 ONLY THE `E ` LINES COUNT AS "THE MESSAGE". Under `--tb=short` pytest also
     echoes the SOURCE of the failing statement, which for an assert carrying an
@@ -291,8 +432,12 @@ def run_suite(messages: bool = False) -> tuple[int, int, list[str], str]:
                       if ln.startswith("FAILED") and "::" in ln})
     nfail = int(m.group(1)) if (m := re.search(r"(\d+) failed", out)) else 0
     npass = int(m.group(1)) if (m := re.search(r"(\d+) passed", out)) else 0
+    # 🔴 `error` IS NOT `failed`, AND PYTEST SAYS SO IN A DIFFERENT WORD. A
+    # mutant that breaks an import produces `N errors` and ZERO of both counts
+    # above — which read as a clean survival until this line existed.
+    nerr = int(m.group(1)) if (m := re.search(r"(\d+) errors?\b", out)) else 0
     msgs = "\n".join(ln for ln in out.splitlines() if ln.startswith("E "))
-    return nfail, npass, killers, msgs
+    return nfail, npass, nerr, killers, msgs
 
 
 def main() -> int:
@@ -300,14 +445,22 @@ def main() -> int:
     orig = {p: p.read_text(encoding="utf-8") for p in files}
     before = {p: _digest(p) for p in files}
     try:
-        nf, np_, _, _ = run_suite()
-        print(f"CONTROL (pristine): {np_} passed, {nf} failed")
+        nf, np_, nerr, _, _ = run_suite()
+        print(f"CONTROL (pristine): {np_} passed, {nf} failed, {nerr} errors")
         # 🔴 BOTH halves. A green-looking zero is what a battery wired to
         # nothing reports.
-        if nf or np_ < 200:
+        if nf or nerr or np_ < 200:
             print("ABORT — baseline is red or collected nothing; no verdict "
                   "below would mean anything")
             return 1
+        # 🔴 THE FLOOR EVERY MUTANT IS MEASURED AGAINST, derived from what the
+        # CONTROL actually collected rather than from a literal that drifts with
+        # the suite. Half, not 90%: a legitimate mutant turns passes into
+        # failures without changing the total, so the only thing this can catch
+        # is a run that lost whole FILES — which is what an unimportable module
+        # does. See `classify`.
+        floor = np_ // 2
+        print(f"observation floor for each mutant: {floor} tests must RUN")
 
         problems: list[str] = []
         for row in MUTANTS:
@@ -333,25 +486,24 @@ def main() -> int:
                 mutated = mutated.replace(o, nw)
             target.write_text(mutated, encoding="utf-8")
             try:
-                nf, _np, killers, msgs = run_suite(messages=expected is not None)
+                nf, _np, _nerr, killers, msgs = run_suite(
+                    messages=expected is not None)
             finally:
                 target.write_text(text, encoding="utf-8")
-            if not nf:
-                verdict = "SURVIVED"
-                problems.append(mid)
-            elif expected is None:
-                verdict = "KILLED"
-            elif expected in msgs:
-                verdict = "KILLED(attributed)"
-            else:
-                verdict = "KILLED-WRONG-REASON"
+            verdict = classify(nf, _np, _nerr, floor, expected, msgs)
+            if verdict in ("SURVIVED", "KILLED-WRONG-REASON", "NOT-OBSERVED"):
                 problems.append(mid)
             shown = ", ".join(k[:52] for k in killers[:3])
             extra = f" (+{len(killers) - 3} more)" if len(killers) > 3 else ""
-            print(f"{mid:4} {shape:12} {verdict:19} f={nf:<3} "
+            print(f"{mid:4} {shape:12} {verdict:19} f={nf:<3} p={_np:<5} "
                   f"[{target.name}] {desc}")
             if verdict == "KILLED-WRONG-REASON":
                 print(f"     expected {expected!r} in the `E ` lines; not found")
+            if verdict == "NOT-OBSERVED":
+                print(f"     🔴 the suite did not RUN: {_np} passed + {nf} "
+                      f"failed is below the floor of {floor}, or it reported "
+                      f"{_nerr} collection error(s). This is NOT a survival — "
+                      f"the mutant probably broke an import.")
             if killers:
                 print(f"     killers: {shown}{extra}")
 

--- a/scripts/tests/test_alacritty_hints.py
+++ b/scripts/tests/test_alacritty_hints.py
@@ -382,6 +382,48 @@ def test_the_mention_hint_swallows_a_six_digit_colour_whole(mention_hint):
     assert m and m.group(0) == "#282828"
 
 
+def test_the_handlers_OFFER_bound_matches_the_hints_own(mention_hint):
+    """🔴 A SEAM BETWEEN TWO FILES, OWNED BY NEITHER.
+
+    The hint decides what the terminal UNDERLINES; `mention-open.py`'s
+    `_OFFER_NUM_RE` decides what a dismissible picker may OFFER for text the
+    strict scanner refused. Those are two spellings of one fact — "how many
+    digits can arrive from a click" — and they live in different files, in
+    different languages, tested by different suites. Each is hermetically green
+    while they disagree, and the disagreement is silent in both directions: a
+    NARROWER handler bound turns a real click back into the dead-end toast this
+    whole path exists to remove, and a WIDER one offers a number no click can
+    produce.
+
+    ⚠ THIS IS NOT THE `_NUM = \\d{1,5}` GUARD and must not be confused with it.
+    That bound decides what may be OPENED and is deliberately narrower than both
+    of these; it is pinned in `test_mention_scan.py` and is not this test's
+    subject.
+    """
+    import importlib.util
+
+    handler = ROOT / "scripts" / "mention-open.py"
+    spec = importlib.util.spec_from_file_location("mention_open_bound", handler)
+    mo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mo)
+
+    hint_bound = re.search(r"#\[0-9\]\{1,(\d+)\}",
+                           _string_attr(mention_hint, "regex"))
+    assert hint_bound, "the mention hint no longer spells its digit bound as {1,N}"
+    offer_bound = re.search(r"\[0-9\]\{1,(\d+)\}", mo._OFFER_NUM_RE.pattern)
+    assert offer_bound, "_OFFER_NUM_RE no longer spells its digit bound as {1,N}"
+    assert offer_bound.group(1) == hint_bound.group(1), (
+        f"the handler offers up to {offer_bound.group(1)} digits while the "
+        f"terminal underlines up to {hint_bound.group(1)}")
+
+    # POSITIVE CONTROL, on the real objects rather than on the two integers: a
+    # number at the shared bound must be underlined by the hint AND recovered by
+    # the handler. Two constants can agree while both are wired to nothing.
+    at_bound = "#" + "8" * int(hint_bound.group(1))
+    assert re.compile(_string_attr(mention_hint, "regex")).search(at_bound)
+    assert mo.offer_number(at_bound) == "8" * int(hint_bound.group(1))
+
+
 def test_the_mention_hint_behaves_like_a_link(mention_hint):
     """Zach's requirement, verbatim: "for click i want it to function the same
     way link clicking already does". Same mouse semantics as the URL hint."""

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
+import time
 import types
 from pathlib import Path
 
@@ -255,7 +257,13 @@ def spy(monkeypatch):
     monkeypatch.setattr(MO, "tmux_pane_repo",
                         lambda: calls.append("tmux") or "civitai/talos-infra")
     monkeypatch.setattr(MO, "open_url", lambda url: calls.append(("open", url)) or 0)
-    monkeypatch.setattr(MO, "pick", lambda c: calls.append(("pick", len(c))) or c[0]["url"])
+    # `mesg=""` mirrors the real signature: `main()` hands the picker a note to
+    # show above the list when the universe is the answer. A stub that took only
+    # `candidates` would raise TypeError on that path — which is a kill, but for
+    # the wrong reason, and it would hide whatever the note actually said.
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": calls.append(("pick", len(c))) or c[0]["url"])
     monkeypatch.setattr(MO, "notify", lambda *a, **k: calls.append(("notify", a[0])))
     return calls
 
@@ -293,9 +301,56 @@ def test_a_multi_digit_clawgate_id_round_trips_to_the_click(spy):
 
 
 def test_a_dismissed_picker_opens_nothing_and_is_not_an_error(spy, monkeypatch):
-    monkeypatch.setattr(MO, "pick", lambda c: "")
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": "")
     assert MO.main(["#370"]) == 0
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+
+
+def test_an_UNEXPECTED_exception_is_REPORTED_rather_than_vanishing(monkeypatch):
+    """🔴 THE DETACHED-PROCESS SILENT CLICK. Alacritty spawns this handler with
+    no terminal, so an uncaught exception writes a traceback to a stderr nobody
+    will ever read and the operator sees a click that did nothing — the exact
+    shape `notify()` exists to prevent, arriving one level above it.
+
+    The case that is not hypothetical: `ThreadPoolExecutor` raises
+    `RuntimeError: can't start new thread` when the box is at its thread limit,
+    and this host routinely runs 100+ concurrent agent worktrees.
+
+    The message must carry the exception TYPE and TEXT — "something went wrong"
+    would be the silent zero with a face on it."""
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+
+    def boom(argv=None):
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(MO, "main", boom)
+    assert MO.guarded_main(["#370"]) == 1
+    assert notices, (
+        "an exception escaped the handler: a DETACHED click then does nothing "
+        "at all — no toast, no readable stderr")
+    assert "RuntimeError" in notices[-1][1], notices[-1]
+    assert "can't start new thread" in notices[-1][1], notices[-1]
+
+
+def test_the_guard_does_not_swallow_a_NORMAL_run(spy):
+    """The negative control: `guarded_main` must be transparent when nothing
+    goes wrong, or every assertion above would hold for a wrapper that always
+    reported a failure."""
+    assert MO.guarded_main(["civitai/talos-infra#1065"]) == 0
+    assert spy == [("open", "https://github.com/civitai/talos-infra/issues/1065")]
+
+
+def test_the_ENTRY_POINT_is_the_guarded_one():
+    """🔴 A GUARD NOTHING CALLS IS NOT A GUARD. `guarded_main` is only reached if
+    `__main__` actually uses it; leaving `raise SystemExit(main())` in place
+    would keep every test above green while production kept vanishing. Read from
+    the SOURCE, because the `__main__` block never executes under pytest."""
+    src = HANDLER.read_text()
+    assert re.search(r'if __name__ == "__main__":\s*\n\s*raise SystemExit\('
+                     r"guarded_main\(\)\)", src), (
+        "scripts/mention-open.py's __main__ block does not call guarded_main() "
+        "— an unexpected exception is a silent click again")
 
 
 def test_a_short_form_repo_is_resolved_from_the_discovered_checkouts(spy):
@@ -304,23 +359,39 @@ def test_a_short_form_repo_is_resolved_from_the_discovered_checkouts(spy):
     assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/issues/1065")
 
 
-def test_a_non_mention_OFFERS_THE_PICKER_instead_of_refusing(spy):
-    """🔴 THE REVERSAL THIS CHANGE EXISTS FOR. `#282828` used to produce the
-    toast `no mention in the clicked text`, which reads as the handler being
-    broken when it is the guard working correctly — and a guard that reads as a
-    bug is one the next maintainer deletes.
+def test_text_the_SCANNER_REFUSED_offers_the_picker_instead_of_refusing(spy):
+    """🔴 THE REVERSAL THIS CHANGE EXISTS FOR. Text the strict scanner rejects
+    used to produce the toast `no mention in the clicked text`, which reads as
+    the handler being broken when it is the guard working correctly — and a
+    guard that reads as a bug is one the next maintainer deletes.
 
-    The picker is now offered instead. Nothing is opened without a selection, and
-    the number never becomes a reference: see
-    `test_a_SIX_DIGIT_number_is_OFFERED_but_NEVER_auto_opened`."""
+    `##370` is such a text: `BARE_RE`'s left guard refuses a `#` run, so
+    `resolve()` returns no span, while `offer_number` still recovers `370`.
+
+    ⚠ NOT `#282828`, AND THE CHANGE OF FIXTURE IS THE POINT. A SIX-digit number
+    now gets a named toast rather than a picker — see
+    `test_a_SIX_DIGIT_click_gets_a_NAMED_toast_not_a_wall_of_repos`. This test is
+    about the `span is None` arm of the measurement pass, which the six-digit
+    branch no longer exercises, so it needs a non-six-digit refusal to stay a
+    guard rather than a duplicate."""
     # 🔴 THE MESSAGE IS ON THE EXIT CODE, which is what a reverted measurement
     # pass turns to 1 — the picker assertion below never evaluates in that case.
-    assert MO.main(['background = "#282828";']) == 0, (
-        "a six-digit click DEAD-ENDED instead of offering the picker")
+    assert MO.main(["##370"]) == 0, (
+        "a scanner-refused click DEAD-ENDED instead of offering the picker")
     assert ("pick", 1) in spy, (
-        f"a six-digit click DEAD-ENDED instead of offering the picker: {spy}")
+        f"a scanner-refused click DEAD-ENDED instead of offering the "
+        f"picker: {spy}")
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "notify"], (
-        "a six-digit click DEAD-ENDED instead of offering the picker")
+        "a scanner-refused click DEAD-ENDED instead of offering the picker")
+
+
+def test_the_span_is_None_fixture_really_IS_refused_by_the_scanner():
+    """POSITIVE CONTROL for the fixture above, on the scanner rather than on
+    `main()`. If `##370` ever started resolving, the test above would pass
+    through the ordinary bare-`#N` path and stop covering the `span is None`
+    arm entirely — green, and testing something else."""
+    assert MO.resolve("##370") == (None, [])
+    assert MO.offer_number("##370") == "370"
 
 
 # --------------------------------------------------------------------------- #
@@ -388,17 +459,41 @@ def test_a_local_checkout_overrides_the_mapping(tmp_path, monkeypatch):
 # ban on the single word `gh` that any other client would walk straight past.
 # --------------------------------------------------------------------------- #
 
-# Every command the resolution path is allowed to spawn, as (argv[0], argv[1]).
+# Every command the resolution path is allowed to spawn, as its VERB PATH — see
+# `_ledger_key`.
 #
 # 🔴 THE SUBCOMMAND IS PART OF THE LEDGER, NOT DECORATION. `git` alone would
 # admit `git ls-remote` and `git fetch`, which are network calls wearing the name
-# of a local tool — the exact substitution a ban on `gh` invites. Both entries
-# here are local-only reads.
+# of a local tool — the exact substitution a ban on `gh` invites.
+#
+# 🔴 AND TWO WORDS WERE NOT ENOUGH, WHICH IS A MEASUREMENT AND NOT A THEORY. The
+# ledger used to be `(argv[0], argv[1])`, so `("git", "remote")` admitted
+# `git remote update` — which runs `git fetch` against EVERY remote, i.e. the
+# network call this whole section exists to keep out, spelled with the same two
+# words as the local `git remote get-url`. Measured on this branch: adding
+# `_git(["remote", "update"], cwd=…)` to `repo_of_checkout` left all 352 tests
+# green, while `git fetch --all` and `curl` both died. The docstring above
+# already claimed the subcommand was in the ledger BECAUSE `git` alone admits a
+# fetch; the key was one level short of the claim.
 RESOLUTION_PATH_COMMANDS = {
-    ("tmux", "display-message"),   # which pane the operator was last in
-    ("git", "rev-parse"),          # that pane's checkout root
-    ("git", "remote"),             # `remote get-url origin` — reads .git/config
+    ("tmux", "display-message"),      # which pane the operator was last in
+    ("git", "rev-parse"),             # that pane's checkout root
+    ("git", "remote", "get-url"),     # reads .git/config — NOT `remote update`
 }
+
+
+def _ledger_key(argv: list[str]) -> tuple[str, ...]:
+    """A command's VERB PATH: `argv[0]`, `argv[1]`, and `argv[2]` when that third
+    word is a bare word rather than an option.
+
+    The third word is what separates `git remote get-url` (a local config read)
+    from `git remote update` (a fetch per remote). It is dropped when it starts
+    with `-`, so `tmux display-message -p -F …` still keys on its subcommand
+    rather than dragging a flag or a format string into the ledger.
+    """
+    key = tuple(argv[:2])
+    third = argv[2] if len(argv) > 2 else ""
+    return key + ((third,) if third and not third.startswith("-") else ())
 
 
 def _assert_only_local_commands(seen: list[list[str]]) -> None:
@@ -408,7 +503,7 @@ def _assert_only_local_commands(seen: list[list[str]]) -> None:
     call, most likely. A SHRUNK set means the path under test never ran the
     measurement at all, which would make every absence below vacuous.
     """
-    got = {(c[0], c[1]) for c in seen if len(c) >= 2}
+    got = {_ledger_key(c) for c in seen if len(c) >= 2}
     assert got == RESOLUTION_PATH_COMMANDS, (
         f"the resolution path's command ledger MOVED: {sorted(got)}")
 
@@ -428,6 +523,30 @@ def test_the_no_network_assertion_can_actually_FIRE():
     # …and in the other direction: a path that measured nothing.
     with pytest.raises(AssertionError, match="ledger MOVED"):
         _assert_only_local_commands([])
+
+
+def test_the_ledger_rejects_git_remote_UPDATE_which_is_a_fetch():
+    """🔴 THE SUBSTITUTION A TWO-WORD LEDGER ADMITTED, kept as its own control.
+
+    `git remote update` runs `git fetch` for every configured remote. Under the
+    old `(argv[0], argv[1])` key it was INDISTINGUISHABLE from
+    `git remote get-url origin`, so it passed — verified by adding it to
+    `repo_of_checkout` and watching all 352 tests stay green. This is the case
+    that must go red, and it is spelled out separately from the `gh`/`curl` row
+    above because those two never passed: a control built only from commands the
+    old key already caught proves nothing about the change that closed this."""
+    local = [["tmux", "display-message", "-p", "-F", "#{pane_current_path}"],
+             ["git", "rev-parse", "--show-toplevel"],
+             ["git", "remote", "get-url", "origin"]]
+    # NEGATIVE CONTROL FIRST: the REAL argv must still pass, or the assertions
+    # below would be satisfied by a key that rejects everything.
+    _assert_only_local_commands(local)
+    for network in (["git", "remote", "update"],
+                    ["git", "fetch", "--all"],
+                    ["git", "ls-remote", "https://github.com/x/y"],
+                    ["curl", "-s", "https://api.github.com/search/repositories"]):
+        with pytest.raises(AssertionError, match="ledger MOVED"):
+            _assert_only_local_commands(local + [network])
 
 
 def test_the_resolution_path_spawns_ONLY_these_local_commands(tmp_path, monkeypatch):
@@ -468,7 +587,7 @@ def test_the_resolution_path_spawns_ONLY_these_local_commands(tmp_path, monkeypa
 
     monkeypatch.setattr(MO.subprocess, "run", record)
     monkeypatch.setattr(MO.subprocess, "Popen", no_launch)
-    monkeypatch.setattr(MO, "pick", lambda c: "")
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": "")
     monkeypatch.setattr(MO, "notify", lambda *a, **k: None)
 
     assert MO.main(["zzznosuchrepo#12"]) == 0
@@ -520,6 +639,63 @@ def test_the_spawned_executable_LEDGER_can_actually_fire():
         "subprocess.run(['gh', 'api', 'search/repositories'])\n")
     assert found == {"gh"}, found
     assert _spawned_executables("import subprocess\nx = 1\n") == set()
+
+
+def test_the_alacritty_wrapper_PATH_covers_every_executable_the_handler_spawns():
+    """🔴 A SEAM BETWEEN TWO FILES IN TWO LANGUAGES, OWNED BY NEITHER.
+    `nix/programs/alacritty/default.nix` pins a PATH for the hint wrapper because
+    Alacritty spawns it with the display manager's environment; `mention-open.py`
+    decides what it spawns. They agree only by coincidence, and BOTH failure
+    directions are silent:
+
+      * a spawn with no package — `FileNotFoundError` is caught as `OSError` and
+        answered with "", so the feature is INERT in production with a fully
+        green suite. That is exactly how the deleted `gh` search would have
+        behaved, and its own comment said so.
+      * a package with no spawn — dead weight in the wrapper's closure, and a
+        comment justifying a call site that no longer exists. `pkgs.gh` was
+        precisely this: its comment named "PASS 3", the branch DELETED that pass
+        and renumbered the rest, so a reader following the comment landed on the
+        fuzzy universe, which spawns nothing.
+
+    `rofi` is the one deliberate omission and it is enumerated, not inferred:
+    it is a SYSTEM package here (`nix/i3/config.nix` invokes it bare), and
+    pulling `pkgs.rofi` in would install a second copy whose theme drifts from
+    the launcher's.
+    """
+    # executable -> the nix attribute that must provide it.
+    PROVIDER = {"git": "pkgs.git", "tmux": "pkgs.tmux",
+                "xdg-open": "pkgs.xdg-utils", "notify-send": "pkgs.libnotify"}
+    # Not spawned by name from PATH: rofi is the system copy on purpose, and
+    # python312 is the interpreter the wrapper `exec`s by store path.
+    NOT_FROM_THE_WRAPPER_PATH = {"rofi"}
+    INTERPRETER = {"pkgs.python312"}
+
+    nix_src = (ROOT / "nix" / "programs" / "alacritty" / "default.nix").read_text()
+    m = re.search(r"makeBinPath\s*\[(.*?)\]", nix_src, re.S)
+    assert m, "the mentionOpen wrapper no longer calls lib.makeBinPath"
+    # Comments in that block are PROSE ABOUT the packages — `pkgs.gh` was named
+    # in one for months. Reading them as config is the mistake this strips.
+    body = re.sub(r"#[^\n]*", "", m.group(1))
+    listed = set(re.findall(r"pkgs\.[A-Za-z0-9_-]+", body))
+    assert listed, "positive control: the wrapper DOES pin a PATH"
+
+    spawned = _spawned_executables(HANDLER.read_text())
+    assert spawned, "positive control: the module DOES spawn things"
+    needed = {PROVIDER[e] for e in spawned - NOT_FROM_THE_WRAPPER_PATH
+              if e in PROVIDER}
+    unknown = spawned - NOT_FROM_THE_WRAPPER_PATH - set(PROVIDER)
+    assert not unknown, (
+        f"mention-open.py spawns {sorted(unknown)}, which this test cannot map "
+        f"to a nix package — add it to PROVIDER and to the wrapper's PATH")
+    assert needed <= listed, (
+        f"the wrapper's PATH is MISSING {sorted(needed - listed)}: the handler "
+        f"spawns it, FileNotFoundError is caught as OSError, and the feature is "
+        f"inert in production with a green suite")
+    assert listed <= needed | INTERPRETER, (
+        f"the wrapper's PATH carries {sorted(listed - needed - INTERPRETER)}, "
+        f"which nothing in mention-open.py spawns — dead weight in the closure, "
+        f"and a comment justifying a call site that no longer exists")
 
 
 def test_the_module_no_longer_carries_a_repository_SEARCH_at_all():
@@ -666,6 +842,115 @@ def test_the_workspace_is_resolved_at_CALL_time_too(tmp_path, monkeypatch):
     assert MO.discover_repos() == {"plotwidget": "gardenersguild/plotwidget"}
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE 16-THREAD FAN-OUT
+#
+# `discover_repos` runs one `git remote get-url` per checkout across a thread
+# pool and re-pairs the results with the checkouts POSITIONALLY. Every other
+# fixture in this file holds exactly ONE checkout, so none of them can see a
+# pairing bug at all: with one entry, `zip(entries, results)` and
+# `zip(entries, reversed(results))` are the same function.
+#
+# Two mutants survived the whole 352-test suite before these tests existed:
+#   * `pool.map(repo_of_checkout, entries[::-1])` — every checkout takes its
+#     NEIGHBOUR's owner. On the real host that maps `~/workspace/devrc` to
+#     another organisation's repository, so `devrc#1291` opens issue 1291
+#     somewhere unrelated: the confident wrong page.
+#   * dropping `if full:` — a child that failed or timed out answers "", and
+#     that "" is written OVER a good row the generated mapping supplied,
+#     silently un-resolving a name the host could answer a moment earlier.
+#
+# 🔴 FOUR CHECKOUTS, PAIRWISE-DISTINCT OWNERS AND REPOS, ALL SYNTHETIC. Four
+# rather than three because a 3-element reversal leaves the MIDDLE element on
+# itself; four has no fixed point. Distinct from `FAKE_UNIVERSE` and from every
+# constant these assertions name, so a mutant that transposes or hardcodes
+# cannot land on an expected value by accident.
+# --------------------------------------------------------------------------- #
+FAN_OUT_CHECKOUTS = {
+    "brambleway": "oxbowlabs/brambleway",
+    "cinderfell": "pitchpine/cinderfell",
+    "duskharrow": "quarrymill/duskharrow",
+    "quillmarsh": "northgate/quillmarsh",
+}
+
+
+def _workspace_of(tmp_path, names) -> Path:
+    ws = tmp_path / "workspace"
+    for name in names:
+        (ws / name / ".git").mkdir(parents=True)
+    return ws
+
+
+def test_the_fan_out_pairs_every_checkout_with_its_OWN_owner(tmp_path, monkeypatch):
+    """🔴 THE TRANSPOSITION GUARD. Every checkout must be paired with the owner
+    measured FOR IT, not with a neighbour's."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "absent.json")
+    ws = _workspace_of(tmp_path, FAN_OUT_CHECKOUTS)
+    monkeypatch.setattr(MO, "repo_of_checkout",
+                        lambda path: FAN_OUT_CHECKOUTS[Path(path).name])
+    got = MO.discover_repos(ws)
+    # POSITIVE CONTROL: the fan-out really ran over four checkouts, so the
+    # equality below is a fact about work that happened.
+    assert len(got) == 4, got
+    assert got == dict(FAN_OUT_CHECKOUTS), (
+        f"the fan-out paired a checkout with a NEIGHBOUR's owner: {got}")
+
+
+def test_the_fan_out_DEGRADES_to_serial_rather_than_vanishing(tmp_path, monkeypatch):
+    """🔴 `RuntimeError: can't start new thread` IS NOT HYPOTHETICAL ON THIS BOX
+    — it routinely runs 100+ concurrent agent worktrees. It used to propagate
+    out of `main()` into a DETACHED process: no toast, no readable stderr, a
+    click that did nothing.
+
+    The serial path must produce the SAME pairing, not merely "an answer" — a
+    fallback that transposes is the confident wrong page again, reached only
+    under load, where nobody is watching."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "absent.json")
+    ws = _workspace_of(tmp_path, FAN_OUT_CHECKOUTS)
+    monkeypatch.setattr(MO, "repo_of_checkout",
+                        lambda path: FAN_OUT_CHECKOUTS[Path(path).name])
+
+    def cannot_start_threads(paths):
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(MO, "_fan_out", cannot_start_threads)
+    got = MO.discover_repos(ws)
+    assert got == dict(FAN_OUT_CHECKOUTS), (
+        f"discovery did not DEGRADE to a serial fan-out: {got}")
+
+
+def test_an_UNREADABLE_checkout_does_not_ERASE_the_mappings_answer(
+        tmp_path, monkeypatch):
+    """🔴 `if full:` IS A GUARD. `repo_of_checkout` answers "" for a checkout
+    whose `git remote` failed or timed out. Writing that "" into the result
+    DELETES the row the generated mapping already supplied for the same name —
+    a name that resolved a moment ago silently stops resolving, and the operator
+    sees a picker where they used to see a page.
+
+    Both directions are asserted: the mapping's row must SURVIVE, and a
+    checkout the mapping never knew about must be ABSENT rather than present
+    with an empty value (an empty value builds `https://github.com//issues/12`).
+    """
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps({"quillmarsh": "northgate/quillmarsh"}))
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", p)
+    ws = _workspace_of(tmp_path, ["brambleway", "cinderfell", "quillmarsh"])
+    unreadable = {"quillmarsh", "cinderfell"}
+    monkeypatch.setattr(
+        MO, "repo_of_checkout",
+        lambda path: "" if Path(path).name in unreadable
+        else FAN_OUT_CHECKOUTS[Path(path).name])
+    got = MO.discover_repos(ws)
+    # POSITIVE CONTROL: the readable checkout DID land, so the two claims below
+    # are about a run that measured something.
+    assert got.get("brambleway") == "oxbowlabs/brambleway", got
+    assert got.get("quillmarsh") == "northgate/quillmarsh", (
+        f"an unreadable checkout ERASED the mapping's answer: {got}")
+    assert "cinderfell" not in got, (
+        f"an unreadable checkout ERASED the mapping's answer by adding an "
+        f"empty row: {got}")
+
+
 # The picker's size, and the empty results that must name their cause
 # --------------------------------------------------------------------------- #
 def test_a_WALL_of_repos_reaches_the_picker_because_it_can_be_TYPED_at(
@@ -767,6 +1052,85 @@ def test_universe_reason_never_names_a_ROW(tmp_path):
     p.write_text(json.dumps({"widget": "acme"}))
     reason = MO.universe_reason(p)
     assert "acme" not in reason and "widget" not in reason, reason
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE MAPPING IS HAND-REGENERATED AND NOTHING CONVERGES IT
+#
+# `scripts/regen-known-repos.py` is run by hand: no timer in `nix/` references
+# it. So a repository created since the last run is invisible to EVERY
+# resolution path, and the only symptom is a picker appearing where a page used
+# to open — which reads as "the picker is noisy", not as "my mapping is old".
+# The age is therefore measured and surfaced. These pin that it is measured at
+# TWO points rather than at one, because a threshold checked on one side of
+# itself cannot tell a working guard from a constant.
+# --------------------------------------------------------------------------- #
+def _mapping_aged(tmp_path, days: float) -> Path:
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps({"plotwidget": "hobbyist/plotwidget"}))
+    when = time.time() - days * 86400
+    os.utime(p, (when, when))
+    return p
+
+
+@pytest.mark.parametrize("days,stale", [
+    (0.0, False),                            # just regenerated
+    (MO.STALE_MAPPING_DAYS - 1, False),      # inside the window
+    (MO.STALE_MAPPING_DAYS + 1, True),       # just outside it
+    (90.0, True),                            # long gone
+])
+def test_the_mapping_age_is_measured_at_FOUR_points(tmp_path, days, stale):
+    """Both sides of the threshold AND a middle. The note must name a COUNT and
+    the regenerator, and must never name a row."""
+    p = _mapping_aged(tmp_path, days)
+    measured = MO.mapping_age_days(p)
+    assert measured is not None and abs(measured - days) < 0.01, measured
+    note = MO.staleness_note(p)
+    assert bool(note) is stale, f"{days}d -> {note!r}"
+    if stale:
+        assert "regen-known-repos.py" in note, note
+        assert "plotwidget" not in note and "hobbyist" not in note, note
+
+
+def test_an_ABSENT_mapping_has_an_UNKNOWN_age_not_a_fresh_one(tmp_path):
+    """🔴 None MEANS UNMEASURED. Answering "0 days" for a file that does not
+    exist would report the staleness signal as clean on exactly the host it
+    cannot measure — the silent zero this module is written against. The absent
+    case has its OWN reason (`universe_reason`), so the staleness note stays
+    empty rather than inventing a second one."""
+    assert MO.mapping_age_days(tmp_path / "nothing-here.json") is None
+    assert MO.staleness_note(tmp_path / "nothing-here.json") == ""
+
+
+def test_a_STALE_mapping_is_NAMED_in_the_refusal_beside_the_primary_cause(
+        spy, monkeypatch, tmp_path):
+    """🔴 APPENDED, NOT SUBSTITUTED — the same rule the advice follows. "no
+    repository owner is known for it" is the primary fact and staleness is the
+    ACTIONABLE addition; reporting only one of them is how the operator ends up
+    regenerating nothing, or regenerating for the wrong reason."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH",
+                        _mapping_aged(tmp_path, MO.STALE_MAPPING_DAYS + 30))
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    # `--print` bars the picker, which is what routes this to a refusal at all.
+    assert MO.main(["--print", "zzznosuchrepo#77"]) == 1
+    body = notices[-1][1]
+    assert "days old" in body, f"the refusal never named the mapping's age: {body}"
+    assert "regen-known-repos.py" in body, body
+    assert "owner/repo#N" in body, "the actionable advice was dropped"
+
+
+def test_a_FRESH_mapping_adds_NO_staleness_noise_to_the_refusal(
+        spy, monkeypatch, tmp_path):
+    """The negative control for the test above. Without it, a `staleness_note`
+    that complained unconditionally would satisfy every assertion there."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 0.0))
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main(["--print", "zzznosuchrepo#77"]) == 1
+    assert "days old" not in notices[-1][1], notices[-1]
 
 
 def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatch,
@@ -879,18 +1243,32 @@ def test_a_ONE_ENTRY_universe_is_still_a_CHOICE_and_never_auto_opens(
     `zzznosuchrepo#77` opened issue 77 in a completely unrelated repository — a
     confident wrong page, the exact failure this handler exists to prevent.
 
-    A mapping hit is evidence about the name; a universe row is only an option."""
+    A mapping hit is evidence about the name; a universe row is only an option.
+
+    🔴 THIS TEST NOW CARRIES THE WHOLE `offered_universe` GUARD. It used to share
+    it with a six-digit case, and six digits no longer reaches the picker at all
+    — so if this one stopped exercising the one-entry shortcut, nothing would.
+    The message says what a failure MEANS rather than what was asserted, because
+    a mutation battery reads the `E ` line to decide whether the row it named is
+    the row that fired."""
     monkeypatch.setattr(MO, "discover_repos",
                         lambda *a, **k: {"spadeworks": "rivalorg/spadeworks"})
     assert MO.main(["zzznosuchrepo#77"]) == 0
-    assert ("pick", 1) in spy, spy
+    assert ("pick", 1) in spy, (
+        f"a universe row was AUTO-OPENED, bypassing the picker: {spy}")
+    # The claim is ORDER, not absence: `spy`'s `pick` answers with row 0, so an
+    # `open` AFTER a pick is what a selection legitimately does. What must never
+    # happen is an open with no pick in front of it.
+    kinds = [c[0] for c in spy if isinstance(c, tuple)]
+    assert kinds.index("pick") < kinds.index("open"), (
+        "a universe row was AUTO-OPENED, bypassing the picker")
 
 
 def test_dismissing_the_universe_picker_opens_NOTHING(spy, universe, monkeypatch):
     """`pick()`'s contract, preserved exactly: a dismissal is not an error and it
     must not open anything. Asserted on the OPENER, not only on the exit code —
     an exit code cannot tell you a browser was launched."""
-    monkeypatch.setattr(MO, "pick", lambda c: "")
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": "")
     assert MO.main(["zzznosuchrepo#12"]) == 0
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
 
@@ -928,7 +1306,7 @@ def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):
     monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     picks, opens, notices = [], [], []
-    monkeypatch.setattr(MO, "pick", lambda c: picks.append(len(c)) or "")
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": picks.append(len(c)) or "")
     monkeypatch.setattr(MO, "open_url", lambda url: opens.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
     assert MO.main(["zzznosuchrepo#12"]) == 1
@@ -954,20 +1332,72 @@ def test_no_discovery_still_means_resolve_only_what_the_TEXT_carries(spy, univer
     ("--print", "there is nobody to ask"),
 ])
 def test_a_flag_that_BARS_the_picker_says_so_by_NAME(monkeypatch, universe,
-                                                     flag, expected):
+                                                     tmp_path, flag, expected):
     """🔴 THE THIRD WAY THE PICKER CANNOT BE SHOWN, and it is not an empty
     universe — the universe here is fine and non-empty. A refusal reporting "no
     repo mapping on this host" would send the operator to run
     `regen-known-repos.py` over a mapping that was never the problem.
 
     Both flags are named in the body because they are the operator's own lever:
-    drop the flag and the picker appears."""
+    drop the flag and the picker appears.
+
+    🔴 THE MAPPING IS PATCHED TO A HEALTHY TMP FILE, and that is not tidiness.
+    `refuse()` reads `KNOWN_REPOS_PATH`; without this the test would consult the
+    OPERATOR'S REAL mapping, so it asserted one thing on the dev host (file
+    present) and another in the nix sandbox tier (HOME is empty, so the file is
+    absent) — the config-blind shape, green for different reasons in the two
+    tiers. The healthy-mapping case is what this test is about; the ABSENT one
+    is the test below, which is the case that was reporting the wrong cause."""
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps({"plotwidget": "hobbyist/plotwidget"}))
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", p)
     notices = []
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
     assert MO.main([flag, "zzznosuchrepo#12"]) == 1
     assert expected in notices[-1][1], notices[-1]
     assert "regen-known-repos" not in notices[-1][1], (
         "blamed the mapping for a refusal the FLAG caused")
+
+
+def test_print_mode_on_a_host_with_NO_mapping_names_the_ACTIONABLE_cause(
+        monkeypatch, universe, tmp_path):
+    """🔴 BOTH CAUSES ARE TRUE; ONLY ONE IS ACTIONABLE, AND IT WAS THE ONE BEING
+    DROPPED. `--print zzz#12` on a host with no mapping at all used to answer
+    "--print cannot show the repository picker" and stop — because the flag was
+    tested BEFORE `universe_reason()`, not because the flag was the better
+    answer. The operator cannot act on "--print is non-interactive"; they can act
+    on "run scripts/regen-known-repos.py". A handler whose stated discipline is
+    "say WHICH empty this is" reported the un-actionable half.
+
+    Both are asserted, and the flag half is asserted FIRST so this cannot pass by
+    having quietly stopped naming the flag."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "nothing-here.json")
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main(["--print", "zzznosuchrepo#12"]) == 1
+    body = notices[-1][1]
+    assert "there is nobody to ask" in body, body
+    assert "has no repo mapping" in body, (
+        f"--print blamed the FLAG and never named the mapping, which is the "
+        f"only cause the operator can act on: {body}")
+    assert "regen-known-repos.py" in body, body
+
+
+def test_no_discovery_still_does_NOT_blame_the_mapping_it_never_read(
+        monkeypatch, universe, tmp_path):
+    """The mirror of the test above, and the reason the two flags are handled
+    differently rather than uniformly. `--no-discovery` means the mapping is
+    never opened, so its state is not a cause of anything — naming it would send
+    the operator to regenerate a file that was not involved. `--print` DOES read
+    it (PASS 2 still runs), which is why it names both."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "nothing-here.json")
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main(["--no-discovery", "zzznosuchrepo#12"]) == 1
+    body = notices[-1][1]
+    assert "resolves only what the text itself carries" in body, body
+    assert "regen-known-repos" not in body, (
+        f"blamed a mapping --no-discovery never read: {body}")
 
 
 def test_print_mode_never_invokes_the_picker_or_the_universe(spy, universe, capsys):
@@ -1029,55 +1459,186 @@ def test_offer_number_is_NOT_a_resolution(spy):
     assert MO.resolve("#282828") == (None, [])
 
 
-def test_a_SIX_DIGIT_number_is_OFFERED_but_NEVER_auto_opened(spy, monkeypatch):
-    """🔴 THE EXACT HAZARD `_NUM = \\d{1,5}` EXISTS FOR, on the new path. With a
-    ONE-entry universe the "exactly one candidate → just open it" shortcut is
-    live, and firing it here would open issue 282828 of an unrelated repository
-    from a click on a colour literal — a confident wrong page produced by the
-    very change meant to be friendlier.
+def test_a_SIX_DIGIT_click_gets_a_NAMED_toast_not_a_wall_of_repos(spy, universe,
+                                                                  monkeypatch):
+    """🔴 THE OPERATOR DECISION, RECORDED. `mention_scan`'s `_NUM` is `\\d{1,5}`
+    because nothing on this host — no clawgate task, no GitHub issue in any repo
+    the operator touches — reaches six digits; devrc itself is in the 1300s. So a
+    six-digit `#N` is ALWAYS a false positive, and every row a universe picker
+    could offer for it names an issue no repository has: several hundred URLs
+    that all 404 is not a choice, it is a wall with no door.
 
-    A one-entry universe is the fixture on purpose: any larger one reaches the
-    picker through the plural branch and could not see this regression at all."""
-    monkeypatch.setattr(MO, "discover_repos",
-                        lambda *a, **k: {"spadeworks": "rivalorg/spadeworks"})
-    assert MO.main(["#282828"]) == 0
-    # 🔴 THE CLAIM IS ORDER, NOT ABSENCE. `spy`'s `pick` answers with row 0, so
-    # an `open` here is legitimate — it is what a SELECTION does. What must never
-    # happen is an open with no pick in front of it, which is the auto-open
-    # shortcut firing. Asserting "no open at all" would instead pass against a
-    # handler that had stopped working entirely.
-    kinds = [c[0] for c in spy if isinstance(c, tuple)]
-    # 🔴 THE MESSAGE IS ON THIS ASSERTION, NOT THE ORDERING ONE BELOW. When the
-    # auto-open shortcut fires there is no "pick" at all, so THIS is the line
-    # that goes red — and a mutation battery reports a kill for the wrong reason
-    # when the phrase it looks for sits on an assertion that never evaluates.
-    assert "pick" in kinds, (
-        f"a number the SCANNER REFUSED was auto-opened, bypassing the "
-        f"picker: {spy}")
-    assert kinds.index("pick") < kinds.index("open"), (
-        "a number the SCANNER REFUSED was auto-opened, bypassing the picker")
+    `#282828` is the operator's own gruvbox background literal, written in the
+    very file that configures this hint. The right answer is "that is a colour",
+    said once.
 
-
-def test_dismissing_the_SIX_DIGIT_picker_opens_nothing(spy, universe, monkeypatch):
-    monkeypatch.setattr(MO, "pick", lambda c: "")
-    assert MO.main(["#282828"]) == 0
+    🔴 IT IS A TOAST, NOT A SILENCE. The dead end this branch replaced was the
+    complaint that started the whole change; answering with nothing would be that
+    dead end again. So the notification must NAME the number and say what it
+    looks like — asserted on the BODY, not merely on the exit code."""
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    # 🔴 THE MESSAGE IS ON THE EXIT CODE, and that placement is not cosmetic.
+    # When the six-digit branch is removed the picker fires and `main()` returns
+    # 0, so THIS is the assertion that goes red first — the picker assertion
+    # below never evaluates, and a battery matching on its phrase would report
+    # `KILLED-WRONG-REASON` for a row that killed exactly the right test.
+    assert MO.main(['background = "#282828";']) == 1, (
+        "a six-digit click raised the repository picker for a colour literal")
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"], (
+        f"a six-digit click raised the repository picker for a colour "
+        f"literal: {spy}")
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+    assert notices, "a six-digit click said NOTHING — the old dead end is back"
+    body = notices[-1][1]
+    assert "282828" in body and "colour literal" in body, notices[-1]
 
 
-def test_a_SELECTED_six_digit_row_opens_the_repo_the_operator_CHOSE(
-        spy, universe, monkeypatch):
-    """The other half: offering it must actually work. A picker that cannot open
-    what was selected is the refusal again, wearing a window.
+def test_a_six_digit_literal_BESIDE_a_real_reference_does_not_suppress_it(spy):
+    """🔴 WHY `colour_literal_offer` ASKS FOR `span is None` FIRST.
 
-    `hobbyist/plotwidget` is the SECOND row of the sorted universe, not the
-    first — so a mutant that ignores the selection and takes row 0 cannot land on
-    this URL by accident."""
+    `offer_number` scans the WHOLE text for the first `#N`, and in
+    `background = "#282828"; fixed in talos-infra#1065` the first one is the
+    COLOUR — while the scanner's span is the reference. Classifying on the
+    number alone would call this click a colour literal, skip discovery, and
+    refuse a reference that resolves perfectly well.
+
+    A number the scanner ACCEPTED is a reference by definition, whatever else
+    the text contains; the six-digit rule may only speak for text the scanner
+    refused outright. This is a command-line surface rather than a click one —
+    Alacritty hands over the matched substring, not the whole line — but it is
+    the guard that keeps the two classifications from being confused, and it
+    survived the whole suite before this test existed."""
+    assert MO.main(['background = "#282828"; fixed in talos-infra#1065']) == 0, (
+        "a colour literal BESIDE a real reference suppressed the reference")
+    assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/issues/1065"), (
+        f"a colour literal BESIDE a real reference suppressed the "
+        f"reference: {spy}")
+
+
+def test_a_SIX_DIGIT_click_does_not_pay_for_the_DISCOVERY_fan_out(spy):
+    """The universe it will not show costs a `git remote` fan-out plus a tmux
+    round-trip to build. A click that already has its answer must not pay for
+    one — the same latency argument that keeps `owner/repo#N` out of PASS 2,
+    applied at the other end of the path."""
+    assert MO.main(["#282828"]) == 1
+    assert "discover" not in spy, spy
+    assert "tmux" not in spy, spy
+
+
+def test_a_FIVE_digit_number_still_reaches_the_picker(spy, universe, monkeypatch):
+    """🔴 THE OTHER HALF OF THE DECISION, AND THE CONTROL FOR IT. Only SIX digits
+    is special-cased; every other unresolvable shape still becomes a choice. A
+    branch measured at one point cannot tell "six digits is refused" from "the
+    picker is gone", so the bound is measured on both sides of itself.
+
+    Five digits is the widest the scanner ACCEPTS, so this is also the boundary
+    case: `#28282` resolves to a clawgate task, is ambiguous, and gets the
+    universe appended below it."""
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    assert MO.main(["#28282"]) == 0
+    assert ("pick", 4) in spy, spy
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 A DISMISSED PICKER CANNOT BE READ, SO THE DIAGNOSIS GOES ABOVE IT
+#
+# MEASURED: `kubectl-neat#1` resolved before this branch and now exits 1.
+# Interactively the operator gets the fuzzy picker, types the name, rofi
+# (`-no-custom`) matches nothing, presses Escape — and `pick()` returns "" for
+# BOTH that and a genuine "I changed my mind". rofi reports them identically;
+# there is no exit code, no stdout, nothing that separates them. So a toast
+# fired after a dismissal would fire after EVERY dismissal, which is noise the
+# handler must not make.
+#
+# The honest place for "this host has no repository called kubectl-neat" is
+# therefore BEFORE the choice, on the one surface the universe may already
+# reach: a `-mesg` line above the list.
+# --------------------------------------------------------------------------- #
+def test_the_universe_picker_EXPLAINS_ITSELF_above_the_list(universe, monkeypatch,
+                                                            tmp_path):
+    """It must name the repo the operator CLICKED — which they already typed —
+    plus how many rows are offered, when the mapping was generated, and the
+    remedy. Never a row from the universe."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 3.0))
+    monkeypatch.setattr(MO, "open_url", lambda url: 0)
+    seen = {}
+
+    def note_pick(cands, mesg=""):
+        seen["mesg"] = mesg
+        seen["rows"] = len(cands)
+        return ""
+
+    monkeypatch.setattr(MO, "pick", note_pick)
+    assert MO.main(["kubectl-neat#1"]) == 0
+    # POSITIVE CONTROL: the picker really was raised over the real universe.
+    assert seen["rows"] == 3, seen
+    mesg = seen["mesg"]
+    assert mesg, (
+        "the universe picker was raised with NO explanation — a dismissal and "
+        "a no-match are then indistinguishable to the operator too")
+    assert "kubectl-neat#1" in mesg, mesg
+    assert "3 offered" in mesg, mesg
+    assert "regen-known-repos.py" in mesg, mesg
+    assert "3d ago" in mesg, mesg
+
+
+def test_the_picker_NOTE_never_names_a_universe_row(universe, monkeypatch,
+                                                    tmp_path):
+    """🔴 THE NOTE IS THE ONE NEW STRING BUILT WHILE THE WHOLE UNIVERSE IS IN
+    HAND, so it is exactly where "did you mean one of these?" would be written
+    next. The rows themselves may go to rofi; the note may say only what the
+    operator already knows plus two numbers."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 1.0))
+    seen = {}
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": seen.update(mesg=mesg) or "")
+    assert MO.main(["kubectl-neat#1"]) == 0
+    for name in FAKE_UNIVERSE.values():
+        assert name not in seen["mesg"], f"PICKER-NOTE DISCLOSURE: {name}"
+        assert name.split("/")[0] not in seen["mesg"], (
+            f"PICKER-NOTE DISCLOSURE: {name}")
+
+
+def test_the_ORDINARY_picker_gets_no_note(spy, monkeypatch):
+    """The bare `#N` picker — clawgate plus a pane-attributed GitHub row — is
+    not a dead end. Putting a line of apology above the single most common
+    interaction in this handler would be a regression dressed as a diagnosis."""
+    seen = {}
     monkeypatch.setattr(
         MO, "pick",
-        lambda c: "https://github.com/hobbyist/plotwidget/issues/282828")
-    assert MO.main(["#282828"]) == 0
-    assert spy[-1] == (
-        "open", "https://github.com/hobbyist/plotwidget/issues/282828")
+        lambda c, mesg="": seen.update(mesg=mesg) or c[0]["url"])
+    assert MO.main(["#370"]) == 0
+    assert seen["mesg"] == "", seen
+
+
+def test_the_picker_passes_its_NOTE_to_rofi_as_mesg(monkeypatch):
+    """🔴 THE SEAM BETWEEN THE DECISION AND THE TOOL, again. Every test above
+    stubs `pick`, so none of them notices if the note is computed and then
+    dropped on the floor. This is the only one that reads the argv rofi is
+    actually handed.
+
+    NOTHING IS LAUNCHED: `subprocess.run` is replaced."""
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = list(cmd)
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(MO.subprocess, "run", fake_run)
+    cands = [{"platform": "github", "id": "7",
+              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}]
+    MO.pick(cands, mesg="nothing here knows widget<1> & co")
+    assert "-mesg" in seen["cmd"], seen["cmd"]
+    body = seen["cmd"][seen["cmd"].index("-mesg") + 1]
+    # `-mesg` is rendered as PANGO MARKUP, so the three significant characters
+    # must arrive escaped or a stray `<` swallows the rest of the line.
+    assert body == "nothing here knows widget&lt;1&gt; &amp; co", body
+
+    # NEGATIVE CONTROL: no note, no flag. A `-mesg` with an empty argument
+    # renders an empty band above the list on every ordinary picker.
+    MO.pick(cands)
+    assert "-mesg" not in seen["cmd"], seen["cmd"]
 
 
 def test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe(
@@ -1117,6 +1678,52 @@ def real_notify(monkeypatch):
     return sent
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 A REFUSAL THAT SHOWS NOTHING IS WORSE THAN THE REFUSAL IT REPLACED
+# --------------------------------------------------------------------------- #
+def test_notify_send_is_given_a_double_dash_before_the_MESSAGE(real_notify):
+    """🔴 MEASURED WITH notify-send 0.8.8, not reasoned about. Several refusal
+    bodies begin with a flag NAME — "--print cannot show the repository picker",
+    "--no-discovery resolves only what the text itself carries" — because naming
+    the operator's own lever is the point. `notify-send` uses GNU getopt, which
+    PERMUTES, so it parses that body as an OPTION wherever it sits:
+
+        $ notify-send -a mention-open S "--no-discovery resolves only …"
+        Unknown option --no-discovery resolves only …   ; exit 1, NO TOAST
+        $ notify-send -a mention-open -- S "--no-discovery resolves only …"
+        ; exit 0, one toast
+
+    And `notify()` runs with `check=False`, so that exit 1 is swallowed: the
+    handler reports the refusal to a stderr nobody reads and shows nothing at
+    all. The `--` is what stops it."""
+    MO.notify("cannot resolve zzz#12",
+              "--print cannot show the repository picker — there is nobody to ask")
+    argv = real_notify[-1]
+    assert argv[0] == "notify-send", argv
+    assert "--" in argv, (
+        f"notify-send got a body starting with `--` and NO `--` terminator, so "
+        f"it exits 1 and shows NOTHING: {argv}")
+    assert argv.index("--") < argv.index("cannot resolve zzz#12"), argv
+    assert argv[-1].startswith("--print"), argv
+
+
+def test_every_flag_refusal_the_handler_can_produce_survives_notify_send(
+        universe, monkeypatch, real_notify, tmp_path):
+    """The seam, not the unit: it is `main()`'s refusal bodies that begin with
+    `--`, and a `--` added to `notify()` is only useful if those bodies still
+    reach it. Both flags are driven through the REAL `notify`."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "nothing-here.json")
+    for flag in ("--no-discovery", "--print"):
+        real_notify.clear()
+        assert MO.main([flag, "zzznosuchrepo#12"]) == 1
+        argv = real_notify[-1]
+        # POSITIVE CONTROL: this really is a body that starts with a flag name.
+        assert argv[-1].startswith("--"), argv
+        assert "--" in argv[:-1], (
+            f"{flag}: the refusal body starts with a flag name and notify-send "
+            f"got no `--`, so the toast never appears: {argv}")
+
+
 # The universe rows may reach the operator's rofi window and NOWHERE else, so
 # every sink the handler can write to is enumerated here rather than left to
 # whichever one a test happened to think of. A sink missing from this list is a
@@ -1137,8 +1744,9 @@ def test_the_universe_never_reaches_a_LOG_a_SPOOL_or_stderr(spy, universe,
     reached stdout, stderr or a desktop notification."""
     seen = {}
 
-    def spy_pick(cands):
+    def spy_pick(cands, mesg=""):
         seen["rows"] = MO.picker_rows(cands)
+        seen["mesg"] = mesg
         return ""
 
     monkeypatch.setattr(MO, "pick", spy_pick)
@@ -1150,7 +1758,7 @@ def test_the_universe_never_reaches_a_LOG_a_SPOOL_or_stderr(spy, universe,
 
 
 def test_the_REFUSAL_path_names_the_clicked_text_and_never_the_universe(
-        universe, monkeypatch, capsys, real_notify):
+        universe, monkeypatch, capsys, real_notify, tmp_path):
     """🔴 THE SECOND HALF OF THE SAME GUARD, on the path PASS 4 never reaches.
 
     `--print` skips PASS 4 entirely, so the handler refuses — but `discovered`
@@ -1162,7 +1770,13 @@ def test_the_REFUSAL_path_names_the_clicked_text_and_never_the_universe(
 
     The positive controls come FIRST: the refusal really happened, and the
     handler really held the universe at that moment. Without them a stubbed-out
-    run that refused for some other reason would satisfy every absence below."""
+    run that refused for some other reason would satisfy every absence below.
+
+    ⚠ THE MAPPING PATH IS PATCHED so the refusal's reason is a property of this
+    fixture rather than of the machine: `refuse()` reads `KNOWN_REPOS_PATH`, and
+    the nix sandbox tier runs under an empty HOME, so an unpatched run reports a
+    different cause there than on the dev host."""
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 1.0))
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     assert MO.main(["--print", "zzznosuchrepo#77"]) == 1
     everywhere = _every_sink(capsys, real_notify)

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import shutil
 import subprocess
 import sys
 import types
@@ -213,10 +212,27 @@ def test_an_ambiguous_click_prints_every_candidate():
 def test_a_non_mention_exits_non_zero_and_says_so():
     """🔴 A handler that fails SILENTLY is indistinguishable from one that was
     never wired up. The refusal is announced on stderr even when no desktop
-    notification is available."""
+    notification is available.
+
+    ⚠ `--no-discovery` is what makes this a refusal at all. Without it a
+    six-digit number now OPENS THE PICKER (see the six-digit tests below); the
+    flag bars the picker by contract, so the named refusal is what remains."""
     r = _run("--print", "--no-discovery", "#282828")
     assert r.returncode == 1
-    assert "no mention" in r.stderr
+    assert "cannot resolve" in r.stderr
+    assert "resolves only what the text itself carries" in r.stderr
+
+
+def test_text_with_no_NUMBER_at_all_still_gets_the_original_refusal():
+    """The one place `no mention in the clicked text` survives verbatim: there is
+    no number, so there is nothing a picker could even offer.
+
+    ⚠ UNREACHABLE FROM A CLICK. The Alacritty hint regex requires `#[0-9]{1,6}`
+    or a ClickUp id, so nothing digitless is ever underlined — this is the
+    command line only."""
+    r = _run("--print", "background = teal;")
+    assert r.returncode == 1
+    assert "no mention in the clicked text" in r.stderr
 
 
 def test_an_unresolvable_owner_exits_non_zero_and_explains():
@@ -288,9 +304,23 @@ def test_a_short_form_repo_is_resolved_from_the_discovered_checkouts(spy):
     assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/issues/1065")
 
 
-def test_a_non_mention_notifies_and_opens_nothing(spy):
-    assert MO.main(['background = "#282828";']) == 1
-    assert spy == [("notify", "no mention in the clicked text")]
+def test_a_non_mention_OFFERS_THE_PICKER_instead_of_refusing(spy):
+    """🔴 THE REVERSAL THIS CHANGE EXISTS FOR. `#282828` used to produce the
+    toast `no mention in the clicked text`, which reads as the handler being
+    broken when it is the guard working correctly — and a guard that reads as a
+    bug is one the next maintainer deletes.
+
+    The picker is now offered instead. Nothing is opened without a selection, and
+    the number never becomes a reference: see
+    `test_a_SIX_DIGIT_number_is_OFFERED_but_NEVER_auto_opened`."""
+    # 🔴 THE MESSAGE IS ON THE EXIT CODE, which is what a reverted measurement
+    # pass turns to 1 — the picker assertion below never evaluates in that case.
+    assert MO.main(['background = "#282828";']) == 0, (
+        "a six-digit click DEAD-ENDED instead of offering the picker")
+    assert ("pick", 1) in spy, (
+        f"a six-digit click DEAD-ENDED instead of offering the picker: {spy}")
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "notify"], (
+        "a six-digit click DEAD-ENDED instead of offering the picker")
 
 
 # --------------------------------------------------------------------------- #
@@ -342,187 +372,170 @@ def test_a_local_checkout_overrides_the_mapping(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# PASS 3 — the GitHub API fallback
+# 🔴 THE CLICK PATH MAKES NO NETWORK CALL
 #
-# 🔴 An earlier version of this path shipped INERT: its jq program compared
-# `.name` against the LITERAL text `"$name"` (a Python string with no f-prefix),
-# selecting nothing for any input, while every test that stubbed `gh` passed.
-# Nothing here mocks the selection — the fake returns the rows `gh` would print
-# and the assertions pin WHICH of them the resolver takes.
+# A GitHub-WIDE namesake search used to live between the local sources and the
+# picker: `gh api search/repositories`, consulted for any `repo#N` the mapping
+# and the checkouts could not name. MEASURED on the deployed copy, `dashboard#12`
+# cost 4.3s through `--print` and ~10s through the real hint path at 6% CPU —
+# all of it network wait — and returned `vzhong/dashboard`, `yorkie-team/
+# dashboard`, `zce/dashboard`: strangers' repositories the operator would never
+# pick. It searched a corpus that structurally could not hold the answer.
+#
+# It is DELETED. These tests exist so it cannot come back by accident, and so no
+# OTHER network call can take its place: the check is a LEDGER of every command
+# the resolution path may spawn, which fails when the set GROWS or SHRINKS, not a
+# ban on the single word `gh` that any other client would walk straight past.
 # --------------------------------------------------------------------------- #
-@pytest.fixture(autouse=True)
-def _clear_api_cache():
-    """The cache is module-global and would carry an answer between tests."""
-    MO._GITHUB_API_CACHE.clear()
-    yield
-    MO._GITHUB_API_CACHE.clear()
+
+# Every command the resolution path is allowed to spawn, as (argv[0], argv[1]).
+#
+# 🔴 THE SUBCOMMAND IS PART OF THE LEDGER, NOT DECORATION. `git` alone would
+# admit `git ls-remote` and `git fetch`, which are network calls wearing the name
+# of a local tool — the exact substitution a ban on `gh` invites. Both entries
+# here are local-only reads.
+RESOLUTION_PATH_COMMANDS = {
+    ("tmux", "display-message"),   # which pane the operator was last in
+    ("git", "rev-parse"),          # that pane's checkout root
+    ("git", "remote"),             # `remote get-url origin` — reads .git/config
+}
 
 
-# Bound BEFORE any test patches the module attribute, so a test that needs a
-# REAL subprocess while `gh` is faked still gets one.
-_REAL_RUN = subprocess.run
+def _assert_only_local_commands(seen: list[list[str]]) -> None:
+    """Fail unless `seen` is exactly the ledger above.
+
+    🔴 BOTH DIRECTIONS. A GROWN set is a new command nobody vetted — a network
+    call, most likely. A SHRUNK set means the path under test never ran the
+    measurement at all, which would make every absence below vacuous.
+    """
+    got = {(c[0], c[1]) for c in seen if len(c) >= 2}
+    assert got == RESOLUTION_PATH_COMMANDS, (
+        f"the resolution path's command ledger MOVED: {sorted(got)}")
 
 
-def _fake_gh(rows, *, returncode=0):
-    """Stand in for `gh api search/repositories`, recording the argv it got.
-    Rows are RELEVANCE-ordered as the endpoint returns them — the exact-name
-    matches are deliberately NOT first."""
-    seen: dict = {}
-
-    def run(cmd, **kwargs):
-        seen["cmd"] = list(cmd)
-        return types.SimpleNamespace(
-            returncode=returncode, stdout="".join(f"{r}\n" for r in rows), stderr="")
-
-    return run, seen
-
-
-# Fixture rows share no substring with any assertion constant, and the two
-# EXACT matches sit at positions 2 and 4 — so a mutant that takes the first row,
-# the last row, or matches on a prefix cannot land on the expected value.
-_SEARCH_ROWS = [
-    "hobbyist/trowelcast-examples",
-    "gardenersguild/trowelcast",
-    "someoneelse/trowelcast-mirror",
-    "rivalorg/trowelcast",
-    "thirdparty/trowelcast-fork",
-]
+def test_the_no_network_assertion_can_actually_FIRE():
+    """🔴 POSITIVE CONTROL ON THE ASSERTION ITSELF, not on the code it guards.
+    `_assert_only_local_commands` is the whole instrument; until it has been
+    watched to reject something, a green run from it is indistinguishable from a
+    check wired to nothing. Feed it the exact argv the deleted search used."""
+    with pytest.raises(AssertionError, match="ledger MOVED"):
+        _assert_only_local_commands([
+            ["tmux", "display-message", "-p"],
+            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "remote", "get-url", "origin"],
+            ["gh", "api", "search/repositories", "-f", "q=dashboard in:name"],
+        ])
+    # …and in the other direction: a path that measured nothing.
+    with pytest.raises(AssertionError, match="ledger MOVED"):
+        _assert_only_local_commands([])
 
 
-def test_the_api_fallback_returns_EVERY_exact_name_match(monkeypatch):
-    """🔴 Relevance order is not name order, and an exact-name hit is not an
-    unambiguous one. Returning the first row silently picks a stranger's repo."""
-    run, seen = _fake_gh(_SEARCH_ROWS)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.gh_api_repo_search("trowelcast") == ({
-        "gardenersguild/trowelcast": "gardenersguild/trowelcast",
-        "rivalorg/trowelcast": "rivalorg/trowelcast"}, "")
-    assert seen["cmd"][:3] == ["gh", "api", "search/repositories"]
+def test_the_resolution_path_spawns_ONLY_these_local_commands(tmp_path, monkeypatch):
+    """🔴 THE GUARD. Drives the FULL unresolvable path — the one that used to
+    reach the network — against a real mapping file and a real workspace, with
+    `subprocess.run` recording instead of executing, and asserts the ledger.
+
+    Nothing here stubs `discover_repos` or `tmux_pane_repo`: those ARE the
+    subject. A fixture that replaced them would leave this test green against a
+    handler that phoned home from either one.
+    """
+    # A real mapping and a real checkout, so both measurement legs do work.
+    mapping = tmp_path / "known_repos.json"
+    mapping.write_text(json.dumps({"plotwidget": "hobbyist/plotwidget"}))
+    ws = tmp_path / "workspace"
+    (ws / "spadeworks" / ".git").mkdir(parents=True)
+    pane = tmp_path / "pane"
+    pane.mkdir()
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", mapping)
+    monkeypatch.setattr(MO, "WORKSPACE", ws)
+
+    seen: list[list[str]] = []
+
+    def record(cmd, **kwargs):
+        seen.append(list(cmd))
+        # Answer each leg plausibly so the NEXT one runs. A fake that returns
+        # failure would truncate the path and shrink the ledger silently.
+        if cmd[:2] == ["tmux", "display-message"]:
+            out = str(pane)
+        elif cmd[:2] == ["git", "rev-parse"]:
+            out = str(pane)
+        else:
+            out = "git@github.com:rivalorg/spadeworks.git"
+        return types.SimpleNamespace(returncode=0, stdout=out + "\n", stderr="")
+
+    def no_launch(argv, *a, **k):
+        raise AssertionError(f"nothing may be launched: {argv!r}")
+
+    monkeypatch.setattr(MO.subprocess, "run", record)
+    monkeypatch.setattr(MO.subprocess, "Popen", no_launch)
+    monkeypatch.setattr(MO, "pick", lambda c: "")
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: None)
+
+    assert MO.main(["zzznosuchrepo#12"]) == 0
+    _assert_only_local_commands(seen)
+    # POSITIVE CONTROL: the fan-out really ran over the real workspace, so the
+    # ledger above is a fact about a path that did the work, not about a
+    # short-circuit. One checkout ⇒ one `git remote` call.
+    assert [c for c in seen if c[:2] == ["git", "remote"]], seen
 
 
-def test_the_api_fallback_matches_a_name_case_insensitively(monkeypatch):
-    run, _ = _fake_gh(["hobbyist/TrowelCast-ui", "gardenersguild/TrowelCast"])
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.gh_api_repo_search("trowelcast") == (
-        {"gardenersguild/TrowelCast": "gardenersguild/TrowelCast"}, "")
+# Every executable the module may ever spawn, from ANY function. Wider than
+# `RESOLUTION_PATH_COMMANDS` because it also covers the ACTION half — opening a
+# browser, raising rofi, sending a notification — which no resolution runs.
+SPAWNABLE_EXECUTABLES = {"git", "tmux", "rofi", "xdg-open", "notify-send"}
 
 
-def test_the_api_fallback_returns_NOTHING_when_no_row_names_the_repo(monkeypatch):
-    """🔴 NOTHING IS GUESSED. Only near-misses ⇒ no candidate at all."""
-    run, _ = _fake_gh(["hobbyist/trowelcast-examples", "thirdparty/trowelcast-fork"])
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    # 🔴 The reason is EMPTY here: the search RAN and matched nothing. That is a
-    # different fact from a search that could not run, and the refusal differs.
-    assert MO.gh_api_repo_search("trowelcast") == ({}, "")
+def _spawned_executables(source: str) -> set[str]:
+    """argv[0] of every `subprocess.run`/`Popen` call in `source`, read from the
+    AST.
+
+    🔴 AST, NOT grep. The module's docstring NAMES `gh api search/repositories`
+    at length — that paragraph is the record of why the call was deleted, and it
+    is the single most valuable thing in the file for the next maintainer. A
+    substring check would either fail on that prose or force it to be softened
+    into uselessness, which is how a hazard note gets deleted to make a test
+    pass. The AST sees calls; it cannot see comments or docstrings at all.
+    """
+    import ast
+    out: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("run", "Popen") or not node.args:
+            continue
+        argv = node.args[0]
+        if isinstance(argv, (ast.List, ast.Tuple)) and argv.elts:
+            head = argv.elts[0]
+            out.add(head.value if isinstance(head, ast.Constant) else "<computed>")
+        else:
+            out.add("<computed>")
+    return out
 
 
-def test_the_api_fallback_returns_nothing_when_gh_fails(monkeypatch):
-    """A non-zero `gh` (no auth, rate limit, no network, BINARY ABSENT) prints
-    its error on stderr; treating stdout as an answer would resolve to garbage.
-
-    ⚠ INVARIANT GUARD, not regression coverage — green on the pre-fix code too."""
-    run, _ = _fake_gh(_SEARCH_ROWS, returncode=1)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    matches, why = MO.gh_api_repo_search("trowelcast")
-    assert matches == {}
-    assert "gh exited 1" in why
+def test_the_spawned_executable_LEDGER_can_actually_fire():
+    """POSITIVE CONTROL on the reader, before its verdict is believed. An AST
+    walk that matched nothing would report a clean empty set forever."""
+    found = _spawned_executables(
+        "import subprocess\n"
+        "subprocess.run(['gh', 'api', 'search/repositories'])\n")
+    assert found == {"gh"}, found
+    assert _spawned_executables("import subprocess\nx = 1\n") == set()
 
 
-def test_the_jq_program_is_a_CONSTANT_that_cannot_do_the_selection(monkeypatch):
-    """🔴 THE SEAM. Every test above stubs `gh`, so a filter that selects
-    nothing in production still passes them — precisely how the original bug
-    survived. `gh api --jq` accepts no `--arg`, so a name in the filter can only
-    be a string literal: assert the program carries neither the searched name
-    nor a `$`, i.e. that jq CANNOT be where the match happens."""
-    run, seen = _fake_gh(_SEARCH_ROWS)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    MO.gh_api_repo_search("trowelcast")
-    jq_program = seen["cmd"][seen["cmd"].index("--jq") + 1]
-    assert "$" not in jq_program
-    assert "trowelcast" not in jq_program
+def test_the_module_no_longer_carries_a_repository_SEARCH_at_all():
+    """🔴 STRUCTURAL, not behavioural — and deliberately both. The ledger test
+    above proves no search RAN on one path; this proves there is no search to run
+    on ANY path, including ones no test drives.
 
-
-@pytest.mark.skipif(shutil.which("jq") is None, reason="jq not on PATH")
-def test_the_jq_program_really_yields_the_rows_the_resolver_filters(monkeypatch):
-    """The other half of the seam: run the EMITTED program through the REAL jq
-    against a realistic payload. The inert original returns zero lines here."""
-    run, seen = _fake_gh(_SEARCH_ROWS)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    MO.gh_api_repo_search("trowelcast")
-    jq_program = seen["cmd"][seen["cmd"].index("--jq") + 1]
-
-    payload = json.dumps({"items": [
-        {"name": full.split("/")[1], "full_name": full} for full in _SEARCH_ROWS]})
-    # 🔴 _REAL_RUN, not subprocess.run: `MO.subprocess` IS the shared module, so
-    # the fake above is installed globally for the duration of the test. Calling
-    # subprocess.run here reaches the FAKE and this test passes on any filter
-    # whatsoever — measured, it passed against the inert original.
-    r = _REAL_RUN(["jq", "-r", jq_program], input=payload,
-                  capture_output=True, text=True, timeout=30)
-    assert r.returncode == 0, r.stderr
-    assert "gardenersguild/trowelcast" in r.stdout.splitlines()
-
-
-def test_one_exact_match_opens_directly(spy, monkeypatch):
-    run, _ = _fake_gh(["hobbyist/trowelcast-examples", "gardenersguild/trowelcast"])
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 0
-    assert ("pick", 2) not in spy
-    assert spy[-1] == ("open", "https://github.com/gardenersguild/trowelcast/issues/77")
-
-
-def test_TWO_owners_with_the_same_repo_name_go_to_the_PICKER(spy, monkeypatch):
-    """🔴 THE NAMESAKE RULE. `dashboard`, `cli`, `api` exist under dozens of
-    owners; measured on the first version, `dashboard#12` silently opened a
-    retired Kubernetes repo. Several owners is a CHOICE, not a ranking."""
-    run, _ = _fake_gh(_SEARCH_ROWS)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 0
-    assert ("pick", 2) in spy, spy
-    urls = MO.picker_rows([
-        {"platform": "github", "id": "77",
-         "url": "https://github.com/gardenersguild/trowelcast/issues/77"},
-        {"platform": "github", "id": "77",
-         "url": "https://github.com/rivalorg/trowelcast/issues/77"}])
-    assert "gardenersguild" in urls[0] and "rivalorg" in urls[1]
-
-
-def test_an_unknown_repo_with_no_exact_match_still_refuses_WHEN_THE_UNIVERSE_IS_EMPTY(
-        spy, monkeypatch):
-    """PASS 3 must not turn an honest refusal into a confident wrong page.
-
-    The refusal is now the LAST resort rather than the only one — it survives
-    exactly when PASS 4 has nothing to offer, which is what an empty
-    `discover_repos()` produces."""
-    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
-    run, _ = _fake_gh(["hobbyist/trowelcast-examples"])
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 1
-    assert spy[-1] == ("notify", "cannot resolve trowelcast#77")
-
-
-def test_PASS_3_never_second_guesses_an_owner_the_text_already_stated(monkeypatch):
-    """🔴 An explicit `owner/repo` is source 1 — the strongest there is. PASS 3's
-    subject pattern must not admit it, or a search by name could REPLACE a
-    stated owner with a guessed one."""
-    assert MO._PASS3_REPO_RE.match("trowelcast#77")
-    assert not MO._PASS3_REPO_RE.match("gardenersguild/trowelcast#77")
-    assert not MO._PASS3_REPO_RE.match("#77")
-    assert not MO._PASS3_REPO_RE.match("see trowelcast#77 today")
-
-
-def test_a_bare_number_never_reaches_the_api(spy, monkeypatch):
-    """A bare `#N` names no repo, so there is nothing to search for — and a
-    search on a number would return arbitrary repos."""
-    calls = []
-
-    def run(cmd, **kwargs):
-        calls.append(cmd)
-        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    MO.main(["#370"])
-    assert not [c for c in calls if c[:1] == ["gh"]]
+    It is a ledger rather than a ban on the word `gh`, for the reason
+    `RESOLUTION_PATH_COMMANDS` is: a `curl`, a `python -c`, or a second `gh`
+    subcommand would all walk straight past a check that only knows one name.
+    """
+    assert not hasattr(MO, "gh_api_repo_search")
+    found = _spawned_executables(HANDLER.read_text())
+    assert found, "positive control: the module DOES spawn things"
+    assert found <= SPAWNABLE_EXECUTABLES, (
+        f"mention-open.py spawns something new: {sorted(found - SPAWNABLE_EXECUTABLES)}")
 
 
 # --------------------------------------------------------------------------- #
@@ -543,13 +556,12 @@ def _write_mapping(tmp_path, mapping):
 def test_a_mapping_ONLY_name_resolves_end_to_end_through_main(tmp_path, monkeypatch):
     """🔴 THE MUTATION THIS PINS: drop `load_known_repos()` from
     `discover_repos` and this is the test that goes red. The name exists in no
-    checkout and `gh` is not reachable, so the mapping is the ONLY thing that
-    can produce this URL."""
+    checkout, and there is no network fallback left, so the mapping is the ONLY
+    thing that can produce this URL."""
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH",
                         _write_mapping(tmp_path, {"plotwidget": "gardenersguild/plotwidget"}))
     monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, "gh disabled for this test"))
     opened = []
     monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main(["plotwidget#42"]) == 0
@@ -654,35 +666,37 @@ def test_the_workspace_is_resolved_at_CALL_time_too(tmp_path, monkeypatch):
     assert MO.discover_repos() == {"plotwidget": "gardenersguild/plotwidget"}
 
 
-# PASS 3 — an unusable picker, and an empty result that names its cause
+# The picker's size, and the empty results that must name their cause
 # --------------------------------------------------------------------------- #
-def test_a_WALL_of_namesakes_now_reaches_the_picker_because_it_can_be_TYPED_at(
+def test_a_WALL_of_repos_reaches_the_picker_because_it_can_be_TYPED_at(
         spy, monkeypatch):
-    """🔴 THE REVERSAL. This used to refuse above 8 namesakes, on the reasoning
-    that "a 100-row list of URLs differing only by owner is not a choice, it is
-    a wall". That is true of a list you can only SCROLL and false of one you can
-    TYPE AT, and `pick()` now runs rofi with `-matching fuzzy`. So the wall is a
-    narrowing, and refusing would remove the operator's ability to choose.
+    """🔴 THE REVERSAL, NOW OVER THE LOCAL UNIVERSE. This used to refuse above 8
+    candidates, on the reasoning that "a 100-row list of URLs differing only by
+    owner is not a choice, it is a wall". That is true of a list you can only
+    SCROLL and false of one you can TYPE AT, and `pick()` runs rofi with
+    `-matching fuzzy`. So the wall is a narrowing, and refusing would remove the
+    operator's ability to choose — which matters far more now that the universe
+    is the operator's own 369-repo mapping rather than a page of search results.
 
     17 rows, not 9: the old cap was 8, so a fixture of 9 would sit one step past
     a boundary that no longer exists and could not tell a re-added cap of 16
     from no cap at all."""
-    rows = [f"owner{i}/trowelcast" for i in range(17)]
-    run, _ = _fake_gh(rows)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 0
+    monkeypatch.setattr(MO, "discover_repos",
+                        lambda *a, **k: {f"n{i}": f"owner{i}/trowelcast"
+                                         for i in range(17)})
+    assert MO.main(["zzznosuchrepo#77"]) == 0
     assert ("pick", 17) in spy, spy
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "notify"]
 
 
-def test_eight_namesakes_still_offer_the_picker(spy, monkeypatch):
+def test_eight_repos_still_offer_the_picker(spy, monkeypatch):
     """The case that worked under the old cap must keep working under no cap —
     a reversal that broke the legitimate side would be the same outage wearing
     the opposite hat."""
-    rows = [f"owner{i}/trowelcast" for i in range(8)]
-    run, _ = _fake_gh(rows)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 0
+    monkeypatch.setattr(MO, "discover_repos",
+                        lambda *a, **k: {f"n{i}": f"owner{i}/trowelcast"
+                                         for i in range(8)})
+    assert MO.main(["zzznosuchrepo#77"]) == 0
     assert ("pick", 8) in spy
 
 
@@ -712,68 +726,61 @@ def test_the_picker_asks_rofi_for_FUZZY_matching(monkeypatch):
     assert "-no-custom" in seen["cmd"]
 
 
-def test_a_search_that_COULD_NOT_RUN_says_so_instead_of_denying_the_repo(spy, monkeypatch):
-    """🔴 An empty result cannot distinguish `gh` missing from no such repo, and
-    the two need opposite next moves. The refusal must not assert the stronger
-    claim. With an EMPTY universe there is nothing to offer, so this is still the
-    refusal path exactly as it was."""
+@pytest.mark.parametrize("state,write,expected", [
+    ("absent", None, "has no repo mapping"),
+    ("unreadable", "not json at all", "could not be read"),
+    ("no usable rows", json.dumps({"widget": "acme"}), "holds no usable rows"),
+])
+def test_universe_reason_names_WHICH_empty_it_is(tmp_path, state, write, expected):
+    """🔴 THREE STATES, ONE EMPTY DICT, THREE DIFFERENT NEXT MOVES. `{}` is what
+    `load_known_repos` returns for all of them by design, so the reason cannot be
+    recovered from its value — and reporting one sentence for all three is the
+    same silent zero as the deleted search's empty result, which could not tell
+    "no such repo" from "gh is missing".
+
+    The third row is a mapping that PARSED and yielded nothing usable
+    (`"acme"` is one segment, so `clean_repo_map` drops it) — a `gh auth`
+    problem, not a mention-open one, and structurally invisible to a check that
+    only asks whether the file exists."""
+    p = tmp_path / "known_repos.json"
+    if write is not None:
+        p.write_text(write)
+    reason = MO.universe_reason(p)
+    assert expected in reason, f"{state}: {reason!r}"
+    assert "regen-known-repos.py" in reason, "the reason names no next move"
+
+
+def test_universe_reason_is_EMPTY_when_the_mapping_is_fine(tmp_path):
+    """The positive control for the three rows above: a readable mapping with a
+    usable row must produce NO reason, or every one of them would pass against a
+    function that returns a complaint unconditionally."""
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps({"plotwidget": "hobbyist/plotwidget"}))
+    assert MO.universe_reason(p) == ""
+
+
+def test_universe_reason_never_names_a_ROW(tmp_path):
+    """🔴 IT IS A NOTIFY BODY, AND `notify()` WRITES TO stderr AND notify-send.
+    "the mapping holds only hobbyist/plotwidget" is a natural-looking
+    improvement that discloses a private repository name."""
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps({"widget": "acme"}))
+    reason = MO.universe_reason(p)
+    assert "acme" not in reason and "widget" not in reason, reason
+
+
+def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatch,
+                                                                 tmp_path):
+    """🔴 The case that names a cause is exactly the case where writing
+    `owner/repo#N` is the workaround — so naming the cause must ADD to the
+    advice, never replace it. It replaced it once."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
-
-    def boom(cmd, **kwargs):
-        raise FileNotFoundError(2, "No such file or directory", "gh")
-
-    monkeypatch.setattr(MO.subprocess, "run", boom)
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "nothing-here.json")
     notices = []
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-    assert MO.main(["trowelcast#77"]) == 1
-    assert "gh is not on PATH" in notices[-1][1]
-    assert "not a claim that no such repo exists" in notices[-1][1]
-
-
-def test_the_picker_does_not_SWALLOW_the_reason_the_search_could_not_run(
-        spy, monkeypatch):
-    """🔴 THE NEW SHAPE OF AN OLD RULE. PASS 4 turns a refusal into a choice, and
-    the easiest way to write that is to drop the refusal entirely — which would
-    silently discard "gh is not on PATH", a fact about the operator's TOOLING
-    that no picker can express. The cause is announced AND the choice is offered:
-    they answer different questions."""
-    def boom(cmd, **kwargs):
-        raise FileNotFoundError(2, "No such file or directory", "gh")
-
-    monkeypatch.setattr(MO.subprocess, "run", boom)
-    notices = []
-    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-    assert MO.main(["trowelcast#77"]) == 0
-    assert ("pick", 1) in spy, spy
-    assert any("gh is not on PATH" in n[1] for n in notices), notices
-
-
-def test_a_search_that_RAN_and_matched_nothing_keeps_the_ordinary_refusal(spy, monkeypatch):
-    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
-    run, _ = _fake_gh(["hobbyist/trowelcast-examples"])
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    notices = []
-    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-    assert MO.main(["trowelcast#77"]) == 1
-    assert "owner/repo#N" in notices[-1][1]
-    assert "not a claim" not in notices[-1][1]
-
-
-def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatch):
-    """🔴 The case where the search could not run is exactly the case where
-    writing `owner/repo#N` is the workaround — so naming the cause must ADD to
-    the advice, never replace it. It replaced it once."""
-    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
-
-    def boom(cmd, **kwargs):
-        raise FileNotFoundError(2, "No such file or directory", "gh")
-
-    monkeypatch.setattr(MO.subprocess, "run", boom)
-    notices = []
-    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-    assert MO.main(["trowelcast#77"]) == 1
+    assert MO.main(["zzznosuchrepo#77"]) == 1
     body = notices[-1][1]
-    assert "gh is not on PATH" in body
+    assert "has no repo mapping" in body
     assert "owner/repo#N" in body, "the actionable advice was dropped"
 
 
@@ -794,19 +801,8 @@ def test_a_value_that_is_not_EXACTLY_owner_slash_repo_is_refused(tmp_path, value
     assert MO.load_known_repos(p) == {}
 
 
-def test_the_search_asks_for_a_FULL_page(monkeypatch):
-    """`per_page` defaults to 30. Removing it shrinks what the exact-name filter
-    can even see — and it is invisible to every other test here, because the
-    fake returns whatever rows the test hands it regardless of the request.
-    Measured: dropping `per_page=100` SURVIVED the whole suite."""
-    run, seen = _fake_gh(_SEARCH_ROWS)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    MO.gh_api_repo_search("trowelcast")
-    assert "per_page=100" in seen["cmd"], seen["cmd"]
-
-
 # --------------------------------------------------------------------------- #
-# PASS 4 — THE FUZZY UNIVERSE
+# PASS 3 — THE FUZZY LOCAL UNIVERSE
 #
 # 🔴 EVERY NAME BELOW IS SYNTHETIC. The real universe is built from
 # `known_repos.json`, the file whose committed ancestor disclosed 232 PRIVATE
@@ -826,14 +822,9 @@ FAKE_UNIVERSE = {
 
 @pytest.fixture
 def universe(monkeypatch):
-    """A three-entry synthetic universe, and NO gh — so anything that resolves
-    below did so through PASS 4 and nothing else."""
+    """A three-entry synthetic universe — so anything that resolves below did so
+    through the local universe and nothing else."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
-    # ("", not a reason): the search RAN and matched nothing. A reason here would
-    # make every test below also exercise the "could not run" notice, which has
-    # its own test — a fixture that bundles two conditions cannot tell you which
-    # one an assertion is about.
-    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
     return FAKE_UNIVERSE
 
 
@@ -888,10 +879,9 @@ def test_a_ONE_ENTRY_universe_is_still_a_CHOICE_and_never_auto_opens(
     `zzznosuchrepo#77` opened issue 77 in a completely unrelated repository — a
     confident wrong page, the exact failure this handler exists to prevent.
 
-    A search HIT is evidence about the name; a universe row is only an option."""
+    A mapping hit is evidence about the name; a universe row is only an option."""
     monkeypatch.setattr(MO, "discover_repos",
                         lambda *a, **k: {"spadeworks": "rivalorg/spadeworks"})
-    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
     assert MO.main(["zzznosuchrepo#77"]) == 0
     assert ("pick", 1) in spy, spy
 
@@ -905,25 +895,23 @@ def test_dismissing_the_universe_picker_opens_NOTHING(spy, universe, monkeypatch
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
 
 
-def test_an_EMPTY_universe_degrades_to_the_NAMED_reason_refusal(spy, monkeypatch):
+def test_an_EMPTY_universe_degrades_to_the_NAMED_reason_refusal(spy, monkeypatch,
+                                                                tmp_path):
     """🔴 NOT A SILENT EMPTY PICKER. A universe that cannot be read must fall
-    back to the refusal that says WHICH empty this is — "gh is not on PATH" and
-    "no repo by that name" need opposite next moves."""
+    back to the refusal that says WHICH empty this is — "no mapping on this host"
+    and "the mapping is corrupt" need opposite next moves."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", tmp_path / "nothing-here.json")
     notices = []
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-
-    def boom(cmd, **kwargs):
-        raise FileNotFoundError(2, "No such file or directory", "gh")
-
-    monkeypatch.setattr(MO.subprocess, "run", boom)
     assert MO.main(["zzznosuchrepo#12"]) == 1
-    assert "gh is not on PATH" in notices[-1][1]
+    assert "has no repo mapping" in notices[-1][1]
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
-    # 🔴 EXACTLY ONE NOTIFICATION. The refusal already names the cause, so PASS 4
-    # must not ALSO announce it on the way past — and this is the assertion that
-    # makes the `and universe` guard load-bearing rather than decorative.
-    # Measured: without it, dropping `and universe` SURVIVED the whole file.
+    # 🔴 EXACTLY ONE NOTIFICATION. The refusal already names the cause, so the
+    # universe pass must not ALSO announce something on the way past — and this
+    # is the assertion that makes the `and universe` guard load-bearing rather
+    # than decorative. Measured: without it, dropping `and universe` SURVIVED the
+    # whole file.
     assert len(notices) == 1, notices
 
 
@@ -939,23 +927,47 @@ def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", bad)
     monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
     picks, opens, notices = [], [], []
     monkeypatch.setattr(MO, "pick", lambda c: picks.append(len(c)) or "")
     monkeypatch.setattr(MO, "open_url", lambda url: opens.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
     assert MO.main(["zzznosuchrepo#12"]) == 1
     assert notices[-1][0] == "cannot resolve zzznosuchrepo#12"
+    # 🔴 THE REASON DISTINGUISHES CORRUPT FROM ABSENT. Both produce `{}`, and the
+    # test above covers absent — asserting only "cannot resolve" here would pass
+    # against a handler that reported the wrong one.
+    assert "could not be read" in notices[-1][1], notices[-1]
     assert picks == [] and opens == []
 
 
 def test_no_discovery_still_means_resolve_only_what_the_TEXT_carries(spy, universe):
-    """🔴 The flag's meaning is unchanged by PASS 4. A host-wide mapping is not
-    something the clicked text carries."""
+    """🔴 The flag's meaning is unchanged by the universe pass. A host-wide
+    mapping is not something the clicked text carries."""
     assert MO.main(["--no-discovery", "zzznosuchrepo#12"]) == 1
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
     assert [c for c in spy if isinstance(c, tuple) and c[0] == "notify"]
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+
+
+@pytest.mark.parametrize("flag,expected", [
+    ("--no-discovery", "resolves only what the text itself carries"),
+    ("--print", "there is nobody to ask"),
+])
+def test_a_flag_that_BARS_the_picker_says_so_by_NAME(monkeypatch, universe,
+                                                     flag, expected):
+    """🔴 THE THIRD WAY THE PICKER CANNOT BE SHOWN, and it is not an empty
+    universe — the universe here is fine and non-empty. A refusal reporting "no
+    repo mapping on this host" would send the operator to run
+    `regen-known-repos.py` over a mapping that was never the problem.
+
+    Both flags are named in the body because they are the operator's own lever:
+    drop the flag and the picker appears."""
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main([flag, "zzznosuchrepo#12"]) == 1
+    assert expected in notices[-1][1], notices[-1]
+    assert "regen-known-repos" not in notices[-1][1], (
+        "blamed the mapping for a refusal the FLAG caused")
 
 
 def test_print_mode_never_invokes_the_picker_or_the_universe(spy, universe, capsys):
@@ -963,9 +975,11 @@ def test_print_mode_never_invokes_the_picker_or_the_universe(spy, universe, caps
     with several hundred is not an answer, and printing them would ALSO write
     private repository names to stdout."""
     assert MO.main(["--print", "zzznosuchrepo#12"]) == 1
-    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"], (
+        "--print raised the interactive picker")
     out = capsys.readouterr().out
-    assert "trowelcast" not in out and "spadeworks" not in out
+    assert "trowelcast" not in out and "spadeworks" not in out, (
+        "the UNIVERSE reached --print's stdout")
 
 
 def test_print_mode_still_prints_a_resolvable_url(spy, universe, capsys):
@@ -984,6 +998,86 @@ def test_a_bare_hash_N_with_NO_repo_context_offers_the_universe_BELOW_clawgate(
     assert ("pick", 4) in spy, spy
     assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks/370"), (
         "the clawgate row must still be the first, default-selected one")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE SIX-DIGIT NUMBER: OFFERED, NEVER AUTO-OPENED
+#
+# `mention_scan._NUM` is `\d{1,5}` so a hex colour can never become a reference.
+# That guard is UNCHANGED and still decides what may be OPENED. What changed is
+# what may be SHOWN: the same click now opens a dismissible picker instead of a
+# toast that read like a failure. The two must stay distinguishable in the code,
+# and these tests are what keeps them so.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("text,expected", [
+    ("#282828", "282828"),                  # the hex colour that started this
+    ('background = "#282828";', "282828"),  # …as it actually arrives from a click
+    ("#7", "7"),
+    ("#1234567", "123456"),                 # bounded at 6, like the hint regex
+    ("no number here", ""),
+    ("", ""),
+])
+def test_offer_number_recovers_a_number_the_SCANNER_refused(text, expected):
+    assert MO.offer_number(text) == expected
+
+
+def test_offer_number_is_NOT_a_resolution(spy):
+    """🔴 THE DISTINCTION, ASSERTED. `offer_number` must not make the scanner
+    accept anything: `resolve()` still sees NO mention in a six-digit colour, so
+    the number cannot arrive as a span, a candidate, or an auto-open."""
+    assert MO.offer_number("#282828") == "282828"
+    assert MO.resolve("#282828") == (None, [])
+
+
+def test_a_SIX_DIGIT_number_is_OFFERED_but_NEVER_auto_opened(spy, monkeypatch):
+    """🔴 THE EXACT HAZARD `_NUM = \\d{1,5}` EXISTS FOR, on the new path. With a
+    ONE-entry universe the "exactly one candidate → just open it" shortcut is
+    live, and firing it here would open issue 282828 of an unrelated repository
+    from a click on a colour literal — a confident wrong page produced by the
+    very change meant to be friendlier.
+
+    A one-entry universe is the fixture on purpose: any larger one reaches the
+    picker through the plural branch and could not see this regression at all."""
+    monkeypatch.setattr(MO, "discover_repos",
+                        lambda *a, **k: {"spadeworks": "rivalorg/spadeworks"})
+    assert MO.main(["#282828"]) == 0
+    # 🔴 THE CLAIM IS ORDER, NOT ABSENCE. `spy`'s `pick` answers with row 0, so
+    # an `open` here is legitimate — it is what a SELECTION does. What must never
+    # happen is an open with no pick in front of it, which is the auto-open
+    # shortcut firing. Asserting "no open at all" would instead pass against a
+    # handler that had stopped working entirely.
+    kinds = [c[0] for c in spy if isinstance(c, tuple)]
+    # 🔴 THE MESSAGE IS ON THIS ASSERTION, NOT THE ORDERING ONE BELOW. When the
+    # auto-open shortcut fires there is no "pick" at all, so THIS is the line
+    # that goes red — and a mutation battery reports a kill for the wrong reason
+    # when the phrase it looks for sits on an assertion that never evaluates.
+    assert "pick" in kinds, (
+        f"a number the SCANNER REFUSED was auto-opened, bypassing the "
+        f"picker: {spy}")
+    assert kinds.index("pick") < kinds.index("open"), (
+        "a number the SCANNER REFUSED was auto-opened, bypassing the picker")
+
+
+def test_dismissing_the_SIX_DIGIT_picker_opens_nothing(spy, universe, monkeypatch):
+    monkeypatch.setattr(MO, "pick", lambda c: "")
+    assert MO.main(["#282828"]) == 0
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+
+
+def test_a_SELECTED_six_digit_row_opens_the_repo_the_operator_CHOSE(
+        spy, universe, monkeypatch):
+    """The other half: offering it must actually work. A picker that cannot open
+    what was selected is the refusal again, wearing a window.
+
+    `hobbyist/plotwidget` is the SECOND row of the sorted universe, not the
+    first — so a mutant that ignores the selection and takes row 0 cannot land on
+    this URL by accident."""
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c: "https://github.com/hobbyist/plotwidget/issues/282828")
+    assert MO.main(["#282828"]) == 0
+    assert spy[-1] == (
+        "open", "https://github.com/hobbyist/plotwidget/issues/282828")
 
 
 def test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe(
@@ -1081,29 +1175,29 @@ def test_the_REFUSAL_path_names_the_clicked_text_and_never_the_universe(
         assert name not in everywhere, f"REFUSAL-PATH DISCLOSURE: {name}"
 
 
-def test_print_mode_prints_EVERY_namesake_rather_than_refusing_above_a_cap(
-        monkeypatch, capsys):
-    """🔴 A DECISION, RECORDED. Removing the namesake cap changed `--print` too:
-    `widget#12` with nine namesakes used to exit 1 with a named refusal and now
-    prints nine URLs and exits 0.
+def test_print_mode_REFUSES_an_unresolvable_reference_rather_than_listing_repos(
+        monkeypatch, universe, capsys):
+    """🔴 A DECISION, RECORDED, AND IT IS A BEHAVIOUR CHANGE. Deleting the
+    GitHub-wide search changed `--print` too: `dashboard#12` used to exit 0 and
+    print one URL per namesake, and now exits 1 with a named reason.
 
-    That is intended. `--print`'s documented contract is "print every candidate
-    when ambiguous", a namesake set IS that ambiguity, and every row is an
-    EXACT-name search hit — evidence about the name the operator typed. It is NOT
-    the PASS 4 universe, which is evidence about nothing and stays barred from
-    `--print` (see the test above). A consumer wanting one answer writes
-    `owner/repo#N`.
+    That is intended, and it is a correction rather than a loss. Those namesakes
+    were `vzhong/dashboard`, `yorkie-team/dashboard`, `zce/dashboard` — an exit 0
+    carrying strangers' repositories is a WRONG answer dressed as an answer, and
+    a consumer parsing it got a plausible URL into somebody else's issue tracker.
 
-    Nine, not eight: the retired cap was 8, so a fixture at or below it could not
-    tell "no cap" from "a cap nobody reached"."""
-    owners = [f"org{i}/widget" for i in range(9)]
-    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
-    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "gh_api_repo_search",
-                        lambda name: ({o: o for o in owners}, ""))
-    assert MO.main(["--print", "widget#12"]) == 0
-    printed = capsys.readouterr().out.split()
-    assert printed == [f"https://github.com/{o}/issues/12" for o in sorted(owners)]
+    `--print` keeps its contract for real ambiguity — several candidates for a
+    reference the text or the host actually attributes still print, see
+    `test_an_ambiguous_click_prints_every_candidate`. What it will not do is ASK,
+    because it is non-interactive: the universe is a question, not an answer, and
+    printing 369 URLs is not one either. A consumer wanting one answer writes
+    `owner/repo#N`."""
+    # 🔴 THE MESSAGE IS ON THE EXIT CODE. If `--print` is allowed to offer the
+    # universe it exits 0 with URLs, so this is the line that goes red first and
+    # the stdout assertion below never runs.
+    assert MO.main(["--print", "zzznosuchrepo#12"]) == 1, (
+        "a refusal must print no URL at all — --print offered the universe")
+    assert capsys.readouterr().out == "", "a refusal must print no URL at all"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_mutation_battery_anchors.py
+++ b/scripts/tests/test_mutation_battery_anchors.py
@@ -264,6 +264,44 @@ def test_the_anchor_check_is_not_vacuous_because_the_tables_are_NON_EMPTY():
         assert mod.SCRIPT.is_file(), f"{battery}: SCRIPT does not exist"
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 A MUTANT THAT COLLECTED NOTHING MUST NOT SCORE `SURVIVED`
+#
+# `SURVIVED` is the strongest finding a battery can report: "no test in the
+# suite can see this change". A run that never RAN satisfies `failed == 0` just
+# as well, and the mentions battery used to read that as survival — its only
+# sanity check on the collected count ran on the CONTROL, once, not per mutant.
+# A mutant that makes a module unimportable produces `0 failed, 0 passed` and
+# pytest's summary says `N errors`, a word the `(\d+) failed` regex cannot see.
+#
+# The verdict is a PURE function so it can be pinned here, in a collected test,
+# rather than only by someone running the battery by hand for half an hour.
+# --------------------------------------------------------------------------- #
+def test_a_mutant_that_COLLECTED_NOTHING_is_not_a_survivor():
+    mod = _load("mutation_battery_mentions.py")
+    floor = 150
+
+    # The hole, verbatim: an unimportable module. Zero failures, zero passes,
+    # and pytest calls it an ERROR rather than a failure.
+    assert mod.classify(0, 0, 4, floor, None, "") == "NOT-OBSERVED"
+    # …and the same shape with no error line at all — a run that silently lost
+    # whole files still sits under the floor.
+    assert mod.classify(0, 3, 0, floor, None, "") == "NOT-OBSERVED"
+    # A kill that ALSO errored is not a clean kill either: the row's own
+    # assertion may never have been reached.
+    assert mod.classify(9, 200, 1, floor, None, "") == "NOT-OBSERVED"
+
+    # 🔴 NEGATIVE CONTROL — the ordinary verdicts must still be reachable, or
+    # the assertions above would hold for a classifier that answers
+    # NOT-OBSERVED to everything and reports a broken battery forever.
+    assert mod.classify(0, 300, 0, floor, None, "") == "SURVIVED"
+    assert mod.classify(2, 298, 0, floor, None, "") == "KILLED"
+    assert mod.classify(2, 298, 0, floor, "ledger MOVED",
+                        "E   ledger MOVED: …") == "KILLED(attributed)"
+    assert mod.classify(2, 298, 0, floor, "ledger MOVED",
+                        "E   something else") == "KILLED-WRONG-REASON"
+
+
 def _python_instruments() -> list[str]:
     """Every Python mutation instrument in `scripts/tests/`, under EITHER
     naming convention — `mutation_battery_*.py` and `mutants-*.py`."""


### PR DESCRIPTION
## The problem

Clicking `dashboard#12` in Alacritty took **3.1–3.6s** (measured; ~10s through the real hint path, at 6% CPU). All of it was network wait in `gh_api_repo_search`, which searched **all of GitHub** for repos named `dashboard` and returned `vzhong/dashboard`, `yorkie-team/dashboard`, `zce/dashboard` — strangers' repositories the operator would never pick.

It was not slow *and* useful. It was slow *because* it searched a corpus that structurally cannot hold the answer.

The correct universe was local the whole time. `~/.config/mention-open/known_repos.json` (369 entries, built by `regen-known-repos.py` from `gh api user/repos --paginate` — owner + collaborator + organization_member — plus local checkouts) **is** "the repos the operator contributes to", and reading it costs 0.3ms.

So the search is **deleted**, not deferred or cached.

Second change, same root cause — a refusal that reads like a failure. `#282828` produced the toast `no mention in the clicked text`. That was the `_NUM = \d{1,5}` guard working correctly, but a guard that reads as a bug is one the next maintainer deletes. Every refusal path that *can* offer a choice now opens the fuzzy picker over the local universe.

A toast survives in exactly one case: **the picker cannot be shown** — the mapping absent, unreadable, or holding no usable rows, or `--print`/`--no-discovery` barring it by contract. It still names *which*.

## Latency

Interleaved A/B against the pre-change file (A,B,A,B… so a load spike hits both arms), `rofi`/`xdg-open`/`notify-send` stubbed, **min/median of 9 runs each**. `rofi` exits 1, so the timing is click → picker on screen.

| case | before | after | |
|---|---|---|---|
| `click dashboard#12` | 3141 / 3572 ms | **69 / 79 ms** | ~45× |
| `click #370` (bare id) | 169 / 174 ms | **69 / 81 ms** | ~2.2× |
| `click owner/repo#12` | 26 / 29 ms | **26 / 28 ms** | unchanged |
| `click #282828` | 29 / 32 ms, rc 1 | **68 / 71 ms, rc 0** | toast → picker |

`#282828` got **slower in wall time** because it now does work instead of refusing. That is the point of the change, not a regression.

## A second finding the brief did not have

`discover_repos` ran **100 serial `git remote get-url` children — 149–184 ms**, which is 60% of a 100 ms budget on its own and would have missed the target even with the network call gone. It is now a 16-thread fan-out (**26 ms**), semantically identical.

`git remote get-url` is **kept** rather than parsing `.git/config` directly: a hand-rolled reader measured 8 ms and agreed with git on all 100 checkouts here (56 of them linked worktrees, 0 disagreements) — but it would have to re-implement `commondir` resolution, submodule gitdirs, `include`/`includeIf` and `url.<base>.insteadOf` to *keep* agreeing. 26 ms is already far inside budget; reimplementing a slice of git to save 18 ms buys a class of divergence bugs for nothing.

`concurrent.futures` is imported **lazily**. At the top of the file it cost ~5 ms of interpreter startup on *every* click, including `owner/repo#N` and bare `#N`, which never reach the fan-out: 29.6 → 35.1 ms for an explicit owner, back to 25.5 ms once moved. Caught by the interleaved measurement; a before/after run done separately had blamed it on load.

## Preserved — pinned, not asserted

- **No owner is ever guessed.** An unresolvable `repo#N` still yields no URL.
- **Dismissing the picker opens NOTHING.**
- **A six-digit number is OFFERED, never AUTO-OPENED.** `_NUM = \d{1,5}` is untouched and still decides what may be *opened*. The new `offer_number` is a strictly weaker thing: its output can only ever become a *universe row*, and `offered_universe` unconditionally excludes universe rows from the single-candidate auto-open shortcut. The distinction is spelled out in both the code and the comments.
- **No universe row reaches a log, spool, stdout, stderr, a notify body, or a fixture.** `refuse()` does not even have `discovered` in scope, which is a structural improvement over the previous inline refusal. No test reads the real mapping.

## `--print`, decided and stated

`--print` **never offers the picker** and now exits 1 with a named reason where it used to exit 0 with one URL per namesake.

That is a correction, not a loss: those namesakes were strangers' repos, so the old exit 0 handed a consumer a plausible URL into somebody else's issue tracker. Real ambiguity — several candidates for a reference the text or the host actually attributes — still prints, unchanged.

`--no-discovery` is unchanged: "resolve only what the text itself carries".

## New guards, each mutation-verified

- `test_the_resolution_path_spawns_ONLY_these_local_commands` — a **ledger** of `(argv[0], argv[1])` that fails when the set grows *or* shrinks, so `git ls-remote` cannot take the deleted call's place. Its assertion carries its own positive control (`test_the_no_network_assertion_can_actually_FIRE`), which watches it reject both a re-added `gh` call and an empty set.
- `test_the_module_no_longer_carries_a_repository_SEARCH_at_all` — reads the **AST**, not the file text, so the docstring can keep *naming* `gh api search/repositories` in the paragraph recording why it was deleted. A substring check would have forced that note to be softened to make the test pass.
- `test_the_handlers_OFFER_bound_matches_the_hints_own` — the seam between the Alacritty hint regex's `{1,6}` and `_OFFER_NUM_RE`. Two files, two languages, two suites; each hermetically green while they disagree, silently in both directions.

## Mutation battery

8 new rows (K17–K24) in the committed `scripts/tests/mutation_battery_mentions.py`.

```
positive control P1: KILLED — the battery can observe
25/25 killed for the stated reason; problems: none
restore: OK
```

`test_alacritty_hints.py` joins its `SUITES` — K20 scored `KILLED-WRONG-REASON` until it did, because the battery was not collecting the guard's own suite. Three further rows scored `KILLED-WRONG-REASON` on the first run because the phrase sat on an assertion that never evaluated; the messages were moved to the assertion that actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
