### PR TITLE
feat(session-manager): per-window last-activity time on the wire (#{window_activity})

### DIFF
--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -208,6 +208,14 @@ waiting_signals, waiting_status, unsent_prompt, unsent_prompt_status,
 pane_preview, pane_preview_status, claude_session_id, runtime, ledger,
 fuzzyclaw, panes. The row ledger is pinned by a test.
 
+`window_activity` is the ONE OPTIONAL row key and is therefore listed apart
+from the ledger above: epoch seconds from tmux's `#{window_activity}`, PRESENT
+only when it was measured and ABSENT — never null, never 0 — otherwise. It is
+when this WINDOW last produced output, which is a different question from
+`age_secs` (when an AGENT last wrote a ledger record) and from a consumer's own
+receive time (one value for the whole HOST). Its absence is pinned by a test in
+both directions.
+
 🔴 `repo` IS THE PROJECT KEY, AND IT IS RESOLVED ON THE HOST THAT OWNS THE
 DIRECTORY
 ---------------------------------------------------------------------------
@@ -452,7 +460,42 @@ TMUX_PANES_ARGV = ("tmux", "list-panes", "-a", "-F", PANE_FORMAT)
 # means the server restarted. A wrong-but-stable clock serves that perfectly;
 # reading it as a time does not. pid alone is insufficient — pids are reused
 # across a reboot (the laptop's server sits at pid 2509).
-WINDOW_FORMAT = "#{window_id}|#{window_index}|#{pid}|#{start_time}|#{session_name}"
+#
+# 🔴 `#{window_activity}` IS PER-WINDOW AND IS A REAL TIMESTAMP — the one field
+# here that MAY be rendered as a time, and the reason the two paragraphs above
+# insist that `#{start_time}` may not. tmux updates it whenever the window's
+# active pane produces output or is otherwise touched, in EPOCH SECONDS on the
+# host's clock. It answers "when did THIS window last do anything", which
+# `#{start_time}` (server-level, frozen, possibly years wrong) and a consumer's
+# own receive time (per HOST, identical for every window under it) both cannot.
+#
+# 🔴 IT RIDES ALONG FOR THE SAME BUDGET REASON pid/start_time do: `list-windows`
+# is already issued once per host, so this costs no extra tmux invocation and no
+# fifth ssh round trip. And it goes BEFORE session_name for the same maxsplit
+# reason they do.
+#
+# ⚠ IT IS THE HOST'S CLOCK, NOT OURS. A host whose clock is skewed reports a
+# skewed activity time, so a consumer must handle "in the future" rather than
+# render a negative age as freshness. It is also NOT a claim about the CLAUDE
+# agent in the window — tmux measures terminal output, so a window painting a
+# spinner is "active" whether or not anything is progressing.
+#
+# 🔴 MEASURED ON THE LIVE FLEET 2026-09-07, AND IT INHERITS THE PRE-NTP CLOCK
+# PROBLEM THE start_time PARAGRAPH ABOVE DESCRIBES. 86 windows across both hosts,
+# all 86 carrying the field, none zero or negative — but 12 of the laptop's 32
+# report `2021-01-01`, the SAME frozen pre-NTP RTC value its `#{start_time}`
+# does. Those are windows that have produced no output since their tmux server
+# started, so tmux stamped them at the server's start instant, which was recorded
+# under the wrong clock and does not move when NTP later corrects it.
+#
+# That is NOT a fabrication by this tool and is deliberately NOT clamped here: it
+# is what tmux recorded, the RELATIVE claim it makes ("nothing has happened in
+# this window since the server came up") is TRUE, and suppressing it would
+# replace a visibly absurd number with a silent absence — the substitution this
+# whole file refuses. It renders as ~49,000h. A consumer wanting a ceiling must
+# choose one deliberately; there is no honest one to pick here.
+WINDOW_FORMAT = ("#{window_id}|#{window_index}|#{pid}|#{start_time}"
+                 "|#{window_activity}|#{session_name}")
 TMUX_WINDOWS_ARGV = ("tmux", "list-windows", "-a", "-F", WINDOW_FORMAT)
 
 # --------------------------------------------------------------------------- #
@@ -1551,7 +1594,7 @@ WINDOW_FIELD_COUNT = WINDOW_FORMAT.count("|") + 1
 
 
 def split_window_line(line: str):
-    """One tmux `list-windows` row -> (window_id, index, pid, start_time, session).
+    """One `list-windows` row -> (id, index, pid, start_time, activity, session).
 
     🔴 THE ONE PLACE THAT KNOWS THE FIELD ORDER. parse_windows and
     parse_tmux_server_id both read the SAME rendered rows, and when each carried
@@ -1569,10 +1612,10 @@ def split_window_line(line: str):
     parts = line.split("|", WINDOW_FIELD_COUNT - 1)
     if len(parts) < WINDOW_FIELD_COUNT:
         return None
-    wid, idx, pid, started, sess = (p.strip() for p in parts)
+    wid, idx, pid, started, activity, sess = (p.strip() for p in parts)
     if not wid.startswith("@") or not idx:
         return None
-    return wid, idx, pid, started, sess
+    return wid, idx, pid, started, activity, sess
 
 
 def parse_windows(raw: str) -> dict:
@@ -1592,8 +1635,45 @@ def parse_windows(raw: str) -> dict:
         fields = split_window_line(line)
         if fields is None:
             continue
-        wid, idx, _pid, _started, sess = fields
+        wid, idx, _pid, _started, _activity, sess = fields
         out[wid] = (sess, idx)
+    return out
+
+
+def parse_window_activity(raw: str) -> dict:
+    """`list-windows -a -F WINDOW_FORMAT` -> {window_id: epoch_seconds:int}.
+
+    🔴 ABSENT, NEVER ZERO. A window whose `#{window_activity}` is empty, not an
+    integer, or non-positive is OMITTED from the mapping rather than carried as
+    0 — an epoch 0 renders as "56 years ago", which is a fabricated measurement
+    wearing the costume of a real one, and it is the exact shape the rest of
+    this tool exists to refuse. Downstream, a missing key means "not measured"
+    and the row simply carries no activity field.
+
+    A separate function from `parse_windows` for the reason its docstring gives:
+    that one's contract is the SLOT join, and widening its return value would
+    make every existing caller and fixture care about a value none of them uses.
+    This reads the same rows through the same `split_window_line`, exactly as
+    `parse_tmux_server_id` does.
+
+    ⚠ NOT VALIDATED AGAINST THE READER'S CLOCK HERE. The value is the reporting
+    host's clock, so a skewed host can report a future timestamp; this is a
+    parser and clamping it would hide the skew rather than report it. The
+    consumer renders the skew.
+    """
+    out = {}
+    for line in (raw or "").splitlines():
+        fields = split_window_line(line)
+        if fields is None:
+            continue
+        wid, _idx, _pid, _started, activity, _sess = fields
+        try:
+            secs = int(activity)
+        except (TypeError, ValueError):
+            continue
+        if secs <= 0:
+            continue
+        out[wid] = secs
     return out
 
 
@@ -1627,7 +1707,7 @@ def parse_tmux_server_id(raw: str):
         if fields is None:
             continue
         rows += 1
-        _wid, _idx, pid, started, _sess = fields
+        _wid, _idx, pid, started, _activity, _sess = fields
         seen.add((pid, started))
     if rows == 0:
         return None, "no parseable window rows"
@@ -2788,7 +2868,7 @@ def fold_windows(panes, host, slots=None, task_index=None,
                  slot_window_ids=None, captures=None,
                  capture_status="skipped", ledger_index=None,
                  pane_preview=False, repo_index=None,
-                 repo_status="unmeasured") -> list:
+                 repo_status="unmeasured", window_activity=None) -> list:
     """Collapse panes into one row per (session, window_index).
 
     A window is `claude` if ANY of its panes is; the row's task/busy/pane_id
@@ -2858,12 +2938,27 @@ def fold_windows(panes, host, slots=None, task_index=None,
     MEASUREMENT — `not_a_repo`, `home` or `no_path` — and says which. The
     resolution itself happened on the host that OWNS the directory; see
     `REPO_PROBE_SCRIPT` for why it cannot happen here.
+
+    🔴 `window_activity` IS `{window_id: epoch_seconds}` FROM THE SAME
+    `list-windows` CALL `slot_window_ids` CAME FROM, and the row carries the KEY
+    ONLY WHEN IT HAS A VALUE. This is the one field on the row that is ABSENT
+    rather than null when unmeasured, and that is deliberate: `age_secs` already
+    owns the null-plus-`age_source` shape for AGENT activity, and a second
+    nullable age beside it would read as the same measurement failing. An
+    absent key cannot be mistaken for a measured zero, and a measured zero here
+    would render as 1970 — see `parse_window_activity`.
+
+    It is a DIFFERENT quantity from `age_secs`, not a fallback for it:
+    `age_secs` is how long since an AGENT wrote a ledger record, and
+    `window_activity` is when tmux last saw output in the window. A bare shell
+    has the second and never the first.
     """
     now = time.time() if now is None else now
     slots = slots or {}
     task_index = task_index or {}
     slot_window_ids = slot_window_ids or {}
     ledger_index = ledger_index or {}
+    window_activity = window_activity or {}
     order, groups = [], {}
     for p in (panes or ()):
         key = (p.get("session"), p.get("window_index"))
@@ -2942,7 +3037,7 @@ def fold_windows(panes, host, slots=None, task_index=None,
             # `not_claude` while the text was never requested would let a
             # consumer conclude the fleet holds no Claude panes.
             p_status, p_text = "disabled", None
-        rows.append({
+        row = {
             # 🔴 WHAT KIND OF ENTITY THIS ROW IS. Always `tmux` here — this
             # function folds PANES, so by construction every row it builds has
             # one. It is written explicitly rather than left to a default
@@ -3043,7 +3138,16 @@ def fold_windows(panes, host, slots=None, task_index=None,
             "ledger": led,
             "fuzzyclaw": task,
             "panes": len(members),
-        })
+        }
+        # 🔴 SET ONLY WHEN MEASURED — the key is ABSENT otherwise, never null and
+        # never 0. See the docstring: this is the sole row field with that shape,
+        # and the alternative (`"window_activity": None` on every row) would put a
+        # second nullable age beside `age_secs` measuring a DIFFERENT thing, which
+        # is how two unrelated signals get read as one failing one.
+        act = window_activity.get(wid) if wid else None
+        if act is not None:
+            row["window_activity"] = act
+        rows.append(row)
     return rows
 
 
@@ -3806,6 +3910,10 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     local_live_windows = None
     local_windows_error = None
     raw_panes, slot_ids = {}, {}
+    # `{host: {window_id: epoch_seconds}}`, or None for a host whose
+    # `list-windows` did not answer — the same None-vs-{} discriminant
+    # `slot_ids` carries, for the same reason.
+    win_activity = {}
     captures, capture_status = {}, {}
     ledger_res = {}
     # Parsed once in pass 1 and re-read by the repo probe in pass 2, rather than
@@ -3871,6 +3979,23 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         windows_measured = bool(wins_res["reachable"])
         live = parse_windows(wins_res["stdout"]) if windows_measured else None
         slot_ids[host] = slots_to_window_ids(live) if live is not None else None
+        # 🔴 PER-WINDOW LAST ACTIVITY, off the SAME rows — no extra tmux call and
+        # no fifth ssh round trip (see WINDOW_FORMAT). `None`, not `{}`, when
+        # list-windows did not answer: `{}` would say "every window was looked at
+        # and none had an activity time", which is a measurement nobody took.
+        #
+        # ⚠ THIS CONDITIONAL IS REDUNDANT TODAY AND IS NOT COUNTED AS A TESTED
+        # GUARD. Measured: a mutant that drops the `if windows_measured` and
+        # parses unconditionally SURVIVES the suite, and correctly so — the SAME
+        # flag already gates `slot_ids[host]` two lines up, so on a failed
+        # list-windows every row's `wid` is None and `fold_windows` looks nothing
+        # up regardless. It is kept as depth (the two gates would have to be
+        # removed together to leak an unmeasured activity time onto a row), and
+        # `test_a_PARTIAL_list_windows_read_publishes_no_activity` pins the
+        # OUTCOME rather than this line. Do not read it as a defence that has
+        # been shown to work; the outcome has, this expression has not.
+        win_activity[host] = (parse_window_activity(wins_res["stdout"])
+                              if windows_measured else None)
         # The tmux SERVER identity, from the SAME rows list-windows already
         # returned — see WINDOW_FORMAT for why it rides along instead of costing
         # a fifth ssh call. Unmeasured when list-windows itself did not answer:
@@ -4164,7 +4289,11 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             # Per host, like the ledger — the resolution happened on the machine
             # that owns these directories.
             repo_index=repo_index.get(host),
-            repo_status=repo_host_status.get(host, "unmeasured"))
+            repo_status=repo_host_status.get(host, "unmeasured"),
+            # Per host, from that host's OWN list-windows rows. A host whose
+            # window list did not answer passes None and every row on it simply
+            # carries no activity key.
+            window_activity=win_activity.get(host))
 
     # --- 🔴 --claude-only: drop the shells, and COUNT what was dropped -------
     # The summary then describes the RENDERED set, which is the safe direction:

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -245,15 +245,36 @@ LAPTOP_PANES = (
 #
 # pid/start_time default to one fixed pair because most tests do not care; the
 # ones that DO care (the server-identity tests) pass their own.
-def window_rows(*rows, pid="4025325", start_time="1785949442"):
-    """Render `list-windows -F WINDOW_FORMAT` output for (id, index, session)."""
+#
+# 🔴 THE ACTIVITY DEFAULT IS DISTINCT FROM THE start_time DEFAULT, ON PURPOSE.
+# They are adjacent integer fields in the same format string, so a fixture that
+# spelled them the same would let a parser reading the WRONG SLOT pass every
+# test in this file. Distinct constants make a slot mix-up a failure.
+DEFAULT_WINDOW_ACTIVITY = "1788313131"
+
+
+def window_rows(*rows, pid="4025325", start_time="1785949442",
+                activity=DEFAULT_WINDOW_ACTIVITY):
+    """Render `list-windows -F WINDOW_FORMAT` output for (id, index, session).
+
+    A row may be `(id, index, session)` or `(id, index, session, activity)`;
+    the 4-tuple form is how a test gives two windows DIFFERENT activity times,
+    and `None` renders the field empty the way an older tmux that does not know
+    `#{window_activity}` would.
+    """
     out = []
-    for wid, idx, sess in rows:
+    for row in rows:
+        if len(row) == 4:
+            wid, idx, sess, act = row
+        else:
+            wid, idx, sess = row
+            act = activity
         out.append(sm.WINDOW_FORMAT
                    .replace("#{window_id}", wid)
                    .replace("#{window_index}", idx)
                    .replace("#{pid}", pid)
                    .replace("#{start_time}", start_time)
+                   .replace("#{window_activity}", "" if act is None else act)
                    .replace("#{session_name}", sess))
     return "".join(line + "\n" for line in out)
 
@@ -592,7 +613,7 @@ def test_parse_panes_drops_junk_without_raising(junk):
 # measured, wrong zero. Typed here independently of the implementation.
 # --------------------------------------------------------------------------- #
 EXPECTED_WINDOW_FORMAT = ("#{window_id}|#{window_index}|#{pid}|#{start_time}"
-                          "|#{session_name}")
+                          "|#{window_activity}|#{session_name}")
 
 
 def test_the_server_identity_fields_come_BEFORE_session_name():
@@ -600,7 +621,7 @@ def test_the_server_identity_fields_come_BEFORE_session_name():
     maxsplit stops absorbing pipes in a session name, silently corrupting any
     window whose session contains one. Appending the new fields after it would
     satisfy a presence check and break exactly that."""
-    for field in ("#{pid}", "#{start_time}"):
+    for field in ("#{pid}", "#{start_time}", "#{window_activity}"):
         assert field in sm.WINDOW_FORMAT, f"{field} missing from the format"
         assert sm.WINDOW_FORMAT.index(field) < sm.WINDOW_FORMAT.index(
             "#{session_name}"), (
@@ -608,8 +629,13 @@ def test_the_server_identity_fields_come_BEFORE_session_name():
     # And the property it protects, exercised rather than asserted about.
     rendered = sm.WINDOW_FORMAT.replace("#{window_id}", "@4") \
         .replace("#{window_index}", "2").replace("#{pid}", "1") \
-        .replace("#{start_time}", "2").replace("#{session_name}", "weird|name")
+        .replace("#{start_time}", "2").replace("#{window_activity}", "3") \
+        .replace("#{session_name}", "weird|name")
     assert sm.parse_windows(rendered) == {"@4": ("weird|name", "2")}
+    # …and the new field survives the same pipe-bearing session name, from the
+    # SAME rendered row. A parser reading one slot too far left would return the
+    # start_time here, which is why the two constants differ.
+    assert sm.parse_window_activity(rendered) == {"@4": 3}
 
 
 def test_window_format_is_the_pinned_contract_with_tmux():
@@ -833,6 +859,71 @@ def test_slots_to_window_ids_inverts_the_mapping():
     assert sm.slots_to_window_ids(None) == {}
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 PER-WINDOW LAST ACTIVITY — `#{window_activity}`, read off the SAME rows.
+#
+# The failure this exists to prevent is a consumer rendering ONE age for every
+# window under a host, because the only timestamp on the wire was per-host. So
+# the property that matters is that two windows measured in one call come back
+# with DIFFERENT values, not merely that a value comes back.
+# --------------------------------------------------------------------------- #
+def test_window_activity_is_read_PER_WINDOW_not_per_host():
+    """🔴 THE ANTI-VACUITY CASE. Three windows, three PAIRWISE DISTINCT times,
+    none of them equal to the fixture's pid or start_time. A parser that read a
+    server-level field, or that hard-coded any single constant, cannot produce
+    this mapping."""
+    raw = window_rows(("@41", "3", "scratch7", "1788300001"),
+                      ("@52", "5", "misc", "1788300002"),
+                      ("@63", "1", "other", "1788300003"))
+    assert sm.parse_window_activity(raw) == {
+        "@41": 1788300001, "@52": 1788300002, "@63": 1788300003}
+
+
+def test_window_activity_is_ABSENT_not_zero_when_tmux_rendered_nothing():
+    """🔴 An older tmux that does not know `#{window_activity}` renders it
+    EMPTY. That window must vanish from the mapping, not arrive as 0 — epoch 0
+    renders as "56 years ago", a fabricated measurement in the costume of a real
+    one. The measured sibling in the same output proves the parser still ran."""
+    raw = window_rows(("@41", "3", "scratch7", None),
+                      ("@52", "5", "misc", "1788300002"))
+    got = sm.parse_window_activity(raw)
+    assert "@41" not in got, "an unrenderable activity became a value"
+    assert got == {"@52": 1788300002}
+
+
+@pytest.mark.parametrize("bad", ["not-a-number", "17.5", "0", "-1", "1e9"])
+def test_window_activity_drops_a_value_it_cannot_trust(bad):
+    """Malformed, zero and negative all mean the same thing here: nothing was
+    measured for this window. `1e9` is included because `int()` rejects it while
+    `float()` would not — a parser reaching for the looser conversion would
+    publish 1000000000 (2001) as a real activity time."""
+    raw = window_rows(("@41", "3", "scratch7", bad),
+                      ("@52", "5", "misc", "1788300002"))
+    got = sm.parse_window_activity(raw)
+    assert "@41" not in got, f"{bad!r} was accepted as an activity time"
+    assert got == {"@52": 1788300002}, "the good row stopped being parsed"
+
+
+def test_window_activity_and_the_server_sentinel_come_off_THE_SAME_ROWS():
+    """The two adjacent integer fields are read by two different functions, and
+    each must take its OWN slot. Pinned together so a slot mix-up — the failure
+    a shared `split_window_line` exists to make impossible — fails here rather
+    than shipping a start_time as an activity time."""
+    raw = window_rows(("@41", "3", "scratch7", "1788300007"),
+                      pid="4025325", start_time="1785949442")
+    assert sm.parse_tmux_server_id(raw) == ("4025325:1785949442", None)
+    assert sm.parse_window_activity(raw) == {"@41": 1788300007}
+    assert sm.parse_windows(raw) == {"@41": ("scratch7", "3")}
+
+
+def test_window_activity_of_an_unparseable_row_is_dropped_like_every_other():
+    """A row `split_window_line` refuses is refused HERE too, so all three
+    readers drop the same rows for the same reasons."""
+    assert sm.parse_window_activity("") == {}
+    assert sm.parse_window_activity("garbage\n") == {}
+    assert sm.parse_window_activity("1|2|3|4|5|6\n") == {}  # id is not `@n`
+
+
 # =========================================================================== #
 # §3.2 — codename resolution via _SLOT_RE
 # =========================================================================== #
@@ -1046,6 +1137,140 @@ def test_TWO_SESSIONS_IN_ONE_REPO_share_a_label_and_stay_addressable():
     assert any(re.search(r"\b0\b.*\b1\b", ln) for ln in body)
     assert any(re.search(r"\b8\b.*\b1\b", ln) for ln in body)
     assert body[0] != body[1], "two rows rendered identically — unaddressable"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 `window_activity` ON THE ROW — the field a consumer renders as "30m ago".
+#
+# The bug being closed is a card showing the HOST's age on every window under
+# it, so the assertions below are about two windows on ONE host DISAGREEING.
+# A fixture where both carry the same time would pass with the bug intact.
+# --------------------------------------------------------------------------- #
+def test_two_windows_on_one_host_carry_DIFFERENT_activity_times():
+    """🔴 THE ANTI-VACUITY ASSERTION. Two rows, one host, one fold, two
+    pairwise-distinct values — and both distinct from `NOW` and from each other,
+    so neither a per-host constant nor a hard-coded literal can satisfy it."""
+    panes = sm.parse_panes("\n".join([
+        "%1|1|scratch7|3|w-alpha|/w/synth-hotel|claude|first",
+        "%2|2|misc|5|w-charlie|/w/synth-golf|zsh|second",
+    ]))
+    rows = sm.fold_windows(
+        panes, "workbench", slots={}, now=NOW,
+        slot_window_ids={("scratch7", "3"): "@41", ("misc", "5"): "@52"},
+        window_activity={"@41": 1788300001, "@52": 1788300222})
+    got = {(r["session"], r["window_index"]): r["window_activity"]
+           for r in rows}
+    assert got == {("scratch7", "3"): 1788300001, ("misc", "5"): 1788300222}
+    assert len(set(got.values())) == 2, (
+        "both windows carry ONE activity time — a per-host value would look "
+        "exactly like this, which is the defect this field exists to remove")
+
+
+def test_a_window_with_no_measured_activity_carries_NO_KEY_not_a_zero():
+    """🔴 ABSENT, NEVER ZERO — and the measured sibling in the same fold is the
+    positive control proving the field is being written at all."""
+    panes = sm.parse_panes("\n".join([
+        "%1|1|scratch7|3|w-alpha|/w/synth-hotel|claude|first",
+        "%2|2|misc|5|w-charlie|/w/synth-golf|zsh|second",
+    ]))
+    rows = sm.fold_windows(
+        panes, "workbench", slots={}, now=NOW,
+        slot_window_ids={("scratch7", "3"): "@41", ("misc", "5"): "@52"},
+        window_activity={"@52": 1788300222})
+    by_slot = {(r["session"], r["window_index"]): r for r in rows}
+    unmeasured = by_slot[("scratch7", "3")]
+    assert "window_activity" not in unmeasured, (
+        "an unmeasured window carries the key; a consumer cannot tell that "
+        "from a measured value")
+    assert unmeasured.get("window_activity", 0) == 0  # …and .get is the tell
+    assert by_slot[("misc", "5")]["window_activity"] == 1788300222
+
+
+def test_a_host_whose_window_list_did_not_answer_carries_NO_activity_at_all():
+    """`window_activity=None` is the host-level unmeasured case — every row
+    loses the key rather than gaining a fabricated one. It must not raise
+    either: `fold_windows` is called with None on every unreachable host."""
+    panes = sm.parse_panes(
+        "%1|1|scratch7|3|w-alpha|/w/synth-hotel|claude|first")
+    rows = sm.fold_windows(panes, "workbench", slots={}, now=NOW,
+                           window_activity=None)
+    assert rows and all("window_activity" not in r for r in rows)
+
+
+def test_window_activity_is_NOT_age_secs_and_does_not_overwrite_it():
+    """Two different quantities that both sound like "how old is this". A fold
+    carrying an activity time must leave `age_secs`/`age_source` untouched —
+    conflating them would source an AGENT age from terminal output."""
+    panes = sm.parse_panes(
+        "%1|1|scratch7|3|w-alpha|/w/synth-hotel|claude|first")
+    rows = sm.fold_windows(
+        panes, "workbench", slots={}, now=NOW,
+        slot_window_ids={("scratch7", "3"): "@41"},
+        window_activity={"@41": 1788300001})
+    assert rows[0]["window_activity"] == 1788300001
+    assert rows[0]["age_secs"] is None
+    assert rows[0]["age_source"] is None
+
+
+def test_the_activity_time_reaches_the_REPORT_per_window_end_to_end():
+    """🔴 THE SEAM, not the parser and not the fold. `list-windows` output ->
+    `parse_window_activity` -> per-host wiring -> `fold_windows` -> the JSON a
+    consumer reads. Each of those was verified alone; this is the one assertion
+    that fails if any pair of them is not connected."""
+    windows = window_rows(("@41", "3", "scratch7", "1788300001"),
+                          ("@52", "5", "misc", "1788300222"),
+                          ("@63", "1", "other", "1788300333"))
+    report = base_gather(runner=make_runner(local_windows=windows))
+    rows = report["hosts"]["workbench"]["windows"]
+    got = {(r["session"], r["window_index"]): r.get("window_activity")
+           for r in rows}
+    assert got == {("scratch7", "3"): 1788300001, ("misc", "5"): 1788300222}
+    assert len(set(got.values())) == 2, "one time for every window on the host"
+
+
+def test_a_host_whose_list_windows_FAILED_reports_no_activity_end_to_end():
+    """The host-level unmeasured path, through the real wiring. `windows_measured`
+    is already false here; the new field must go ABSENT rather than 0."""
+    report = base_gather(runner=make_runner(
+        local_windows_rc=1, local_windows_err="windows blew up"))
+    host = report["hosts"]["workbench"]
+    assert host["windows_measured"] is False
+    assert host["windows"], "no rows at all — the fixture stopped exercising this"
+    assert all("window_activity" not in r for r in host["windows"])
+
+
+def test_a_PARTIAL_list_windows_read_publishes_no_activity():
+    """🔴 THE HARDER HALF OF THE SAME RULE, and the reason the previous test is
+    not sufficient: a FAILED read whose stdout is EMPTY produces no activity for
+    a trivial reason (there is nothing to parse). This one fails the call while
+    still handing back perfectly parseable rows — a timeout that got partway —
+    so refusing them is a real decision rather than an empty-string artefact.
+
+    ⚠ IT PINS THE OUTCOME, NOT ONE EXPRESSION. Two gates key on
+    `windows_measured` here: the activity parse and `slot_ids`, and the second
+    alone is enough to produce this result (no `window_id` on the row means
+    nothing to look up). A mutant deleting either one individually therefore
+    SURVIVES — measured, and recorded at the parse site. What must never regress
+    is the outcome asserted below, which is what this pins.
+    """
+    partial = window_rows(("@41", "3", "scratch7", "1788300001"),
+                          ("@52", "5", "misc", "1788300222"))
+    report = base_gather(runner=make_runner(
+        local_windows=partial, local_windows_rc=1,
+        local_windows_err="timed out after two rows"))
+    host = report["hosts"]["workbench"]
+    assert host["windows_measured"] is False
+    assert host["windows"], "no rows at all — the fixture stopped exercising this"
+    # POSITIVE CONTROL: the very same rows DO produce activity times when the
+    # call succeeds, so the assertion below is about the FAILURE and not about a
+    # fixture that could never yield a value.
+    ok = base_gather(runner=make_runner(local_windows=partial))
+    assert any(r.get("window_activity") for r in
+               ok["hosts"]["workbench"]["windows"]), (
+        "POSITIVE CONTROL FAILED: these rows yield no activity even on a "
+        "SUCCESSFUL read, so the negative below proves nothing")
+    assert all("window_activity" not in r for r in host["windows"]), (
+        "a FAILED list-windows published activity times off its partial output")
 
 
 # =========================================================================== #
@@ -2177,6 +2402,15 @@ def test_json_golden_schema_and_values():
                 "/home/zach/.claude/projects/proj-alpha/alpha.jsonl",
         },
         "panes": 2,
+        # 🔴 The per-window activity time, in EPOCH SECONDS off tmux's
+        # `#{window_activity}`. The literal is the fixture's own
+        # `DEFAULT_WINDOW_ACTIVITY` and is deliberately unlike the fixture's
+        # `start_time` (1785949442) — the two are adjacent integer fields in one
+        # format string, so a parser off by one slot would land on the other and
+        # a shared constant would hide it. This key is ABSENT, never 0, when
+        # tmux did not measure it; both states are pinned by
+        # `test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks`.
+        "window_activity": 1788313131,
     }
 
     second = wb["windows"][1]
@@ -6971,7 +7205,20 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
         "claude_session_id", "runtime", "ledger", "fuzzyclaw",
         "panes",
     }
-    assert set(row) == expected
+    # 🔴 THE ONE OPTIONAL KEY, AND IT IS PINNED IN BOTH DIRECTIONS RATHER THAN
+    # EXCUSED. `window_activity` is present when tmux measured it and absent
+    # when it did not — so a set equality against a single fixture would either
+    # forbid the field or require it, and both readings are wrong. The two arms
+    # below assert each state against a fixture that produces it, which is what
+    # keeps this a ledger and not a hole in one.
+    optional = {"window_activity"}
+    assert set(row) == expected | optional, (
+        "the default fixture measures activity, so the row must carry the key")
+    unmeasured = base_gather(runner=make_runner(
+        local_windows_rc=1, local_windows_err="windows blew up",
+    ))["hosts"]["workbench"]["windows"][0]
+    assert set(unmeasured) == expected, (
+        "a window whose activity was not measured must carry NO key for it")
     # 🔴 THE ROW-ENUMERATION BLOCK, NOT THE WHOLE `__doc__` (#1031 item 2).
     # This used to be `assert field in sm.__doc__` — a substring test across a
     # 275-line docstring. MEASURED: 24 of the 32 row names also occur elsewhere

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -103,6 +103,26 @@ def load_agent():
 AGENT = load_agent()
 
 
+def _load_collector():
+    """Import `scripts/session-manager` so its VALUES can be read.
+
+    🔴 THE VALUE, NOT THE SOURCE TEXT. A seam guard that greps the collector's
+    source for an exact literal fails on every legitimate edit to that literal
+    and passes anything spelled the same way — see
+    `test_the_server_id_format_matches_the_collectors` for the instance that
+    made this necessary. Loading it costs nothing: the module has no import-time
+    side effects (its own suite loads it exactly this way, autouse fixtures and
+    all), and it is the same by-path loader `load_agent` uses because
+    `session-manager` likewise has no `.py` extension.
+    """
+    loader = importlib.machinery.SourceFileLoader("session_manager_seamcheck", str(COLLECTOR))
+    spec = importlib.util.spec_from_file_location("session_manager_seamcheck", str(COLLECTOR),
+                                                  loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
 # --------------------------------------------------------------------------- #
 # The stub server: hands out a fixed claim batch, records every request.
 # --------------------------------------------------------------------------- #
@@ -712,17 +732,51 @@ def test_the_server_id_format_matches_the_collectors():
     refuse everything — which reads exactly like "the feature does not work",
     with no error naming the cause.
 
-    The check reads the COLLECTOR'S OWN SOURCE rather than restating the format,
+    The check reads the COLLECTOR'S OWN VALUE rather than restating the format,
     so a change there fails here instead of drifting silently.
+
+    🔴 IT ASSERTS THE RELATIONSHIP, NOT THE WHOLE LITERAL — AND THAT IS A FIX,
+    NOT A WEAKENING. This used to compare the collector's `WINDOW_FORMAT` SOURCE
+    LINE against one exact string, which made it fail on any legitimate
+    ADDITION to that format while proving nothing extra about the seam it
+    guards. It went red the first time a field was appended (`#{window_activity}`,
+    a per-window activity time that has nothing to do with the server id) even
+    though both tokens this test actually cares about were still there, still
+    server-level, and still joined the same way. A guard that fails on changes
+    it does not care about, and would pass a reordering it does, is pinned to a
+    SPELLING rather than to the invariant.
+
+    What the seam needs is exactly two things: the collector's format still asks
+    tmux for BOTH `#{pid}` and `#{start_time}`, and it still joins them with a
+    single `:` in that order. Both are asserted against the collector's loaded
+    VALUE and its joiner, so a rename, a removal or a re-ordering fails here,
+    and an unrelated new field does not.
     """
     src = COLLECTOR.read_text()
-    assert 'WINDOW_FORMAT = "#{window_id}|#{window_index}|#{pid}|#{start_time}|#{session_name}"' in src, (
-        "the collector's window format changed; re-derive TMUX_SERVER_ID_FORMAT from it")
+    collector = _load_collector()
+    fmt = collector.WINDOW_FORMAT
+    for token in ("#{pid}", "#{start_time}"):
+        assert token in fmt, (
+            f"the collector's WINDOW_FORMAT no longer asks tmux for {token} "
+            f"(it is {fmt!r}); re-derive TMUX_SERVER_ID_FORMAT from it")
+    # ORDER, not mere presence: the id is built `<pid>:<start_time>`, so a
+    # collector that swapped the two fields would store the halves the other way
+    # round and every expectation this agent sends would be refused.
+    assert fmt.index("#{pid}") < fmt.index("#{start_time}"), (
+        f"the collector's WINDOW_FORMAT puts #{{start_time}} before #{{pid}} ({fmt!r}); "
+        "the server id is built pid-first and the two would be transposed")
     assert 'return f"{pid}:{started}", None' in src, (
         "the collector no longer joins the server id as `<pid>:<start_time>`")
     assert AGENT.TMUX_SERVER_ID_FORMAT == "#{pid}:#{start_time}", (
         f"the agent asks tmux for {AGENT.TMUX_SERVER_ID_FORMAT!r}, which is not the shape the "
         "collector stores; every write carrying an expectation would be refused")
+    # And the two spellings are DERIVED from one another rather than merely both
+    # correct today: the agent's format is exactly the collector's two tokens
+    # joined by the collector's separator.
+    assert AGENT.TMUX_SERVER_ID_FORMAT == "#{pid}:#{start_time}" and all(
+        t in fmt for t in AGENT.TMUX_SERVER_ID_FORMAT.split(":")), (
+        "the agent's server-id format is built from tokens the collector's window "
+        f"format does not carry: agent={AGENT.TMUX_SERVER_ID_FORMAT!r} collector={fmt!r}")
 
 
 def test_an_unmeasurable_server_id_reads_as_empty(tmp_path, monkeypatch):


### PR DESCRIPTION
Producer half of clawgate task **516**. The consumer half is `ZacxDev/homelab-infra` (`containers/clawgate`) — **merge this one first**; the consumer decode is permissive, so the two can land in either order without breaking a page, but the field only becomes observable once this ships.

## What and why

clawgate's tmux page renders a card per window. Its "4m ago" came from `Snapshot.ReceivedAt` — how long ago clawgate last heard from the **host** — so all 45 cards under one host showed the same number and none of them said anything about its own window. The renderer was never the missing piece; the per-window datum was.

tmux already exposes `#{window_activity}` (epoch seconds, updated when the window's active pane produces output), and `list-windows` already runs once per host, so this costs **no extra tmux invocation and no fifth ssh round trip** — the same argument `#{pid}`/`#{start_time}` ride on.

- `WINDOW_FORMAT` gains `#{window_activity}` **before** `#{session_name}` (session name must stay last or the bounded maxsplit stops absorbing pipes in a session name).
- `split_window_line` returns it; `parse_windows` and `parse_tmux_server_id` are unchanged in contract.
- New `parse_window_activity` → `{window_id: epoch_seconds}`. **Absent, never zero:** an empty, non-numeric or non-positive value is omitted, because epoch 0 renders as "56 years ago" — a fabricated measurement in the costume of a real one.
- `fold_windows` writes `window_activity` **only when it has a value**. It is the one optional row key and is documented apart from the row ledger in the module docstring.

## Measured on the real fleet — not a fixture

`scripts/session-manager --json` from this branch, 2026-09-07, both hosts:

| host | rows | carrying `window_activity` | distinct times | zero/negative |
|---|---|---|---|---|
| workbench | 54 | 54 | 36 | 0 |
| laptop | 32 | 32 | 18 | 0 |
| **total** | **86** | **86** | — | **0** |

Distinct-times > 1 per host is the assertion that matters: windows on one host genuinely disagree, which is what the consumer needs.

### Known limit, measured rather than assumed

**12 of the laptop's 32 windows report `2021-01-01`** — the *same* frozen pre-NTP RTC value that host's tmux `#{start_time}` carries (already documented above `WINDOW_FORMAT`). They are windows that have produced no output since their tmux server started, so tmux stamped them at the server's start instant, recorded under a clock that was wrong and does not move when NTP later corrects it. They render as ~49,000h.

Deliberately **not clamped**: the relative claim ("nothing has happened here since the server came up") is *true*, only the magnitude is wrong, and suppressing it would swap a visibly absurd number for a silent absence — the substitution this whole file refuses. A consumer wanting a ceiling has to choose one deliberately; there is no honest one to pick here. Recorded in the code at `WINDOW_FORMAT` and mirrored in the consumer's renderer comment.

## RED → GREEN matrix

This commit's **test file** applied to a clean worktree of `origin/main` (`969f0581`) with the **unchanged** `session-manager`:

```
18 failed, 804 passed
```

At HEAD of this branch:

```
823 passed
```

The 18 red-at-base: the two format-contract tests, the eight `parse_window_activity` cases, five `fold_windows` cases, the end-to-end seam test, and the two ledger/golden guards that had to learn the new key.

Wider sweep, unchanged by this PR: `test_agent_ledger`, `test_bar_status`, `test_claude_sessions`, `test_clawgate_predicate_single_source`, `test_session_manager_skill_size`, `test_standup_local_health`, `test_tmux_snapshot_push`, `test_skill_descriptions`, `test_drift_check` — **1237 passed**.

## Mutation battery

Restore verified by `sha256sum` before/after; `D0` unmutated control green first.

| # | mutation | result |
|---|---|---|
| D1 | `parse_window_activity` accepts a non-positive epoch | **KILLED** — `drops_a_value_it_cannot_trust[0]`, `[-1]` |
| D2 | `fold_windows` writes the key even when unmeasured | **KILLED** — `carries_NO_KEY_not_a_zero` |
| D3 | move `#{window_activity}` after `#{session_name}` | **KILLED** — `fields_come_BEFORE_session_name` |
| D4 | never wire the parsed map into `fold_windows` | **KILLED** — `reaches_the_REPORT_per_window_end_to_end` |
| D5 | `int(float(x))` instead of `int(x)` | **KILLED** — `drops_a_value_it_cannot_trust[17.5]`, `[1e9]` |
| D6 | drop the `windows_measured` gate on the activity parse | **SURVIVED — by design** |

Each kill was checked to fail with **that test's own** node id, not a neighbour's.

**D6 is reported, not hidden.** The same `windows_measured` flag already gates `slot_ids` two lines up, so on a failed `list-windows` every row's `window_id` is `None` and `fold_windows` looks nothing up regardless — the conditional is depth, not a defence anyone has watched work. That is now stated at the parse site rather than implied away, and the **outcome** is pinned by `test_a_PARTIAL_list_windows_read_publishes_no_activity`, which fails the call while still returning parseable rows so the refusal is a real decision rather than an empty-string artefact.

## Not verified

- No live clawgate page was driven from **this** branch's collector; the cross-repo seam was verified by feeding this branch's real `--json` capture through the consumer's real ingest + view code (86/86 windows decoded, 18/36 distinct times per host), not by watching the deployed pusher.
- `--lean` (`LEAN_ROW_FIELDS`) deliberately does **not** carry the new key; that view is a separate, trimmed contract and widening it was out of scope.
