### PR TITLE
test(git-isolation): the co-tenant precondition flakes UNATTRIBUTABLY — name the intruder, and retract the obvious theory

### DIFF
--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -88,6 +88,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -1486,6 +1487,72 @@ def test_the_module_root_pin_does_not_depend_on_this_tree_being_a_checkout():
 # --------------------------------------------------------------------------- #
 # 4d. 🔴 THE CO-TENANT PROBE (finding A)
 # --------------------------------------------------------------------------- #
+def _describe_cotenants(cotenants: "list[str]") -> str:
+    """`pid:comm` is not enough to attribute an intruder — add cwd and cmdline.
+
+    `live_cotenants` returns a bounded `pid:comm` list by design (it is a
+    detector, not a debugger). When the PRECONDITION above fails we need the two
+    fields that actually identify the process, and we need them at failure time:
+    /proc entries for a transient process are gone before anyone reads the log.
+    Best-effort by construction — a process that exits between the scan and this
+    call yields `<gone>`, which is itself the useful answer.
+    """
+    out = []
+    for entry in cotenants:
+        pid = entry.split(":", 1)[0]
+        try:
+            cwd = os.readlink(f"/proc/{pid}/cwd")
+        except OSError:
+            cwd = "<gone>"
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                cmdline = fh.read().replace(b"\0", b" ").decode(errors="replace").strip()
+        except OSError:
+            cmdline = "<gone>"
+        out.append(f"{entry} cwd={cwd!r} cmdline={cmdline!r}")
+    return "; ".join(out) or "<none>"
+
+
+def test_describe_cotenants_names_cwd_and_cmdline(tmp_path):
+    """🔴 A DIAGNOSTIC NOBODY TESTED IS WORTH NOTHING AT THE MOMENT IT FIRES.
+    This helper only ever runs on a failing precondition, so without a test its
+    first execution would be inside an already-confusing failure."""
+    _require_proc()
+    repo = _mkrepo(tmp_path / "repo")
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
+                            cwd=str(repo), stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+    try:
+        deadline = time.time() + 5
+        seen: "list[str]" = []
+        while time.time() < deadline and not seen:
+            seen = live_cotenants([resolve_git_dir(repo)])
+            if not seen:
+                time.sleep(0.05)
+        assert seen, "probe never saw the spawned process — nothing to describe"
+
+        described = _describe_cotenants(seen)
+
+        assert str(repo) in described, (
+            f"the description omits the intruder's cwd, which is the field that "
+            f"distinguishes an xdist sibling from a stray host process: {described}")
+        assert "cmdline=" in described and "time.sleep" in described, (
+            f"the description omits the cmdline: {described}")
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+def test_describe_cotenants_degrades_rather_than_raising(tmp_path):
+    """It runs INSIDE an assertion message, so raising there would replace the
+    real failure with its own — the one place a helper must not throw."""
+    # a pid that cannot exist: /proc/sys/kernel/pid_max is well below this
+    assert _describe_cotenants(["999999999:ghost"]) == (
+        "999999999:ghost cwd='<gone>' cmdline='<gone>'")
+    # and an empty set must not render as something that reads like a finding
+    assert _describe_cotenants([]) == "<none>"
+
+
 def test_live_cotenants_sees_another_process_in_the_repo(tmp_path):
     """The POSITIVE control. Without it, an empty co-tenant list is
     indistinguishable from a probe wired to nothing — and an empty list is what
@@ -1493,7 +1560,29 @@ def test_live_cotenants_sees_another_process_in_the_repo(tmp_path):
     _require_proc()
     repo = _mkrepo(tmp_path / "repo")
     git_dir = resolve_git_dir(repo)
-    assert live_cotenants([git_dir]) == [], "a brand-new tmp repo already has tenants?"
+    # 🔴 THIS PRECONDITION HAS FAILED IN THE SANDBOX TIER AND THE FAILURE WAS
+    # UNATTRIBUTABLE. MEASURED 2026-09-06: `['126220:git']` on a brand-new tmp
+    # repo, dev-host tier green on the same tree, and a re-run of the identical
+    # derivation clean. The obvious mechanism is REFUTED, not merely
+    # unreproduced: `git commit` can fork a detached `gc --auto`, but `gc.auto`
+    # defaults to 6700 loose objects and `_mkrepo` leaves THREE, so it cannot
+    # fire — and 80 iterations at load 31, with a positive control proving the
+    # probe sees a spawned co-tenant, produced 0 hits.
+    #
+    # So the cause is still unknown, and a message that only says "already has
+    # tenants?" cannot advance it. Name the intruder instead: its cwd and
+    # cmdline are what distinguish an xdist sibling from a stray host process
+    # from one of our own children, and they are gone by the time anyone reads
+    # the log. This costs nothing on the passing path.
+    pre_existing = live_cotenants([git_dir])
+    assert pre_existing == [], (
+        "a brand-new tmp repo already has tenants: "
+        f"{_describe_cotenants(pre_existing)}\n"
+        f"repo={repo} git_dir={git_dir}\n"
+        "This is the flake recorded in devrc/tests.md (2026-09-06). The "
+        "`gc --auto` theory is refuted; capture the cwd/cmdline above and the "
+        "xdist worker id, then diagnose from those rather than re-running."
+    )
     proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
                             cwd=str(repo), stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL)


### PR DESCRIPTION
test(git-isolation): the co-tenant precondition flakes UNATTRIBUTABLY — name the intruder, and retract the obvious theory

🔴 THE `gc --auto` THEORY IS REFUTED, NOT MERELY UNREPRODUCED — and it is
written down here so the next session does not spend a round re-deriving it.

MEASURED 2026-09-06: the sandbox `pytests` derivation went red with
`live_cotenants(...) == []` returning `['126220:git']` on a BRAND-NEW tmp repo,
while the dev-host tier was green on the same tree and a re-run of the
BYTE-IDENTICAL derivation passed. The obvious mechanism is that `_mkrepo`'s
commit forks a detached `gc --auto` whose cwd is the new repo. It cannot:

  * `gc.auto` defaults to **6700** loose objects; `_mkrepo` leaves **3**
    (`count-objects -v`: `count: 3`). The threshold is unreachable by
    construction.
  * 80 iterations at load 31, both as-shipped and with `gc.auto=0` forced:
    **0 hits in both arms**.
  * That zero is trustworthy because the probe was positively controlled first
    — spawning a process in the repo made `live_cotenants` return
    `['<pid>:python3.12']`, so it CAN see a co-tenant. Without that control the
    0/80 would be indistinguishable from a harness wired to nothing.

So the cause is UNKNOWN and this change does not claim to fix it. What it fixes
is that the failure could not be diagnosed after the fact: `pid:comm` alone does
not distinguish an xdist sibling from a stray host process from one of our own
children, and `/proc` for a transient process is gone before anyone reads the
log. The precondition now reports the intruder's **cwd and cmdline** at failure
time, plus the repo and git-dir it was scanning.

🔴 A DIAGNOSTIC NOBODY TESTED IS WORTH NOTHING AT THE MOMENT IT FIRES — this
helper only ever runs on an already-failing assertion, so its first execution
would otherwise be inside an already-confusing failure. Two tests:

  * it names cwd and cmdline of a real spawned co-tenant;
  * it DEGRADES rather than raising on a dead pid (`<gone>`) and renders an
    empty set as `<none>` rather than something that reads like a finding —
    it runs inside an assertion message, which is the one place a helper must
    not throw.

MUTATION MATRIX (re-run, one site each, PYTHONDONTWRITEBYTECODE=1):
  drop cwd+cmdline, return bare `pid:comm`  -> KILLED (2)
  let a dead pid raise instead of degrading -> KILLED (1)

`test_git_repo_isolation.py`: 116 passed (114 before), 0 failed.

⚠ NOT FIXED, and deliberately: the flake itself. Re-running is not a fix — a
flaky gate trains everyone to click through it — but neither is shipping a
remedy for a mechanism that has been refuted. The next occurrence will now say
who the intruder was.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
