### PR TITLE
docs(clawgate): a ready_for_review card is not evidence work remains

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -123,6 +123,17 @@ else means you **DERIVED** them, and that verdict is frozen at your first read.
 | DERIVED | yes | **`ready_for_review`** — you must not grade an exam you wrote |
 | either | **no** | **`ready_for_review`**, naming WHICH criterion and WHY it was not validatable |
 
+🔴 **READING that third row: `ready_for_review` is not evidence work remains.** The row's own output —
+a card whose work is finished, parked because ONE criterion was not validatable — is
+indistinguishable from an unfinished card on the board, so it ages there. **The tell is a criterion
+reality cannot satisfy**: a fixed number against a usage-based price, "the two numbers agree" against
+a per-token rate, "update the enumeration in its PR body" when the sentence is in an unamendable
+commit message. Grading those is minutes of reading and is the AUTHOR's call by construction — the
+worker was right to refuse. Measured 2026-09-06: three such cards sat complete-but-parked for over a
+week and two were auto-tagged `stale`. 🔴 **And the mirror, for the author: ask what makes a criterion
+FALSE before you write it** — one no correct implementation can meet is a trap for the next worker,
+not a bar.
+
 ## machine (hook-token) Task API
 🔴 **Authoring one? `flows/task-authoring.md` FIRST** — a hook denies a criteria-less create.
 Read/create with `clawgatectl task ls --summary [--status open --tag t --limit n]` · `task get <id>`

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -123,17 +123,6 @@ else means you **DERIVED** them, and that verdict is frozen at your first read.
 | DERIVED | yes | **`ready_for_review`** — you must not grade an exam you wrote |
 | either | **no** | **`ready_for_review`**, naming WHICH criterion and WHY it was not validatable |
 
-🔴 **READING that third row: `ready_for_review` is not evidence work remains.** The row's own output —
-a card whose work is finished, parked because ONE criterion was not validatable — is
-indistinguishable from an unfinished card on the board, so it ages there. **The tell is a criterion
-reality cannot satisfy**: a fixed number against a usage-based price, "the two numbers agree" against
-a per-token rate, "update the enumeration in its PR body" when the sentence is in an unamendable
-commit message. Grading those is minutes of reading and is the AUTHOR's call by construction — the
-worker was right to refuse. Measured 2026-09-06: three such cards sat complete-but-parked for over a
-week and two were auto-tagged `stale`. 🔴 **And the mirror, for the author: ask what makes a criterion
-FALSE before you write it** — one no correct implementation can meet is a trap for the next worker,
-not a bar.
-
 ## machine (hook-token) Task API
 🔴 **Authoring one? `flows/task-authoring.md` FIRST** — a hook denies a criteria-less create.
 Read/create with `clawgatectl task ls --summary [--status open --tag t --limit n]` · `task get <id>`

--- a/claude/skills/clawgate/flows/task-authoring.md
+++ b/claude/skills/clawgate/flows/task-authoring.md
@@ -163,6 +163,18 @@ be a gate that reports safety it did not deliver.
 criterion. "The bar feels better" is not. Each one should map to something in the
 Verifier section.
 
+🔴 **AND ASK WHAT WOULD MAKE EACH ONE FALSE — a criterion reality cannot satisfy is a
+trap for the next worker, not a bar.** Settle-able is not enough: a criterion can be
+perfectly machine-checkable and still be unmeetable by any correct implementation,
+because it pins a number or an artefact that was never going to hold. Measured
+2026-09-06 on three cards, all parked for over a week and two auto-tagged `stale`:
+*"`buzz-balance` decrements by exactly 1"* against a price the orchestrator re-quotes
+per token; *"the two numbers agree"* where one side is a live rate and the other a
+constant; *"update the enumeration in its PR body"* when the sentence lives in an
+unamendable merge-commit message. Each cost a correct, finished implementation its
+`complete`. **A criterion quoting a CONSTANT is the shape to re-read** — ask where the
+constant comes from and whether anything guarantees it stays true.
+
 ## Phase 4 — CONFIRM
 
 **Render the full body and get approval before POSTing.** `create` returns only

--- a/claude/skills/clawgate/flows/task-pickup.md
+++ b/claude/skills/clawgate/flows/task-pickup.md
@@ -83,6 +83,17 @@ completion report.
 AUTHOR-SPECIFIED/DERIVED × validated table that decides `complete` vs `ready_for_review`. Read it
 there; it is deliberately not duplicated here.
 
+🔴 **READING a card the gate's third row produced: `ready_for_review` is NOT evidence work
+remains.** That row — *not every criterion validated ⇒ `ready_for_review`, naming which and why* —
+is also what a FINISHED card looks like when one criterion turned out to be unvalidatable. On the
+board the two are indistinguishable, so it sits there and ages. **The tell is a criterion reality
+cannot satisfy** (see `flows/task-authoring.md` → "ask what would make each one FALSE"): grading it
+is minutes of reading, and it is the AUTHOR's call by construction — the worker who refused was
+right, and re-picking the card up as *work* re-does something already done. Measured 2026-09-06:
+three such cards, complete for over a week, two auto-tagged `stale` by the retention sweep; all
+three closed on a read. **Before working a `ready_for_review` card, read its last comment** — a
+refusal-to-self-grade says so in as many words.
+
 🔴 **That gate is LOCAL-pickup only, structurally.** The in-devpod agent route
 `PATCH /agent/task/status` **forbids `complete`** (`notes.StatusAllowedForAgent`), so a dispatched
 devpod agent ends at `ready_for_review` regardless of what this skill says. Only the machine route


### PR DESCRIPTION
The status gate's third row — *either / not every criterion validated / `ready_for_review`, naming WHICH criterion and WHY* — produces cards whose **work is finished** and which are parked on one unvalidatable criterion. On the board those are indistinguishable from unfinished cards, so they age there. The gate documented the worker's obligation and said nothing to the reader.

Adds one block under the table:

- the tell — **a criterion reality cannot satisfy** (a fixed number against a usage-based price; "the two numbers agree" against a per-token rate; "update the enumeration in its PR body" when the sentence is in an unamendable commit message)
- grading it is the **author's call by construction**, so the worker was right to refuse
- the mirror for the author: **ask what makes a criterion FALSE before you write it** — one no correct implementation can meet is a trap for the next worker, not a bar

**Measured 2026-09-06** on clawgate #386 / #425 / #379: three complete-but-parked cards, over a week old, two auto-tagged `stale` by the retention sweep. All three closed in minutes once read as gradings rather than as work.

Docs only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSwTMMRtTBk53CodrMf1LP
