### PR TITLE
docs(handoff): ranks 5 and 9 closed and merged; ranks 3/4/6 re-verified untouched

### DIFF
--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -18,40 +18,39 @@ is the PRIVATE proposal, not this doc.
 
 ## State now
 
-- **`ZacxDev/cairn` EXISTS, is PUBLIC as of 2026-09-05, `main` = `b25abb5`.** **7** commits,
-  not 6 — this line said 6, counted before the PR #1 squash landed. Suite **1647
-  passed / 0 failed**; `tests/leakscan.py` rc 0 across 33 files with its own controls green.
-- **Phase A1 (extraction) DONE.** Server + client + shared libs + tests, MIT, fresh
-  history (no imported commits), GitHub Actions CI (leakscan job runs BEFORE tests so a
-  test failure cannot mask it; the test job asserts a collected-test floor).
-- **Phase A2 (token hot-reload) DONE and MERGED** — cairn PR #1, squash `b25abb5`,
-  verified by CONTENT not ancestry.
-- **Proposal PR OPEN, NOT merged:** `civitai/talos-infra` **#1414**, branch
-  `docs/cairn-civitai-instance-proposal`, worktree at `~/workspace/civit/dp-cairnprop`.
-- **devrc `claudedocs/handoff-cairn-phase3.md` ranks 1 and 10 closed** this session via
-  devrc #1294 (`b8107b5aa`) and homelab-infra #683 (`93e15ee09`). Both merged and verified.
-- 🔴 **NOT deployed anywhere.** No civitai instance exists; no image published; devrc does
-  NOT yet consume cairn. The homelab pod still runs its own copy of the code.
-- ✅ **`ZacxDev/cairn` IS PUBLIC — flipped 2026-09-05 on the operator's explicit go-ahead.**
-  Verified by the ACTUAL public path, not by the command's exit code: unauthenticated
-  `api.github.com/repos/ZacxDev/cairn` → **200** and
-  `raw.githubusercontent.com/ZacxDev/cairn/main/LICENSE` → **200**, from a shell holding no
-  credential for the request. ⚠ `gh repo view --json licenseInfo` still reads **null**
-  despite a stock MIT `LICENSE`; GitHub's licence detection re-indexes on push, so re-read
-  it rather than editing the file.
+- **`ZacxDev/cairn` is PUBLIC** (2026-09-05) and now has **two** merged PRs: #1 the SIGHUP
+  hot-reload, #2 the ledger narrowing (`c8aee7203`, 2026-09-06). Suite **1651 passed**,
+  `leakscan.py` rc 0 with controls green. CI ran both jobs on #2 — leakscan 6s, tests 8m1s,
+  `mergeStateStatus: CLEAN` — so **cairn's GitHub Actions gate is now a demonstrated
+  instrument**, not an untested badge. That is worth knowing: a brand-new check in this
+  ecosystem has been red-on-arrival before.
+- **Session capture is DESIGNED, DECIDED and MERGED as a proposal, and BUILT NOWHERE.**
+  `claudedocs/proposal-cairn-session-capture.md`, devrc `e16f9609a` (#1326). Sixteen operator
+  decisions in its §2. Rank 8 carries the detail.
+- **The opencode exporter SHIPPED** — devrc `f58d2df04` (#1338), clawgate #511 `complete`.
+  `scripts/collector/opencode/export.py` + 32 tests. **It has NO CALLER**; it is a command,
+  not a pipeline.
+- **`ZacxDev/homelab-infra` #714 merged** (`ed2c4a0db`) and Flux-applied — verified a no-op
+  (pod `…-59x6v` unchanged, `restarts=0`).
+- Branch: devrc `main`, clean but for five pre-existing untracked files that are not mine
+  (`nix/system/apply-nebula-relay.sh`, `check-nebula-relays.sh`, `output.txt`,
+  `scripts/diagnose-nix-disk.sh`, `scripts/tmux-restore-observe.sh`).
+- **All worktrees from this session are removed**; devrc and cairn base clones re-synced.
+- 🔴 **STILL NOT DEPLOYED ANYWHERE — carried forward, and re-verified 2026-09-06.** No civitai
+  instance exists; **no cairn image is published**; devrc does **NOT** consume cairn (`flake.nix`
+  has zero cairn references, `scripts/cairn` is still an out-of-store symlink). The homelab pod
+  still runs its own copy of the code. Everything above is source and design, not deployment.
 
-### What the extraction actually cost, measured
-`subsystem_touch.py` (6,654 lines, the origin's local authoring tool) was NOT extracted.
-Its borrowed surface measured **350 lines of 6,654 (5.3%)** and split cleanly: six symbols
-used by the library, 327 lines used only by tests of the authoring CLI. The dependency was
-**inverted** — `lib/entry_shape.py` + `lib/host_identity.py`, **379 lines replacing 6,654**
-— so an authoring tool now depends on the store's format rather than the reverse.
+🔴 **THE PROPOSAL'S AUDIT LADDER ENDED BY OPERATOR INSTRUCTION AT ROUND 9, NOT ON A CLEAN
+ROUND — and round 9's own fixes were never audited.** Rounds 8 and 9 each found a real design
+defect in the immediately preceding fix. The three unaudited prescriptions are §5.1's ledger
+constraints, §8's control 8, and §5.3's cost correction. Treat those as the likeliest wrong
+thing in the document; "merged after nine rounds" otherwise reads as "settled".
 
-`cairn who` was REMOVED from the client: it shells into tmux on named hosts to answer
-"which sessions worked a task", which is session forensics about one operator's machines,
-not an operation on a store. Removing it also removed the last private infrastructure baked
-into the INTERFACE rather than a comment (`--host` had `choices=[<two real machine names>]`,
-so every `--help` printed them), and fixed **81 of 107** then-failing tests.
+🔴 **`claim-work` WAS NOT USED FOR RANKS 1 AND 2** (it was used, correctly, for rank 5). The
+ranked list is a shared queue with no lock and the claim must be taken BEFORE acting. Nothing
+collided and there is no claim to release — but the protection was absent while 20 live claims
+from other sessions showed the mechanism in active use around this work.
 
 ## Open investigations — live diagnosis state
 
@@ -95,75 +94,100 @@ so every `--help` printed them), and fixed **81 of 107** then-failing tests.
   and extend the fail-closed arm to non-`Call` raises, in one commit, when someone is next in
   that file.
 
+### The full-suite intermittent in cairn — STILL UNRESOLVED, and the population moved under it
+- **Symptom + exact repro:** no reliable repro.
+  `TestTheDeployedEntrypoint::test_a_TWO_LINE_token_file_authorises_BOTH_lines` failed once in
+  ~25 full-suite runs, only ever in a full run.
+- **Observed (with values):** this session ran the full cairn suite once more on the rank-5
+  branch — **1651 passed, 0 failed, 447.77s** — and CI ran it again on #2: **pass, 8m1s**. So
+  the denominator is now ~27 runs with 1 failure, and neither of this session's runs
+  reproduced it. via: measurement
+- **Ruled out:** that the +4 tests from #2 perturb it — they are pure AST/collector helpers
+  with no subprocess and no signal handling, and both post-#2 runs were clean. via: code
+- **Leading hypothesis:** unchanged — genuinely pre-existing and order/timing dependent,
+  inherited from the origin repo. Not confirmed.
+- **Next probe:** unchanged and still the right one, now cheaper because CI runs it for free —
+  `for i in $(seq 10); do cd ~/workspace/cairn && nix develop ~/workspace/devrc -c python3 -m pytest tests -q -p no:randomly 2>&1 | tail -1; done`
+  ~75 min wall clock at 7.5 min/run. A RATE is what turns this into either "fix it" or "it
+  does not exist".
+
+### Whether the opencode exporter's artifact is USEFUL as receipts — never judged
+- **Symptom + exact repro:** not a bug; an unclosed question the shipped work deliberately
+  did not answer.
+- **Observed (with values):** tool parts carry their payload — **0 of 21,749** tool parts
+  store-wide have `text`, and **21,749 of 21,749** have `_data`. A real session exports to 210
+  records / 1.13 MB, two runs byte-identical. via: measurement
+- **Ruled out:** that `text` alone suffices — measured false at 58× the sample the task
+  assumed. via: measurement
+- **Leading hypothesis:** `_data` carries enough, but nobody has read an artifact end to end
+  and said so.
+- **Next probe:** export one real session and read it. That is a human judgement over named
+  evidence, not a command.
+
 ## Next steps (ranked)
 
-🔴 **Numbering is stable and is half a claim's identity** (`claim-work --slug-for <this doc> <rank>`).
-Items are marked done IN PLACE; new items APPEND.
+🔴 **Numbering is STABLE and is half a claim's identity** (`claim-work --slug-for <this doc>
+<rank>`). Items are marked done IN PLACE; new items APPEND.
 
-1. ✅ **DONE 2026-09-05 — `ZacxDev/cairn` IS PUBLIC.** Operator said go; flipped with
-   `gh repo edit --visibility public`. **Verified by the actual public path** (anonymous API
-   200, anonymous raw `LICENSE` 200), never by the command's exit status.
-   🔴 **The pre-publication audit covered TWELVE commits, not the 7 on `main` — and the
-   extra 5 are the ones a tree-scan would have missed.** `refs/pull/1/head` (`b51fb349`)
-   is served by GitHub on a public repo, so PR #1's pre-squash history publishes too:
-   `90d30ab`, `0ee60a9`, `93fd486`, `d2ebdf2`, `b51fb34` — including the states BEFORE the
-   round-1 and round-2 credential-leak fixes. All 12 scanned **rc 0** under the CURRENT
-   `leakscan.py` (old trees, today's rules), controls green on every run.
-   🔴 **The first sweep of that was WRONG and looked right.** It checked out each commit
-   after `cp`ing the current scanner in, so `git checkout` aborted on the dirtied file from
-   commit 4 onward and **four commits silently re-scanned one stale tree** — seven plausible
-   green lines, three of them real. Caught by printing a per-commit `git ls-files` count and
-   noticing it did not move (5→5→7→24→34→35→35 once fixed with `checkout -f`). **Any
-   per-revision sweep must print a per-revision quantity that CHANGES, or it cannot tell you
-   it walked anything.**
-   ⚠ **Residual, accepted and not acted on:** the 7 `main` commit messages carry
-   `Claude-Session:` URLs (opaque session ids, not credentials); `licenseInfo` reads null.
+1. ✅ **DONE 2026-09-05 — `ZacxDev/cairn` IS PUBLIC.** Verified by the ACTUAL public path
+   (anonymous API 200, anonymous raw `LICENSE` 200), never by the command's exit status.
+   🔴 The pre-publication audit covered **12** commits, not the 7 on `main` — GitHub serves
+   `refs/pull/1/head` on a public repo, so PR #1's five pre-squash commits publish too,
+   including the states BEFORE the round-1 and round-2 credential-leak fixes. All 12 scanned
+   rc 0 under the CURRENT `leakscan.py`.
+   🔴 **The first sweep of that was WRONG and looked right** — it `cp`'d the scanner in before
+   each checkout, so `git checkout` aborted on the dirtied file and four commits silently
+   re-scanned one stale tree. Caught by printing a per-commit `git ls-files` count and noticing
+   it did not move. **Any per-revision sweep must print a per-revision quantity that CHANGES.**
+   ⚠ Residual, accepted: the 7 `main` commit messages carry `Claude-Session:` URLs;
+   `licenseInfo` still reads null despite a stock MIT `LICENSE`.
    forcing: none — done
 
 2. ⚠ **DONE 2026-09-05, BUT NOT AS WRITTEN — THIS ITEM'S OWN PREMISE WAS FALSE.**
-   `ZacxDev/homelab-infra` **#714**, branch `fix/subsystem-store-reload-comment`, OPEN.
-   🔴 **The comment is TRUE, and retiring it would have shipped the failure it prevents.**
-   "Cairn PR #1 makes that false" is a claim about cairn's SOURCE; the comment describes the
-   DEPLOYED artifact, and nothing builds an image from cairn. Measured against the running
-   pod on `0.7.0`, not inferred: `grep -rl SIGHUP /app` → **no matches**, with `grep -rn "def
-   load_tokens" /app` matching as the positive control that the search could see the tree at
-   all. `/app/scripts/subsystem-store-api/server.py` is byte-identical
-   (`sha256 917936db…`) to devrc `origin/main`'s copy, which holds **0** occurrences of
-   SIGHUP. Had this been done as written, the next operator would have edited the secret and
-   waited for a reload this image will never perform.
-   **What was actually wrong** is that the instruction read as a property of the STORE while
-   being a property of this IMAGE TAG. It now names its own scope, cites the measurement and
-   its control, names `b25abb5` as the successor, states the trigger (retire it in the same
-   commit that moves `image:` past that sha — not before, not after), and gives the
-   one-command check so nobody trusts the comment's age.
-   **Inertness verified, not assumed:** both YAML versions canonicalise to the same hash
-   (`019fc076…`) with a `replicas: 1`→`2` control proving the comparator can see a change;
-   `kustomize-validate.sh` PASS 7/7, its negative control (`replicas: "not-a-number"`) red
-   and naming `/spec/replicas`. ⚠ That script reports a missing `kustomize`/`kubeconform`/
-   pyyaml as **FAIL** — could-not-run, not a bad manifest. Run it under
-   `nix-shell -p kustomize kubeconform "(python3.withPackages(ps: [ps.pyyaml]))"`.
-   🔴 **The transferable lesson: "X makes Y false" needs to name WHICH ARTIFACT Y describes.**
-   A merged fix in a repo nothing deploys changes no operational fact. This is the same
-   stale-blocker class as the two below, inverted — a blocker written down as removed when it
-   was not.
-   forcing: none — the real forcing item is now rank 7
+   `ZacxDev/homelab-infra` **#714**, merged `ed2c4a0db`, Flux-applied and verified a no-op.
+   🔴 "Cairn PR #1 makes that false" is a claim about cairn's SOURCE; the comment describes the
+   DEPLOYED artifact, and nothing builds an image from cairn. Measured on the running pod:
+   `grep -rl SIGHUP /app` → no matches, with `grep -rn "def load_tokens" /app` matching as the
+   positive control. The image's `server.py` is byte-identical (`sha256 917936db…`) to devrc
+   `origin/main`'s copy, which holds **0** occurrences of SIGHUP. Doing it as written would
+   have told the next operator a secret edit takes effect on SIGHUP.
+   **The transferable rule: "X makes Y false" must name WHICH ARTIFACT Y describes.**
+   forcing: none — done
 
 3. **Phase A3 — devrc consumes cairn as a pinned flake input.** `nix/home.nix` currently
    deploys `scripts/cairn` as an out-of-store symlink (edits are live, no switch). A flake
    input changes that: client edits will need a `home-manager switch`. Real ergonomic trade,
    decided deliberately, and `readlink -f` stays the only arbiter of which state a path is in.
+   ⚠ **Re-verified 2026-09-06 as NOT started:** `flake.nix` contains **zero** cairn
+   references and `scripts/cairn` is still an `mkOutOfStoreSymlink`.
    forcing: none
 
 4. **Merge or close `civitai/talos-infra` #1414** (the instance proposal). It has four open
    questions in §11 — teammate count and identities, hostname, who else administers the token
    file, and whether the OSS repo accepts outside contributions from day one. None blocks A3.
+   ⚠ **Re-verified 2026-09-06: still OPEN.**
    forcing: none
 
-5. **Close the two open ledger 🟢s in cairn** (see the open investigation above). One commit.
-   forcing: none
+5. ✅ **DONE 2026-09-06 — `ZacxDev/cairn` #2, squash `c8aee7203`.** Both ledger 🟢s closed,
+   each as its OWN docstring prescribed. Claimed via `claim-work` and released on merge.
+   🔴 **Neither is regression coverage, and the commit says so.** Guard A's live dropped-count
+   is **0**, so its assertion is an **INVARIANT GUARD, labelled one** — backed by a positive
+   control feeding the collector a source that MUST yield three shapes, so the zero is not the
+   reassuring kind. Guard B's narrowing is **behaviour-neutral today**: measured `checked=8`
+   and every one of the 8 is `print`/`emit` by bare NAME, so the attr arm contributes zero
+   matches; the only `.write` receivers in `server.py` are binary `fh.write` ×2 and
+   `self.wfile.write`. What it prevents is a future module-level writer making the ledger
+   demand `reload_safe` on BYTES.
+   Two-way control on the narrowing: `sys.stdout.write` → 1, binary `fh.write` → 0, and
+   `checked` still 8 on the real source. Mutants: reverting the narrowing (= the pre-fix code,
+   i.e. red at base) and disabling the bare-re-raise arm each killed exactly their own test.
+   forcing: none — done
 
 6. **Get a RATE for the full-suite intermittent** (see the open investigation above), then
-   either fix it or record that it does not reproduce.
+   either fix it or record that it does not reproduce. ⚠ The denominator moved this session:
+   ~27 runs, 1 failure, two clean runs added (one local at 447.77s, one in CI at 8m1s).
+   **~75 min wall clock**, and CI now runs the suite on every PR for free, so the cheapest
+   version of this is to read the next N CI runs rather than burn a local hour.
    forcing: none
 
 7. **Retire `deployment.yaml`'s no-reload paragraph IN THE SAME COMMIT that moves the store's
@@ -177,35 +201,37 @@ Items are marked done IN PLACE; new items APPEND.
    (rank 3) is the nearest thing that would force one.
    forcing: none — it cannot fire before the image exists
 
-8. **Session capture — DESIGNED AND DECIDED, NOT BUILT.** A whole new arm of this programme
-   that this doc's ranked list would otherwise not mention at all: ship a session's transcript
-   to object storage at handoff time and attach it to the cairn entries the session touched, so
-   an entry carries its receipts instead of only its conclusion.
-   **`claudedocs/proposal-cairn-session-capture.md`, merged 2026-09-06 as `e16f9609a` (#1326).**
-   Sixteen operator decisions are settled in its §2 and are NOT to be re-litigated — a session
-   ships as a SET of objects (subagent transcripts are 64% of the bytes), the pointer is an
-   opaque id, retention is indefinite with **no retraction path** by policy, and the entry
-   carries a block list of ids with the digest on the object.
-   🔴 **Read §10 before starting: four things are genuinely undecided**, led by *who READS* the
-   recorded fan-out sets — a recorded set nothing compares against detects nothing.
-   ⚠ **The audit ladder ended by operator instruction at round 9, NOT on a clean round.** Rounds
-   8 and 9 each found a real design defect in the immediately preceding fix, and round 9's own
-   fixes — §5.1's three ledger constraints, the rewritten control 8, the §5.3 cost correction —
-   were never audited. Treat those three as the likeliest wrong thing in the document.
+8. **Session capture — DESIGNED AND DECIDED, NOT BUILT.** Ship a session's transcript to
+   object storage at handoff time and attach it to the cairn entries the session touched.
+   **`claudedocs/proposal-cairn-session-capture.md`, merged 2026-09-06 as `e16f9609a`
+   (#1326).** Sixteen operator decisions in §2, NOT to be re-litigated — a session ships as a
+   SET of objects (subagent transcripts are 64% of the bytes), the pointer is an opaque id,
+   retention is indefinite with **no retraction path** by policy, the entry carries a block
+   list of ids with the digest on the object.
+   🔴 **Read §10 first: four things are genuinely undecided**, led by *who READS* the recorded
+   fan-out sets — a recorded set nothing compares against detects nothing.
+   ⚠ **The audit ladder ended by operator instruction at round 9, NOT on a clean round**, and
+   round 9's own fixes (§5.1's three ledger constraints, control 8, the §5.3 cost correction)
+   were never audited. Likeliest wrong thing in the document.
    **Closing condition:** none yet — this is a design, and the first implementation PR is what
    would earn one. Do not treat "the proposal merged" as the work being done.
    forcing: none
 
-9. **opencode session capture — clawgate task #511**, open, dispatchable, no gate.
-   🔴 **Pre-verification refuted the proposal's own framing**, which is the reusable part: the
-   opencode reader ALREADY EXISTS (`scripts/collector/opencode/_shared.py` — read-only SQLite,
-   normalised sessions → messages → parts, plus a tailer, backfill and tests), and
-   `find-session` already searches that corpus. The task is the DELTA — serialise a session to
-   one byte-deterministic artifact — not an exporter from scratch, and "do not add a second
-   reader" is one of its tested criteria because a fresh connection path would be the third.
-   **Closing condition:** task #511 reaches `complete` — it carries author-specified acceptance
-   criteria, so a pickup can close it rather than stopping at `ready_for_review`.
-   forcing: none
+9. ✅ **DONE 2026-09-06 — clawgate #511 `complete`, devrc `f58d2df04` (#1338).**
+   `scripts/collector/opencode/export.py`, 32 tests, two audit rounds.
+   🔴 **Pre-verification refuted the proposal's framing** — the opencode reader ALREADY EXISTS
+   (`scripts/collector/opencode/_shared.py`), so the task was the DELTA and "do not add a
+   second reader" became a tested criterion.
+   🔴 **The task body's own ASSUMPTION was false and its stop condition is what caught it:**
+   `text` is populated on 25% of parts and on **NONE** of the 378 tool parts sampled (0 of
+   21,749 store-wide). An exporter built to its letter ships an artifact three-quarters empty
+   with zero tool calls, while looking correct.
+   🔴 **I MADE BOTH GATE TIERS RED AND FOUND IT BY TESTING INSTEAD OF GATING** — the suite
+   collected 223 against a floor of 162, above the drift ceiling. `pytest <dir>` said "223
+   passed"; the drift check lives ONLY in the runner. Floor set to **224**, copied verbatim
+   from the gate's own output.
+   ⚠ **The module has NO CALLER.** Wiring it in is rank 8's work.
+   forcing: none — done
 
 ## Gotchas / decisions / dead-ends
 
@@ -262,27 +288,64 @@ gate checks for tokens; it cannot tell that prose still means something.
   `error`, not a `failure`. Push from inside
   `nix-shell -p "(python3.withPackages(ps: [ps.pyyaml]))" git` and it passes.
 
+**🔴 A TEST SUBSET IS NOT THE GATE, AND THIS COST A RED `main` NEAR-MISS.** `pytest <dir>`
+reported "223 passed" and I read it as success; the per-target **drift ceiling** lives only in
+`run-tests.sh`, so the PR turned BOTH tiers red and only an audit caught it. When a floor
+needs changing, **copy the number the gate prints** — it emits `"<target>|<n>"` explicitly —
+never compute it from the two sides.
+
+**🔴 A CONTROL BUILT OUT OF THE INSTRUMENT CERTIFIES NOTHING.** The exporter's criterion-4
+negative control re-implemented the AST matcher inline instead of driving the guard. Measured:
+disarming the guard's own pattern left the suite at **11 passed** — the "instrument can go
+red" control stayed green while the instrument was fully disarmed, and the copy had already
+drifted from the guard it was supposedly validating. Guard and control must share one function.
+
+**🔴 A MEASUREMENT STATED AT A SCOPE IT DOES NOT HOLD ARGUES FOR DELETING THE FIX.** I wrote
+"zero ties across 617 messages and 2,907 parts — real data cannot exhibit the bug" from a
+**3.7%** sample, stated at host scope. Store-wide: **5 tie-groups, 10 rows, 5 sessions across
+77,671 parts**. The direction is what made it dangerous — it invited the next maintainer to
+delete the sort the PR exists to add. **The same error recurred in the commit that fixed it**
+("the source DB is 0600" — it is **0644**), which is why this is written as a class and not
+an incident.
+
+**🔴 CLOSE A HAZARD BY CONSTRUCTION BEFORE REACHING FOR ANOTHER GUARD.** Two mutants survived
+the exporter's suite: deleting `O_NOFOLLOW`, and gutting the boundary `except`. `O_NOFOLLOW`
+defended a *predictable* temp path that no fixture attacked. Switching to `mkstemp` — unique,
+`O_EXCL`, 0600 — removed the predictable-name hazard, the symlink-at-temp hazard AND the
+untestable flag together. Prefer removing the need for a guard over adding a test for one.
+
+**🔴 `created` OUTRANKS `worked` IN THE CLAWGATE HANDOFF RESOLVER, AND THAT IS A BLIND SPOT
+THIS SESSION HIT.** Filing #511 and then working it left the session's only link as
+`created`, so `clawgate_handoff.sh resolve` exits **6** ("NONE of them WORKED") for a task the
+session did all the work on. The skill names this; it is real. No field was recorded here
+because #511 is *rank 9* of this effort, not the effort itself.
+
+**A DOC'S OWN DOCSTRING OFTEN PRESCRIBES ITS FIX, AND FOLLOWING IT BEATS INVENTING ONE.**
+Both cairn ledger 🟢s were closed exactly as their comments already specified — "count the
+dropped shapes and assert the count, not widen the phrase match". No design was needed.
+
 ## How to verify
 
 ```bash
-# cairn: suite + the security gate, both from a clean checkout
+# cairn: the suite and the security gate, both from a clean checkout
 cd ~/workspace/cairn && nix develop ~/workspace/devrc -c python3 -m pytest tests -q -p no:randomly
 cd ~/workspace/cairn && python3 tests/leakscan.py            # rc 0, controls green
-cd ~/workspace/cairn && python3 tests/leakscan.py --self-test # the controls alone
 
-# the three defect shapes the audit ladder closed — all must refuse, neither verbatim nor folded
-python3 - <<'PY'
-import importlib.util,sys,pathlib,tempfile,os,secrets
-spec=importlib.util.spec_from_file_location("srv","server/server.py"); m=importlib.util.module_from_spec(spec)
-sys.modules["srv"]=m; sys.path.insert(0,"lib"); spec.loader.exec_module(m)
-A,N=secrets.token_urlsafe(43),secrets.token_urlsafe(43)
-for label,c in [("identity",f"{A} {N} alpha\n"),("scope",f"{A} zach {N}\n"),("dup",f"{A} zach alpha\n{A} zach {N}\n")]:
-    with tempfile.TemporaryDirectory() as d:
-        f=pathlib.Path(d)/"t"; f.write_text(c)
-        try: m.load_tokens(f,dict(os.environ)); print(f"{label}: LOADED (!)")
-        except Exception as e:
-            msg=str(e); print(f"{label}: refused verbatim={N in msg} folded={N.lower().replace('_','-') in msg}")
+# the opencode exporter, end to end on a real session (no content printed)
+cd ~/workspace/devrc && nix develop . -c python3 - <<'PY'
+import sys, hashlib; sys.path.insert(0,'scripts/collector/opencode')
+import _shared as S, export as E
+db=S.get_db(); sid=list(S.iter_sessions(db))[3]["id"]
+a=E.export_session(db,sid); b=E.export_session(db,sid)
+print("lines",len(a.splitlines()),"identical",
+      hashlib.sha256(a.encode()).hexdigest()==hashlib.sha256(b.encode()).hexdigest(),
+      "ascii",a.isascii())
 PY
+
+# the devrc gate — BOTH tiers, on the MERGED tree, never a test subset
+nix develop ~/workspace/devrc -c bash scripts/gate.sh --tier both
+nix build .#checks.x86_64-linux.pytests --no-link      # one at a time
+nix build .#checks.x86_64-linux.nodetests --no-link
 ```
-Expected: `1647 passed, 0 failed`; leakscan `0 findings across 33 files`; all three shapes
-`refused verbatim=False folded=False`.
+Expected: cairn `1651 passed`, leakscan `0 findings across 33 files`; the exporter identical
+across runs and pure ASCII; `PASS scripts/collector/opencode/tests (collected=235 floor=224)`.


### PR DESCRIPTION
Updates `claudedocs/handoff-cairn-oss-multi-instance.md` in place (one doc per effort; the slug is the key).

**Closed this session:** rank 5 — `ZacxDev/cairn` #2 (`c8aee7203`), both ledger 🟢s closed each as its own docstring prescribed. Rank 9 — devrc #1338 (`f58d2df04`), clawgate #511 `complete`. Plus the session-capture proposal merged as #1326 (`e16f9609a`).

**Re-verified as still untouched**, rather than assumed: rank 3 (`flake.nix` has zero cairn references, `scripts/cairn` is still an out-of-store symlink), rank 4 (`civitai/talos-infra` #1414 still OPEN), rank 6 (no rate yet).

Three things recorded that a reader would otherwise re-derive or get wrong:

- 🔴 **The proposal's audit ladder ended by operator instruction at round 9, not on a clean round**, and round 9's own fixes were never audited. Named as the likeliest wrong thing in the document, because "merged after nine rounds" otherwise reads as "settled".
- 🔴 **`claim-work` was not used for ranks 1 and 2** (it was used correctly for rank 5). Nothing collided, but the protection was absent while 20 live claims from other sessions showed the mechanism in active use.
- 🔴 **Still not deployed anywhere** — carried forward from the previous State-now and re-verified, since the merge would otherwise have dropped it and everything above it reads like deployment.

Two new gotchas, both measured: a control that re-implements the guard certifies a *copy* (disarming the guard left the suite green at 11 passed), and a test subset is not the gate (the per-target drift ceiling lives only in `run-tests.sh`, so "223 passed" read as success while both tiers went red).

Landed via `handoff_doc.py --confirm --push` on a feature branch — **not** `main`, which this repo forbids committing to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)