### PR TITLE
feat(tmux-reply-agent): ARM the host half — enableTmuxReplyAgent = true, and every guard that pinned the disabled state flips with it

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -149,9 +149,24 @@ let
   # decided is that building it and ARMING it are separate acts, so the write path
   # was merged, deployed, read and audited across seven rounds while this flag was
   # still false and it could execute nothing. It shipped `false` for exactly that
-  # reason — that ordering is history now, not a live guard, and the SHAPE it left
-  # behind is what still matters: setting this back to `false` is a one-line,
-  # reviewable disarm of the host half, independent of the pod's secret.
+  # reason — that ordering is history now, not a live guard.
+  #
+  # 🔴 DISARMING IS TWO STEPS, NOT ONE, AND THE SECOND IS NOT OPTIONAL. Setting
+  # this back to `false` and shipping does NOT stop a RUNNING agent. The unit
+  # DEFINITION is emitted unconditionally, so the flag only removes the
+  # `[Install]` block — home-manager's `sd-switch` then sees a CHANGED unit and
+  # plans **Stop/Start**, restarting the very process you meant to stop. It goes
+  # on polling and executing until logout, reboot, or an explicit stop. MEASURED
+  # with `sd-switch --dry-run` against three fixtures: identical generations =>
+  # `No action`; unit deleted outright => `Stop`; `[Install]` removed with the
+  # unit still present => `Stop/Start (SwitchMethod(StopStart))`.
+  #
+  #     enableTmuxReplyAgent = false;   # then merge + scripts/ship.sh, THEN:
+  #     systemctl --user stop tmux-reply-agent          # on BOTH hosts
+  #
+  # The flag alone is a durable disarm (nothing wants the unit at next login);
+  # the `stop` is what makes it take effect NOW. Removing CLAWGATE_TERMINAL_TOKEN
+  # from the POD is the other lever and is immediate for every host at once.
   #
   # 🔴 TWO INDEPENDENT SWITCHES, AND NEITHER IMPLIES THE OTHER. Arming needs
   # (1) CLAWGATE_TERMINAL_TOKEN provisioned into the POD's secret — until then the
@@ -3825,8 +3840,9 @@ in
       # tmux-snapshot-push: notify-failure@ toasts are wired to DEFEAT
       # do-not-disturb, and that bypass is justified by a MEASURED rate of about
       # one firing in nine days. This unit polls every few seconds, so any
-      # sustained condition — the surface not armed (which is the state it ships
-      # in), clawgate mid-redeploy, the laptop's network down — would fire a
+      # sustained condition — the surface not armed (which since arming means the
+      # pod's secret was REMOVED), clawgate mid-redeploy, the laptop's network
+      # down — would fire a
       # DND-bypassing toast on every restart and burn down the one alert channel
       # that has to keep its meaning.
       #

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -165,8 +165,14 @@ let
   #     systemctl --user stop tmux-reply-agent          # on BOTH hosts
   #
   # The flag alone is a durable disarm (nothing wants the unit at next login);
-  # the `stop` is what makes it take effect NOW. Removing CLAWGATE_TERMINAL_TOKEN
-  # from the POD is the other lever and is immediate for every host at once.
+  # the `stop` is what makes it take effect NOW, on the host you run it on.
+  #
+  # Removing CLAWGATE_TERMINAL_TOKEN from the POD is the other lever. It is
+  # fleet-wide rather than per-host — but 🔴 NOT INSTANT: per the paragraph
+  # below and the pod's own boot line, it takes effect on the POD'S NEXT BOOT,
+  # so the route keeps answering until then. Neither lever is immediate on its
+  # own; `systemctl --user stop` on both hosts is the one that stops execution
+  # at the moment you run it.
   #
   # 🔴 TWO INDEPENDENT SWITCHES, AND NEITHER IMPLIES THE OTHER. Arming needs
   # (1) CLAWGATE_TERMINAL_TOKEN provisioned into the POD's secret — until then the

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -142,13 +142,16 @@ let
   # wired into `default.target`; the unit definition is always emitted, so it can
   # be started by hand regardless.
   #
-  # 🔴 IT SHIPS **false**, AND THAT IS THE POINT OF THE WHOLE SHAPE — not caution
-  # about an unfinished feature. What this agent delivers is `tmux send-keys`
-  # followed by Enter, i.e. arbitrary command execution as the operator on this
-  # host, driven by a route on a LAN NodePort that has no human auth. The operator
+  # 🔴 THIS IS NOW **true** — THE AGENT IS ARMED, AND WHAT IT DELIVERS IS ARBITRARY
+  # COMMAND EXECUTION AS THE OPERATOR ON THIS HOST. `tmux send-keys` followed by
+  # Enter, driven by a route on a LAN NodePort that has no human auth. The operator
   # took that decision deliberately, with the blast radius stated; what was ALSO
   # decided is that building it and ARMING it are separate acts, so the write path
-  # can be merged, deployed, read and audited before it can execute anything.
+  # was merged, deployed, read and audited across seven rounds while this flag was
+  # still false and it could execute nothing. It shipped `false` for exactly that
+  # reason — that ordering is history now, not a live guard, and the SHAPE it left
+  # behind is what still matters: setting this back to `false` is a one-line,
+  # reviewable disarm of the host half, independent of the pod's secret.
   #
   # 🔴 TWO INDEPENDENT SWITCHES, AND NEITHER IMPLIES THE OTHER. Arming needs
   # (1) CLAWGATE_TERMINAL_TOKEN provisioned into the POD's secret — until then the
@@ -167,7 +170,7 @@ let
   # ONLY from the machine it lives on, so a workbench-only agent would leave every
   # laptop pane permanently unanswerable. The queue is keyed on the host label, so
   # two agents claiming disjoint host scopes cannot collide.
-  enableTmuxReplyAgent = false;
+  enableTmuxReplyAgent = true;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -3801,10 +3804,11 @@ in
   # either host's tmux socket, and the alternative (an inbound port, or an ssh
   # credential inside a pod on an unauthenticated LAN surface) is strictly worse.
   #
-  # 🔴 SHIPPED DISABLED. `enableTmuxReplyAgent` is false — see its comment above
-  # for the two independent switches that arm this and why building it and arming
-  # it were deliberately separated. The unit below EXISTS on both hosts and is
-  # wired into nothing.
+  # 🔴 ARMED. `enableTmuxReplyAgent` is true — see its comment above for the two
+  # independent switches that arm this and why building it and arming it were
+  # deliberately separated. The unit below is wanted by `default.target` on both
+  # hosts and RUNS; it executes what the queue hands it. It shipped disabled and
+  # was armed only after the server half was deployed and audited.
   #
   # 🔴 Type = "simple", NOT the oneshot-plus-timer shape its two siblings use, and
   # the difference is the cadence. A ~5s poll cannot be a timer: the user manager
@@ -3876,8 +3880,8 @@ in
       ];
     };
     Install = {
-      # 🔴 SHIPPED DISABLED — see enableTmuxReplyAgent. A `default.target` want,
-      # not `timers.target`: this is a resident service, not a timer.
+      # 🔴 ARMED — see enableTmuxReplyAgent. A `default.target` want, not
+      # `timers.target`: this is a resident service, not a timer.
       WantedBy = lib.optionals enableTmuxReplyAgent [ "default.target" ];
     };
   };

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -373,9 +373,14 @@ ACKNOWLEDGED_UNSTUBBED = {
         "behind sudo and neither script is executed by scripts/tests"),
     "wmctrl": (
         {"session-write"},
-        "The FOURTH occurrence of the prose-mention shape already justified "
-        "three times under `home-manager` above, and justified here rather "
-        "than reworded away — this scan is a TEXT scan "
+        "Another occurrence of the prose-mention shape justified under "
+        "`home-manager` above (that entry numbers its own), and justified here "
+        "rather than reworded away. 🔴 THIS SENTENCE DELIBERATELY CARRIES NO "
+        "RUNNING TOTAL: it said \"the FOURTH … three times\" and was still "
+        "saying it after the population reached five, so two entries in one "
+        "dict disagreed about the same figure. A count kept beside what it "
+        "counts drifts — number the list, not the prose. This scan is a TEXT "
+        "scan "
         "(launcher_scan.hazard_hits regexes the file body), so naming a binary "
         "in order to promise you never call it is indistinguishable from "
         "calling it. session-write (added 2026-08-19) names `wmctrl` in ONE "

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -273,10 +273,12 @@ ACKNOWLEDGED_UNSTUBBED = {
         "than against a copied literal, so this justification goes red if the "
         "call site ever grows a mutating verb. "
         "tmux-reply-agent (added 2026-09-06 with the ARMING change) is the "
-        "PROSE-MENTION shape this table already carries three times under "
-        "`home-manager` (notify-failure.sh, session-manager, session-resolve) "
-        "and once here under session-write's entry, and it is re-justified the "
-        "same way rather than reworded to dodge the scanner. Its SINGLE "
+        "PROSE-MENTION shape this table already carries FIVE times under "
+        "`home-manager` (notify-failure.sh, session-manager, session-resolve, "
+        "tmux-scratch-slots.sh, resume-state.sh — that entry numbers the last "
+        "two itself) and once under `wmctrl` (session-write), and it is "
+        "re-justified the same way rather than reworded to dodge the scanner. "
+        "Its SINGLE "
         "occurrence of the name is one line of module-docstring prose giving "
         "the operator the second half of the DISARM procedure — "
         "`systemctl --user stop tmux-reply-agent` — which exists because "
@@ -290,8 +292,16 @@ ACKNOWLEDGED_UNSTUBBED = {
         "is arbitrary command execution as the operator. Verified by grep "
         "that the file carries no call site: its complete set of argv[0] "
         "literals is `tmux_bin()` alone, at the single `subprocess.run` in "
-        "run_tmux, and test_tmux_reply_agent.py pins that the agent shells "
-        "out to nothing else"),
+        "run_tmux. 🔴 THAT LAST CLAUSE NAMED A PIN THAT DID NOT EXIST until an "
+        "audit checked it, and the gap was MEASURED: hazard_hits returns a FILE "
+        "set and this file is now IN it, so injecting a real "
+        "`subprocess.run([\"systemctl\", ...])` here left THIS suite at 77 passed "
+        "— the acknowledgement had blinded the guard it is filed under. The pin "
+        "is now real: test_tmux_reply_agent.py::test_the_agent_SHELLS_OUT_TO_"
+        "TMUX_AND_NOTHING_ELSE walks the agent's AST and asserts its spawn "
+        "argv[0] set is exactly {tmux_bin}, with both controls watched (clean "
+        "tree passes; the injected call site fails with that test's own "
+        "message). Do not restore this entry without that pin"),
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "keylog-spin-capture.sh",
          "notify-failure.sh", "playwright-nixos", "resume-state.sh",

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -245,7 +245,7 @@ ACKNOWLEDGED_UNSTUBBED = {
     "systemctl": (
         {"airvpn-menu", "keylog-spin-capture.sh",
          "monitor-blackout.sh", "run-tests.sh", "sync-claude-permissions.py",
-         "syshealth"},
+         "syshealth", "tmux-reply-agent"},
         "verb-split rather than record-only — see the systemctl tests below. "
         "run-tests.sh is a THIRD case, re-justified rather than absorbed: its "
         "only occurrences of the name are GUARD 7's accounting, which counts "
@@ -271,7 +271,27 @@ ACKNOWLEDGED_UNSTUBBED = {
         "closed. `test_syshealth.py::test_failed_units_asks_systemctl_for_a_"
         "read_verb` pins the argv against SYSTEMCTL_READ_VERBS itself rather "
         "than against a copied literal, so this justification goes red if the "
-        "call site ever grows a mutating verb"),
+        "call site ever grows a mutating verb. "
+        "tmux-reply-agent (added 2026-09-06 with the ARMING change) is the "
+        "PROSE-MENTION shape this table already carries three times under "
+        "`home-manager` (notify-failure.sh, session-manager, session-resolve) "
+        "and once here under session-write's entry, and it is re-justified the "
+        "same way rather than reworded to dodge the scanner. Its SINGLE "
+        "occurrence of the name is one line of module-docstring prose giving "
+        "the operator the second half of the DISARM procedure — "
+        "`systemctl --user stop tmux-reply-agent` — which exists because "
+        "flipping enableTmuxReplyAgent false does NOT stop a running agent: "
+        "the unit definition is emitted unconditionally, so the flag only "
+        "drops [Install] and sd-switch then plans Stop/Start. MEASURED with "
+        "`sd-switch 0.6.4 --dry-run` against a RUNNING unit, both controls "
+        "passing (identical generations => No action; unit deleted => Stop; "
+        "[Install] removed => Stop/Start). Deleting the word to get green "
+        "would delete the only written rollback for a surface whose payload "
+        "is arbitrary command execution as the operator. Verified by grep "
+        "that the file carries no call site: its complete set of argv[0] "
+        "literals is `tmux_bin()` alone, at the single `subprocess.run` in "
+        "run_tmux, and test_tmux_reply_agent.py pins that the agent shells "
+        "out to nothing else"),
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "keylog-spin-capture.sh",
          "notify-failure.sh", "playwright-nixos", "resume-state.sh",

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -913,8 +913,14 @@ def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
     # 🔴 SO THE MUTATION IS ANCHORED, NOT SUBSTRING-MATCHED. `^  <flag> = …;$`
     # under re.M is the same shape `_wanted_by_expr` already uses, and it is why
     # THAT function was never fooled by the comment. `subn`'s count is asserted
-    # to be exactly 1, so a second declaration — or a comment that starts at
-    # column 0 — is a failure rather than a silent extra substitution.
+    # to be exactly 1, so a SECOND DECLARATION fails loudly with `substituted 2`
+    # rather than silently taking an extra substitution.
+    #
+    # ⚠ Precisely, because an earlier draft of this sentence overstated it: a
+    # comment at COLUMN 0 (`#  enableTmuxReplyAgent = true;`) is INVISIBLE to the
+    # anchor, not a failure — MEASURED `1 passed`. That is the wanted behaviour
+    # (a comment must not be mutated), but it is not detection, and claiming
+    # detection would be the same overclaim this whole control exists to record.
     #
     # The documentation is NOT the thing to delete here: the disarm example is
     # the only written rollback for a surface that executes commands. Fix the
@@ -1830,29 +1836,77 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
     acknowledgement had blinded the very guard it was filed under.
 
     So the pin is written here, where it can see argv rather than file names:
-    every `subprocess` invocation in the agent must take its argv from
-    `tmux_bin()`. AST, not grep — this file and the agent both NAME `systemctl`
-    in prose, and a text scan cannot tell a docstring from a call.
+    every spawn in the agent must take its argv from `tmux_bin()`. AST, not grep
+    — this file and the agent both NAME `systemctl` in prose, and a text scan
+    cannot tell a docstring from a call.
+
+    🔴 IT RESOLVES IMPORT BINDINGS, BECAUSE ITS FIRST VERSION DID NOT AND WAS
+    NARROWER THAN THIS DOCSTRING. That draft matched only a literal
+    `subprocess.<verb>(...)` / `os.<verb>(...)` attribute call, so an ALIAS
+    walked straight past a guard whose sentence said "nothing else". MEASURED,
+    with every `__pycache__` purged and PYTHONDONTWRITEBYTECODE=1 (a `cp -a`
+    battery preserves pytest-rewritten bytecode and scores phantom survivors):
+
+        subprocess.run(["systemctl", ...])          KILLED
+        os.execv("/bin/systemctl", [...])           KILLED
+        subprocess.run(cmd)  # variable argv        KILLED
+        from subprocess import run as _r; _r([...]) SURVIVED
+        from subprocess import run;      run([...]) SURVIVED
+        import subprocess as _sp; _sp.run([...])    SURVIVED
+        os.posix_spawn("/.../systemctl", [...], {}) SURVIVED
+
+    Four survivors, and with one of them live the two files were 183 passed —
+    the round-2 defect exactly, one import spelling narrower. `claude/RULES.md`:
+    "a guard's DESCRIPTION claims COVERAGE — check the implementation is as wide
+    as the sentence."
+
+    So the binding map below is the guard, not a nicety: `import subprocess as X`
+    and `from subprocess import run as Y` are resolved to their real targets, and
+    `posix_spawn` is named explicitly rather than caught by a prefix.
     """
     import ast
 
-    tree = ast.parse(SCRIPT.read_text())
+    src = SCRIPT.read_text()
+    tree = ast.parse(src)
+
+    SUBPROCESS_VERBS = {"run", "Popen", "call", "check_call", "check_output"}
+    # 🔴 NOT every `os.*` — an early draft took the whole module and matched
+    # `os.getpid()`, failing on a CLEAN tree. A negative control that goes red is
+    # a broken instrument, not a finding. Only verbs that can START a process.
+    def _os_spawns(a):
+        return a.startswith("exec") or a.startswith("spawn") or a in (
+            "system", "popen", "posix_spawn", "posix_spawnp", "forkpty", "fork")
+
+    # name -> "subprocess" | "os", following `as` aliases.
+    mod_alias = {}
+    # bare name -> the module it was imported OUT of, following `as` aliases.
+    fn_alias = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name in ("subprocess", "os"):
+                    mod_alias[a.asname or a.name] = a.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.module in ("subprocess", "os"):
+                for a in node.names:
+                    fn_alias[a.asname or a.name] = (node.module, a.name)
+
     argv0 = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         fn = node.func
-        # subprocess.run / .Popen / .check_output / .call, and bare os.exec*/os.system
-        mod = getattr(getattr(fn, "value", None), "id", None)
-        attr = getattr(fn, "attr", "")
-        # 🔴 NOT every `os.*` — the first draft of this walker took the whole
-        # module and matched `os.getpid()`, failing on a CLEAN tree. A negative
-        # control that goes red is a broken instrument, not a finding. Only the
-        # verbs that can START a process count.
-        spawns = (mod == "subprocess" and attr in (
-                      "run", "Popen", "call", "check_call", "check_output")) or \
-                 (mod == "os" and (attr.startswith("exec") or attr.startswith("spawn")
-                                   or attr in ("system", "popen")))
+        mod = attr = None
+        if isinstance(fn, ast.Attribute):
+            base = getattr(getattr(fn, "value", None), "id", None)
+            mod, attr = mod_alias.get(base), fn.attr
+        elif isinstance(fn, ast.Name) and fn.id in fn_alias:
+            mod, attr = fn_alias[fn.id]
+
+        if mod is None:
+            continue
+        spawns = (mod == "subprocess" and attr in SUBPROCESS_VERBS) or \
+                 (mod == "os" and _os_spawns(attr))
         if not spawns:
             continue
         if not node.args:

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -1963,3 +1963,75 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
         "mention of `systemctl` on exactly this basis. A new argv[0] here is invisible to "
         "that ledger (it asserts a FILE set, and this file is already in it), so this is the "
         "only place the addition can be seen. Do not relax it to make a call site pass.")
+
+
+def test_an_EMPTY_pane_current_path_does_not_collapse_the_readback(monkeypatch):
+    """🔴 A WINDOW TMUX ALREADY CREATED WAS BEING REJECTED BY A `.strip()`.
+
+    `NEW_WINDOW_FORMAT` is `#{pane_id}\\t#{session_name}\\t#{pane_current_path}`.
+    The read-back did `out.strip().splitlines()[0].split("\\t")` — and `.strip()`
+    removes a TRAILING TAB, so a well-formed three-field line whose last field is
+    empty arrives as TWO fields and fails the length check. The window exists by
+    then: the caller gets an error, a stray window is left behind, and a retry
+    would make a second one.
+
+    MEASURED as an intermittent real-tmux failure, 3 occurrences across ~12 runs
+    of `test_the_EXACT_session_still_works`, one on a completely unmutated tree,
+    with wall times within 0.5 s of the control — so not a load flake. The
+    observed string `'%2\\tscratch20'` is byte-identical to `'%2\\tscratch20\\t'`
+    after `.strip()`, which is what identified the mechanism.
+
+    🔴 AND THE PARSE IS ONLY HALF OF IT. With the fields split correctly,
+    `landed_path` is `""`, and `same_directory("", cwd)` does NOT compare empty
+    against cwd — `os.path.realpath("")` returns the AGENT'S OWN cwd, so the
+    check would silently compare the wrong directory and usually refuse. An
+    unreadable path is "not readable yet", NOT "tmux fell back to the wrong
+    directory", and the two must not share a code path.
+
+    This drives `run_tmux` directly rather than through the tmux stub, because
+    the stub composes its own third field and cannot express an EMPTY one — the
+    exact value under test.
+    """
+    calls = []
+
+    def fake_run_tmux(args):
+        calls.append(args)
+        if args[0] == "new-window":
+            # Well-formed, three fields, last one EMPTY. Note the trailing tab.
+            return 0, "%2\tscratch20\t\n", ""
+        if args[0] == "display-message":
+            return 0, str(pathlib.Path.home()) + "\n", ""
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    monkeypatch.setattr(AGENT, "run_tmux", fake_run_tmux)
+    pane, err = AGENT.open_window(str(pathlib.Path.home()), "scratch20")
+
+    assert not err, (
+        f"a three-field read-back whose last field is empty was rejected: {err!r}. "
+        "The window already exists at this point, so this is a lost window plus a "
+        "misleading error, not a refusal.")
+    assert pane == "%2", pane
+    assert any(a[0] == "display-message" for a in calls), (
+        "an empty pane_current_path must be RE-READ for that pane, not treated as a "
+        "directory mismatch — `os.path.realpath('')` is the agent's own cwd, so the "
+        "same_directory check would compare something nobody asked about.")
+
+
+def test_an_UNREADABLE_pane_current_path_still_REFUSES(monkeypatch):
+    """The other half, so the fix above cannot become "accept anything".
+
+    If the re-read ALSO comes back empty the directory is genuinely unverifiable,
+    and this agent presses Enter — so it must refuse rather than type into a pane
+    whose location nothing confirmed.
+    """
+    def fake_run_tmux(args):
+        if args[0] == "new-window":
+            return 0, "%2\tscratch20\t\n", ""
+        if args[0] == "display-message":
+            return 0, "\n", ""
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    monkeypatch.setattr(AGENT, "run_tmux", fake_run_tmux)
+    pane, err = AGENT.open_window(str(pathlib.Path.home()), "scratch20")
+    assert pane == "", pane
+    assert "directory" in err.lower(), err

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -38,11 +38,13 @@ nobody would notice:
      proves the stub tmux and the stub server can observe anything at all. Every
      "no send-keys happened" assertion below is meaningless without it.
 
-⚠ THE AGENT SHIPS DISABLED and cannot be exercised on a live host at all: the
-server's routes answer 503 until CLAWGATE_TERMINAL_TOKEN is provisioned, and the
-unit is not wired into `default.target` until `enableTmuxReplyAgent` is true.
-That is why these tests drive the script directly against stubs rather than
-asserting anything about a running system.
+⚠ THE AGENT SHIPPED DISABLED AND IS NOW ARMED — `enableTmuxReplyAgent` is true —
+but that changes NOTHING about how these tests are built. They still drive the
+script directly against stubs rather than asserting anything about a running
+system: a test that reached the live agent would be sending keystrokes into the
+operator's real panes. The two switches remain independent — the server's routes
+answer 503 until CLAWGATE_TERMINAL_TOKEN is provisioned on the POD, and the unit
+is wired into `default.target` only while `enableTmuxReplyAgent` is true.
 """
 from __future__ import annotations
 
@@ -741,12 +743,22 @@ def home_nix() -> str:
     return HOME_NIX.read_text()
 
 
-def test_the_agent_unit_SHIPS_DISABLED():
-    """🔴 THE CENTRAL CLAIM OF THIS CHANGE, ASSERTED AGAINST THE CONFIGURATION.
+def test_the_agent_unit_IS_ARMED():
+    """🔴 THE CENTRAL CLAIM OF THE ARMING CHANGE, ASSERTED AGAINST THE CONFIGURATION.
+
+    This guard used to pin the flag `false` and is now pinned `true`, and the
+    SYMMETRY is the point rather than a weakening: what it has always enforced is
+    that the armed state is a deliberate, reviewed edit in BOTH directions. While
+    it read `false`, arming meant editing this test; now that it reads `true`,
+    DISARMING means editing this test. An accidental revert to `false` would stop
+    every queued reply from ever executing while the server kept accepting them
+    and the UI kept looking healthy — a silent reopening of the loop rank 32
+    closed, which is exactly the shape a config guard exists to catch.
 
     What this agent delivers is arbitrary command execution as the operator on
     this host. Building it and ARMING it were deliberately separated so the write
-    path could be merged, deployed and audited before it could execute anything.
+    path could be merged, deployed and audited before it could execute anything;
+    that separation did its job across seven audit rounds and is now history.
 
     The flag is read through the comment-stripping reader, not a substring
     search: this file's blocks quote directives verbatim in prose, so a raw
@@ -754,18 +766,19 @@ def test_the_agent_unit_SHIPS_DISABLED():
     that exact failure once left a guard green over a deleted unit.
     """
     src = nix_units.strip_nix_comments(home_nix())
-    assert "enableTmuxReplyAgent = false;" in src, (
-        "the terminal-write agent's master switch is not false. Arming this is an "
-        "operator act, deliberately separate from shipping it: it needs "
-        "CLAWGATE_TERMINAL_TOKEN provisioned on the POD *and* this flag flipped, and "
-        "neither implies the other.")
-    assert "enableTmuxReplyAgent = true;" not in src
+    assert "enableTmuxReplyAgent = true;" in src, (
+        "the terminal-write agent's master switch is not true. Disarming is an operator "
+        "act and a reviewed edit, not a drive-by revert: with this false the unit is "
+        "wanted by nothing, every reply typed in the web UI queues for ever, and nothing "
+        "in the server or the UI says so.")
+    assert "enableTmuxReplyAgent = false;" not in src
 
 
-def test_the_agent_unit_is_declared_even_though_it_is_disabled():
-    """The SERVICE must exist on both hosts even while nothing wants it, so an
-    operator arming the surface can start it by hand and watch it before wiring
-    it into the target. The `Install.WantedBy` is what the flag gates."""
+def test_the_agent_unit_is_declared_independently_of_the_flag():
+    """The SERVICE definition is emitted unconditionally; only `Install.WantedBy`
+    is gated. That is what let an operator start it by hand and watch it before
+    it was wired into the target, and it is what makes disarming a matter of the
+    unit no longer being WANTED rather than no longer existing."""
     src = home_nix()
     assert nix_units.declares("systemd.user.services.tmux-reply-agent", src)
     unit = nix_units.strip_nix_comments(
@@ -806,13 +819,22 @@ def _wanted_by_expr(nix_src: str) -> tuple:
     return flag.group(1), cond, targets
 
 
-def test_the_agent_unit_IS_WANTED_BY_NOTHING_as_shipped():
+def test_default_target_wants_the_agent_and_ONLY_via_the_bare_flag():
     """🔴 THE CENTRAL CLAIM, PINNED AS AN EXPRESSION RATHER THAN AS SUBSTRINGS.
 
-    Two facts together determine that nothing wants this unit, and BOTH are
-    asserted: the condition is the BARE flag (not a negation, not a wider
-    expression), and the flag is `false`. A mutant that changes either is a
+    Two facts together determine that `default.target` wants this unit, and BOTH
+    are asserted: the condition is the BARE flag (not a negation, not a wider
+    expression), and the flag is `true`. A mutant that changes either is a
     different string here.
+
+    🔴 THE CONDITION ASSERTION IS THE HALF THAT DID NOT CHANGE MEANING WHEN THE
+    FLAG FLIPPED, AND IT IS THE MORE IMPORTANT HALF. Pinning the bare flag is
+    what keeps the flag the ONLY thing deciding whether the agent runs: a
+    disjunction like `(enableTmuxReplyAgent || isNixOS)` would want the unit on
+    every host regardless of the switch, so setting the flag `false` would no
+    longer disarm anything. That mutant mentions the flag's name and passes a
+    word-pinning guard, which is why the whole condition is normalised and
+    compared as one string.
 
     🔴 DETERMINISTIC, AND THERE IS DELIBERATELY NO `nix eval` BESIDE IT. A first
     draft added one as "confirmation". It PASSED on the dev host and turned the
@@ -833,10 +855,11 @@ def test_the_agent_unit_IS_WANTED_BY_NOTHING_as_shipped():
         f"the WantedBy condition is `{cond}`, not the bare flag. Anything else — a negation, a "
         "disjunction, a different flag — can want this unit while still mentioning the flag's "
         "name, which is exactly how the previous guard was walked past.")
-    assert flag == "false", (
-        f"enableTmuxReplyAgent is `{flag}`. As shipped it must be false: starting this unit means "
-        "arbitrary command execution as the operator on this host, and arming it is a separate "
-        "operator act.")
+    assert flag == "true", (
+        f"enableTmuxReplyAgent is `{flag}`. The agent is ARMED: with this false the unit is "
+        "wanted by nothing, and every reply typed in the web UI queues and is never executed "
+        "— silently, because the server still accepts the write. Disarming is a deliberate "
+        "operator act and edits this assertion with it.")
     assert targets == '[ "default.target" ]', targets
 
 
@@ -853,10 +876,17 @@ def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
         "the inverted-flag mutant reads identically to the shipped condition; this guard cannot "
         "see the one mutation that would start the agent on both hosts")
 
-    flipped = src.replace("  enableTmuxReplyAgent = false;",
-                          "  enableTmuxReplyAgent = true;")
-    assert flipped != src
-    assert _wanted_by_expr(flipped)[0] == "true"
+    # 🔴 THE FLAG CONTROL MUTATES IN THE DIRECTION THAT IS NOW THE HAZARD.
+    # It used to flip false -> true (arming by accident); with the agent armed
+    # the accident to catch is the reverse — a revert to `false`, which disarms
+    # the host half while the server keeps accepting writes. Left in its old
+    # direction this `replace` would match nothing, `flipped` would equal `src`,
+    # and the control would assert `"true" == "true"` about the UNMUTATED file:
+    # green, and blind. That is why the assertion below is `== "false"`.
+    flipped = src.replace("  enableTmuxReplyAgent = true;",
+                          "  enableTmuxReplyAgent = false;")
+    assert flipped != src, "the flag declaration this control mutates was not found verbatim"
+    assert _wanted_by_expr(flipped)[0] == "false"
 
 
 def test_the_unit_PATH_carries_tmux_and_python():

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -1836,9 +1836,21 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
     acknowledgement had blinded the very guard it was filed under.
 
     So the pin is written here, where it can see argv rather than file names:
-    every spawn in the agent must take its argv from `tmux_bin()`. AST, not grep
-    — this file and the agent both NAME `systemctl` in prose, and a text scan
-    cannot tell a docstring from a call.
+    a DIRECT spawn in the agent must take its argv from `tmux_bin()`. AST, not
+    grep — this file and the agent both NAME `systemctl` in prose, and a text
+    scan cannot tell a docstring from a call.
+
+    🔴 WHAT IT DOES NOT SEE, STATED RATHER THAN IMPLIED — an unqualified "every
+    spawn" is what made the two previous versions of this docstring false, and a
+    guard whose sentence is wider than its body reads as coverage while providing
+    none. MEASURED SURVIVORS at this revision: reflective lookup
+    (`getattr(subprocess, "run")`, `importlib.import_module`, `__import__`), a
+    star-import (`from subprocess import *`), an indirect binding
+    (`_m = subprocess` / `f = run`), and spawners in OTHER modules (`pty.spawn`,
+    `asyncio.create_subprocess_exec`). Those are residuals, not oversights: each
+    needs a deliberate indirection, whereas the verbs above are what ordinary
+    code reaches for. If this file ever grows one of them, this guard will not
+    say so — and neither will the launcher ledger.
 
     🔴 IT RESOLVES IMPORT BINDINGS, BECAUSE ITS FIRST VERSION DID NOT AND WAS
     NARROWER THAN THIS DOCSTRING. That draft matched only a literal
@@ -1869,7 +1881,14 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
     src = SCRIPT.read_text()
     tree = ast.parse(src)
 
-    SUBPROCESS_VERBS = {"run", "Popen", "call", "check_call", "check_output"}
+    # 🔴 `getoutput`/`getstatusoutput` ARE IN THIS SET BECAUSE THEY RUN A SHELL
+    # and were missing from the first five. Same module, same `subprocess.<verb>()`
+    # shape this walker already sees — no aliasing, no reflection — so
+    # `subprocess.getoutput(f"systemctl --user is-active {unit}")` SURVIVED a guard
+    # whose sentence said "nothing else", while the launcher ledger (which asserts
+    # a FILE set, and this file is already in it) is structurally blind to it too.
+    SUBPROCESS_VERBS = {"run", "Popen", "call", "check_call", "check_output",
+                        "getoutput", "getstatusoutput"}
     # 🔴 NOT every `os.*` — an early draft took the whole module and matched
     # `os.getpid()`, failing on a CLEAN tree. A negative control that goes red is
     # a broken instrument, not a finding. Only verbs that can START a process.
@@ -1880,6 +1899,15 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
     # name -> "subprocess" | "os", following `as` aliases.
     mod_alias = {}
     # bare name -> the module it was imported OUT of, following `as` aliases.
+    # ⚠ SCOPE-BLIND, BOTH WAYS, AND LATENT TODAY. This walks the whole module, so
+    # a `from subprocess import ...` inside a function body registers globally
+    # (over-strict — fails loud, safe direction), and a LOCAL rebinding of the
+    # same name is read as the import (a FALSE POSITIVE: a parameter named `run`
+    # in `def _use(run, argv): return run(argv)` is flagged as a spawn). Latent
+    # because `scripts/tmux-reply-agent` imports `os` and `subprocess` as modules
+    # only, with no from-import, so this dict is EMPTY on the real tree. It goes
+    # live the first time anyone adds one; prefer renaming the local over
+    # loosening this map.
     fn_alias = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -1928,7 +1956,9 @@ def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
 
     assert set(argv0) == {"tmux_bin"}, (
         f"the agent's subprocess argv[0] set is {sorted(set(argv0))}, not {{'tmux_bin'}}. "
-        "This agent must shell out to tmux and nothing else — it runs as the operator, is "
+        "This agent must shell out to tmux and nothing else (this check sees DIRECT spawns; "
+        "see the docstring for the reflective/star-import residuals it does not) — it runs "
+        "as the operator, is "
         "driven by a network route, and `test_no_real_launchers.py` ACKNOWLEDGES its prose "
         "mention of `systemctl` on exactly this basis. A new argv[0] here is invisible to "
         "that ledger (it asserts a FILE set, and this file is already in it), so this is the "

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -196,6 +196,13 @@ def tmux_stub(tmp_path):
         f'''if [ "$1" = "-V" ]; then echo 'tmux 3.4'; exit 0; fi\n'''
         f'''python3 -c 'import json,sys; open(sys.argv[1],"a").write(json.dumps(sys.argv[2:])+"\\n")' '''
         f'''{log} "$@"\n'''
+        # ⚠ THIS BRANCH MATCHES **ANY** `display-message`, INCLUDING the
+        # `#{pane_current_path}` RE-READ `open_window` now makes when tmux returns
+        # an empty path. Unreachable today ONLY because this stub cannot express an
+        # empty third field. If you extend the stub to cover that path,
+        # DISCRIMINATE ON THE FORMAT ARGUMENT FIRST — otherwise the re-read is
+        # handed a server id (`1234:5678`) as its directory and the run refuses
+        # with the misleading "tmux fell back" message.
         f'''if [ "$1" = "display-message" ]; then cat {server_id}; exit 0; fi\n'''
         # 🔴 THE STUB NOW ECHOES WHAT THE AGENT READS BACK. The agent verifies the
         # session and working directory tmux ACTUALLY chose, so a stub printing a
@@ -1981,6 +1988,16 @@ def test_an_EMPTY_pane_current_path_does_not_collapse_the_readback(monkeypatch):
     observed string `'%2\\tscratch20'` is byte-identical to `'%2\\tscratch20\\t'`
     after `.strip()`, which is what identified the mechanism.
 
+    🔴 AND THE TRIGGER HAS SINCE BEEN FORCED DIRECTLY, so this no longer rests on
+    byte-identity. On a private `-L` socket (tmux 3.7c), `new-window -P -F` with
+    this format produced an EMPTY third field **11 times in ~310 warm-server
+    creations (~3.6%)**, and **0 times in 60 cold-server creations** — so the race
+    is not server startup. In **11 of 11** the immediate
+    `display-message -p -t <pane>` re-read returned the correct populated path,
+    which is end-to-end evidence for the remedy below against REAL tmux rather
+    than against a stub. That also retires the rival mechanism byte-identity alone
+    could not exclude: tmux genuinely emitting two fields.
+
     🔴 AND THE PARSE IS ONLY HALF OF IT. With the fields split correctly,
     `landed_path` is `""`, and `same_directory("", cwd)` does NOT compare empty
     against cwd — `os.path.realpath("")` returns the AGENT'S OWN cwd, so the
@@ -2023,6 +2040,25 @@ def test_an_UNREADABLE_pane_current_path_still_REFUSES(monkeypatch):
     If the re-read ALSO comes back empty the directory is genuinely unverifiable,
     and this agent presses Enter — so it must refuse rather than type into a pane
     whose location nothing confirmed.
+
+    🔴 IT PINS THE WHOLE NORMALISED STRING, BECAUSE THE FIRST VERSION OF THIS
+    TEST PINNED THE WORD "directory" AND WAS WALKABLE BY ITS OWN NEIGHBOUR.
+    That word appears in the unverifiable-path refusal AND in the `same_directory`
+    MISMATCH message four lines below it, so deleting the refusal outright left
+    this test GREEN — measured as a surviving mutant. The fallthrough then
+    produced:
+
+        tmux opened the window in '', not the requested '/home/zach' — the
+        directory does not exist on this host, so tmux fell back
+
+    which satisfied both of the old assertions while asserting the exact
+    confusion the fix exists to prevent, since `os.path.realpath("")` is the
+    AGENT'S OWN cwd (verified) and the unit runs with `WorkingDirectory=~`.
+    ⚠ Worse, the old test's verdict depended on an UNPINNED dimension: with
+    pytest's cwd at `/home/zach` the mutant died, from `/tmp` or the repo root it
+    survived — and the gate runs from the repo root.
+
+    `claude/RULES.md`: assert the STATE, never a word another branch can spell.
     """
     def fake_run_tmux(args):
         if args[0] == "new-window":
@@ -2034,4 +2070,13 @@ def test_an_UNREADABLE_pane_current_path_still_REFUSES(monkeypatch):
     monkeypatch.setattr(AGENT, "run_tmux", fake_run_tmux)
     pane, err = AGENT.open_window(str(pathlib.Path.home()), "scratch20")
     assert pane == "", pane
-    assert "directory" in err.lower(), err
+    assert " ".join(err.split()) == (
+        "tmux did not report the new window's directory, so where it landed "
+        "could not be verified"), (
+        f"the refusal message is {err!r}. This asserts the WHOLE normalised string "
+        "on purpose: pinning a word lets the `same_directory` mismatch branch below "
+        "satisfy this test while the refusal is gone.")
+    assert "fell back" not in err, (
+        f"the unverifiable-path refusal must not be the FALLTHROUGH mismatch: {err!r}. "
+        "'could not read where it landed' and 'tmux landed somewhere else' are "
+        "different facts and must not share a code path.")

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -888,23 +888,44 @@ def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
     # the accident to catch is the reverse — a revert to `false`, which disarms
     # the host half while the server keeps accepting writes.
     #
-    # ⚠ RETRACTED, and left here because the retraction is the useful part. The
-    # commit that inverted this control claimed the OLD direction would have gone
-    # "green and blind" — asserting `"true" == "true"` about an unmutated file.
-    # That was FALSE, and an audit measured it: `assert flipped != src` was
-    # ALREADY on the line below before the flip, and `enableTmuxReplyAgent =
-    # false` occurs zero times in the armed file, so the stale direction failed
-    # LOUDLY on exactly that assertion. Reverting it and re-running gives
-    # `1 failed`, not a pass.
+    # ⚠ TWICE-CORRECTED, and the SECOND correction is the one worth reading,
+    # because a fix for the first one CREATED the hazard the first one denied.
     #
-    # So the inversion is still right — a control should mutate toward the live
-    # hazard, and the failure message here now names what actually broke — but it
-    # was never load-bearing against a silent pass. Do not re-derive the stronger
-    # claim: the `!= src` line is what makes a stale direction impossible, and it
-    # is the thing to preserve if this control is ever rewritten again.
-    flipped = src.replace("  enableTmuxReplyAgent = true;",
-                          "  enableTmuxReplyAgent = false;")
-    assert flipped != src, "the flag declaration this control mutates was not found verbatim"
+    # Round 1 of this change claimed the pre-flip direction would have gone
+    # "green and blind". An audit refuted it: `assert flipped != src` already
+    # existed, `enableTmuxReplyAgent = false` occurred ZERO times in the armed
+    # file, so the stale direction failed loudly. True — at that commit.
+    #
+    # 🔴 THEN THE FIX FOR THAT CLAIM MADE IT FALSE. The same round wrote a
+    # DISARM EXAMPLE into `nix/home.nix`'s comments:
+    #
+    #     #     enableTmuxReplyAgent = false;   # then merge + ship.sh, THEN:
+    #
+    # A comment — but `str.replace` cannot tell a declaration from a comment
+    # describing one, and that line's `  #     ` prefix ENDS IN SPACES, so the
+    # two-space-prefixed literal matches INSIDE it. MEASURED: reverting this
+    # control to its pre-flip direction on that tree gives `1 passed` — the
+    # replace hits the comment, `flipped != src` is satisfied, `_wanted_by_expr`
+    # reads the untouched real declaration, and the control passes about a file
+    # whose flag was never mutated. Exactly "green and blind", arrived at by
+    # fixing the claim that it could not happen.
+    #
+    # 🔴 SO THE MUTATION IS ANCHORED, NOT SUBSTRING-MATCHED. `^  <flag> = …;$`
+    # under re.M is the same shape `_wanted_by_expr` already uses, and it is why
+    # THAT function was never fooled by the comment. `subn`'s count is asserted
+    # to be exactly 1, so a second declaration — or a comment that starts at
+    # column 0 — is a failure rather than a silent extra substitution.
+    #
+    # The documentation is NOT the thing to delete here: the disarm example is
+    # the only written rollback for a surface that executes commands. Fix the
+    # test, not the sentence.
+    flipped, n_flipped = re.subn(r"^  enableTmuxReplyAgent = true;$",
+                                 "  enableTmuxReplyAgent = false;", src, flags=re.M)
+    assert n_flipped == 1, (
+        f"expected exactly ONE anchored flag declaration to mutate, substituted {n_flipped}. "
+        "Zero means the declaration moved or changed spelling; more than one means there is a "
+        "second declaration and this control no longer names which one it tested.")
+    assert flipped != src
     assert _wanted_by_expr(flipped)[0] == "false"
 
 
@@ -1785,3 +1806,76 @@ def test_a_window_that_landed_in_the_WRONG_DIRECTORY_is_refused(
         [r for r in server.requests if r["path"].endswith("/result")][0]["body"])
     assert body["state"] == "failed", body
     assert "not the requested" in body["detail"], body
+
+
+def test_the_agent_SHELLS_OUT_TO_TMUX_AND_NOTHING_ELSE():
+    """🔴 THE PIN `test_no_real_launchers.py`'s ACKNOWLEDGEMENT PROMISES, and it
+    did not exist until an audit went looking for it.
+
+    That ledger acknowledges this file as reaching `systemctl` in PROSE — one
+    line of module docstring giving the operator the second half of the disarm
+    procedure. The acknowledgement is only honest while the prose stays prose,
+    and its justification asserted that "test_tmux_reply_agent.py pins that the
+    agent shells out to nothing else". No such test existed; the sentence named
+    a compensating control that was never written.
+
+    🔴 THAT GAP WAS MEASURED, NOT INFERRED. `launcher_scan.hazard_hits` returns a
+    FILE SET, and the ledger asserts set equality — so once this file is IN the
+    set for `systemctl`, a genuine call site added to it changes the set by
+    nothing and the ledger stays green. Injecting
+
+        subprocess.run(["systemctl", "--user", "restart", "some-unit"], check=False)
+
+    into this agent left `test_no_real_launchers.py` at **77 passed**. The
+    acknowledgement had blinded the very guard it was filed under.
+
+    So the pin is written here, where it can see argv rather than file names:
+    every `subprocess` invocation in the agent must take its argv from
+    `tmux_bin()`. AST, not grep — this file and the agent both NAME `systemctl`
+    in prose, and a text scan cannot tell a docstring from a call.
+    """
+    import ast
+
+    tree = ast.parse(SCRIPT.read_text())
+    argv0 = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        # subprocess.run / .Popen / .check_output / .call, and bare os.exec*/os.system
+        mod = getattr(getattr(fn, "value", None), "id", None)
+        attr = getattr(fn, "attr", "")
+        # 🔴 NOT every `os.*` — the first draft of this walker took the whole
+        # module and matched `os.getpid()`, failing on a CLEAN tree. A negative
+        # control that goes red is a broken instrument, not a finding. Only the
+        # verbs that can START a process count.
+        spawns = (mod == "subprocess" and attr in (
+                      "run", "Popen", "call", "check_call", "check_output")) or \
+                 (mod == "os" and (attr.startswith("exec") or attr.startswith("spawn")
+                                   or attr in ("system", "popen")))
+        if not spawns:
+            continue
+        if not node.args:
+            argv0.append(f"<no-argv:{mod}.{attr}>")
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.BinOp) and isinstance(first.left, ast.List):
+            first = first.left
+        if isinstance(first, ast.List) and first.elts:
+            head = first.elts[0]
+        else:
+            head = first
+        if isinstance(head, ast.Call) and isinstance(head.func, ast.Name):
+            argv0.append(head.func.id)
+        elif isinstance(head, ast.Constant):
+            argv0.append(repr(head.value))
+        else:
+            argv0.append(ast.dump(head)[:60])
+
+    assert set(argv0) == {"tmux_bin"}, (
+        f"the agent's subprocess argv[0] set is {sorted(set(argv0))}, not {{'tmux_bin'}}. "
+        "This agent must shell out to tmux and nothing else — it runs as the operator, is "
+        "driven by a network route, and `test_no_real_launchers.py` ACKNOWLEDGES its prose "
+        "mention of `systemctl` on exactly this basis. A new argv[0] here is invisible to "
+        "that ledger (it asserts a FILE set, and this file is already in it), so this is the "
+        "only place the addition can be seen. Do not relax it to make a call site pass.")

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -737,7 +737,7 @@ def test_an_unmeasurable_server_id_reads_as_empty(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# 7. The unit ships DISABLED, and carries what the child needs.
+# 7. The unit is ARMED (it shipped disabled), and carries what the child needs.
 # --------------------------------------------------------------------------- #
 def home_nix() -> str:
     return HOME_NIX.read_text()
@@ -754,6 +754,13 @@ def test_the_agent_unit_IS_ARMED():
     every queued reply from ever executing while the server kept accepting them
     and the UI kept looking healthy — a silent reopening of the loop rank 32
     closed, which is exactly the shape a config guard exists to catch.
+
+    🔴 BUT THE FLAG IS NOT A LIVE KILL SWITCH, AND THIS GUARD MUST NOT BE READ AS
+    ONE. Flipping it `false` and shipping does NOT stop a RUNNING agent: the unit
+    definition is emitted unconditionally, so the flag only removes `[Install]`,
+    and `sd-switch` reads that as a CHANGED unit and plans Stop/Start. What this
+    pins is the DECLARED state at next login. Stopping it now is
+    `systemctl --user stop tmux-reply-agent`, on both hosts.
 
     What this agent delivers is arbitrary command execution as the operator on
     this host. Building it and ARMING it were deliberately separated so the write
@@ -879,10 +886,22 @@ def test_the_wanted_by_guard_can_SEE_an_inverted_flag():
     # 🔴 THE FLAG CONTROL MUTATES IN THE DIRECTION THAT IS NOW THE HAZARD.
     # It used to flip false -> true (arming by accident); with the agent armed
     # the accident to catch is the reverse — a revert to `false`, which disarms
-    # the host half while the server keeps accepting writes. Left in its old
-    # direction this `replace` would match nothing, `flipped` would equal `src`,
-    # and the control would assert `"true" == "true"` about the UNMUTATED file:
-    # green, and blind. That is why the assertion below is `== "false"`.
+    # the host half while the server keeps accepting writes.
+    #
+    # ⚠ RETRACTED, and left here because the retraction is the useful part. The
+    # commit that inverted this control claimed the OLD direction would have gone
+    # "green and blind" — asserting `"true" == "true"` about an unmutated file.
+    # That was FALSE, and an audit measured it: `assert flipped != src` was
+    # ALREADY on the line below before the flip, and `enableTmuxReplyAgent =
+    # false` occurs zero times in the armed file, so the stale direction failed
+    # LOUDLY on exactly that assertion. Reverting it and re-running gives
+    # `1 failed`, not a pass.
+    #
+    # So the inversion is still right — a control should mutate toward the live
+    # hazard, and the failure message here now names what actually broke — but it
+    # was never load-bearing against a silent pass. Do not re-derive the stronger
+    # claim: the `!= src` line is what makes a stale direction impossible, and it
+    # is the thing to preserve if this control is ever rewritten again.
     flipped = src.replace("  enableTmuxReplyAgent = true;",
                           "  enableTmuxReplyAgent = false;")
     assert flipped != src, "the flag declaration this control mutates was not found verbatim"
@@ -933,9 +952,9 @@ def test_the_unit_does_not_wire_the_DND_defeating_failure_toast():
     bypass is justified by a MEASURED rate of about one firing in nine days.
 
     This unit restarts on failure and polls every few seconds, so any sustained
-    condition — the surface not armed, which is the state it ships in — would
-    fire a DND-bypassing toast on every restart and burn down the one alert
-    channel that has to keep its meaning.
+    condition — the surface not armed, which since arming means the pod's secret
+    was REMOVED — would fire a DND-bypassing toast on every restart and burn down
+    the one alert channel that has to keep its meaning.
     """
     unit = nix_units.strip_nix_comments(
         nix_units.unit_source("systemd.user.services.tmux-reply-agent", home_nix()))

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -570,12 +570,39 @@ def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
     if rc != 0:
         return "", (err or f"tmux exited {rc}")
 
-    fields = (out.strip().splitlines() or [""])[0].split("\t")
+    # 🔴 SPLIT THE LINE BEFORE STRIPPING IT. `out.strip()` removes a TRAILING
+    # TAB, so a well-formed three-field line whose last field is empty —
+    # `#{pane_current_path}` is empty until the pane's process cwd is readable —
+    # arrives here as TWO fields and fails the length check below. The window
+    # EXISTS by then: the caller got an error, a stray window was left behind,
+    # and a retry would have made a second one. Measured as an intermittent
+    # real-tmux failure, 3 occurrences in ~12 runs, the reported string
+    # byte-identical to the good line after `.strip()`. Strip only the line
+    # ending; strip the FIELDS individually afterwards.
+    lines = out.splitlines() or [""]
+    fields = lines[0].split("\t")
     if len(fields) != 3:
         return "", f"tmux did not report the new window's identity (got {out.strip()!r})"
     pane, landed_session, landed_path = (f.strip() for f in fields)
     if not pane.startswith("%"):
         return "", f"tmux did not report a pane id for the new window (got {pane!r})"
+
+    # 🔴 EMPTY IS "NOT READABLE YET", NOT "THE WRONG DIRECTORY" — and the two must
+    # not share a code path. `os.path.realpath("")` returns THIS PROCESS'S cwd, so
+    # handing an empty value to same_directory() below compares a directory nobody
+    # asked about and usually refuses, with a message naming a fallback that never
+    # happened. Re-read the path for this specific pane instead; one extra call, in
+    # the rare case only.
+    if not landed_path:
+        rc2, out2, _ = run_tmux(["display-message", "-p", "-t", pane,
+                                 "#{pane_current_path}"])
+        if rc2 == 0:
+            landed_path = (out2.splitlines() or [""])[0].strip()
+    if not landed_path:
+        # Still unreadable. This agent presses Enter, so an unverifiable location
+        # is a refusal, not a shrug.
+        return "", ("tmux did not report the new window's directory, so where it "
+                    "landed could not be verified")
 
     # 🔴 REFUSE ON A MISMATCH RATHER THAN TYPE INTO IT. Both checks are about one
     # thing: tmux resolved the target to something other than what was asked for,

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -23,9 +23,12 @@ instead of it.
 write routes sit behind a FAIL-CLOSED wrapper that answers 503 until
 CLAWGATE_TERMINAL_TOKEN is set on the POD; and this unit is not wired into the
 user manager's default target until `enableTmuxReplyAgent` is set true in
-`nix/home.nix`. Neither implies the other, and both are deliberately off in the
-change that introduced them. A 503 is therefore this agent's NORMAL state, logged
-once and backed off from — never an error.
+`nix/home.nix`. Neither implies the other. Both were deliberately off in the
+change that introduced them, and BOTH ARE NOW ON — the secret is provisioned and
+the flag is true, so this agent is LIVE and does execute what the queue hands it.
+A 503 is still this agent's NORMAL state whenever the pod's secret is removed
+(that is how the surface is disarmed), logged once and backed off from — never
+an error.
 
 🔴 AT MOST ONCE, NEVER AT LEAST ONCE. A retried `send-keys` runs a command twice.
 The server's claim moves a row out of `pending` permanently, so a write this agent
@@ -791,11 +794,13 @@ def main(argv: list[str]) -> int:
     token = resolve("CLAWGATE_TERMINAL_TOKEN", CONF_FILE)
     if not token:
         # 🔴 A CONFIGURATION ERROR THAT CANNOT SELF-HEAL, so this one exits rather
-        # than backing off. It is also the state this ships in: arming the
-        # surface means provisioning that secret on the pod AND handing this host
-        # a copy, and neither has been done. The unit is not wired into the user
-        # manager's default target until `enableTmuxReplyAgent` is true, so this
-        # exit is what an operator sees if they start it by hand before arming.
+        # than backing off. It was the state this shipped in; arming meant
+        # provisioning that secret on the pod AND handing this host a copy, and
+        # both have since been done, so on an armed host reaching here means the
+        # host's copy has GONE — ~/.claude/clawgate.env rewritten, or the unit
+        # started under an environment that cannot read it — not that the feature
+        # is unbuilt. The unit is wired into the user manager's default target
+        # only while `enableTmuxReplyAgent` is true.
         log(f"no CLAWGATE_TERMINAL_TOKEN in the environment or {CONF_FILE} — "
             "the terminal write surface is not armed on this host; refusing to poll")
         return 2

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -19,16 +19,24 @@ into ANY pane, and clawgate presses Enter, because type-only makes remote
 answering pointless. Everything defensive below exists because of that, not
 instead of it.
 
-🔴 IT IS INERT UNTIL SOMEONE ARMS IT, IN TWO INDEPENDENT PLACES. The server's
-write routes sit behind a FAIL-CLOSED wrapper that answers 503 until
-CLAWGATE_TERMINAL_TOKEN is set on the POD; and this unit is not wired into the
-user manager's default target until `enableTmuxReplyAgent` is set true in
-`nix/home.nix`. Neither implies the other. Both were deliberately off in the
-change that introduced them, and BOTH ARE NOW ON — the secret is provisioned and
-the flag is true, so this agent is LIVE and does execute what the queue hands it.
-A 503 is still this agent's NORMAL state whenever the pod's secret is removed
-(that is how the surface is disarmed), logged once and backed off from — never
-an error.
+🔴 IT IS ARMED, AND IT DOES EXECUTE WHAT THE QUEUE HANDS IT. It was inert until
+BOTH of two independent switches were set, and both now are: the server's write
+routes sit behind a FAIL-CLOSED wrapper that answers 503 until
+CLAWGATE_TERMINAL_TOKEN is set on the POD (provisioned), and this unit is wired
+into the user manager's default target only while `enableTmuxReplyAgent` is true
+in `nix/home.nix` (true). Neither implies the other; both were deliberately off
+in the change that introduced them.
+
+🔴 DISARMING THE HOST HALF IS TWO STEPS. Flipping `enableTmuxReplyAgent` false
+and shipping does NOT stop a running agent: the unit definition is emitted
+unconditionally, so the flag only drops the `[Install]` block, and `sd-switch`
+reads a CHANGED unit and plans Stop/Start — it restarts the process. Follow the
+ship with `systemctl --user stop tmux-reply-agent` on BOTH hosts. Removing the
+pod's secret is the other lever, and that one is immediate for every host.
+
+A 503 is therefore no longer this agent's ordinary state. Since arming it means
+the pod's secret was REMOVED — a change on the server, not the shipped state —
+and it is logged once and backed off from rather than exited on.
 
 🔴 AT MOST ONCE, NEVER AT LEAST ONCE. A retried `send-keys` runs a command twice.
 The server's claim moves a row out of `pending` permanently, so a write this agent
@@ -109,8 +117,9 @@ DEFAULT_LOCAL_HOST = "workbench"
 # that is idle almost all the time.
 POLL_SECONDS = float(os.environ.get("TMUX_REPLY_POLL_SECONDS", "5"))
 # The backoff for every state that is not "a healthy empty queue": unreachable,
-# 503 (not armed — the normal state today), 401, a malformed body. Long enough
-# that a pod being redeployed or a token being absent costs almost nothing.
+# 503 (the server's surface not armed — since arming, that means the pod's
+# secret was REMOVED, i.e. somebody disarmed it), 401, a malformed body. Long
+# enough that a pod being redeployed costs almost nothing.
 BACKOFF_SECONDS = float(os.environ.get("TMUX_REPLY_BACKOFF_SECONDS", "60"))
 HTTP_TIMEOUT = float(os.environ.get("TMUX_REPLY_HTTP_TIMEOUT", "20"))
 # Bounds one `tmux send-keys`. It is a local unix-socket call that returns in
@@ -318,9 +327,17 @@ def post_json(url: str, token: str, payload: dict) -> dict:
             raw = resp.read(MAX_RESPONSE_BYTES)
     except urllib.error.HTTPError as exc:
         if exc.code == 503:
+            # 🔴 THIS TEXT CHANGED MEANING WHEN THE SURFACE WAS ARMED. While the
+            # feature shipped disabled a 503 was the ordinary state and the message
+            # said so. It is now a STATE CHANGE: the pod's secret has been removed,
+            # which is exactly how the server half is disarmed. Do not restore the
+            # reassuring wording — an operator reading "normal" over a disarm is the
+            # failure this line exists to prevent.
             raise Refused("the terminal write surface is NOT ARMED on the server "
                           "(HTTP 503) — CLAWGATE_TERMINAL_TOKEN is unset there. "
-                          "This is the shipped state, not a fault.") from exc
+                          "This host IS armed, so that is a CHANGE on the server, "
+                          "not the shipped state: the pod's secret was removed or "
+                          "the deployment lost it.") from exc
         if exc.code == 401:
             raise Refused("the server rejected this agent's terminal token (HTTP 401)") from exc
         if exc.code == 404:


### PR DESCRIPTION
Rank 32 of `claudedocs/handoff-tmux-webapp.md`. The server half of the reply loop
has been merged, deployed and armed as **0.8.26** since 2026-09-06
(`ZacxDev/homelab-infra#711`/`#715`/`#712` + `innovation-upstream/devrc#1324`).
The host half was still wanted by nothing, so a reply typed in the web UI queued
and was never executed. Measured before this change:
`systemctl --user is-active tmux-reply-agent` → `inactive`.

The functional change is one line. Everything else is here because that one line
makes six other statements in the tree false.

## 🔴 What this arms, stated plainly

`tmux send-keys` followed by Enter is **arbitrary command execution as the
operator, on both hosts**, driven by a route on a LAN NodePort with **no human
auth**, gated solely by `CLAWGATE_TERMINAL_TOKEN`.

That is an operator decision taken with the blast radius stated (handoff rank 29
records four such decisions, including "free text into ANY pane, unrestricted" —
offered and declined the narrower scoping). The deliberate part was that
**building and arming are separate acts**, so the write path could be merged,
deployed, read and audited across seven rounds while it could execute nothing.
That ordering has happened. This is the arming half, and it is one line to
reverse.

## Measured, with a paired control

| tree | flag | `Install.WantedBy` |
|---|---|---|
| base clone | `false` | `[]` |
| this branch | `true` | `["default.target"]` |

Both read from `nix eval` on the real flake — the flag is demonstrably what
drives the install, in **both** directions, not one reading asserted twice.

## The guards flip rather than being deleted

`test_the_agent_unit_SHIPS_DISABLED` pinned the flag `false`; it is now
`test_the_agent_unit_IS_ARMED` and pins it `true`. **The symmetry is the point.**
What that guard has always enforced is that the armed state is a deliberate,
reviewed edit in both directions: while it read `false`, arming meant editing the
test; now it reads `true`, disarming means editing the test. An accidental revert
would stop every queued reply from executing while the server kept accepting
writes and the UI kept looking healthy — a silent reopening of the loop this rank
closes.

The condition assertion (`cond == "enableTmuxReplyAgent"`, the bare flag) did
**not** change meaning and is the more important half: it keeps the flag the only
thing deciding whether the agent runs. `(enableTmuxReplyAgent || isNixOS)` would
want the unit regardless of the switch — and it mentions the flag's name, so it
walks past any word-pinning guard.

### The positive control — and the two corrections it took

This section has been WRONG TWICE, and the history is the useful part.

**Draft 1** claimed the control, left mutating `false → true`, would have gone
"green and blind". **Audit round 1 refuted it**: `assert flipped != src` already
existed and `enableTmuxReplyAgent = false` occurred zero times in the armed file,
so the stale direction would have failed loudly.

**Draft 2 retracted that — and was falsified by its own fix.** The retraction
commit also wrote a disarm example into `nix/home.nix`'s comments:

```
  #     enableTmuxReplyAgent = false;   # then merge + scripts/ship.sh, THEN:
```

That prefix ends in spaces, so the two-space-prefixed literal matches **inside the
comment**. **Audit round 2 measured it**: reverting the control to its pre-flip
direction on that tree gives **`1 passed`** — the vacuous green draft 2 had just
finished explaining could not occur. A fix for a claim created the hazard the
claim denied.

**Now:** the mutation is ANCHORED — `re.subn(r"^  enableTmuxReplyAgent = true;$",
flags=re.M)` with the substitution count asserted `== 1`, the same shape
`_wanted_by_expr` always used, which is why *it* was never fooled by the comment.
The disarm example stays: it is the only written rollback for a surface that
executes commands. Fix the test, not the sentence.

## Mutation battery — each mutant killed by ITS OWN assertion

Controls green either side; `PYTHONDONTWRITEBYTECODE=1`; tree verified clean
after restore.

| mutant | result | the assertion text it produced |
|---|---|---|
| control (unmutated) | **105 passed** | — |
| flag `true` → `false` | **3 failed** | `the terminal-write agent's master switch is not true` · ``enableTmuxReplyAgent is `false` `` · `the flag declaration this control mutates was not found verbatim` |
| cond → `(!enableTmuxReplyAgent)` | **2 failed** | ``the WantedBy condition is `(!enableTmuxReplyAgent)`, not the bare flag`` |
| cond → `(enableTmuxReplyAgent \|\| true)` | **2 failed** | ``the WantedBy condition is `(enableTmuxReplyAgent \|\| true)`, not the bare flag`` |
| post-restore control | **105 passed** | — |

A green run was not treated as evidence until each guard had been watched to go
red for its own reason.

⚠ **This table first reported `3 failed` for mutant 3. That was wrong** — the two
condition mutants change only `cond`, so they cannot differ. The third failure in
that run was an UNRELATED intermittent test (`test_the_EXACT_session_still_works`),
which later failed again on a completely unmutated tree: 2 occurrences in 10 runs.
Independently re-measured as `2` by audit rounds 1 and 2 and by a re-run here. The
intermittent test is a pre-existing defect in `#1324`'s `open_window` read-back —
`out.strip()` eats an empty trailing `#{pane_current_path}`, collapsing 3 fields to
2 — recorded under "Not closed by this PR", not fixed here.

## Gate — leg by leg, on the merged tree

🔴 **Re-run from scratch after the base moved TWICE mid-review** (`f0b9c474 -> c5a445d8 -> 88f1bda4`).
The numbers below are against **`c25ef63c`**, merged into this branch, with
`origin/main` re-confirmed as an ancestor of HEAD afterwards — so the branch tree
IS the merged tree. The earlier green runs at `f0b9c474` and `88f1bda4` are superseded and are NOT
quoted as evidence for this head — each was a real four-leg green, against a base
that has since moved and a tree without the later audit fixes. "The gate passed"
is true of one run, one tier, one base; it is not a property of the change.

| tier | leg | verdict |
|---|---|---|
| 1 (dev host) | `run-tests.sh` (pytest) | ✅ **PASS** — `RESULT: PASS (exit=0)`, **21,867 / 21,870**, 3 skipped, **0 failed**, floor 18,610 |
| 1 (dev host) | `run-node-tests.sh` | ✅ **PASS** — 5 suites, 41 files, **1,449 / 1,449**, floor 1,367 |
| 2 (nix sandbox) | `checks.x86_64-linux.pytests` | ✅ **PASS** — `RESULT: PASS (exit=0)`, **21,867 / 21,870**, 0 failed |
| 2 (nix sandbox) | `checks.x86_64-linux.nodetests` | ✅ **PASS** — `RESULT: PASS (exit=0)`, **1,449 / 1,449** |

Each verdict is the runner's own `RESULT:` line, not a shell exit code. The two
sandbox derivations were built **one at a time**; `database is locked` /
`SQLite database is busy` appear **0** times in either log, despite other sessions
running the same check derivation concurrently throughout.

🔴 **An intermediate run of this gate was RED, and it was this PR's own fault.**
Adding `systemctl --user stop tmux-reply-agent` to the agent docstring (the round-1
rollback fix) made `test_no_real_launchers.py`'s text scan see a new file reaching
an acknowledged binary — `scripts/tests` 12,740 passed / **1 failed**. Fixed by
ACKNOWLEDGING the prose mention with grep evidence of no call site, **not** by
rewording the docstring: that ledger's own `session-write` entry says "Deleting the
word to get green would delete the guarantee", and here the word is the only
written rollback for a surface whose payload is arbitrary command execution. That
red run is the acknowledgement's positive control — the guard was watched failing
for exactly this reason before it was satisfied.

⚠ **The first tier-1 attempt of all exited `3` — a PRECONDITION failure, not a red
suite** (`gate.sh` from a plain shell has no toolchain on PATH and prints the
`nix develop` form to re-run). In that same output `| tail` printed a reassuring
`GATE_RC=0` directly beneath the runner's own `GATE: RESULT=FAIL exit=1`; the
status belonged to `tail`.

## Comments are claims too

The five sentences this line falsified are corrected, not left:

- `nix/home.nix` — "🔴 IT SHIPS **false**, AND THAT IS THE POINT OF THE WHOLE SHAPE"
- `nix/home.nix` — "🔴 SHIPPED DISABLED … The unit below EXISTS on both hosts and is wired into nothing"
- `nix/home.nix` — "🔴 SHIPPED DISABLED — see enableTmuxReplyAgent" (on `Install`)
- `scripts/tmux-reply-agent` — "both are deliberately off in the change that introduced them"
- `scripts/tmux-reply-agent` — the no-token exit describing itself as "the state this ships in … neither has been done"

The last now says what reaching it **means** on an armed host: the host's copy of
the credential has gone (`~/.claude/clawgate.env` rewritten, or a unit
environment that cannot read it), not that the feature is unbuilt.

## Not closed by this PR

- The rank-32 closing condition is `systemctl --user is-active tmux-reply-agent`
  reading `active` on **both** hosts — that needs `scripts/ship.sh` after merge,
  reading every per-host line rather than the final verdict.
- **Rank 33** — a real reply typed in the UI landing in a real pane, exercising
  the `=` session-target prefix specifically — is untouched, and is the closing
  condition for the whole effort. `devrc/tests` in the subsystem index records
  that the `=` fix and the `isdir` check each *survived their first mutation* and
  have never run against real tmux outside a test.
- **Rank 34** — the two residuals the audit recorded as ACCEPTED (the browser
  tier authenticates nobody; the host agent posts an execution-grade token over
  plain HTTP to the LAN NodePort every ~5 s) are unchanged and now live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bDkLZ3BgR1c5wKKqc1G5G
