### PR TITLE
feat(i3): game mode — an empty binding mode that releases every Alt grab, plus a bar toggle

### DIFF
--- a/claude/skills/bar/SKILL.md
+++ b/claude/skills/bar/SKILL.md
@@ -112,13 +112,42 @@ X — your call"). Leave the setup a little more modern than you found it; never
 | media | `i3status-media` | 16 | n/a | qBit-POD AirVPN pill (net_down), **state-driven**: neutral=connected, **RED**=firewalled (tunnel/port-fwd broken), soft-yellow=stale. poller `parse_media`/`fetch_media` read creds from `~/.config/bar/media.env` (0600) — the same `media.env` also feeds `deep-search`, a media release search/grab CLI on PATH (workbench) after `home-manager switch`. **left → `media-menu`**; **right → qBit WebUI** |
 | telemetry deadman | `i3status-telemetry` | 17 | n/a | `tlm N` = N activity-telemetry (host, source) pairs have STOPPED emitting into ClickHouse. 🔴 **`tlm ?` now means ALL FOUR ways of not knowing**, not just one: the deadman evaluated and could not tell (grace-gated >30 min in `parse_telemetry`), OR the poller wrote a `stale`/`error` marker, OR the cache is missing/corrupt, OR the poller stopped refreshing it. They render alike on purpose — the operator's action is the same. `tlm N?` = N were dead as of the last readable poll and this is not current (Critical; a measurement outage never downgrades a known alarm). ⚠ On the MARKER path `stale()` zeroes the count, so that shape is a bare `tlm ?`. Measures BOTH hosts from the workbench poller (it reads the shared table). Logic + the per-source budget table: `scripts/collector/deadman.py` (run it bare for the table; left-click floats it). See the `activity` skill. |
 | airvpn (host) | `i3status-airvpn` | 10 | n/a | **HOST** AirVPN WireGuard pill (net_vpn), **state-driven**, default-OFF. **left → `airvpn-menu`**; **right → `airvpn-detail` float**. 🔴 Full detail + the killswitch re-test protocol: **`~/.claude/skills/bar/reference/airvpn.md`** |
+| game mode (BOTH hosts) | `i3status-gamemode` | 18 | n/a | 󰊗 toggle for i3's empty `mode "game"`. `󰊗 GAME` Critical in the mode, bare `󰊗` Idle otherwise, empty pill if i3-msg cannot answer. **left-click → the SAME script with `--toggle`**. See "Game mode" below |
 
 Bars differ by host (`isLaptop` in `graphical.nix`): laptop gets `batteryBlock` and **omits** GPU
 + all count blocks + poller (nebula-only, no LAN path to homelab endpoints); workbench gets GPU
 (RTX 5080), the count blocks, the state-driven `mediaBlock` (qBit/AirVPN), `claudeRunsBlock` (▦ —
 live Claude-in-tmux count, **indicator only**: its click launched the retired `agent-ops` TUI and
-went with it), `rigcontrolBlock` (⚙). `loadBlock` is one of the few CUSTOM blocks on **both** hosts
-(`/proc/loadavg` needs no poller).
+went with it), `rigcontrolBlock` (⚙). `loadBlock` and `gamemodeBlock` are the CUSTOM blocks on
+**both** hosts (`/proc/loadavg` and one `i3-msg` need no poller).
+
+## Game mode (the 󰊗 pill + `mode "game"`)
+🔴 **`set $mod Mod1` — `$mod` is ALT, not Super.** i3 therefore holds a global X11 grab on ~60
+Alt combos (Alt+Tab, Alt+1..0, Alt+Shift+1..0, Alt+Return, Alt+d/f/e/a/b/n/r/h/j/k/l/space/
+grave/minus/equal). **A grab means the focused window never receives the keypress at all** — a
+game is not merely interrupted by rofi, it is *deaf* to those keys.
+- **An EMPTY binding mode is the only native fix.** Entering a mode ungrabs every default-mode
+  binding and grabs only that mode's. A guard script on the `exec` does NOT work (i3 has already
+  eaten the key), and `bindsym` takes no `[class=…]` criteria, so a conditional grab is
+  impossible. **The emptiness of `mode "game"` is the mechanism — anything you add there is a
+  key the game goes back to not receiving** (pinned: no `$mod` binding may appear inside it).
+- **In:** left-click the 󰊗 pill. There is deliberately **no default-mode keybind to enter** —
+  that would be one more Alt grab, and getting in is the easy direction (the bar is visible).
+- **Out:** `Pause` **or** `Scroll_Lock` (bound *inside* the mode), or the pill again. Two escape
+  keys because not every keyboard has a Pause key and being stuck with no escape is the worst
+  failure this feature has. `test_i3_game_mode.py` fails if a future default-mode binding
+  silently claims either key.
+- 🔴 **RESCUE — stuck in game mode with the bar behind a fullscreen game:** from the laptop
+  (or any nebula peer), `ssh zach@10.42.0.30` then **`DISPLAY=:0 i3-msg mode default`**.
+  Nothing about that path depends on the pill or the script.
+- **i3bar renders the binding-mode indicator natively**, so the word `game` appears on the bar
+  for free whenever the bar is visible — the pill is the *toggle*, not the only indicator.
+- 🔴 **i3 OWNS THE MODE — there is no state file.** The block reads
+  `i3-msg -t get_binding_state`. Two writers exist (the click and the Pause key), so a shadow
+  file would desync the instant the operator escaped by keyboard.
+- Phase 2 — **auto-detect a game by focus (i3 IPC `window::focus` + a WM_CLASS list)** — is
+  deliberately NOT built: nobody has captured real Steam/Proton or Lutris WM_CLASS samples yet,
+  and a guessed list is a mode that engages on the wrong window.
 
 🔴 **Two ways a new block ships dead, both now gated.** (a) A block and its `home.file` must be
 gated the SAME way in BOTH places — an ungated block whose script is `mkIf (!isLaptop)` renders a

--- a/claude/skills/i3/SKILL.md
+++ b/claude/skills/i3/SKILL.md
@@ -62,6 +62,16 @@ i3-msg -t get_tree | jq '.. | select(.focused? == true) | select(.window? | type
 i3-msg -t get_tree | jq '[recurse(.nodes[]?, .floating_nodes[]?) | select(.type == "workspace") | select(.name | startswith("__") | not) | {workspace: .name, windows: [recurse(.nodes[]?, .floating_nodes[]?) | select(.window | type == "number") | {class: .window_properties.class, title: (.name | if length > 60 then .[:57] + "..." else . end), focused: .focused}]}]'
 ```
 
+### Binding modes — and the `game` rescue
+`i3-msg -t get_binding_state` → `{"name":"default"}`. Two non-default modes exist:
+`resize` ($mod+r) and **`game`** — an intentionally EMPTY mode that makes i3 release its
+~60 **Alt** grabs so a fullscreen game actually receives those keys (`$mod` is `Mod1`).
+Entered by clicking the 󰊗 bar pill; left with `Pause` / `Scroll_Lock` / the pill.
+🔴 **Rescue when the bar is hidden behind a fullscreen game:** from another nebula peer,
+`ssh zach@10.42.0.30` then `DISPLAY=:0 i3-msg mode default`. Do NOT bind anything new to
+`Pause` or `Scroll_Lock` — a default-mode binding on either strands the operator (gated by
+`scripts/tests/test_i3_game_mode.py`). Design + the bar pill: the `bar` skill.
+
 ## 2. Act
 For `focus`, `move`, `workspace`, `layout`, `exec`, `mark`, `resize`, `scratch`:
 validate the target exists (query the tree first for focus/move), prefer criteria

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -369,6 +369,49 @@ let
     json = true;
     interval = 15;
   };
+  # gamemode (BOTH hosts): the toggle for i3's empty `mode "game"` binding mode.
+  #   in game mode -> ` 󰊗 GAME `  Critical
+  #   otherwise    -> ` 󰊗 `       Idle, ALWAYS VISIBLE
+  #
+  # 🔴 WHY THIS PILL EXISTS AT ALL. `$mod` is Mod1 — ALT — so i3 holds a global
+  # X11 grab on ~60 Alt combos and a fullscreen game never receives any of them.
+  # An EMPTY binding mode is the only native way to make i3 release those grabs
+  # (a guard on the `exec` does not: i3 has already eaten the key), and i3 has no
+  # per-window `bindsym` criteria, so the mode has to be switched deliberately.
+  # The way IN is this pill; the way OUT is `Pause`/`Scroll_Lock` (bound INSIDE
+  # the mode) or this pill again. There is deliberately no default-mode keybind
+  # to enter — that would be one more Alt grab for no gain.
+  #
+  # NOT hide-at-zero, unlike every count pill: this block is the only entrance,
+  # so an invisible idle state would be a toggle with no off-state affordance —
+  # the same reason `notifsBlock` renders a bare bell at zero.
+  #
+  # signal 18: the next free real-time signal. 10-14, 16 and 17 belong to
+  # `SIGNALS` in bar-status-poll (airvpn/clawgate/mail/alerts/civitai/media/
+  # telemetry) and 15 to notifs, so 18 is the first unused. It is repainted by
+  # the script's own `pkill -RTMIN+18` on both paths — the click below, and the
+  # `mode "game"` escape bindings in nix/i3/config.nix. `interval` is a BACKSTOP
+  # only, for a mode change made by some other route (`i3-msg mode game` by hand,
+  # the SSH rescue path); the signal is what makes it feel instant.
+  #
+  # i3status-rust does NOT pass `$BLOCK_BUTTON` to custom block commands (see
+  # rigcontrolBlock above), so the toggle is a `[[block.click]]` handler. It
+  # re-invokes the SAME script with `--toggle` rather than open-coding the
+  # i3-msg dance in nix: one deployed file, and the flip logic lands somewhere a
+  # unit test can reach it.
+  #
+  # BOTH hosts — purely local (one i3-msg to the running WM), no poller, no
+  # cache, no network. The laptop's `$mod` is the same Alt.
+  gamemodeBlock = {
+    block = "custom";
+    command = "${scriptsDir}/i3status-gamemode";
+    json = true;
+    interval = 30;
+    signal = 18;
+    click = [
+      { button = "left"; cmd = "${scriptsDir}/i3status-gamemode --toggle"; }
+    ];
+  };
 
   blocks =
     [ memoryBlock diskBlock netBlock cpuBlock loadBlock temperatureBlock ]
@@ -378,7 +421,7 @@ let
     ++ lib.optionals (!isLaptop) [ telemetryBlock alertsBlock civitaiBlock mailBlock clawgateBlock mediaBlock airvpnBlock ]
     ++ [ timeBlock ]
     ++ lib.optionals (!isLaptop) [ claudeRunsBlock rigcontrolBlock ]
-    ++ [ notifsBlock ];
+    ++ [ gamemodeBlock notifsBlock ];
 in
 lib.mkIf isNixOS {
   programs.i3status-rust = {
@@ -473,6 +516,15 @@ lib.mkIf isNixOS {
   };
   home.file.".config/i3status-rust/scripts/i3status-claude-runs" = {
     source = ../scripts/i3status-claude-runs;
+    executable = true;
+  };
+  # gamemode: see `gamemodeBlock` above. UNCONDITIONAL, matching the block's
+  # presence in the unconditional half of `blocks`. It is ALSO the block's own
+  # left-click target (`… --toggle`), so a narrower gate here would ship a pill
+  # that renders on a host where clicking it does nothing — and unlike a broken
+  # `command`, a broken click is invisible until someone tries it mid-game.
+  home.file.".config/i3status-rust/scripts/i3status-gamemode" = {
+    source = ../scripts/i3status-gamemode;
     executable = true;
   };
   # load: see `loadBlock` above. UNCONDITIONAL, matching the block's presence in

--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -209,6 +209,45 @@ mode "resize" {
 
 bindsym $mod+r mode "resize"
 
+# 🔴 GAME MODE — an EMPTY binding mode, and "empty" is the entire mechanism.
+#
+# `$mod` is Mod1 (line 66) — ALT, not Super. i3 therefore holds a global X11
+# grab on ~60 Alt combos: Alt+Tab, Alt+1..Alt+0, Alt+Shift+1..0, Alt+Return,
+# Alt+d/f/e/a/b/n/r/h/j/k/l/space/grave/minus/equal. A grab means the keypress
+# is delivered to i3 and NEVER reaches the focused window, so inside a game
+# every one of those keys is simply dead — this is not merely "rofi pops over
+# the game", the game does not see the key at all.
+#
+# Two fixes were considered and rejected:
+#   * a guard script on the exec (`bindsym $mod+d exec launcher-guard`) — i3
+#     still holds the grab and still swallows the key, so the game stays deaf.
+#     It only changes what i3 does AFTER eating the keypress.
+#   * a conditional grab (bind only when the focused window is not a game) —
+#     `bindsym` takes no `[class=…]` criteria; i3 has no such mechanism.
+# Switching binding mode is the ONLY native way to make i3 release the grabs:
+# entering a mode ungrabs every default-mode binding and grabs only this mode's.
+# So the emptiness below is load-bearing — anything added here is a key the
+# game goes back to not receiving.
+#
+# TWO escape keys on purpose, not redundancy: not every keyboard has a
+# dedicated Pause key, and the worst failure this feature can have is being
+# stuck in game mode with no way out. Both are UNBOUND in the default mode, and
+# `test_i3_game_mode.py` fails if a future binding silently takes either one.
+# Neither is a $mod combo — a mode that exists to release Alt must not need Alt
+# to leave. Rescue path if the bar is hidden behind a fullscreen game:
+# `DISPLAY=:0 i3-msg mode default` over SSH (see the `bar` skill).
+#
+# The `pkill -RTMIN+18` repaints the bar's game pill instantly. 18 must match
+# `gamemodeBlock.signal` in nix/graphical.nix and the pill's own click handler;
+# all three are pinned together by test_i3_game_mode.py. There is deliberately
+# NO `bindsym … mode "game"` in the default mode: the way IN is the bar pill
+# (getting in is the easy direction — the bar is visible and clickable then),
+# and a default-mode binding would be one more grab for no gain.
+mode "game" {
+        bindsym Pause       mode "default", exec --no-startup-id pkill -RTMIN+18 i3status-rs
+        bindsym Scroll_Lock mode "default", exec --no-startup-id pkill -RTMIN+18 i3status-rs
+}
+
 # Status bar (Gruvbox dark) — statusline is now i3status-rust (i3status-rs); the
 # i3bar workspace/background colors below stay as-is (i3status-rust replaces only
 # the statusline content, not the i3bar chrome).

--- a/scripts/i3status-gamemode
+++ b/scripts/i3status-gamemode
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""i3status-rust custom block: the GAME MODE pill (render + its click toggle).
+
+Game mode is an EMPTY i3 binding mode (`mode "game"` in nix/i3/config.nix).
+`$mod` is Mod1 — ALT — so the default mode holds a global X11 grab on ~60 Alt
+combos and a game NEVER RECEIVES those keypresses at all. Entering an empty
+binding mode is the only native i3 mechanism that releases those grabs; see the
+long comment above `mode "game"` for the two alternatives that were rejected.
+
+  game mode active ->  ` 󰊗 GAME `  Critical (RED — unmissable, and the pill is
+                                    the way back out)
+  any other mode   ->  ` 󰊗 `       Idle (neutral, ALWAYS VISIBLE)
+  cannot measure   ->  empty block, exit 0
+
+🔴 WHY THE IDLE CASE IS NOT HIDE-AT-ZERO. Every count pill on this bar hides at
+a measured zero, and the CALM-bar rule says steady state is invisible. This
+block is the deliberate exception, for the same reason `i3status-notifs` renders
+a bare bell at zero: THE PILL IS THE ONLY WAY IN. There is deliberately no
+`bindsym … mode "game"` in the default mode (that would be one more Alt grab,
+and the operator asked for the toggle to live on the bar), so a pill that hid
+itself in the default mode would be a toggle with no off-state affordance.
+Neutral-and-visible, not invisible.
+
+🔴 SINGLE SOURCE OF TRUTH: i3 OWNS THE MODE. This block reads
+`i3-msg -t get_binding_state` and keeps NO state file. Two writers exist — the
+bar click here and the `Pause`/`Scroll_Lock` bindings inside the mode itself —
+so a shadow state file would desync the moment the operator escaped by keyboard,
+and the pill would then lie about a mode it cannot see. i3's answer is the only
+authority; there is nothing else to reconcile.
+
+FAIL-SAFE (same contract as `i3status-notifs`): any i3-msg error, timeout or
+malformed answer -> empty JSON, exit 0. A broken query must NEVER crash or wedge
+the bar. Losing the pill is survivable in a way losing the ESCAPE KEY would not
+be: `Pause` is grabbed by i3 itself and keeps working whether or not this script
+can talk to it, and `DISPLAY=:0 i3-msg mode default` over SSH is the last resort.
+An i3-msg that cannot answer also means `i3-msg mode …` could not act anyway, so
+there is no state in which a rendered pill would still be clickable.
+
+Unit-tested (pure halves only, no live i3) in scripts/tests/test_i3_game_mode.py.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+# nf-md-gamepad_variant (U+F0297) — verified present in JetBrainsMono Nerd Font,
+# the bar's font, by cmap lookup rather than by eyeballing a terminal.
+GLYPH = "\U000f0297"  # 󰊗
+
+#: The i3 binding mode this pill is about. Spelled ONCE here; the test derives
+#: the mode name from nix/i3/config.nix and pins it against this constant, so a
+#: rename in the i3 config cannot leave the pill watching a mode nobody enters.
+GAME_MODE = "game"
+
+#: Real-time signal that repaints this block: `pkill -RTMIN+18 i3status-rs`.
+#: MUST equal `gamemodeBlock.signal` in nix/graphical.nix and the number in the
+#: `mode "game"` escape bindings in nix/i3/config.nix — all three are pinned
+#: together by test_i3_game_mode.py, because a mismatch is silent (the mode
+#: still flips; the pill just keeps showing the old state until its interval).
+SIGNAL = 18
+
+_EMPTY = {"text": "", "state": "Idle"}
+
+
+# --------------------------------------------------------------------------- #
+# Pure / mockable logic (unit-tested against fixtures — NO i3-msg)
+# --------------------------------------------------------------------------- #
+def parse_binding_state(raw) -> str | None:
+    """`i3-msg -t get_binding_state` stdout -> the mode name, or None.
+
+    i3 4.24 answers `{"name":"default"}`. Anything else — empty output, invalid
+    JSON, a list, a missing/blank/non-string `name` — is NOT MEASURED and
+    returns None rather than being coerced into a mode name. Never raises.
+    """
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    name = obj.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return name.strip()
+
+
+def render(mode) -> dict:
+    """Pure: binding-mode name (or None) -> i3status-rust block dict.
+
+    Critical is spent ONLY on the active game mode. That is not decoration: it
+    is the state in which every Alt binding on this machine is deliberately
+    dead, so an operator who wandered away and came back needs to be able to
+    tell at a glance why nothing works.
+    """
+    if mode is None:
+        return dict(_EMPTY)
+    if mode == GAME_MODE:
+        return {"text": " %s GAME " % GLYPH,
+                "short_text": " %s " % GLYPH, "state": "Critical"}
+    return {"text": " %s " % GLYPH,
+            "short_text": " %s " % GLYPH, "state": "Idle"}
+
+
+def next_mode(mode):
+    """Pure: current binding mode -> the mode a click should switch to.
+
+    `game` -> `default`, ANY other measured mode -> `game`. None -> None, i.e.
+    a click does NOTHING when the current mode could not be read. That is the
+    honest branch: the read and the write go through the same `i3-msg`, so if
+    the read failed the write had no chance either, and guessing would let one
+    click enter game mode on a host that is already in it (a no-op) or leave it
+    on a host that is not (grabs restored mid-game, with the bar possibly hidden
+    behind a fullscreen window).
+    """
+    if mode is None:
+        return None
+    return "default" if mode == GAME_MODE else GAME_MODE
+
+
+# --------------------------------------------------------------------------- #
+# Side-effecting (i3-msg / pkill — not unit-tested directly)
+# --------------------------------------------------------------------------- #
+def _i3msg(*args, timeout=2):
+    return subprocess.run(["i3-msg", *args], capture_output=True,
+                          text=True, timeout=timeout)
+
+
+def current_mode():
+    """The live binding mode via i3-msg, or None on ANY failure."""
+    try:
+        return parse_binding_state(_i3msg("-t", "get_binding_state").stdout)
+    except Exception:
+        return None
+
+
+def refresh_bar():
+    """Repaint this block now instead of waiting for its interval."""
+    try:
+        subprocess.run(["pkill", "-RTMIN+%d" % SIGNAL, "i3status-rs"],
+                       capture_output=True, timeout=2)
+    except Exception:
+        pass
+
+
+def toggle() -> int:
+    """The bar pill's left-click: flip the binding mode, then repaint.
+
+    Returns 0 always — a click handler that errors gives the operator nothing
+    useful and i3status-rust has nowhere to show it.
+    """
+    target = next_mode(current_mode())
+    if target is None:
+        return 0
+    try:
+        _i3msg("mode", target)
+    except Exception:
+        return 0
+    refresh_bar()
+    return 0
+
+
+def main(argv) -> int:
+    if "--toggle" in argv:
+        return toggle()
+    sys.stdout.write(json.dumps(render(current_mode())) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except Exception:   # a bar block must never crash loudly
+        sys.stdout.write(json.dumps(_EMPTY) + "\n")
+        sys.exit(0)

--- a/scripts/tests/test_bar_status.py
+++ b/scripts/tests/test_bar_status.py
@@ -3367,12 +3367,12 @@ _HOME_FILE = re.compile(
 #: scriptsDir-backed custom blocks, MEASURED. The floor exists so a regex that
 #: silently stops matching fails loudly instead of vacuously passing. Raise it
 #: when you add a block; the failure message prints the number it saw.
-_EXPECTED_SCRIPT_BLOCKS = 11
+_EXPECTED_SCRIPT_BLOCKS = 12
 #: ALL block definitions, MEASURED — including the ones with no scriptsDir
 #: command. Pins the `^  }` terminator: with `^  };`, `temperatureBlock`'s
 #: `} // (if isLaptop …)` idiom swallowed `gpuBlock` whole and only 19 were
 #: found. Nothing else notices, because the swallowed block has no command.
-_EXPECTED_BLOCK_DEFS = 20
+_EXPECTED_BLOCK_DEFS = 21
 #: Ungated/gated split, MEASURED. Guards `_block_gates` itself: if gate parsing
 #: collapses to all-True or all-False (a stray `isLaptop` in a comment, the list
 #: reflowed onto one line), `checked` stays correct while the gate assertion

--- a/scripts/tests/test_i3_game_mode.py
+++ b/scripts/tests/test_i3_game_mode.py
@@ -1,0 +1,631 @@
+"""🔴 GAME MODE IS AN *EMPTY* i3 BINDING MODE — the emptiness IS the mechanism.
+
+`set $mod Mod1` makes `$mod` ALT, so i3's default mode holds a global X11 grab
+on ~60 Alt combos (Alt+Tab, Alt+1..0, Alt+Shift+1..0, Alt+Return, Alt+d/f/e/a/
+b/n/r/h/j/k/l/space/grave/minus/equal). A grab means the keypress is delivered
+to i3 and the focused window NEVER SEES IT — a game is not merely interrupted by
+rofi, it is deaf to those keys. i3 offers no per-window `bindsym` criteria and no
+conditional grab, so switching to a binding mode that binds (almost) nothing is
+the only native way to make it let go.
+
+WHAT THAT MAKES TESTABLE, and why each guard is shaped the way it is:
+
+1. THE MODE MUST EXIST ON BOTH HOSTS. `nix/i3/config.nix` is a function of
+   `{ isLaptop }`, and three of its fragments are host-conditional. A mode
+   parked inside one of those would silently not exist on the other machine.
+   So this file RENDERS the config for both values of `isLaptop` (a tiny nix
+   string evaluator, positive-controlled below) and asserts against the render,
+   not against the source text.
+
+2. THE ESCAPE KEYS MUST STILL BE ESCAPES. Being stuck in game mode with no way
+   out is the worst failure this feature has: every Alt binding is dead by
+   design, so a keyboard with no working escape leaves `i3-msg` over SSH as the
+   only exit. The hazard is NOT "somebody deleted the escape" — it is that some
+   FUTURE default-mode binding quietly claims the same key, which is legal, is
+   silent, and makes the escape unreachable the moment you need it. So the guard
+   pins a RELATIONSHIP: **every key bound inside the mode must be bound nowhere
+   in the default mode**, with both sets DERIVED by parsing. Spelling `Pause` and
+   `Scroll_Lock` here would be a guard on words — a rename of the escape keys
+   would walk straight past it while the collision it exists to catch persists.
+
+3. NOTHING IN THE MODE MAY USE `$mod`. Anything bound there is a key the game
+   goes back to not receiving, and `$mod` is the entire set this feature is
+   about. A `$mod` escape would also be self-defeating: a mode whose purpose is
+   to release Alt must not need Alt to leave.
+
+4. THE PILL AND EVERY FILE IT NEEDS MUST DEPLOY ON THE SAME HOSTS, from the
+   right source. Modelled on the ▦ claude-runs pill's guard
+   (`test_the_bar_block_and_EVERY_file_it_needs_deploy_on_the_SAME_hosts`),
+   which was written after three real breakages survived a SPELLED check — so
+   this one reads assignments rather than vocabulary, and covers the block's
+   CLICK target as well as its `command` (this pill is its own click handler,
+   and a dead click is invisible until someone tries it mid-game).
+
+5. ONE SIGNAL NUMBER, THREE PLACES. The i3 escape bindings, the nix block and
+   the script each name the RTMIN offset that repaints the pill. A mismatch is
+   completely silent: the mode still flips, the bar just keeps showing the old
+   state until its backstop interval. Pinned as equality, plus uniqueness
+   against every other block's signal and the poller's `SIGNALS`.
+
+NOT TESTED HERE, deliberately: that i3 actually releases the grabs. That is a
+property of i3 4.24, not of this repo, and no hermetic test can observe it — the
+mechanism is documented in the config comment instead.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+I3_CONFIG = REPO / "nix" / "i3" / "config.nix"
+GRAPHICAL_NIX = REPO / "nix" / "graphical.nix"
+BLOCK_SCRIPT_REL = "scripts/i3status-gamemode"
+
+_HOSTS = ("workbench", "laptop")
+
+
+def _load(relpath, modname):
+    loader = importlib.machinery.SourceFileLoader(
+        modname, str(REPO / relpath))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+blk = _load(BLOCK_SCRIPT_REL, "i3status_gamemode")
+
+
+# --------------------------------------------------------------------------- #
+# A TINY NIX STRING EVALUATOR for nix/i3/config.nix.
+#
+# The file is `{ isLaptop ? false }: let <fragments> in ''<body>''`, where every
+# fragment is `if isLaptop then <string> else <string>`. Rendering it properly
+# would mean asking `nix`, which is ground truth and CANNOT RUN in the nix-build
+# check tier that gates merges (no nested nix, and that is the authoritative
+# tier). So: parse the three shapes this file actually uses, and REFUSE loudly
+# on anything else — `_render` raises rather than returning a body with an
+# unresolved `${…}` in it, because a silently unsubstituted interpolation would
+# make every assertion below pass over text no host ever gets.
+# --------------------------------------------------------------------------- #
+_INTERP = re.compile(r"\$\{(\w+)\}")
+
+
+def _nix_string_at(text, pos):
+    """Parse the nix string literal starting at/after `pos`.
+
+    Handles `''…''` and `"…"`. Returns (value, index just past the literal).
+    """
+    i = pos
+    while i < len(text) and text[i] in " \t\n":
+        i += 1
+    if text.startswith("''", i):
+        end = text.index("''", i + 2)
+        return text[i + 2:end], end + 2
+    if text[i] == '"':
+        end = text.index('"', i + 1)
+        return text[i + 1:end], end + 1
+    raise AssertionError(
+        "nix/i3/config.nix fragment at offset %d is not a string literal this "
+        "evaluator understands (%r…) — extend it rather than letting the "
+        "config render with an unresolved interpolation" % (i, text[i:i + 40]))
+
+
+def _fragments(header):
+    """{name: (laptop_value, workbench_value)} for each `if isLaptop` binding."""
+    out = {}
+    for m in re.finditer(r"^  (\w+) =", header, re.M):
+        name = m.group(1)
+        region_end = len(header)
+        nxt = re.search(r"^  \w+ =", header[m.end():], re.M)
+        if nxt:
+            region_end = m.end() + nxt.start()
+        region = header[m.start():region_end]
+        cond = region.find("if isLaptop then")
+        if cond < 0:
+            continue                      # not host-conditional; nothing to do
+        then_val, after = _nix_string_at(region, cond + len("if isLaptop then"))
+        els = region.index("else", after)
+        else_val, _ = _nix_string_at(region, els + len("else"))
+        out[name] = (then_val, else_val)
+    return out
+
+
+def _render(is_laptop: bool) -> str:
+    """The i3 config as it is written to ~/.config/i3/config on that host."""
+    text = I3_CONFIG.read_text()
+    marker = "\nin\n''\n"
+    head, body = text.split(marker, 1)
+    body = body[:body.rindex("''")]
+    frags = _fragments(head)
+
+    def sub(m):
+        name = m.group(1)
+        assert name in frags, (
+            "`${%s}` in the i3 config body is not an `if isLaptop` fragment "
+            "this evaluator can resolve — extend `_fragments`, or this test "
+            "renders text no host ever receives" % name)
+        return frags[name][0 if is_laptop else 1]
+
+    rendered = _INTERP.sub(sub, body)
+    assert "${" not in rendered, (
+        "unresolved interpolation left in the rendered config: "
+        + rendered[rendered.index("${"):rendered.index("${") + 60])
+    return rendered
+
+
+def test_the_renderer_really_renders_two_different_configs():
+    """🔴 POSITIVE CONTROL for the evaluator every guard below reads through.
+
+    A renderer that returned the raw body, or the same string twice, would make
+    "present on both hosts" true by construction. So: the two renders must
+    DIFFER, and each must carry the fragment that belongs only to it.
+    """
+    laptop, workbench = _render(True), _render(False)
+    assert laptop != workbench
+    assert "brightnessctl" in laptop and "brightnessctl" not in workbench
+    assert "xrandr --output DP-0" in workbench
+    assert "xrandr --output DP-0" not in laptop
+    # …and the shared body is in both, so the split did not eat it.
+    for cfg in (laptop, workbench):
+        assert "set $mod Mod1" in cfg
+        assert "default_border pixel 2" in cfg
+
+
+# --------------------------------------------------------------------------- #
+# Parsing the RENDERED i3 config: bindings, per binding mode.
+# --------------------------------------------------------------------------- #
+_BINDSYM = re.compile(r"^\s*bindsym\s+((?:--\S+\s+)*)(\S+)\s+(.*)$")
+_MODE_OPEN = re.compile(r'^\s*mode\s+"([^"]+)"\s*\{')
+
+
+def _bindings_by_mode(cfg: str) -> dict:
+    """{mode_name: {keyspec: command}}; the default mode is keyed `""`.
+
+    Brace-depth tracked so the `bar { … colors { … } }` stanza and any nested
+    block cannot be mistaken for a binding mode. Comment lines are dropped; a
+    TRAILING comment is harmless because only the keyspec is compared.
+    """
+    out = {"": {}}
+    depth = 0
+    mode = ""
+    for raw in cfg.splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue
+        opened = _MODE_OPEN.match(raw)
+        if opened and depth == 0:
+            mode = opened.group(1)
+            out.setdefault(mode, {})
+        m = _BINDSYM.match(raw)
+        if m:
+            out.setdefault(mode, {})[m.group(2)] = m.group(3).strip()
+        depth += line.count("{") - line.count("}")
+        if depth <= 0:
+            depth = 0
+            mode = ""
+    return out
+
+
+def test_the_binding_parser_sees_the_modes_that_are_actually_there():
+    """🔴 POSITIVE CONTROL for `_bindings_by_mode`.
+
+    Every assertion below is of the form "the game mode's keys avoid X". A
+    parser that returned an empty game mode, or folded every binding into the
+    default mode, would satisfy all of them silently. So pin that it separates
+    modes, finds a healthy number of default-mode bindings, and does NOT invent
+    a mode out of the `bar { … }` stanza.
+    """
+    modes = _bindings_by_mode(_render(False))
+    assert "resize" in modes, sorted(modes)
+    assert "bar" not in modes and "colors" not in modes, sorted(modes)
+    # the default mode really is the big one — ~60 Alt grabs live there
+    assert len(modes[""]) > 40, len(modes[""])
+    # resize is parsed as its own, much smaller set, and its keys are bare
+    assert 0 < len(modes["resize"]) < len(modes[""])
+    assert "h" in modes["resize"] and "h" not in modes[""]
+
+
+def _game_mode(cfg: str) -> dict:
+    modes = _bindings_by_mode(cfg)
+    assert blk.GAME_MODE in modes, (
+        "nix/i3/config.nix defines no `mode %r` — the pill in "
+        "scripts/i3status-gamemode watches a binding mode nothing enters, and "
+        "renders its neutral state forever. Modes found: %s"
+        % (blk.GAME_MODE, sorted(k for k in modes if k)))
+    return modes[blk.GAME_MODE]
+
+
+@pytest.mark.parametrize("is_laptop", [False, True], ids=_HOSTS)
+def test_the_game_mode_exists_on_BOTH_hosts(is_laptop):
+    """Parking the mode inside a host-conditional fragment is silent: the other
+    machine simply has no such mode, `i3-msg mode game` fails, and the pill sits
+    neutral forever."""
+    assert _game_mode(_render(is_laptop))
+
+
+@pytest.mark.parametrize("is_laptop", [False, True], ids=_HOSTS)
+def test_the_game_mode_has_at_least_one_escape_back_to_default(is_laptop):
+    """Without one, entering game mode is a one-way trip for the keyboard."""
+    game = _game_mode(_render(is_laptop))
+    escapes = {k: v for k, v in game.items() if 'mode "default"' in v}
+    assert escapes, (
+        "no binding inside `mode %r` returns to `mode \"default\"` — every Alt "
+        "binding is released by design, so with no escape the only way out is "
+        "`DISPLAY=:0 i3-msg mode default` from another machine. Bindings "
+        "found: %s" % (blk.GAME_MODE, game))
+
+
+@pytest.mark.parametrize("is_laptop", [False, True], ids=_HOSTS)
+def test_no_escape_key_is_ALSO_bound_in_the_default_mode(is_laptop):
+    """🔴 THE ONE THAT MATTERS. A future default-mode binding claiming an escape
+    key is legal i3, silent, and strands the operator exactly when they cannot
+    reach the bar. Both sets are DERIVED, never spelled: renaming the escape
+    keys keeps the guard pointed at whatever they were renamed to.
+    """
+    cfg = _render(is_laptop)
+    modes = _bindings_by_mode(cfg)
+    game = _game_mode(cfg)
+    clash = {k: modes[""][k] for k in game if k in modes[""]}
+    assert not clash, (
+        "a key bound inside `mode %r` is ALSO bound in the DEFAULT mode:\n"
+        % blk.GAME_MODE
+        + "\n".join("  %s -> game: %r | default: %r"
+                    % (k, game[k], cmd) for k, cmd in sorted(clash.items()))
+        + "\nThat is legal i3 and produces no warning, but it means the key is "
+          "grabbed for something else on the way in, and the escape becomes "
+          "unreachable at the exact moment it is needed. Pick a free key, or "
+          "free this one in the default mode."
+    )
+
+
+@pytest.mark.parametrize("is_laptop", [False, True], ids=_HOSTS)
+def test_nothing_in_the_game_mode_uses_the_mod_key(is_laptop):
+    """The mode exists to make i3 let go of ~60 ALT grabs. A `$mod` binding here
+    re-grabs one of them — and an escape that needs Alt would be self-defeating
+    in a mode whose whole purpose is that Alt is free.
+    """
+    game = _game_mode(_render(is_laptop))
+    modded = {k: v for k, v in game.items()
+              if "$mod" in k or "Mod1" in k or "Alt" in k}
+    assert not modded, (
+        "`mode %r` binds a $mod/Alt combo: %s. Every binding in this mode is a "
+        "key the game goes back to NOT receiving, and $mod is the entire set "
+        "this feature releases." % (blk.GAME_MODE, modded))
+
+
+# --------------------------------------------------------------------------- #
+# The pill: block list, deploy gates, sources, click target.
+# Parsers deliberately read ASSIGNMENTS, not the file's vocabulary — the ▦
+# pill's first guard was spelled on substrings and three real breakages
+# survived it while every spelled string was still present.
+# --------------------------------------------------------------------------- #
+def _nix_guard_hosts(guard):
+    g = (guard or "").strip()
+    while g.startswith("(") and g.endswith(")"):
+        g = g[1:-1].strip()
+    if g == "":
+        return set(_HOSTS)
+    if g == "isLaptop":
+        return {"laptop"}
+    if g == "!isLaptop":
+        return {"workbench"}
+    raise AssertionError(
+        "unrecognised nix guard %r — extend `_nix_guard_hosts` rather than "
+        "letting an unknown gate read as 'enabled everywhere'" % guard)
+
+
+def _parse_home_file_entries(text):
+    out = {}
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = re.match(r'\s*home\.file\."([^"]+)"\s*=\s*(.*)$', line)
+        if not m:
+            continue
+        attr, rhs = m.group(1), m.group(2).strip()
+        g = re.match(r'lib\.mkIf\s+(.+?)\s*\{$', rhs)
+        guard = g.group(1) if g else ""
+        src = None
+        for j in range(i + 1, min(i + 12, len(lines))):
+            if re.match(r'\s*\};\s*$', lines[j]):
+                break
+            # up to the SEMICOLON, so a trailing `#` comment cannot contribute
+            sm = re.match(r'\s*source\s*=\s*([^;]+);', lines[j])
+            if sm:
+                src = sm.group(1).strip()
+        out[attr] = {"guard": guard, "source": src}
+    return out
+
+
+def _parse_block_list(text):
+    m = re.search(r'\n  blocks =\s*\n(.*?);\n', text, re.S)
+    assert m, "could not find the `blocks =` assignment in nix/graphical.nix"
+    body = "\n".join(ln for ln in m.group(1).splitlines()
+                     if not ln.strip().startswith("#"))
+    out = {}
+    for seg in body.split("++"):
+        seg = seg.strip()
+        if not seg:
+            continue
+        om = re.match(r'lib\.optionals?\s+(\([^)]*\)|!?\w+)\s*(.*)$', seg, re.S)
+        guard, rest = (om.group(1), om.group(2)) if om else ("", seg)
+        for ident in re.findall(r'\b([a-z]\w*Block)\b', rest):
+            out[ident] = guard
+    assert out, "parsed no blocks out of:\n" + body
+    return out
+
+
+def _block_body(text, ident):
+    m = re.search(r'\n  %s = \{(.*?)\n  \};' % re.escape(ident), text, re.S)
+    assert m, "no block definition named " + ident
+    return m.group(1)
+
+
+def _scripts_dir_targets(body):
+    """Every `${scriptsDir}/<name>` the block references — command AND clicks."""
+    return set(re.findall(r'\$\{scriptsDir\}/([\w.-]+)', body))
+
+
+def test_the_gamemode_pill_and_EVERY_file_it_needs_deploy_on_the_SAME_hosts():
+    """🔴 The relationship, not the vocabulary.
+
+    Covers the CLICK target as well as the `command`: this pill is its own
+    toggle, and unlike a broken `command` (a visibly missing block) a broken
+    click is invisible until the operator tries it — plausibly mid-game, with
+    the bar behind a fullscreen window.
+    """
+    text = GRAPHICAL_NIX.read_text()
+    blocks = _parse_block_list(text)
+    files = _parse_home_file_entries(text)
+
+    assert "gamemodeBlock" in blocks, (
+        "gamemodeBlock is not in the bar's block list — the pill is gone from "
+        "the bar and there is then NO way into game mode at all (there is "
+        "deliberately no default-mode keybind). Found: %s" % sorted(blocks))
+    block_hosts = _nix_guard_hosts(blocks["gamemodeBlock"])
+    assert block_hosts, "the block is enabled on no host at all"
+
+    body = _block_body(text, "gamemodeBlock")
+    targets = _scripts_dir_targets(body)
+    assert targets, "gamemodeBlock references no ${scriptsDir} script at all"
+    # the click target must be resolved FROM the block, not restated here
+    assert any("--toggle" in ln for ln in body.splitlines()), (
+        "gamemodeBlock has no `--toggle` click handler — the pill renders the "
+        "mode but cannot change it, and nothing else can enter game mode")
+
+    for name in sorted(targets):
+        attr = ".config/i3status-rust/scripts/" + name
+        want_source = "../scripts/" + name
+        assert attr in files, (
+            "%s has no home.file entry — the block would exec a path "
+            "home-manager does not deploy" % attr)
+        hosts = _nix_guard_hosts(files[attr]["guard"])
+        assert block_hosts <= hosts, (
+            "%s deploys on %s but its block runs on %s: the gate is NARROWER "
+            "than its consumer's" % (attr, sorted(hosts), sorted(block_hosts)))
+        assert files[attr]["source"] == want_source, (
+            "%s deploys source=%r, expected %r"
+            % (attr, files[attr]["source"], want_source))
+        assert (REPO / want_source[3:]).is_file(), want_source
+
+
+def test_the_block_script_is_VISIBLE_TO_THE_FLAKE():
+    """A flake copies only TRACKED files: an un-`git add`ed script produces a
+    perfectly successful `home-manager switch` with the pill simply absent.
+
+    Measured differently per tier on purpose. In the nix build sandbox the tree
+    IS what the flake could see (no `.git`), so `is_file()` is the direct
+    measurement and the only one available; on a dev host the tree also holds
+    untracked files, so `git ls-files` is consulted there.
+    """
+    assert (REPO / BLOCK_SCRIPT_REL).is_file(), BLOCK_SCRIPT_REL
+    out = subprocess.run(["git", "-C", str(REPO), "ls-files", BLOCK_SCRIPT_REL],
+                         capture_output=True, text=True, timeout=30)
+    if out.returncode == 0:           # dev host; the sandbox has no .git
+        assert BLOCK_SCRIPT_REL in out.stdout.split(), (
+            "%s is UNTRACKED — `git add` it or the flake ships a switch that "
+            "silently lacks it" % BLOCK_SCRIPT_REL)
+
+
+def test_the_guard_evaluator_and_parsers_are_not_wired_to_nothing():
+    """🔴 POSITIVE CONTROL for the machinery above: the parsers must DISAGREE
+    across entries that genuinely differ, or every "X covers Y" assertion is
+    vacuous. Every subject named here is deliberately NOT the block under test.
+    """
+    text = GRAPHICAL_NIX.read_text()
+    files = _parse_home_file_entries(text)
+    blocks = _parse_block_list(text)
+
+    assert _nix_guard_hosts("") == {"workbench", "laptop"}
+    assert _nix_guard_hosts("(!isLaptop)") == {"workbench"}
+    assert _nix_guard_hosts("isLaptop") == {"laptop"}
+    with pytest.raises(AssertionError):
+        _nix_guard_hosts("(config.something.else)")
+
+    guards = {v["guard"] for v in files.values()}
+    assert "" in guards and any("isLaptop" in g for g in guards), guards
+    assert len({v["source"] for v in files.values() if v["source"]}) > 5
+    assert _nix_guard_hosts(blocks["memoryBlock"]) == {"workbench", "laptop"}
+    assert _nix_guard_hosts(blocks["rigcontrolBlock"]) == {"workbench"}
+    assert _nix_guard_hosts(blocks["batteryBlock"]) == {"laptop"}
+
+    # `_scripts_dir_targets` must find MORE than one target on a block that has
+    # more than one — otherwise the click-coverage claim above is a coincidence.
+    assert len(_scripts_dir_targets(_block_body(text, "notifsBlock"))) >= 2
+
+
+# --------------------------------------------------------------------------- #
+# ONE signal number, three places.
+# --------------------------------------------------------------------------- #
+def _poller_signals():
+    m = re.search(r"^SIGNALS = \{(.*?)\}",
+                  (REPO / "scripts" / "bar-status-poll").read_text(),
+                  re.S | re.M)
+    assert m, "could not find SIGNALS in scripts/bar-status-poll"
+    return {int(n) for n in re.findall(r":\s*(\d+)", m.group(1))}
+
+
+def test_the_signal_number_agrees_in_all_three_places_and_collides_with_none():
+    """🔴 A signal mismatch is COMPLETELY SILENT. The mode still flips and the
+    escape key still works; the bar just keeps painting the old state until its
+    backstop interval — which reads as "the toggle is flaky", not as "two files
+    disagree about a number". And a signal that COLLIDES repaints somebody
+    else's pill, which is worse: the wrong block refreshes and this one does not.
+    """
+    nix = GRAPHICAL_NIX.read_text()
+    body = _block_body(nix, "gamemodeBlock")
+    m = re.search(r"signal\s*=\s*(\d+)\s*;", body)
+    assert m, "gamemodeBlock declares no `signal` — the pill can only ever be " \
+              "repainted by its backstop `interval`"
+    nix_signal = int(m.group(1))
+
+    assert blk.SIGNAL == nix_signal, (
+        "scripts/i3status-gamemode SIGNAL=%d but gamemodeBlock signal=%d — the "
+        "click handler would signal a block that is not listening"
+        % (blk.SIGNAL, nix_signal))
+
+    game = _game_mode(_render(False))
+    in_mode = sorted({int(n) for cmd in game.values()
+                      for n in re.findall(r"-RTMIN\+(\d+)", cmd)})
+    assert in_mode, (
+        "no `pkill -RTMIN+N i3status-rs` in the `mode %r` escape bindings — "
+        "escaping by KEYBOARD would leave the pill showing GAME until its "
+        "backstop interval, i.e. the bar lies about the mode it is in"
+        % blk.GAME_MODE)
+    assert in_mode == [nix_signal], (
+        "the `mode %r` escape bindings signal %s but the block listens on %d"
+        % (blk.GAME_MODE, in_mode, nix_signal))
+
+    others = [int(n) for n in re.findall(r"signal\s*=\s*(\d+)\s*;", nix)]
+    assert others.count(nix_signal) == 1, (
+        "signal %d is declared by more than one block in nix/graphical.nix (%s)"
+        % (nix_signal, sorted(others)))
+    assert nix_signal not in _poller_signals(), (
+        "signal %d is already used by a bar-status-poll source — the poller "
+        "would repaint the game pill and vice versa" % nix_signal)
+    # POSITIVE CONTROL: the two uniqueness assertions above are meaningless if
+    # the parsers found nothing to collide with.
+    assert len(others) >= 6, others
+    assert len(_poller_signals()) >= 5, _poller_signals()
+
+
+# --------------------------------------------------------------------------- #
+# The render script's pure halves. No i3 anywhere in this section.
+# --------------------------------------------------------------------------- #
+def test_parse_binding_state_reads_i3s_answer():
+    """The shape i3 4.24 actually returns, measured on this host."""
+    assert blk.parse_binding_state('{"name":"default"}') == "default"
+    assert blk.parse_binding_state('{"name":"game"}') == "game"
+    assert blk.parse_binding_state('{"name": "resize"}\n') == "resize"
+
+
+@pytest.mark.parametrize("raw", [
+    "",                       # i3-msg produced nothing (timeout, killed)
+    "   \n",
+    "not json at all",
+    "ERROR: no such reply type",
+    "[]",                     # a list, not the object we expect
+    "null",
+    '{"nome":"game"}',        # right shape, wrong key
+    '{"name":null}',
+    '{"name":42}',
+    '{"name":"   "}',         # blank is not a mode name
+])
+def test_parse_binding_state_is_UNMEASURED_not_a_guess(raw):
+    """🔴 None, never a coerced string. Every one of these must be
+    distinguishable from a real mode — `render` and `next_mode` both branch on
+    None, and a coerced `""` would render the neutral pill (claiming "not in
+    game mode") on a host that might be squarely in it."""
+    assert blk.parse_binding_state(raw) is None
+
+
+def test_render_is_LOUD_in_game_mode():
+    out = blk.render("game")
+    assert out["state"] == "Critical"
+    assert "GAME" in out["text"]
+    assert blk.GLYPH in out["text"] and blk.GLYPH in out["short_text"]
+
+
+def test_render_is_NEUTRAL_but_VISIBLE_in_every_other_mode():
+    """🔴 NOT hide-at-zero, deliberately — the pill is the only way IN, so an
+    invisible idle state would be a toggle with no off-state affordance."""
+    for mode in ("default", "resize", "some_future_mode"):
+        out = blk.render(mode)
+        assert out["state"] == "Idle", mode
+        assert out["text"].strip() == blk.GLYPH, mode
+        assert "GAME" not in out["text"], mode
+
+
+def test_render_is_FAIL_SAFE_when_the_mode_could_not_be_read():
+    """The documented contract, shared with i3status-notifs: an unreadable
+    query renders an empty block rather than guessing a state."""
+    assert blk.render(None) == {"text": "", "state": "Idle"}
+
+
+def test_the_rendered_block_is_JSON_i3status_rust_can_parse():
+    for mode in ("game", "default", None):
+        assert json.loads(json.dumps(blk.render(mode)))["state"] in (
+            "Idle", "Critical")
+
+
+def test_next_mode_flips_both_ways():
+    assert blk.next_mode("game") == "default"
+    assert blk.next_mode("default") == "game"
+    # any OTHER measured mode is still "not in game mode" -> a click enters it
+    assert blk.next_mode("resize") == "game"
+
+
+def test_next_mode_does_NOTHING_when_the_current_mode_is_unknown():
+    """🔴 The read and the write go through the same i3-msg, so a failed read
+    means the write had no chance either. Guessing would let one click LEAVE
+    game mode on a host that never entered it — restoring ~60 Alt grabs
+    mid-game, with the bar plausibly hidden behind a fullscreen window."""
+    assert blk.next_mode(None) is None
+
+
+#: PATH pointed at a directory that DOES NOT EXIST, so `i3-msg` and `pkill` are
+#: both unresolvable. REPLACING is required to reach the case at all: i3-msg is
+#: installed on the dev host AND resolvable in the check sandbox, so no amount
+#: of PREPENDING can make it unfindable, and a prepending version would measure
+#: the LIVE i3 on this workbench instead of the fail-safe branch. Nothing is
+#: reachable through the replacement — it holds no binaries because it holds
+#: nothing; both call sites go through this ONE helper so the guard in
+#: test_no_real_launchers.py has a single site to pin. `sys.executable` is
+#: absolute, so the interpreter still resolves.
+def _env_with_no_i3():
+    return dict(os.environ,
+                PATH=str(REPO / "scripts" / "tests" / "no-such-bin-dir"))
+
+
+def test_the_toggle_is_reachable_from_the_command_line():
+    """The pill's click handler is `<script> --toggle`, so the script must
+    accept that argument — and the fail-safe path must exit 0 and print NOTHING
+    (a click handler has nowhere to show an error, and stdout on a click is
+    stray output i3status-rust would try to parse).
+    """
+    out = subprocess.run(
+        [sys.executable, str(REPO / BLOCK_SCRIPT_REL), "--toggle"],
+        capture_output=True, text=True, timeout=30, env=_env_with_no_i3())
+    assert out.returncode == 0, out
+    assert out.stdout == "", out.stdout
+
+
+def test_the_block_renders_an_EMPTY_pill_when_i3_msg_is_UNREACHABLE():
+    """END-TO-END fail-safe, through `main()` — the contract that a broken query
+    must never crash or wedge the bar. POSITIVE CONTROL for the `None` unit test
+    above: it proves the empty pill is what a real unreachable i3 produces, not
+    only what `render(None)` returns when hand-fed."""
+    out = subprocess.run(
+        [sys.executable, str(REPO / BLOCK_SCRIPT_REL)],
+        capture_output=True, text=True, timeout=30, env=_env_with_no_i3())
+    assert out.returncode == 0, out
+    assert json.loads(out.stdout) == {"text": "", "state": "Idle"}, out.stdout

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -1514,6 +1514,23 @@ PINNED_PATH_CLOBBERS = {
         'e["PATH"]' + ' = str(tmp_path / "empty-bin")',
         "an empty directory in tmp_path — the point of the test is that "
         "logrotate is absent; nothing else is present either"),
+    "test_i3_game_mode.py": (
+        'PATH' + '=str(REPO / "scripts" / "tests" / "no-such-bin-dir")',
+        "justified by NON-EXISTENCE, which is strictly stronger than the "
+        "emptiness cases above: the replacement directory is not created by "
+        "the test and is not in the tree, so it holds no binaries because it "
+        "holds nothing, and no HAZARD_VOCABULARY name — i3-msg least of all — "
+        "is reachable through it. 🔴 REPLACING is required to reach the case "
+        "at all. The two tests using it exercise the game-mode block's "
+        "documented fail-safe (`i3-msg` unreachable -> empty pill, exit 0, and "
+        "for `--toggle` NO stdout at all), and i3-msg is installed on the dev "
+        "host — this very workbench is running i3 — so no amount of PREPENDING "
+        "can make it unfindable, and a prepending version would query the LIVE "
+        "window manager and measure whatever mode the operator happens to be "
+        "in. Both call sites go through ONE helper, `_env_with_no_i3`, so this "
+        "single needle covers every site rather than pinning whichever the "
+        "scan reaches first. `sys.executable` is absolute, so the interpreter "
+        "still resolves with PATH gone"),
     "test_standup_local_health.py": (
         'env["PATH"]' + ' = str(self._restricted_bin())',
         "the FIRST pinned clobber whose replacement directory is not empty, so "


### PR DESCRIPTION
## What this does

Adds **game mode**: an i3 binding mode that binds (almost) nothing, plus a bar pill to toggle it.

```
mode "game" {
        bindsym Pause       mode "default", exec --no-startup-id pkill -RTMIN+18 i3status-rs
        bindsym Scroll_Lock mode "default", exec --no-startup-id pkill -RTMIN+18 i3status-rs
}
```

## Why an empty binding mode was the only viable mechanism

`nix/i3/config.nix` sets `$mod Mod1` — **`$mod` is ALT, not Super**. i3 therefore holds a
global X11 grab on ~60 Alt combos: Alt+Tab, Alt+1..Alt+0, Alt+Shift+1..0, Alt+Return,
Alt+d/f/e/a/b/n/r/h/j/k/l/space/grave/minus/equal. **A grab means the focused window never
receives the keypress at all** — a fullscreen game is *deaf* to those keys, which is a
strictly worse problem than "rofi pops over my game".

Two alternatives, both dead:

- **A guard script on the `exec`** (`bindsym $mod+d exec launcher-guard`) changes only what
  i3 does *after* eating the keypress. The grab is still held, the game is still deaf.
- **A conditional grab** (bind only when the focused window is not a game) is not
  expressible: `bindsym` takes no `[class=…]` criteria and i3 offers no per-window binding.

Entering a binding mode ungrabs every default-mode binding and grabs only that mode's. That
is the only native mechanism that actually releases the grabs — so **the emptiness of the
mode is the feature**, and a test pins that nothing inside it uses `$mod`.

## Two escape keys, on purpose

`Pause` **and** `Scroll_Lock`. Not redundancy: some keyboards have no dedicated Pause key,
and being stuck in game mode with no way out is the worst failure this feature can have —
every Alt binding is dead *by design* at that moment. Neither is a `$mod` combo, because a
mode that exists to release Alt must not need Alt to leave.

Both are currently unbound elsewhere, and the guard that keeps them that way is structural,
not spelled (below).

There is deliberately **no `bindsym … mode "game"` in the default mode**. Getting *in* is the
easy direction (the bar is visible and clickable then), and a default-mode binding would be
one more Alt grab for no gain.

## Single source of truth: i3 owns the mode

The block reads `i3-msg -t get_binding_state` and keeps **no state file**. There are two
writers — the bar click and the `Pause`/`Scroll_Lock` bindings inside the mode — so a shadow
file would desync the instant the operator escaped by keyboard, and the pill would then lie
about a mode it cannot see.

Fail-safe, same contract as `i3status-notifs`: any i3-msg error/timeout → empty JSON, exit 0.
Losing the pill is survivable in a way losing the escape key would not be — `Pause` is grabbed
by i3 itself and works whether or not the script can talk to it.

## The pill

`gamemodeBlock`, **both hosts** (purely local, one `i3-msg`, no poller/cache/network), signal
**18** — the first free RTMIN offset (10-14/16/17 are `bar-status-poll`'s `SIGNALS`, 15 is
notifs).

| state | render |
|---|---|
| game mode active | ` 󰊗 GAME ` **Critical** |
| any other mode | ` 󰊗 ` Idle — **always visible** |
| i3-msg unreachable | empty block, exit 0 |

**Not hide-at-zero**, unlike every count pill on this bar. The pill is the only way *in*, so
an invisible idle state would be a toggle with no off-state affordance — the same reason
`notifsBlock` renders a bare bell at zero. Left-click re-invokes the same script with
`--toggle` (i3status-rust does not pass `$BLOCK_BUTTON` to custom block commands, so the
toggle lives in a `[[block.click]]` handler); one deployed file, and the flip logic sits
somewhere a unit test can reach it.

`i3bar` renders the binding-mode indicator natively, so the word `game` also shows on the bar
for free whenever the bar is visible — the pill is the *toggle*, not the only indicator.

## Rescue path

Stuck in game mode with the bar behind a fullscreen game: from the laptop or any nebula peer,
`ssh zach@10.42.0.30` then `DISPLAY=:0 i3-msg mode default`. Documented in the `bar` skill
(full design) and the `i3` skill (runtime + "do not bind `Pause`").

## Phase 2 is deliberately out of scope

Automatic focus-based detection via i3 IPC (`window::focus` + a WM_CLASS list) is **not
built and not stubbed**. It is blocked on real WM_CLASS samples from Steam/Proton and Lutris
titles, which nobody has captured — and a guessed class list is a mode that engages on the
wrong window.

## Test matrix

New guards in `scripts/tests/test_i3_game_mode.py` (33 tests). Every one was driven RED on
purpose and confirmed to fail **with its own assertion message** — not a collection error and
not a neighbouring guard's. Tree restored and sha256-verified after each mutant; the sweep ran
under `PYTHONDONTWRITEBYTECODE=1` so a same-second, same-length edit could not be scored
SURVIVED off a stale `.pyc`.

| # | mutation | test driven red | red evidence |
|---|---|---|---|
| M1 | `mode "game"` moved into the `!isLaptop` `monitorLayout` fragment | `…exists_on_BOTH_hosts` | **only `[laptop]` failed**, `[workbench]` stayed green — exactly the asymmetry |
| M2 | escapes no longer `mode "default"` | `…has_at_least_one_escape_back_to_default` | "no binding inside `mode 'game'` returns to…" |
| M3 | `bindsym Pause` added to the DEFAULT mode | `…no_escape_key_is_ALSO_bound_in_the_default_mode` | "a key bound inside `mode 'game'` is ALSO bound in the DEFAULT mode" |
| M4 | `bindsym $mod+g` added inside the mode | `…nothing_in_the_game_mode_uses_the_mod_key` | "binds a $mod/Alt combo" |
| M5a | `gamemodeBlock` dropped from the `blocks` list | `…deploy_on_the_SAME_hosts` | "is not in the bar's block list" |
| M5b | its `home.file` gated `lib.mkIf isLaptop` | same | "the gate is NARROWER than its consumer's" |
| M5c | `source =` swapped, correct path parked in a trailing comment | same | "deploys source=…" |
| M5d | `--toggle` click handler removed | same | "has no `--toggle` click handler" |
| M6 | script left un-`git add`ed | `…is_VISIBLE_TO_THE_FLAKE` | observed live before the `git add`: "is UNTRACKED" |
| M7a | nix `signal = 19`, script `SIGNAL = 18` | `…signal_number_agrees_in_all_three_places…` | "SIGNAL=18 but gamemodeBlock signal=19" |
| M7b | all three moved to 15 (notifs' signal) | same | "is declared by more than one block" |
| M7c | the i3 escapes signal `-RTMIN+13` | same | "escape bindings signal [13] but the block listens on 18" |
| M8 | `render("game")` state → Idle | `test_render_is_LOUD_in_game_mode` | `assert 'Idle' == 'Critical'` |
| M9 | idle pill made hide-at-zero | `…NEUTRAL_but_VISIBLE_in_every_other_mode` | asserted the glyph, got `""` |
| M10 | `next_mode(None)` guesses `game` | `…does_NOTHING_when_the_current_mode_is_unknown` | asserted `is None` |
| M11 | `parse_binding_state` coerces a non-string `name` | `…is_UNMEASURED_not_a_guess` (10 params) | asserted `is None` |
| M12 | `current_mode`'s try/except removed | `…toggle_is_reachable_from_the_command_line` | stdout no longer empty on a click |
| C1 | the test file's own nix renderer made isLaptop-blind | `…renders_two_different_configs` | control for M1's evaluator |
| C2 | its binding parser folded every mode into default | `…sees_the_modes_that_are_actually_there` | control for M2-M4's parser |

**18/18 killed, own message each.** (M1/M2/M8 were re-run after a mis-quoted `expect` string in
the sweep harness — an instrument bug, not a guard gap; the re-run is in the transcript.)

Live read-only probe against the running i3 on this workbench:
`i3-msg -t get_binding_state` → `{"name":"default"}`, block renders
`{"text":" 󰊗 ","short_text":" 󰊗 ","state":"Idle"}`, rc 0. `--toggle` was deliberately NOT run
against the live WM.

### Gate

Base sha `254b487d` — the branch is a fast-forward of `origin/main`, so the merged tree IS this
tree. All four runs green:

| tier | command | result |
|---|---|---|
| dev-host pytest | `scripts/gate.sh --tier both` | `RESULT: PASS (exit=0)` — 21899 passed, 3 skipped, **0 failed** (floor 18610) |
| dev-host node | same | `RESULT: PASS (exit=0)` — 1449 pass, 0 fail (floor 1367) |
| sandbox pytest | `nix build .#checks.x86_64-linux.pytests` | rc 0 — 21899 passed, 0 failed |
| sandbox node | `nix build .#checks.x86_64-linux.nodetests` | rc 0 — 1449 pass, 0 fail |

The two `nix build`s were run **one at a time**, per the documented store-contention false-failure.

### Two existing ledgers updated (both are gates that fired, not incidental churn)

- `test_bar_status.py`: `_EXPECTED_SCRIPT_BLOCKS` 11→12, `_EXPECTED_BLOCK_DEFS` 20→21 (the
  measured floors these tests tell you to raise when you add a block).
- `test_no_real_launchers.py`: a `PINNED_PATH_CLOBBERS` entry for the two fail-safe tests. They
  replace `PATH` with a directory that **does not exist**, which is required to reach the case
  at all — i3-msg is installed on this host (it is running i3), so no amount of *prepending*
  can make it unfindable, and a prepending version would query the live WM and measure whatever
  mode the operator happens to be in. Both sites go through one helper so the ledger has a
  single needle.

## Not deployed

Nothing was switched. `home-manager switch` from a worktree would deploy the worktree's tree to
the live host, so this was validated with `nix-instantiate --parse`, both gate tiers, and the
read-only live probe above. 🔴 **Adding a block is in the restart class**: after merge the
sequence is `ship.sh` → **`i3-msg restart`** → re-check the pill renders. The bar holds the block
list it parsed at startup, so until i3 is restarted the pill is simply absent on a host reporting
a fully successful deploy.
