### PR TITLE
test(disk-accounting): a gate for the root-only bash nothing ever ran — plus the live defects three audit rounds found in it

### DIFF
--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -176,22 +176,50 @@ _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 # The `-print0` form this replaced still printed the NAME when the stat failed;
 # `-printf '%D\t%p\0'` prints nothing, so such an entry vanishes from the size
 # breakdown AND the inode breakdown AND the foreign-entry listing at once — and
-# `foreign_entries` then affirmatively printed "none". MEASURED 2026-09-07 over
-# a mode-0400 directory holding three entries, on the two GNU findutils builds
-# this script can actually resolve, both rc 1: 4.10.0 (the system PATH, what a
-# non-interactive `bash` and therefore a `sudo` run gets) `-print0` 116 bytes /
-# `-printf '%D\t%p\0'` 0 bytes; 4.11.0 (the nix dev shell) 119 bytes / 0 bytes.
-# Not specific to one build. (Not measured on `bfs`, which is only an
-# interactive zsh alias here and never what this script runs.)
+# `foreign_entries` then affirmatively printed "none".
+#
+# 🔴 RE-MEASURED 2026-09-07 (round 3) BECAUSE THE FIGURES THAT STOOD HERE COULD
+# NOT ALL HAVE BEEN TRUE. They read "116 bytes (4.10.0) / 119 bytes (4.11.0)"
+# over ONE fixture — but `-print0` emits the paths it FOUND, not the binary's
+# own path, so two builds cannot disagree about the byte count of one fixture.
+# One fixture, `/tmp/…/fix/denied` (a 35-character base, mode 0400, holding
+# three entries), THREE implementations, each run twice:
+#
+#   implementation                        -print0        -printf '%D\t%p\0'
+#   GNU findutils 4.10.0 (the bash PATH)  114 B, rc 0    0 B, rc 1
+#   GNU findutils 4.11.0 (nix dev shell)  114 B, rc 0    0 B, rc 1
+#   bfs 4.1.1 (the interactive alias)     114 B, rc 0    0 B, rc 1
+#
+# Two corrections to what stood here, both against this round's own evidence:
+# the byte counts AGREE across builds (the 114 scales with the fixture path, so
+# it is a figure about that fixture and nothing else), and `-print0` exits **0**,
+# not 1 — it needs no stat, which is exactly why it still emits the names. Only
+# the `%D` form errors. bfs was measured this round and agrees, so the parenthesis
+# that said "not measured on bfs" is gone; the load-bearing half — `0 bytes` under
+# `%D` — reproduces identically on all three and was never in doubt.
 #
 # Root is NOT immune, which is what makes this worth code rather than a note. A
 # FUSE mountpoint not mounted `allow_other` (an AppImage's /tmp/.mount_*, gvfs,
 # sshfs), or an entry on a device answering ESTALE/EIO, fails `stat` for uid 0
 # too — and /tmp is exactly where those live.
 #
-# So the stderr is KEPT, in a file, and every caller reports the count. Same
-# reason section 2's find writes to $DENIED_LOG instead of /dev/null: a scan
-# that reports a number with no denial count is a FLOOR presented as a total.
+# So the stderr is KEPT, in a file, and all three of THIS function's callers
+# report the count. Same reason section 2's find writes to $DENIED_LOG instead of
+# /dev/null: a scan that reports a number with no denial count is a FLOOR
+# presented as a total.
+#
+# 🔴 "ALL THREE OF THIS FUNCTION'S CALLERS", NOT "EVERY CALLER" — the wider
+# wording stood here for a round and was false. `split_by_device` below does not
+# use this enumeration and is a KNOWN FOURTH SITE with the same shape and NO
+# count: its `[ -d "$p" ] || continue` drops a directory root cannot stat (a gvfs
+# or sshfs mount under /home/<user>/… is exactly the root-reachable mechanism)
+# and nothing tallies it. It is recorded rather than fixed because bash's file
+# tests cannot separate the three reasons `[ -d "$p" ]` says no — not a
+# directory, stat refused, or an unmatched glob left the pattern itself — so a
+# count there needs a different enumeration, not a `+ 1`. What limits the damage
+# is that `report_foreign_mounts`'s empty branch does not read as a clean result:
+# it tells the reader outright that an empty list on a host with foreign mounts
+# under /home is a BUG.
 #
 # The `|| true` here covers route (a) ONLY — find's own rc 1 — of the two aborts
 # `size_breakdown`'s comment describes. Route (b), `xargs` rc 123, happens one
@@ -201,18 +229,24 @@ _depth1_nul() {
   find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '%D\t%p\0' 2>"$errf" || true
 }
 
-# How many entries the enumeration whose stderr is in $1 could not stat. ALWAYS
-# a single integer and never empty — the callers compare it with `-gt`, and the
-# `grep -c` / `|| echo 0` two-line-zero defect `report_denials` carries a
-# comment about is the same hazard one function over.
-_unstattable_count() {
+# How many diagnostic lines the stderr file $1 holds. ALWAYS a single integer
+# and never empty — the callers compare it with `-gt`, and the `grep -c` /
+# `|| echo 0` two-line-zero defect `report_denials` carries a comment about is
+# the same hazard one function over.
+#
+# 🔴 IT USED TO BE CALLED `_unstattable_count`, and the name became a false
+# description the moment a second kind of stderr went through it: du's. It
+# counts LINES IN A FILE and knows nothing about why they are there. Which blind
+# spot a count represents is decided by which file you hand it, and that is the
+# reporting function's business, not this one's.
+_errline_count() {
   local n
   n=$(grep -c . "$1" 2>/dev/null; true)
   case "$n" in ''|*[!0-9]*) echo 0 ;; *) echo "$n" ;; esac
 }
 
 # Print the blind spot the count in $1 represents, or nothing. $2 = the base
-# being measured, $3 = the stderr file. Loud on purpose: an entry that reached
+# being measured, $3 = find's stderr file. Loud on purpose: an entry that reached
 # no list is the difference between a floor and a total.
 _report_unstattable() {
   local n="$1" base="$2" errf="$3"
@@ -224,6 +258,64 @@ _report_unstattable() {
   # all three sections — i.e. the same `set -e` exposure the sweep above the
   # executable region is about, one level of indirection down.
   head_n 5 < "$errf" | sed 's/^/       /' || true
+}
+
+# The same for du's OWN stderr. $1 = the base, $2 = du's stderr file.
+#
+# 🔴 A DIFFERENT BLIND SPOT FROM `_report_unstattable`, and this is the half
+# that was still at `/dev/null`. An entry find CAN stat but du cannot fully READ
+# is not erased — it is listed above WITH A NUMBER, and the number is short.
+# MEASURED 2026-09-07 over `base/{open,locked/inner}`, each holding one 4 KiB
+# file, with `inner` mode 000: `du -sh -x` printed `8.0K` for `locked` against a
+# true `12K` — a 33% under-count presented as a total — exited 1 (so `xargs`
+# exited 123), and with `2>/dev/null` on that stage nothing in the report said
+# so. `xargs` itself adds no line of its own here, so this count is du's alone.
+#
+# 🔴 AND THE `2>/dev/null` GOT WORSE WHEN `_report_unstattable` LANDED, which is
+# why a pre-existing discard is fixed in this round. Before it, silence meant
+# nothing either way; now the ABSENCE of a `!! UNSTATTABLE` line reads as an
+# affirmative "nothing was missed" — the same floor-presented-as-a-total
+# reading, arrived at by trusting a report that never had the evidence.
+_report_unreadable() {
+  local base="$1" errf="$2" n
+  n=$(_errline_count "$errf")
+  [ "$n" -gt 0 ] || return 0
+  printf '  !! PARTIALLY READ: du could not read %d path(s) under %s.\n' "$n" "$base"
+  printf '     The sizes above are FLOORS for those paths, not totals. First lines:\n'
+  head_n 5 < "$errf" | sed 's/^/       /' || true
+}
+
+# Open a temp file for this run and leave its path in $REPLY. $1 is a kind tag.
+#
+# 🔴 THE TEMPLATE IS THE POINT. Three
+# `errf=$(mktemp)` calls used to open ANONYMOUS `/tmp/tmp.XXXXXXXXXX` files —
+# in /tmp, the directory this script exists to diagnose — and NONE of the three
+# was in the EXIT trap: only its own function's last statement removed it. The
+# realistic way this run ends is not an abort but SIGINT, because the run this
+# script was written for took ~3 h over 78 million entries, and MEASURED
+# 2026-09-07 on bash 5.3.15 an EXIT trap DOES run when the shell is killed by an
+# untrapped SIGINT. So the trap removed $DENIED_LOG, which is named, and left up
+# to three files that nothing could attribute to anything.
+#
+# It is NOT the only `mktemp` in the file — the four in the executable region
+# below write their own identifying templates inline, because they are opened
+# once, at top level, where a helper would only hide them. What every one of
+# them shares is the naming convention and `_cleanup_temps`.
+_scan_mktemp() { REPLY=$(mktemp "/tmp/disk-accounting-$1.XXXXXX") || { REPLY=; return 1; }; }
+
+# Remove every temp file the run currently holds open. It reads the variables at
+# CALL time, so ONE `trap` installed before the first `mktemp` covers every
+# later one.
+#
+# 🔴 THAT IS THE WHOLE FIX. What it replaces was a trap that had to be WIDENED
+# BY HAND once section 6c opened two more files — and the three the breakdowns
+# open were simply never added to either version of it. A trap naming a fixed
+# list is an enumeration done by eye, which is the failure this file has already
+# recorded twice for `set -e` sites. MEASURED: `rm -f ""` is silent and rc 0, so
+# a slot that is unset costs nothing and needs no test around it.
+_cleanup_temps() {
+  rm -f "${DENIED_LOG:-}" "${DU_ERR:-}" "${ONROOT_LIST:-}" "${FOREIGN_LIST:-}" \
+        "${SCAN_ERRF:-}" "${SCAN_DUERR:-}"
 }
 
 # Top-level entries of $1 that are ON $1's OWN FILESYSTEM, largest first.
@@ -291,26 +383,38 @@ _report_unstattable() {
 # printed nothing at all. The suite could not see it: a suite that sources this
 # file must turn `set -e` back OFF to run, so it took the refusal branch either
 # way. The probe in section 4c of the suite runs `set -e` for real.
+#
+# 🔴 TWO STDERR SINKS, NOT ONE, AND THEY ARE NOT INTERCHANGEABLE. find's holds
+# the entries that reached NO list; du's holds the paths that ARE listed but
+# short. Merging them into one file would make one count out of two different
+# claims and print whichever message happened to be wired to it — read
+# `_report_unreadable` for what the du half measured.
 size_breakdown() {
-  local base="$1" dev errf blind out
+  local base="$1" dev blind out
   dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
     echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (size breakdown)"
     return 0
   fi
-  errf=$(mktemp) || { echo "COULD NOT MEASURE: no temp file for $base's size breakdown"; return 0; }
-  out=$(_depth1_nul "$base" "$errf" \
+  _scan_mktemp size-find-stderr || { echo "COULD NOT MEASURE: no temp file for $base's size breakdown"; return 0; }
+  SCAN_ERRF=$REPLY
+  _scan_mktemp size-du-stderr || {
+    rm -f "$SCAN_ERRF"; SCAN_ERRF=
+    echo "COULD NOT MEASURE: no temp file for $base's size breakdown"; return 0; }
+  SCAN_DUERR=$REPLY
+  out=$(_depth1_nul "$base" "$SCAN_ERRF" \
     | { _on_device "$dev" || true; } \
-    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | { xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true; } \
     | sort -rh | head_n 15)
-  blind=$(_unstattable_count "$errf") || blind=0
+  blind=$(_errline_count "$SCAN_ERRF") || blind=0
   if [ -n "$out" ]; then
     printf '%s\n' "$out"
   else
     echo "  none — no depth-1 entry of $base is on $base's own filesystem (NOT zero bytes)"
   fi
-  _report_unstattable "$blind" "$base" "$errf"
-  rm -f "$errf"
+  _report_unstattable "$blind" "$base" "$SCAN_ERRF"
+  _report_unreadable "$base" "$SCAN_DUERR"
+  rm -f "$SCAN_ERRF" "$SCAN_DUERR"; SCAN_ERRF=; SCAN_DUERR=
 }
 
 # Inode count per top-level DIRECTORY of $1 that is on $1's OWN filesystem,
@@ -339,26 +443,33 @@ size_breakdown() {
 #
 # The device filter and the two `|| true`s are the same two defects as
 # `size_breakdown` above; read its comment.
+#
+# ONE stderr sink here, not two: this breakdown runs no `du` — the per-directory
+# walk is a `find … -printf .` whose own `2>/dev/null` is inside the inner shell
+# — so there is no second stream to keep and `_report_unreadable` has nothing to
+# say. Stated, because an inconsistency between two adjacent functions otherwise
+# reads as an omission.
 inode_breakdown() {
-  local base="$1" dev errf blind out
+  local base="$1" dev blind out
   dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
     echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (inode breakdown)"
     return 0
   fi
-  errf=$(mktemp) || { echo "COULD NOT MEASURE: no temp file for $base's inode breakdown"; return 0; }
-  out=$(_depth1_nul "$base" "$errf" -type d \
+  _scan_mktemp inode-find-stderr || { echo "COULD NOT MEASURE: no temp file for $base's inode breakdown"; return 0; }
+  SCAN_ERRF=$REPLY
+  out=$(_depth1_nul "$base" "$SCAN_ERRF" -type d \
     | { _on_device "$dev" || true; } \
     | { xargs -0 -r -n1 sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ || true; } \
     | sort -rn | head_n 15)
-  blind=$(_unstattable_count "$errf") || blind=0
+  blind=$(_errline_count "$SCAN_ERRF") || blind=0
   if [ -n "$out" ]; then
     printf '%s\n' "$out"
   else
     echo "  none — no depth-1 DIRECTORY of $base is on $base's own filesystem (NOT zero inodes)"
   fi
-  _report_unstattable "$blind" "$base" "$errf"
-  rm -f "$errf"
+  _report_unstattable "$blind" "$base" "$SCAN_ERRF"
+  rm -f "$SCAN_ERRF"; SCAN_ERRF=
 }
 
 # The depth-1 entries of $1 that the two breakdowns above SKIPPED, because they
@@ -384,18 +495,19 @@ inode_breakdown() {
 # could not stat is absent from this listing too (see `_depth1_nul`), so "none"
 # is only honest when the enumeration saw everything. When it did not, say so.
 foreign_entries() {
-  local base="$1" dev errf blind p n=0
+  local base="$1" dev blind p n=0
   dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
     echo "  COULD NOT MEASURE: no device id for $base — NOT an absence of foreign mounts"
     return 0
   fi
-  errf=$(mktemp) || { echo "  COULD NOT MEASURE: no temp file for $base's foreign-entry listing"; return 0; }
+  _scan_mktemp foreign-find-stderr || { echo "  COULD NOT MEASURE: no temp file for $base's foreign-entry listing"; return 0; }
+  SCAN_ERRF=$REPLY
   while IFS= read -r -d '' p; do
     n=$((n + 1))
     [ "$n" -gt 15 ] || printf '  %s\n' "$p"
-  done < <(_depth1_nul "$base" "$errf" | _not_on_device "$dev")
-  blind=$(_unstattable_count "$errf") || blind=0
+  done < <(_depth1_nul "$base" "$SCAN_ERRF" | _not_on_device "$dev")
+  blind=$(_errline_count "$SCAN_ERRF") || blind=0
   if [ "$n" -gt 15 ]; then
     printf '  ... and %d more\n' "$((n - 15))"
   elif [ "$n" -eq 0 ]; then
@@ -405,8 +517,8 @@ foreign_entries() {
       echo "  none — every depth-1 entry is on the same filesystem as $base"
     fi
   fi
-  _report_unstattable "$blind" "$base" "$errf"
-  rm -f "$errf"
+  _report_unstattable "$blind" "$base" "$SCAN_ERRF"
+  rm -f "$SCAN_ERRF"; SCAN_ERRF=
 }
 
 # Partition the directories under $1 by filesystem: on-root candidates into $2,
@@ -433,6 +545,18 @@ foreign_entries() {
 # listing half could never fire, so the code was narrower than its own comment.
 # shellcheck SC2030/SC2031 flags exactly this; the repo has no shellcheck gate,
 # so nothing caught it.
+#
+# 🔴 KNOWN, DECLARED BLIND SPOT — the fourth site of the shape `_depth1_nul`'s
+# comment describes, and the one this round did NOT fix. `[ -d "$p" ]` says no
+# for three different reasons — not a directory, `stat` refused, or the glob
+# matched nothing and left its own pattern — and bash's file tests cannot tell
+# them apart, so `continue` silently drops a /home directory root cannot stat (a
+# gvfs or sshfs mount under /home/<user>/… is exactly that) with no count. It is
+# NOT fixed here because a count needs a different enumeration, and inventing one
+# inside an audit-fix round is how every previous round of this ladder produced
+# the next round's finding. What is claimed instead is only what holds: the
+# empty branch of `report_foreign_mounts` below does not present itself as a
+# clean host.
 split_by_device() {
   local base="$1" onroot="$2" foreign="$3" root_dev="$4" p d
   : > "$onroot"
@@ -515,32 +639,55 @@ fi
 # 🔴 THE `set -e` SWEEP, AND WHAT IT DELIBERATELY LEAVES OPEN. Twice now an
 # enumeration of "commands whose failure kills the report" was done BY EYE and
 # missed a site (round 1 covered the pipelines and missed section 5's bare
-# `du -sh`). It is now done mechanically: join backslash continuations, then
-# take every line in this file whose first word is one of
-# find/du/ls/dumpe2fs/findmnt/lsof/stat/xargs/grep/sed/sort/uniq/wc/tr/awk/
-# mktemp/date/seq/dd/id, plus every `VAR=$(…)`, and require a `||` (or a
-# trailing `; true` inside the substitution, which has the same effect).
-# Everything that scan reports is guarded above EXCEPT these, each checked by
-# hand and left open on purpose:
+# `du -sh`). It is now done mechanically — but read the next paragraph before
+# reading the exception list as an inventory.
+#
+# 🔴 WHAT THE SWEEP CAN SEE, EXACTLY. It joins backslash continuations, strips
+# whole-line comments, keeps every line whose FIRST WORD (after an optional
+# `{ `) is one of find/du/ls/dumpe2fs/findmnt/lsof/stat/xargs/grep/sed/sort/
+# uniq/wc/tr/awk/mktemp/seq/dd/id, and drops any line containing `||`. Two
+# consequences, and the second is why the list below grew this round:
+#   (i) A line headed by anything else — `for`, `done`, `printf`, `echo`, a
+#       `VAR=$(…)` assignment — is INVISIBLE to it, whatever it pipes into.
+#   (ii) ONE `||` anywhere on the joined line silences the WHOLE line, so a
+#       pipeline whose early stages are guarded is dropped even when its LAST
+#       stage is not.
+# So "everything the sweep reports is guarded" is a true sentence about a narrow
+# scan, not a statement about the file. The exceptions below are what a reading
+# BY HAND found on top of it; §7b of the suite pins the sweep's own result as a
+# ledger, and pins the trailing-`sort` inventory separately for the same reason.
+#
+# Left open on purpose, each checked by hand:
 #   * `X=$((…))` — MEASURED: an arithmetic assignment is rc 0 even when the
 #     expression evaluates to 0, so it is not in the class at all.
 #   * `read … < <(find … | awk …)` in section 2 — MEASURED: a process
 #     substitution's status is NOT checked by `set -e`, which is why denials in
 #     section 2 do not kill the run.
-#   * `out=$(… | sort … | head_n …)` in the two breakdowns — every stage but
-#     `sort` carries its own `|| true`, and `sort` deliberately does not; the
-#     reason, and what it measured, is in `size_breakdown`'s comment. What is
-#     exposed is a `sort` that fails for its own reasons (no space for its temp
-#     files), which is the same exposure the statement-level pipeline had before
-#     this round rather than a new one.
-#   * `DENIED_LOG=$(mktemp …)` and the five `stat -f` reads in section 1 — these
-#     abort BEFORE any figure is printed, so they cannot leave a floor looking
-#     like a total. They end the run with a blank report, which is wrong-looking
-#     rather than reassuring. That is the criterion, and it is the only reason
-#     they are not guarded.
+#   * EVERY unguarded trailing `sort`, of which there are FIVE, not the two a
+#     previous wording implied. `sort` is deliberately never guarded: the whole
+#     point of `head_n` is that `sort` never takes SIGPIPE, so masking its status
+#     is exactly what would make a reinstated `head -n` invisible (MEASURED — it
+#     broke both `sigpipe-head-closes-the-pipe` rows). Two sit inside
+#     `out=$(… | sort … | head_n …)` captures in the breakdowns; THREE more are
+#     statement-level pipelines that reason (i) or (ii) above hides from the
+#     sweep — section 5's PVC listing and its inodes-per-PVC loop, and section
+#     6c's /home listing. What is exposed in all five is a `sort` that fails for
+#     its OWN reasons (no space for its temp files), which is the exposure these
+#     pipelines have always had rather than anything this round introduced.
+#   * `DENIED_LOG=$(mktemp …)`, `DU_ERR=$(mktemp …)` and the five `stat -f`
+#     reads in section 1 — these abort BEFORE any figure is printed, so they
+#     cannot leave a floor looking like a total. They end the run with a blank
+#     report, which is wrong-looking rather than reassuring. That is the
+#     criterion, and it is the only reason they are not guarded.
 DEV=${DEV:-/dev/nvme0n1p2}
+# 🔴 THE TRAP GOES UP FIRST, BEFORE ANY mktemp, and it names a FUNCTION rather
+# than a list. `_cleanup_temps` reads the variables when it RUNS, so this one
+# line covers every temp file opened later — including the ones the breakdowns
+# open per call, which no hand-written list ever covered, and the pair at
+# section 6c, which used to need the trap re-installed by hand.
+trap _cleanup_temps EXIT
 DENIED_LOG=$(mktemp /tmp/disk-accounting-denied.XXXXXX)
-trap 'rm -f "$DENIED_LOG"' EXIT
+DU_ERR=$(mktemp /tmp/disk-accounting-root-du-stderr.XXXXXX)
 
 echo "============================================"
 echo "  Root-fs accounting — $DEV"
@@ -652,8 +799,17 @@ if [ -d /var/lib/rancher/k3s/storage ]; then
   # No device filter here, unlike section 6d: these are k3s local-path PVC
   # directories, which are by construction on the node's own filesystem. If that
   # ever stops being true this needs the same treatment.
+  #
+  # 🔴 du's stderr goes to $DU_ERR, not /dev/null, for the reason
+  # `_report_unreadable` carries: a PVC directory du cannot fully read is listed
+  # here with an UNDER-COUNTED size and no marker, and once the breakdowns
+  # started reporting their blind spots the absence of a marker started reading
+  # as "nothing was missed". Truncated per site so one site's count cannot be
+  # attributed to another.
+  : > "$DU_ERR"
   { find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null || true; } \
-    | { xargs -0 -r du -sh --exclude=/mnt 2>/dev/null || true; } | sort -rh | head_n 30
+    | { xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true; } | sort -rh | head_n 30
+  _report_unreadable /var/lib/rancher/k3s/storage "$DU_ERR"
   echo "--- total ---"
   # 🔴 `|| echo`, NOT a bare `du`. This site sat directly under the two guarded
   # pipelines above, under a comment that described the treatment it did not
@@ -709,15 +865,23 @@ ROOT_DEV=$(_dev_of /) || ROOT_DEV=
 if ! _dev_is_valid "$ROOT_DEV"; then
   echo "COULD NOT MEASURE: no device id for / — skipping 6c rather than calling every /home directory foreign"
 else
-# Create BOTH before widening the trap: if the second mktemp failed while the trap
-# still named only $DENIED_LOG, the first temp file leaked on that exit path.
-ONROOT_LIST=$(mktemp) && FOREIGN_LIST=$(mktemp) || { rm -f "${ONROOT_LIST:-}"; exit 3; }
-trap 'rm -f "$DENIED_LOG" "$ONROOT_LIST" "$FOREIGN_LIST"' EXIT
+# 🔴 NO TRAP WIDENING HERE ANY MORE. This used to read "Create BOTH before
+# widening the trap: if the second mktemp failed while the trap still named only
+# $DENIED_LOG, the first temp file leaked on that exit path" — a hazard that only
+# existed because the trap named a fixed LIST. `_cleanup_temps` reads these two
+# variables when it runs, so the single trap at the top of the executable region
+# already covers them, in either order and however many of them got created.
+ONROOT_LIST=$(mktemp /tmp/disk-accounting-home-onroot.XXXXXX) \
+  && FOREIGN_LIST=$(mktemp /tmp/disk-accounting-home-foreign.XXXXXX) || exit 3
 split_by_device /home "$ONROOT_LIST" "$FOREIGN_LIST" "$ROOT_DEV"
 # `|| true` for the same reason as section 6d: xargs exits 123 when any `du` it
 # ran exited 1, which is what a /home directory unlinked mid-scan produces, and
-# `pipefail` + `set -e` would take the whole report with it.
-{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; } | sort -rh | head_n 15
+# `pipefail` + `set -e` would take the whole report with it. du's stderr is KEPT
+# (see section 5 and `_report_unreadable`): a /home directory du could not fully
+# read is listed here short, and silence is not evidence that none was.
+: > "$DU_ERR"
+{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>>"$DU_ERR" || true; } | sort -rh | head_n 15
+_report_unreadable /home "$DU_ERR"
 echo "--- NOT on the root filesystem, so NOT part of this accounting ---"
 report_foreign_mounts "$FOREIGN_LIST"
 fi

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -301,6 +301,20 @@ _report_unreadable() {
 # below write their own identifying templates inline, because they are opened
 # once, at top level, where a helper would only hide them. What every one of
 # them shares is the naming convention and `_cleanup_temps`.
+#
+# 🔴 `/tmp` IS HARDCODED, NOT `${TMPDIR:-/tmp}`, AND THAT IS THE DELIBERATE HALF
+# OF A BEHAVIOUR CHANGE. The bare `mktemp` this replaced HONOURED `$TMPDIR`; the
+# template does not. That is the safer direction for this file specifically:
+# `$DENIED_LOG` already hardcodes /tmp, and this script's whole premise is that a
+# local unprivileged process must not influence a root run — an inherited
+# `TMPDIR=/anything` deciding where a root run writes its scan stderr is the
+# `LSOF_BIN` lesson (see the seam) wearing a different name. The cost is real and
+# is accepted: a non-root CALLER — i.e. the test suite — now writes into the
+# system /tmp rather than into its own sandbox, and when a deliberately broken
+# copy of this script dies between the `mktemp` and the `rm` (which is what the
+# mutation battery does, ~60 times per full sweep) the files stay there. They are
+# harmless, empty, and — the point of this whole change — NAMED, which is how
+# they get noticed and swept at all.
 _scan_mktemp() { REPLY=$(mktemp "/tmp/disk-accounting-$1.XXXXXX") || { REPLY=; return 1; }; }
 
 # Remove every temp file the run currently holds open. It reads the variables at

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -16,6 +16,220 @@
 #
 set -euo pipefail
 
+# =============================================================================
+# SOURCEABLE SEAM — everything down to the `return` below is pure text/tree
+# transforms that need NO root, so `scripts/tests/test_diagnose_disk_accounting.sh`
+# can drive them against fixtures. The defects each one carries a comment about
+# were all shipped once and were invisible to the merge gate because this file
+# had no test and this repo has no shellcheck gate.
+#
+# `source`ing this file defines the helpers and RUNS NOTHING: BASH_SOURCE[0] is
+# always this file, while $0 is the sourcing shell's own name, so they differ
+# only when sourced. Executing it (`bash …`/`./…`) makes them equal and the
+# script proceeds exactly as before — the guard is not reachable from the
+# environment, so no stray variable can silently turn a real run into a no-op.
+#
+# 🔴 `set -euo pipefail` above executes at SOURCE time and leaks into the
+# sourcing shell. The test suite re-asserts its own options immediately after
+# sourcing; anything else that sources this must do the same.
+# =============================================================================
+
+# Print the first $1 lines of stdin. Behaviourally `head -n $1`, minus the
+# SIGPIPE it induces UPSTREAM.
+#
+# 🔴 `<producer> | sort | head -N` IS A SIZE-DEPENDENT ABORT UNDER `pipefail`.
+# `head` exits after N lines; as soon as the producer's output exceeds one pipe
+# buffer it blocks on the next write, takes SIGPIPE and exits 141, `pipefail`
+# promotes that to the pipeline's status and `set -e` kills the whole run — with
+# NO message, because nothing wrote one. MEASURED at two sizes on this host:
+# 40 entries SURVIVE (sort's output fits a single write that completes before
+# head exits, rc 0), 20,000 entries DIE rc 141. The real /tmp had 171,886, so
+# every `head` below was a live abort waiting on the directory it summarised.
+# That is the same "truncated scan reported as a total" the E2BIG comment
+# further down describes, reached by a second route.
+#
+# awk reads to EOF, so the producer never sees a closed pipe.
+head_n() { awk -v n="$1" 'NR<=n'; }
+
+# Summarise `lsof +L1` output read on STDIN. $1 = lsof's exit status, used only
+# in the no-rows message.
+#
+# 🔴 DO NOT HARDCODE THE COLUMN. The original summed $8, which under `+L1` is
+# NLINK — 0 for every row by the definition of +L1 — so it printed a hard
+# `bytes=0.0 GiB` on every run: the reassuring reading, in the very section
+# rewritten to stop emitting a misleading number. Its "two rows give
+# bytes=2.0 GiB" control passed only against a fixture shaped to the code.
+#
+# $7 is correct for `+L1` on this host (MEASURED 2026-09-02: header is
+# `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NLINK NODE NAME`) — but the index is
+# NOT stable across invocations: plain `lsof -n -P` here emits TID and TASKCMD
+# too, putting SIZE/OFF at $9. A fixed index is a latent version dependency, so
+# find the column by NAME from the header and fail loudly if it is absent.
+#
+# 🔴 And never `NR-1` to drop the header. The 2026-09-01 run printed
+# `count=-1`: with no output at all NR is 0. A negative count also hid the
+# distinction between "lsof found nothing" and "lsof did not run" — the two
+# readings that matter most here, since a zero is the reassuring one.
+lsof_deleted_summary() {
+  local rc="${1:-0}" out
+  out="$(cat)"
+  if [ -z "$out" ]; then
+    printf 'count=0 bytes=0.0 GiB  (lsof exited %s with no rows — no deleted-but-open files)\n' "$rc"
+    return 0
+  fi
+  printf '%s\n' "$out" | awk '
+    NR==1 { for (i=1; i<=NF; i++) if ($i == "SIZE/OFF") col=i; next }
+    { n++; if (col) s += $col }
+    END {
+      if (!col) { printf "COULD NOT MEASURE: no SIZE/OFF column in lsof header (rows=%d) — NOT a zero\n", n+0; exit }
+      printf "count=%d bytes=%.1f GiB (SIZE/OFF=col %d, resolved from the header)\n", n+0, s/1073741824, col
+    }'
+}
+
+# Section 7's whole body. `$LSOF_BIN` exists so the suite can drive both the
+# not-on-PATH branch and the rows branch without planting a binary.
+#
+# 🔴 `OUT=$(lsof …); RC=$?` IS UNREACHABLE UNDER `set -e`. lsof documents exit 1
+# when it finds nothing, and a command substitution in an assignment is a
+# CHECKED command: `set -e` kills the whole script on that line, mid-report,
+# with the message already eaten by `2>/dev/null`. Sections 7 and 8 then never
+# print and the run ends looking complete. So the no-rows message this function
+# carries — the one written specifically to stop a zero being mistaken for a
+# non-measurement — could never actually be reached. `|| rc=$?` keeps the status
+# without arming `set -e`.
+LSOF_BIN=${LSOF_BIN:-lsof}
+report_deleted_open_files() {
+  local out rc=0
+  if ! command -v "$LSOF_BIN" >/dev/null 2>&1; then
+    echo "COULD NOT MEASURE: lsof not on PATH — this is NOT a zero"
+    return 0
+  fi
+  out="$("$LSOF_BIN" +L1 2>/dev/null)" || rc=$?
+  if [ -z "$out" ]; then
+    lsof_deleted_summary "$rc" </dev/null
+  else
+    printf '%s\n' "$out" | lsof_deleted_summary "$rc"
+  fi
+}
+
+# Top-level entries of $1, largest first.
+#
+# 🔴 NOT `du -sh -x "$1"/*`. MEASURED 2026-09-02: /tmp held 171,886 top-level
+# entries = ~4.32 MiB of argv against an ARG_MAX of 2,097,152, so the glob dies
+# E2BIG. `2>/dev/null` swallows the message and `set -euo pipefail` then kills
+# the WHOLE SCRIPT mid-section — sections 6d-inodes, 7 and 8 never run, and the
+# report ends with no error. That is the "truncated scan reported as a total"
+# failure this very script exists to prevent.
+size_breakdown() {
+  find "$1" -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
+    | xargs -0 -r du -sh -x 2>/dev/null | sort -rh | head_n 15
+}
+
+# Inode count per top-level DIRECTORY of $1, largest first.
+#
+# 🔴 NOT `xargs -I{} sh -c '… "{}" …'`. That substitutes the directory NAME into
+# a shell string, and /tmp is mode 1777, and this script demands sudo — so any
+# local process could plant a directory whose name is a command and get it run
+# AS ROOT. VERIFIED 2026-09-02: a dir named `evil";echo PWNED-AS-$(id -un) >&2;"x`
+# made the old pipeline print PWNED-AS-zach. -exec with "$1" passes the name as
+# an ARGUMENT, never as text to parse.
+inode_breakdown() {
+  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d \
+    -exec sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ {} \; 2>/dev/null \
+    | sort -rn | head_n 15
+}
+
+# Device id of $1, or empty. Its own function so the suite can substitute a
+# fixture-controlled device map without needing two real filesystems.
+_dev_of() { stat -c '%D' "$1" 2>/dev/null; }
+
+# Partition the directories under $1 by filesystem: on-root candidates into $2
+# (NUL-separated, ready for `xargs -0`), foreign ones into $3 (one per line).
+# $4 is the root device id.
+#
+# 🔴 `du -x` only stops du CROSSING AWAY from its starting point. When the
+# starting point IS a foreign mount, du walks the whole thing: the 2026-09-01
+# run reported 12T for /home/zach/hdd-20tb (/dev/sda1, xfs, 18.2T) and 1.2T for
+# old-nix-hdd (/dev/sdc1) under a root filesystem that is 1.8T in total —
+# figures a reader can take for root-fs usage. Walking them is also what made
+# that run take ~3 hours. So compare each candidate's device against / and skip
+# the foreign ones, then list them separately.
+#
+# 🔴 The loop must NOT be the head of a pipeline, and the accumulator must not be
+# a VARIABLE. It was both, so `FOREIGN=` was assigned in a SUBSHELL and was empty
+# by the time the listing read it — on a host with five foreign filesystems under
+# /home the report affirmatively printed "none". The exclusion half worked and the
+# listing half could never fire, so the code was narrower than its own comment.
+# shellcheck SC2030/SC2031 flags exactly this; the repo has no shellcheck gate,
+# so nothing caught it.
+split_by_device() {
+  local base="$1" onroot="$2" foreign="$3" root_dev="$4" p d
+  : > "$onroot"
+  : > "$foreign"
+  for p in "$base"/*/* "$base"/*/.*; do
+    case "${p##*/}" in .|..) continue ;; esac
+    [ -d "$p" ] || continue
+    d=$(_dev_of "$p") || continue
+    [ -n "$d" ] || continue
+    if [ "$d" = "$root_dev" ]; then printf '%s\0' "$p" >> "$onroot"
+    else printf '%s\n' "$p" >> "$foreign"; fi
+  done
+}
+
+# List the foreign mounts recorded by split_by_device. The "none" branch has to
+# stay loud: an empty list here was, historically, the SUBSHELL BUG, not a clean
+# host.
+report_foreign_mounts() {
+  local p
+  if [ -s "$1" ]; then
+    while IFS= read -r p; do
+      printf '  %-40s %s\n' "$p" "$(findmnt -n -o SOURCE,FSTYPE,SIZE,USED --target "$p" 2>/dev/null | head_n 1)"
+    done < "$1"
+  else
+    echo "  none found — on a host with foreign mounts under /home this is a BUG, not a clean result"
+  fi
+}
+
+# Section 4's whole body: classify the stderr `find` was told to keep.
+#
+# 🔴 `grep -c` prints 0 AND exits 1 when there are no matches, so `|| echo 0`
+# used to emit a two-line "0\n0" and every later [ -gt ] on it died with
+# "integer expected" — i.e. the denial guard failed exactly when it had
+# something to report. Count with a form that cannot fail, and verify it is a
+# single integer.
+#
+# 🔴 A scan that reports a number with no denial count is a FLOOR presented as a
+# total. That is why section 2's find sends stderr to a LOG and not to
+# /dev/null, and why this section is a positive control rather than a footnote.
+report_denials() {
+  local log="$1" denied other total unclassified
+  denied=$(grep -c 'Permission denied' "$log" 2>/dev/null; true)
+  other=$(grep -c 'No such file or directory' "$log" 2>/dev/null; true)
+  total=$(wc -l < "$log" 2>/dev/null || echo 0)
+  case "$denied$other" in
+    *[!0-9]*|'')
+      echo "!! denial counter is broken — treat every count above as UNVERIFIED"
+      denied=0; other=0 ;;
+  esac
+  unclassified=$((total - denied - other))
+  echo "directories find could not read      : $denied"
+  echo "vanished mid-scan (benign, transient): $other"
+  echo "OTHER, unclassified                  : $unclassified"
+  if [ "$denied" -gt 0 ]; then
+    echo "!! Running as root and STILL denied — the counts above are FLOORS, not totals."
+    grep 'Permission denied' "$log" | head_n 20
+  fi
+  if [ "$unclassified" -gt 0 ]; then
+    echo "-- unclassified errors (read these; they are not known-benign) --"
+    grep -v 'Permission denied' "$log" | grep -v 'No such file or directory' | head_n 20 || true
+  fi
+}
+
+# --- end of the sourceable seam ---------------------------------------------
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
+fi
+
 if [ "$(id -u)" -ne 0 ]; then
   echo "FATAL: must run as root — an unprivileged run silently skips the trees" >&2
   echo "       this script exists to measure. Re-run with sudo." >&2
@@ -112,38 +326,23 @@ echo "A small positive residual is expected — the tree moves while this runs."
 
 echo
 echo "=== 4. Blind-spot report (positive control) ==="
-# `grep -c` prints 0 AND exits 1 when there are no matches, so `|| echo 0` used to
-# emit a two-line "0\n0" and every later [ -gt ] on it died with "integer expected"
-# — i.e. the denial guard failed exactly when it had something to report. Count
-# with a form that cannot fail, and verify it is a single integer.
-DENIED=$(grep -c 'Permission denied' "$DENIED_LOG" 2>/dev/null; true)
-OTHER=$(grep -c 'No such file or directory' "$DENIED_LOG" 2>/dev/null; true)
-TOTAL_ERR=$(wc -l < "$DENIED_LOG" 2>/dev/null || echo 0)
-case "$DENIED$OTHER" in *[!0-9]*|'') echo "!! denial counter is broken — treat every count above as UNVERIFIED"; DENIED=0; OTHER=0 ;; esac
-UNCLASSIFIED=$((TOTAL_ERR - DENIED - OTHER))
-echo "directories find could not read      : $DENIED"
-echo "vanished mid-scan (benign, transient): $OTHER"
-echo "OTHER, unclassified                  : $UNCLASSIFIED"
-if [ "$DENIED" -gt 0 ]; then
-  echo "!! Running as root and STILL denied — the counts above are FLOORS, not totals."
-  grep 'Permission denied' "$DENIED_LOG" | head -20
-fi
-if [ "$UNCLASSIFIED" -gt 0 ]; then
-  echo "-- unclassified errors (read these; they are not known-benign) --"
-  grep -v 'Permission denied' "$DENIED_LOG" | grep -v 'No such file or directory' | head -20
-fi
+report_denials "$DENIED_LOG"
 
 echo
 echo "=== 5. k3s local-path PVCs (unreadable without root; the prior '1.7GB' claim) ==="
 if [ -d /var/lib/rancher/k3s/storage ]; then
-  du -sh --exclude=/mnt /var/lib/rancher/k3s/storage/* 2>/dev/null | sort -rh | head -30
+  # Same NUL-safe enumeration as size_breakdown, for the same reason: a glob
+  # expanded into `du` is an E2BIG waiting for the directory to grow, and this
+  # one is bounded only by how many PVCs the node happens to hold.
+  find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
+    | xargs -0 -r du -sh --exclude=/mnt 2>/dev/null | sort -rh | head_n 30
   echo "--- total ---"
   du -sh /var/lib/rancher/k3s/storage 2>/dev/null
   echo "--- inodes per PVC (top 15) ---"
   for p in /var/lib/rancher/k3s/storage/*; do
     [ -d "$p" ] || continue
     printf '%12d  %s\n' "$(find "$p" -xdev -printf . 2>/dev/null | wc -c)" "$p"
-  done | sort -rn | head -15
+  done | sort -rn | head_n 15
 else
   echo "absent — NOT the same as zero"
 fi
@@ -169,40 +368,18 @@ printf 'store paths     : %d\n' "$(ls /nix/store/ 2>/dev/null | wc -l)"
 
 echo
 echo "=== 6c. /home breakdown — ROOT FILESYSTEM ONLY (top 15 by allocated size) ==="
-# 🔴 `du -x` only stops du CROSSING AWAY from its starting point. When the starting
-# point IS a foreign mount, du walks the whole thing: the 2026-09-01 run reported
-# 12T for /home/zach/hdd-20tb (/dev/sda1, xfs, 18.2T) and 1.2T for old-nix-hdd
-# (/dev/sdc1) under a root filesystem that is 1.8T in total — figures a reader can
-# take for root-fs usage, contradicting section 2's correct 686.8 GiB for /home.
-# Walking them is also what made that run take ~3 hours. Compare each candidate's
-# device against / and skip the foreign ones, then list them separately.
-# 🔴 The loop must NOT be the head of a pipeline. It was, so `FOREIGN=` assigned in
-# a SUBSHELL and was empty by the time the listing read it — on a host with five
-# foreign filesystems under /home the report affirmatively printed "none". The
-# exclusion half worked and the listing half could never fire, so the code was
-# narrower than its own comment. shellcheck SC2030/SC2031 flags exactly this; the
-# repo has no shellcheck gate, so nothing caught it.
-ROOT_DEV=$(stat -c '%D' / 2>/dev/null)
+# The device split and the foreign listing both live in `split_by_device` /
+# `report_foreign_mounts` above; read their comments for the `du -x` and
+# subshell-accumulator defects they exist to prevent.
+ROOT_DEV=$(_dev_of /)
 # Create BOTH before widening the trap: if the second mktemp failed while the trap
 # still named only $DENIED_LOG, the first temp file leaked on that exit path.
 ONROOT_LIST=$(mktemp) && FOREIGN_LIST=$(mktemp) || { rm -f "${ONROOT_LIST:-}"; exit 3; }
 trap 'rm -f "$DENIED_LOG" "$ONROOT_LIST" "$FOREIGN_LIST"' EXIT
-for p in /home/*/* /home/*/.*; do
-  case "${p##*/}" in .|..) continue ;; esac
-  [ -d "$p" ] || continue
-  d=$(stat -c '%D' "$p" 2>/dev/null) || continue
-  if [ "$d" = "$ROOT_DEV" ]; then printf '%s\0' "$p" >> "$ONROOT_LIST"
-  else printf '%s\n' "$p" >> "$FOREIGN_LIST"; fi
-done
-xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null | sort -rh | head -15
+split_by_device /home "$ONROOT_LIST" "$FOREIGN_LIST" "$ROOT_DEV"
+xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null | sort -rh | head_n 15
 echo "--- NOT on the root filesystem, so NOT part of this accounting ---"
-if [ -s "$FOREIGN_LIST" ]; then
-  while IFS= read -r p; do
-    printf '  %-40s %s\n' "$p" "$(findmnt -n -o SOURCE,FSTYPE,SIZE,USED --target "$p" 2>/dev/null | head -1)"
-  done < "$FOREIGN_LIST"
-else
-  echo "  none found — on a host with foreign mounts under /home this is a BUG, not a clean result"
-fi
+report_foreign_mounts "$FOREIGN_LIST"
 
 echo
 echo "=== 6d. /tmp breakdown — MEASURED 2026-09-01 as the largest inode consumer ==="
@@ -210,61 +387,16 @@ echo "  78,501,285 entries / 469 GiB, 81% of this filesystem's inodes. /tmp is o
 echo "  the ROOT partition here, not tmpfs, so nothing clears it at boot."
 printf 'top-level entries : %d\n' "$(ls -A /tmp 2>/dev/null | wc -l)"
 echo "--- top 15 by allocated size ---"
-# 🔴 NOT `du -sh -x /tmp/*`. MEASURED 2026-09-02: /tmp held 171,886 top-level
-# entries = ~4.32 MiB of argv against an ARG_MAX of 2,097,152, so the glob dies
-# E2BIG. `2>/dev/null` swallows the message and `set -euo pipefail` then kills the
-# WHOLE SCRIPT mid-section — sections 6d-inodes, 7 and 8 never run, and the report
-# ends with no error. That is the "truncated scan reported as a total" failure this
-# very script exists to prevent, reintroduced by the fix for section 6c.
-find /tmp -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
-  | xargs -0 -r du -sh -x 2>/dev/null | sort -rh | head -15
+size_breakdown /tmp
 echo "--- top 15 by inode count ---"
-# 🔴 NOT `xargs -I{} sh -c '… "{}" …'`. That substitutes the directory NAME into a
-# shell string, and /tmp is mode 1777, and this script demands sudo — so any local
-# process could plant a directory whose name is a command and get it run AS ROOT.
-# VERIFIED 2026-09-02: a dir named `evil";echo PWNED-AS-$(id -un) >&2;"x` made the
-# old pipeline print PWNED-AS-zach. -exec with "$1" passes the name as an ARGUMENT,
-# never as text to parse.
-find /tmp -xdev -mindepth 1 -maxdepth 1 -type d \
-  -exec sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ {} \; 2>/dev/null \
-  | sort -rn | head -15
+inode_breakdown /tmp
 echo "--- entry-name families (what is generating them) ---"
 ls -A /tmp 2>/dev/null | sed -E 's/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//' \
-  | sort | uniq -c | sort -rn | head -20
+  | sort | uniq -c | sort -rn | head_n 20
 
 echo
 echo "=== 7. Deleted-but-open files ==="
-# The 2026-09-01 run printed `count=-1`: the awk did NR-1 to drop lsof's header,
-# but with no output at all NR is 0. A negative count also hid the distinction
-# between "lsof found nothing" and "lsof did not run" — the two readings that
-# matter most here, since a zero is the reassuring one.
-if ! command -v lsof >/dev/null 2>&1; then
-  echo "COULD NOT MEASURE: lsof not on PATH — this is NOT a zero"
-else
-  LSOF_OUT=$(lsof +L1 2>/dev/null); LSOF_RC=$?
-  if [ -z "$LSOF_OUT" ]; then
-    echo "count=0 bytes=0.0 GiB  (lsof exited $LSOF_RC with no rows — no deleted-but-open files)"
-  else
-    # 🔴 DO NOT HARDCODE THE COLUMN. The original summed $8, which under `+L1` is
-    # NLINK — 0 for every row by the definition of +L1 — so it printed a hard
-    # `bytes=0.0 GiB` on every run: the reassuring reading, in the very section
-    # rewritten to stop emitting a misleading number. Its "two rows give
-    # bytes=2.0 GiB" control passed only against a fixture shaped to the code.
-    #
-    # $7 is correct for `+L1` on this host (MEASURED 2026-09-02: header is
-    # `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NLINK NODE NAME`) — but the index is
-    # NOT stable across invocations: plain `lsof -n -P` here emits TID and TASKCMD
-    # too, putting SIZE/OFF at $9. A fixed index is a latent version dependency, so
-    # find the column by NAME from the header and fail loudly if it is absent.
-    printf '%s\n' "$LSOF_OUT" | awk '
-      NR==1 { for (i=1; i<=NF; i++) if ($i == "SIZE/OFF") col=i; next }
-      { n++; if (col) s += $col }
-      END {
-        if (!col) { printf "COULD NOT MEASURE: no SIZE/OFF column in lsof header (rows=%d) — NOT a zero\n", n+0; exit }
-        printf "count=%d bytes=%.1f GiB (SIZE/OFF=col %d, resolved from the header)\n", n+0, s/1073741824, col
-      }'
-  fi
-fi
+report_deleted_open_files
 
 echo
 echo "=== 8. Leftover diagnostic mounts ==="

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -168,6 +168,64 @@ _on_device() { sed -z -n "s/^$1\t//p"; }
 # stream that are NOT on device $1.
 _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 
+# The depth-1 enumeration all three /tmp sections share, in ONE place.
+# $1 = base, $2 = the file find's stderr is kept in, $3.. = extra find
+# predicates (`-type d` for the inode breakdown).
+#
+# 🔴 `%D` MAKES find STAT EVERY ENTRY, AND A FAILED STAT EMITS NO RECORD AT ALL.
+# The `-print0` form this replaced still printed the NAME when the stat failed;
+# `-printf '%D\t%p\0'` prints nothing, so such an entry vanishes from the size
+# breakdown AND the inode breakdown AND the foreign-entry listing at once — and
+# `foreign_entries` then affirmatively printed "none". MEASURED 2026-09-07 over
+# a mode-0400 directory holding three entries, on the two GNU findutils builds
+# this script can actually resolve, both rc 1: 4.10.0 (the system PATH, what a
+# non-interactive `bash` and therefore a `sudo` run gets) `-print0` 116 bytes /
+# `-printf '%D\t%p\0'` 0 bytes; 4.11.0 (the nix dev shell) 119 bytes / 0 bytes.
+# Not specific to one build. (Not measured on `bfs`, which is only an
+# interactive zsh alias here and never what this script runs.)
+#
+# Root is NOT immune, which is what makes this worth code rather than a note. A
+# FUSE mountpoint not mounted `allow_other` (an AppImage's /tmp/.mount_*, gvfs,
+# sshfs), or an entry on a device answering ESTALE/EIO, fails `stat` for uid 0
+# too — and /tmp is exactly where those live.
+#
+# So the stderr is KEPT, in a file, and every caller reports the count. Same
+# reason section 2's find writes to $DENIED_LOG instead of /dev/null: a scan
+# that reports a number with no denial count is a FLOOR presented as a total.
+#
+# The `|| true` here covers route (a) ONLY — find's own rc 1 — of the two aborts
+# `size_breakdown`'s comment describes. Route (b), `xargs` rc 123, happens one
+# stage later and is guarded at each caller's `xargs`.
+_depth1_nul() {
+  local base="$1" errf="$2"; shift 2
+  find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '%D\t%p\0' 2>"$errf" || true
+}
+
+# How many entries the enumeration whose stderr is in $1 could not stat. ALWAYS
+# a single integer and never empty — the callers compare it with `-gt`, and the
+# `grep -c` / `|| echo 0` two-line-zero defect `report_denials` carries a
+# comment about is the same hazard one function over.
+_unstattable_count() {
+  local n
+  n=$(grep -c . "$1" 2>/dev/null; true)
+  case "$n" in ''|*[!0-9]*) echo 0 ;; *) echo "$n" ;; esac
+}
+
+# Print the blind spot the count in $1 represents, or nothing. $2 = the base
+# being measured, $3 = the stderr file. Loud on purpose: an entry that reached
+# no list is the difference between a floor and a total.
+_report_unstattable() {
+  local n="$1" base="$2" errf="$3"
+  [ "$n" -gt 0 ] || return 0
+  printf '  !! UNSTATTABLE: %d depth-1 entries of %s reached NO list above.\n' "$n" "$base"
+  printf '     Every figure for %s here is a FLOOR, not a total. First lines:\n' "$base"
+  # `|| true`: this pipeline is the LAST command of the function, so its status
+  # is the function's status, and the function is called at statement level in
+  # all three sections — i.e. the same `set -e` exposure the sweep above the
+  # executable region is about, one level of indirection down.
+  head_n 5 < "$errf" | sed 's/^/       /' || true
+}
+
 # Top-level entries of $1 that are ON $1's OWN FILESYSTEM, largest first.
 #
 # 🔴 NOT `du -sh -x "$1"/*`. MEASURED 2026-09-02: /tmp held 171,886 top-level
@@ -196,19 +254,63 @@ _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 # `set -e`: sections 6d-inodes, 7 and 8 never print and the report ends with no
 # error. MEASURED 2026-09-07: (a) rc 1, (b) rc 123, each reproducible on its own.
 # That is the same truncated-scan failure as E2BIG and SIGPIPE, reached by a
-# third and a fourth route. What is tolerated is per-ENTRY failure; a total
-# failure is still visible, as an empty section.
+# third and a fourth route.
+#
+# 🔴 THE GUARDS ARE PER-STAGE, AND THE CAPTURE CARRIES NONE. An earlier draft of
+# this round wrapped the whole `out=$(…)` in `|| true` instead. It works — and it
+# destroys the only thing that could tell you it works: with an outer guard,
+# DELETING any inner one changes nothing observable, and MEASURED, both `|| true`
+# mutants in the battery went WRONG-KILLER. A guard whose removal is invisible is
+# not a guard.
+#
+# 🔴 AND `sort` IS DELIBERATELY THE ONE STAGE LEFT UNGUARDED — the mirror image
+# of the same trap. `_on_device` gained a `|| true` here (the audit's note that
+# it was the one stage without one), but putting one on `sort` MEASURED as
+# breaking BOTH `sigpipe-head-closes-the-pipe` rows: the whole point of `head_n`
+# is that `sort` never takes SIGPIPE, so masking `sort`'s status is exactly what
+# makes a reinstated `head -n` invisible. What stays exposed is a `sort` that
+# fails for its OWN reasons — no space for its temp files, say — and that is the
+# same exposure the statement-level pipeline had before this round, not a new
+# one. It is listed with the other deliberate exceptions above section 1.
+#
+# 🔴 THIS COMMENT USED TO END: "What is tolerated is per-ENTRY failure; a total
+# failure is still visible, as an empty section." BOTH HALVES WERE FALSE, and
+# the round that wrote them is the round that falsified them. Per-entry failure
+# was not tolerated but SILENTLY ERASED — `-printf '%D\t%p\0'` emits no record
+# for an entry it cannot stat (see `_depth1_nul`) — and an empty section was not
+# "visible" but indistinguishable from a clean directory, because nothing said
+# which of the two it was. Both are fixed below: the stderr is counted and
+# reported, and the empty list says in words that it is empty.
+#
+# 🔴 `dev=$(…) || dev=`, NOT a bare assignment. A command substitution in an
+# assignment is a CHECKED command under `set -e`, so a failing `stat` killed the
+# whole run ON THIS LINE and the refusal below never printed — the same
+# unreachable-message defect this file records for `OUT=$(lsof …)`, reintroduced
+# by the round that added the refusal. MEASURED 2026-09-07: under the script's
+# own `set -euo pipefail`, `size_breakdown /tmp/<absent>` exited 1 having
+# printed nothing at all. The suite could not see it: a suite that sources this
+# file must turn `set -e` back OFF to run, so it took the refusal branch either
+# way. The probe in section 4c of the suite runs `set -e` for real.
 size_breakdown() {
-  local base="$1" dev
-  dev=$(_dev_of "$base")
+  local base="$1" dev errf blind out
+  dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
-    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (size breakdown)"
     return 0
   fi
-  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0' 2>/dev/null || true; } \
-    | _on_device "$dev" \
+  errf=$(mktemp) || { echo "COULD NOT MEASURE: no temp file for $base's size breakdown"; return 0; }
+  out=$(_depth1_nul "$base" "$errf" \
+    | { _on_device "$dev" || true; } \
     | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
-    | sort -rh | head_n 15
+    | sort -rh | head_n 15)
+  blind=$(_unstattable_count "$errf") || blind=0
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  else
+    echo "  none — no depth-1 entry of $base is on $base's own filesystem (NOT zero bytes)"
+  fi
+  _report_unstattable "$blind" "$base" "$errf"
+  rm -f "$errf"
 }
 
 # Inode count per top-level DIRECTORY of $1 that is on $1's OWN filesystem,
@@ -238,16 +340,25 @@ size_breakdown() {
 # The device filter and the two `|| true`s are the same two defects as
 # `size_breakdown` above; read its comment.
 inode_breakdown() {
-  local base="$1" dev
-  dev=$(_dev_of "$base")
+  local base="$1" dev errf blind out
+  dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
-    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (inode breakdown)"
     return 0
   fi
-  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '%D\t%p\0' 2>/dev/null || true; } \
-    | _on_device "$dev" \
+  errf=$(mktemp) || { echo "COULD NOT MEASURE: no temp file for $base's inode breakdown"; return 0; }
+  out=$(_depth1_nul "$base" "$errf" -type d \
+    | { _on_device "$dev" || true; } \
     | { xargs -0 -r -n1 sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ || true; } \
-    | sort -rn | head_n 15
+    | sort -rn | head_n 15)
+  blind=$(_unstattable_count "$errf") || blind=0
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  else
+    echo "  none — no depth-1 DIRECTORY of $base is on $base's own filesystem (NOT zero inodes)"
+  fi
+  _report_unstattable "$blind" "$base" "$errf"
+  rm -f "$errf"
 }
 
 # The depth-1 entries of $1 that the two breakdowns above SKIPPED, because they
@@ -259,20 +370,43 @@ inode_breakdown() {
 # a total. Section 6c already prints the same listing for /home, and its "none
 # found" branch is deliberately loud for the same reason. A section that drops
 # what it could not count without saying so is worse than one that never tried.
+#
+# 🔴 ONE ROW PER NUL RECORD — never `tr '\0' '\n' | head_n 15`, which is what
+# this function was written with in round 1. It reintroduced, in the same
+# commit that fixed it
+# for `split_by_device`, the defect `report_foreign_mounts` reads its list with
+# `read -r -d ''` to avoid: /tmp is mode 1777, so any local process can create a
+# directory whose name contains a newline, `tr` turns it into two report rows —
+# the second of which reads as a real path — and `head_n`, which counts LINES,
+# lets that one name eat two of the fifteen slots.
+#
+# 🔴 AND THE "none" BRANCH MUST NOT OUTRANK ITS OWN BLIND SPOT. An entry find
+# could not stat is absent from this listing too (see `_depth1_nul`), so "none"
+# is only honest when the enumeration saw everything. When it did not, say so.
 foreign_entries() {
-  local base="$1" dev out
-  dev=$(_dev_of "$base")
+  local base="$1" dev errf blind p n=0
+  dev=$(_dev_of "$base") || dev=
   if ! _dev_is_valid "$dev"; then
     echo "  COULD NOT MEASURE: no device id for $base — NOT an absence of foreign mounts"
     return 0
   fi
-  out=$({ find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0' 2>/dev/null || true; } \
-        | _not_on_device "$dev" | tr '\0' '\n' | head_n 15)
-  if [ -n "$out" ]; then
-    printf '%s\n' "$out" | sed 's/^/  /'
-  else
-    echo "  none — every depth-1 entry is on the same filesystem as $base"
+  errf=$(mktemp) || { echo "  COULD NOT MEASURE: no temp file for $base's foreign-entry listing"; return 0; }
+  while IFS= read -r -d '' p; do
+    n=$((n + 1))
+    [ "$n" -gt 15 ] || printf '  %s\n' "$p"
+  done < <(_depth1_nul "$base" "$errf" | _not_on_device "$dev")
+  blind=$(_unstattable_count "$errf") || blind=0
+  if [ "$n" -gt 15 ]; then
+    printf '  ... and %d more\n' "$((n - 15))"
+  elif [ "$n" -eq 0 ]; then
+    if [ "$blind" -gt 0 ]; then
+      echo "  none VISIBLE — and the line below says why that is NOT 'no foreign mounts'"
+    else
+      echo "  none — every depth-1 entry is on the same filesystem as $base"
+    fi
   fi
+  _report_unstattable "$blind" "$base" "$errf"
+  rm -f "$errf"
 }
 
 # Partition the directories under $1 by filesystem: on-root candidates into $2,
@@ -354,7 +488,7 @@ report_denials() {
   echo "OTHER, unclassified                  : $unclassified"
   if [ "$denied" -gt 0 ]; then
     echo "!! Running as root and STILL denied — the counts above are FLOORS, not totals."
-    grep 'Permission denied' "$log" | head_n 20
+    grep 'Permission denied' "$log" | head_n 20 || true
   fi
   if [ "$unclassified" -gt 0 ]; then
     echo "-- unclassified errors (read these; they are not known-benign) --"
@@ -378,6 +512,32 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 2
 fi
 
+# 🔴 THE `set -e` SWEEP, AND WHAT IT DELIBERATELY LEAVES OPEN. Twice now an
+# enumeration of "commands whose failure kills the report" was done BY EYE and
+# missed a site (round 1 covered the pipelines and missed section 5's bare
+# `du -sh`). It is now done mechanically: join backslash continuations, then
+# take every line in this file whose first word is one of
+# find/du/ls/dumpe2fs/findmnt/lsof/stat/xargs/grep/sed/sort/uniq/wc/tr/awk/
+# mktemp/date/seq/dd/id, plus every `VAR=$(…)`, and require a `||` (or a
+# trailing `; true` inside the substitution, which has the same effect).
+# Everything that scan reports is guarded above EXCEPT these, each checked by
+# hand and left open on purpose:
+#   * `X=$((…))` — MEASURED: an arithmetic assignment is rc 0 even when the
+#     expression evaluates to 0, so it is not in the class at all.
+#   * `read … < <(find … | awk …)` in section 2 — MEASURED: a process
+#     substitution's status is NOT checked by `set -e`, which is why denials in
+#     section 2 do not kill the run.
+#   * `out=$(… | sort … | head_n …)` in the two breakdowns — every stage but
+#     `sort` carries its own `|| true`, and `sort` deliberately does not; the
+#     reason, and what it measured, is in `size_breakdown`'s comment. What is
+#     exposed is a `sort` that fails for its own reasons (no space for its temp
+#     files), which is the same exposure the statement-level pipeline had before
+#     this round rather than a new one.
+#   * `DENIED_LOG=$(mktemp …)` and the five `stat -f` reads in section 1 — these
+#     abort BEFORE any figure is printed, so they cannot leave a floor looking
+#     like a total. They end the run with a blank report, which is wrong-looking
+#     rather than reassuring. That is the criterion, and it is the only reason
+#     they are not guarded.
 DEV=${DEV:-/dev/nvme0n1p2}
 DENIED_LOG=$(mktemp /tmp/disk-accounting-denied.XXXXXX)
 trap 'rm -f "$DENIED_LOG"' EXIT
@@ -401,8 +561,18 @@ printf 'blocks used     : %d  (%.1f GiB)\n' "$BLOCKS_USED" "$(echo "$BLOCKS_USED
 printf 'inodes used     : %d\n' "$INODES_USED"
 echo
 echo "--- static ext4 metadata (this is the ONLY 'overhead' that is not files) ---"
-dumpe2fs -h "$DEV" 2>/dev/null | grep -iE 'Inode size|Inode count|Block count|Reserved block count|Journal size|Filesystem state|Last checked'
-INODE_SIZE=$(dumpe2fs -h "$DEV" 2>/dev/null | awk -F: '/^Inode size/{gsub(/ /,"",$2);print $2}')
+# 🔴 `|| echo`, NOT a bare pipeline. `$DEV` is a GUESS (`/dev/nvme0n1p2` unless
+# the caller overrides it) and `grep` exits 1 when nothing matches, so on a host
+# where the guess is wrong — or where dumpe2fs is not installed — this pipeline
+# returns 1, `set -e` kills the run HERE, and the operator is left holding the
+# "blocks used / inodes used" figures printed three lines above with sections
+# 2-8 missing and no error. MEASURED 2026-09-07 in an isolated probe of these
+# two lines with `DEV=/dev/nope-xyz`: the pipeline returned 1 under
+# `set -euo pipefail` and the next statement never ran. Same class as the
+# `du -sh` in section 5 below.
+dumpe2fs -h "$DEV" 2>/dev/null | grep -iE 'Inode size|Inode count|Block count|Reserved block count|Journal size|Filesystem state|Last checked' \
+  || echo "COULD NOT MEASURE: dumpe2fs read no ext4 superblock fields from $DEV — set DEV=<device> if that is the wrong partition"
+INODE_SIZE=$(dumpe2fs -h "$DEV" 2>/dev/null | awk -F: '/^Inode size/{gsub(/ /,"",$2);print $2}') || INODE_SIZE=
 if [ -n "${INODE_SIZE:-}" ]; then
   echo "$INODES_TOTAL $INODE_SIZE" | awk '{printf "inode TABLES    : %.1f GiB (preallocated, counted as used blocks)\n", $1*$2/1073741824}'
 fi
@@ -438,7 +608,7 @@ for d in /*; do
         }
         END {print n+0, b+0, dup+0}'
   )
-  gib=$(echo "$blocks" | awk '{printf "%.1f", $1*512/1073741824}')
+  gib=$(echo "$blocks" | awk '{printf "%.1f", $1*512/1073741824}') || gib=
   printf '%14d %12s %10d  %s\n' "$n" "$gib" "$dups" "$d"
   TOTAL_INODES=$((TOTAL_INODES + n))
   TOTAL_DEDUPED=$((TOTAL_DEDUPED + dups))
@@ -485,7 +655,16 @@ if [ -d /var/lib/rancher/k3s/storage ]; then
   { find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null || true; } \
     | { xargs -0 -r du -sh --exclude=/mnt 2>/dev/null || true; } | sort -rh | head_n 30
   echo "--- total ---"
-  du -sh /var/lib/rancher/k3s/storage 2>/dev/null
+  # 🔴 `|| echo`, NOT a bare `du`. This site sat directly under the two guarded
+  # pipelines above, under a comment that described the treatment it did not
+  # have. `du` prints an UNDER-COUNTED total and exits 1 when a PVC directory is
+  # unlinked between readdir and stat, or is simply unreadable — MEASURED
+  # 2026-09-07 over a directory holding a mode-000 subdirectory: `12K` printed,
+  # rc 1 — and with the message already at /dev/null `set -e` then killed the
+  # run, so sections 6, 6b, 6c, 6d, 7 and 8 never printed. A floor presented as
+  # a total, and then no error. The `|| echo` labels the floor as one.
+  du -sh /var/lib/rancher/k3s/storage 2>/dev/null \
+    || echo "COULD NOT MEASURE: du failed under /var/lib/rancher/k3s/storage — any total it printed is a FLOOR"
   echo "--- inodes per PVC (top 15) ---"
   for p in /var/lib/rancher/k3s/storage/*; do
     [ -d "$p" ] || continue
@@ -519,7 +698,17 @@ echo "=== 6c. /home breakdown — ROOT FILESYSTEM ONLY (top 15 by allocated size
 # The device split and the foreign listing both live in `split_by_device` /
 # `report_foreign_mounts` above; read their comments for the `du -x` and
 # subshell-accumulator defects they exist to prevent.
-ROOT_DEV=$(_dev_of /)
+# `|| ROOT_DEV=` then a digits check, for the reason `size_breakdown` carries a
+# comment about: a bare `VAR=$(…)` is a CHECKED command under `set -e`, so a
+# failing `stat` would kill the run here rather than reach a refusal. An EMPTY
+# root device is worse than no section — `split_by_device` compares each
+# candidate against it, so every directory under /home would come back "foreign"
+# and 6c would print a confident list of foreign mounts that are nothing of the
+# kind.
+ROOT_DEV=$(_dev_of /) || ROOT_DEV=
+if ! _dev_is_valid "$ROOT_DEV"; then
+  echo "COULD NOT MEASURE: no device id for / — skipping 6c rather than calling every /home directory foreign"
+else
 # Create BOTH before widening the trap: if the second mktemp failed while the trap
 # still named only $DENIED_LOG, the first temp file leaked on that exit path.
 ONROOT_LIST=$(mktemp) && FOREIGN_LIST=$(mktemp) || { rm -f "${ONROOT_LIST:-}"; exit 3; }
@@ -531,6 +720,7 @@ split_by_device /home "$ONROOT_LIST" "$FOREIGN_LIST" "$ROOT_DEV"
 { xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; } | sort -rh | head_n 15
 echo "--- NOT on the root filesystem, so NOT part of this accounting ---"
 report_foreign_mounts "$FOREIGN_LIST"
+fi
 
 echo
 echo "=== 6d. /tmp breakdown — MEASURED 2026-09-01 as the largest inode consumer ==="
@@ -541,11 +731,20 @@ echo "--- top 15 by allocated size ---"
 size_breakdown /tmp
 echo "--- top 15 by inode count ---"
 inode_breakdown /tmp
-echo "--- NOT on the root filesystem, so EXCLUDED from the two lists above ---"
+# 🔴 "NOT on /TMP'S OWN filesystem", not "not on the root filesystem". The three
+# helpers above compare each entry against `stat -c '%d' /tmp`, NOT against
+# $ROOT_DEV, so on a host where /tmp is its own mount this heading named the
+# wrong filesystem. (On the host this targets they are the same device — 6d's
+# own text says /tmp is on the root partition — which is exactly why a wrong
+# heading here could sit unnoticed.)
+echo "--- NOT on /tmp's own filesystem, so EXCLUDED from the two lists above ---"
 foreign_entries /tmp
 echo "--- entry-name families (what is generating them) ---"
-ls -A /tmp 2>/dev/null | sed -E 's/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//' \
-  | sort | uniq -c | sort -rn | head_n 20
+# `|| true` for the same reason as section 5's `du`: `ls` exits 2 if /tmp cannot
+# be read, `pipefail` promotes it and `set -e` would end the report one line
+# before section 7. Found by the same mechanical sweep, not by eye.
+{ ls -A /tmp 2>/dev/null | sed -E 's/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//' \
+  | sort | uniq -c | sort -rn | head_n 20; } || true
 
 echo
 echo "=== 7. Deleted-but-open files ==="

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -276,6 +276,25 @@ _report_unstattable() {
 # nothing either way; now the ABSENCE of a `!! UNSTATTABLE` line reads as an
 # affirmative "nothing was missed" — the same floor-presented-as-a-total
 # reading, arrived at by trusting a report that never had the evidence.
+#
+# 🔴 EXACTLY WHICH SITES THIS COVERS — a DECLARED scope, in the sense
+# `split_by_device` below uses the phrase. It fires only for a caller that gave
+# du a stderr FILE — as written today, `size_breakdown`'s own capture, section
+# 5's PVC listing and section 6c's /home listing. Every OTHER `du` in this file
+# still sends its stderr to `/dev/null`, and this report says nothing whatever
+# about them.
+#
+# Do NOT take a number from this comment. Round 4's finding was a sentence
+# elsewhere that counted these sites and counted them wrong, so what is written
+# here is the derivation instead of the answer:
+#
+#   grep -n '_report_unreadable' scripts/diagnose-disk-accounting.sh   # callers
+#   grep -nE '(^|[^#[:alnum:]_])du ' scripts/diagnose-disk-accounting.sh \
+#     | grep -v ':[[:space:]]*#'                                       # du sites
+#
+# For any du site that comes back and is not one of the callers, silence is not
+# evidence of a complete figure. Read that site's own comment for what it says
+# instead.
 _report_unreadable() {
   local base="$1" errf="$2" n
   n=$(_errline_count "$errf")
@@ -312,9 +331,29 @@ _report_unreadable() {
 # is accepted: a non-root CALLER — i.e. the test suite — now writes into the
 # system /tmp rather than into its own sandbox, and when a deliberately broken
 # copy of this script dies between the `mktemp` and the `rm` (which is what the
-# mutation battery does, ~60 times per full sweep) the files stay there. They are
-# harmless, empty, and — the point of this whole change — NAMED, which is how
-# they get noticed and swept at all.
+# mutation battery does, once per mutant) the files stay there. They are mode
+# 0600 and NAMED — the point of this whole change, because the name is how they
+# get noticed and swept at all.
+#
+# 🔴 THEY ARE NOT ALL EMPTY, which is what this said for a round. MEASURED
+# 2026-09-08 on this host: leftovers of both kinds were present and some held a
+# fixture's captured stderr, e.g. `du: cannot read directory
+# '/tmp/tmp.XXXXXXXXXX/du-errors/locked': Permission denied`. Fixture noise
+# rather than host data, and 0600 keeps it out of another user's reach — but
+# "empty" was simply the wrong word. No count is written down here, because the
+# number is whatever the last interrupted sweep happened to leave;
+# `ls -l /tmp/disk-accounting-*` is the answer.
+#
+# 🔴 AND THE HALF THAT WAS NEVER RECORDED: hardcoding /tmp also removes `TMPDIR`
+# as an ESCAPE ROUTE, on exactly the failure this script is pointed at.
+# `$DENIED_LOG` and `$DU_ERR` are opened at the top of the executable region and
+# are deliberately unguarded (see the exception list above section 1), so a root
+# filesystem out of inodes — the condition being diagnosed — ends the run on
+# those two lines with a blank report. The exception list accepts the blank
+# report as the honest outcome; what it does not say, and this does, is that the
+# bare `mktemp` this replaced would have honoured an inherited `$TMPDIR` and the
+# template cannot. Pointing this run's scratch at another filesystem now means
+# editing this file.
 _scan_mktemp() { REPLY=$(mktemp "/tmp/disk-accounting-$1.XXXXXX") || { REPLY=; return 1; }; }
 
 # Remove every temp file the run currently holds open. It reads the variables at
@@ -820,7 +859,17 @@ if [ -d /var/lib/rancher/k3s/storage ]; then
   # started reporting their blind spots the absence of a marker started reading
   # as "nothing was missed". Truncated per site so one site's count cannot be
   # attributed to another.
-  : > "$DU_ERR"
+  #
+  # 🔴 `|| echo`, NOT a bare `: >`. A redirection failure on a SPECIAL BUILTIN
+  # is fatal under `set -e` — MEASURED 2026-09-08 on bash 5.3.15:
+  # `set -euo pipefail; : > /absent/x` ends the shell, rc 1, nothing after it
+  # runs; the same line with `|| echo` is caught and the run continues. This
+  # shape is in NEITHER ledger §7b keeps: the sweep's regex reads a line's first
+  # word and this line's is `:`, and it carries no `| sort`. It also cannot be a
+  # bare `|| true` — a file that did not truncate still holds an EARLIER site's
+  # paths, and `_report_unreadable` would then attribute them to this one, which
+  # is the "one count standing for two claims" the two-sinks comment is about.
+  : > "$DU_ERR" || echo "COULD NOT MEASURE: could not truncate du's stderr file — any PARTIALLY READ count below may include paths from an earlier section"
   { find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null || true; } \
     | { xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true; } | sort -rh | head_n 30
   _report_unreadable /var/lib/rancher/k3s/storage "$DU_ERR"
@@ -848,9 +897,27 @@ echo
 echo "=== 6. Other root-only trees the unprivileged scan could not see ==="
 for d in /root /var/lib/docker /var/lib/containerd /var/lib/kubelet /var/lib/private; do
   if [ -d "$d" ]; then
-    printf '%10s %12d inodes  %s\n' \
-      "$(du -sh -x "$d" 2>/dev/null | awk '{print $1}')" \
-      "$(find "$d" -xdev -printf . 2>/dev/null | wc -c)" "$d"
+    # 🔴 du's STATUS IS READ HERE, AND THE MARKER IS WHAT IT BUYS. A `du` that
+    # cannot fully read a tree prints a PARTIAL total on stdout and exits 1 —
+    # a stale NFS/CSI mount under /var/lib/kubelet is the realistic case on a
+    # k3s node. With the status thrown away and the message already at
+    # /dev/null, this row rendered that floor EXACTLY like a complete figure,
+    # and since `_report_unreadable` landed the absence of a marker reads as an
+    # affirmative "nothing was missed" (see its comment). This site has no
+    # stderr FILE to report a path count from, so what it can say is that the
+    # number is a floor.
+    # `if du_out=$(…)`, not a bare assignment: a command in an `if` condition
+    # is not checked by `set -e`, so a failing du marks the row instead of
+    # ending the report — the same checked-assignment reasoning as section 6c's
+    # `ROOT_DEV` reading, reached by an `if` rather than an `||`. (Spelled
+    # WITHOUT quoting that line verbatim: the mutation battery matches raw text,
+    # and a comment reproducing a mutant's literal makes the mutation ambiguous
+    # and scores it MUTATION DID NOT APPLY. That is how this comment was first
+    # written, and the occurrence check caught it.)
+    if du_out=$(du -sh -x "$d" 2>/dev/null); then du_mark=; else du_mark='  !! FLOOR — du could not read all of it'; fi
+    printf '%10s %12d inodes  %s%s\n' \
+      "$(printf '%s\n' "$du_out" | awk '{print $1}')" \
+      "$(find "$d" -xdev -printf . 2>/dev/null | wc -c)" "$d" "$du_mark"
   else
     printf '%10s %12s          %s\n' absent - "$d"
   fi
@@ -893,7 +960,12 @@ split_by_device /home "$ONROOT_LIST" "$FOREIGN_LIST" "$ROOT_DEV"
 # `pipefail` + `set -e` would take the whole report with it. du's stderr is KEPT
 # (see section 5 and `_report_unreadable`): a /home directory du could not fully
 # read is listed here short, and silence is not evidence that none was.
-: > "$DU_ERR"
+# Guarded for the reason section 5's copy carries — and this is the site that
+# makes it matter: here the truncation runs AFTER sections 1 through 6b have
+# already printed, so an unguarded failure ends the report mid-way with figures
+# above it and no message, which is precisely the criterion the exception list
+# above section 1 uses to decide a site may stay unguarded.
+: > "$DU_ERR" || echo "COULD NOT MEASURE: could not truncate du's stderr file — any PARTIALLY READ count below may include paths from an earlier section"
 { xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>>"$DU_ERR" || true; } | sort -rh | head_n 15
 _report_unreadable /home "$DU_ERR"
 echo "--- NOT on the root filesystem, so NOT part of this accounting ---"

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -23,11 +23,27 @@ set -euo pipefail
 # were all shipped once and were invisible to the merge gate because this file
 # had no test and this repo has no shellcheck gate.
 #
-# `source`ing this file defines the helpers and RUNS NOTHING: BASH_SOURCE[0] is
-# always this file, while $0 is the sourcing shell's own name, so they differ
-# only when sourced. Executing it (`bash …`/`./…`) makes them equal and the
-# script proceeds exactly as before — the guard is not reachable from the
-# environment, so no stray variable can silently turn a real run into a no-op.
+# `source`ing this file defines the helpers and RUNS NOTHING. The seam test is
+# `(return 0 2>/dev/null)`: at the top level of a subshell, `return` SUCCEEDS
+# when the enclosing shell is executing a sourced file and FAILS otherwise, and
+# the diagnostic is discarded, so neither branch prints anything.
+#
+# 🔴 IT USED TO READ `[ "${BASH_SOURCE[0]}" != "$0" ]`, and the sentence that
+# stood here — "the guard is not reachable from the environment" — was FALSE.
+# bash imports BASH_SOURCE from the environment as an ordinary scalar, so
+# `env 'BASH_SOURCE=(nope)' bash scripts/diagnose-disk-accounting.sh` took the
+# SOURCED branch and hit `return` at top level: rc 2 and no report at all — and
+# rc 2 is this script's own "you forgot sudo" status, so two unrelated causes
+# shared one exit code. `bash < script` / `bash -s` was the mirror image:
+# BASH_SOURCE unset, `set -u`, dead on the guard's own line.
+#
+# MEASURED for the replacement (2026-09-07, bash 5.3 on this host): `bash FILE`,
+# `./FILE`, `bash < FILE`, `bash -s < FILE` and `env 'BASH_SOURCE=(nope)' bash
+# FILE` all take the EXECUTE branch; `source FILE` and `bash -c 'source FILE'`
+# take the sourced branch, with or without a poisoned BASH_SOURCE. `return`
+# reads no variable, so there is no variable left to poison. What is NOT
+# claimed: a caller that deliberately `source`s this file gets the no-op branch
+# — that is the seam doing its job, not a bypass.
 #
 # 🔴 `set -euo pipefail` above executes at SOURCE time and leaks into the
 # sourcing shell. The test suite re-asserts its own options immediately after
@@ -97,7 +113,14 @@ lsof_deleted_summary() {
 # carries — the one written specifically to stop a zero being mistaken for a
 # non-measurement — could never actually be reached. `|| rc=$?` keeps the status
 # without arming `set -e`.
-LSOF_BIN=${LSOF_BIN:-lsof}
+#
+# 🔴 `LSOF_BIN` IS SET AT THE SEAM, AND ONLY THE SOURCED BRANCH HONOURS AN
+# OVERRIDE. It used to be `LSOF_BIN=${LSOF_BIN:-lsof}` here, ABOVE the seam,
+# which is on the execute path: an inherited `LSOF_BIN=/anything` was then what
+# a ROOT run executed. In a script whose entire premise is that a local
+# unprivileged process must not be able to influence a root run, a test seam
+# that widens what root executes is backwards. The execute branch now pins
+# `LSOF_BIN=lsof` unconditionally and discards whatever the environment said.
 report_deleted_open_files() {
   local out rc=0
   if ! command -v "$LSOF_BIN" >/dev/null 2>&1; then
@@ -112,7 +135,40 @@ report_deleted_open_files() {
   fi
 }
 
-# Top-level entries of $1, largest first.
+# Device id of $1 IN DECIMAL, or empty. Its own function so the suite can
+# substitute a fixture-controlled device map without needing two real
+# filesystems.
+#
+# 🔴 DECIMAL (`%d`), NOT `%D`. `stat -c '%D'` is HEX; `find -printf '%D'` is
+# DECIMAL. The two breakdowns below compare a `stat` reading of the base against
+# find's per-entry reading, so a hex/decimal mismatch would silently classify
+# EVERY entry as foreign and print an empty section — the reassuring reading of
+# a broken instrument. One format, one helper, every comparison.
+_dev_of() { stat -c '%d' "$1" 2>/dev/null; }
+
+# Is $1 a usable device id? ONE place, because three callers below need the same
+# test — `size_breakdown`, `inode_breakdown` and `foreign_entries` — and a
+# predicate open-coded at three sites is typically wrong at two of them.
+#
+# 🔴 DIGITS, not merely non-empty. The value is interpolated into a `sed` script
+# by `_on_device` below, so a `/` or a `*` would silently change the expression
+# rather than fail. `stat -c '%d'` cannot produce one today — which is an
+# argument for checking it in one place, not for trusting it at three.
+_dev_is_valid() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+# Read a NUL-separated `<device>\t<path>` stream (find -printf '%D\t%p\0') on
+# stdin and emit, NUL-separated, only the paths whose device is $1.
+#
+# `sed -z` because the whole point of the NUL stream is names containing
+# newlines; a `while read` loop would be a `stat` fork per entry, and /tmp had
+# 171,886 top-level entries.
+_on_device() { sed -z -n "s/^$1\t//p"; }
+
+# The mirror image, for the blind-spot report: the depth-1 entries of the same
+# stream that are NOT on device $1.
+_not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
+
+# Top-level entries of $1 that are ON $1's OWN FILESYSTEM, largest first.
 #
 # 🔴 NOT `du -sh -x "$1"/*`. MEASURED 2026-09-02: /tmp held 171,886 top-level
 # entries = ~4.32 MiB of argv against an ARG_MAX of 2,097,152, so the glob dies
@@ -120,32 +176,113 @@ report_deleted_open_files() {
 # the WHOLE SCRIPT mid-section — sections 6d-inodes, 7 and 8 never run, and the
 # report ends with no error. That is the "truncated scan reported as a total"
 # failure this very script exists to prevent.
+#
+# 🔴 `-xdev` DOES LIST FOREIGN MOUNTPOINTS AT DEPTH 1 — it only stops find
+# DESCENDING past them. So a mount under /tmp arrives here as a starting point
+# for `du -sh -x`, which is the one case `du -x` cannot handle (see
+# `split_by_device` below: started ON a foreign mount, du walks all of it), and
+# its whole size lands in a figure an operator reads as root-fs /tmp usage.
+# Defect 7 was fixed for /home in section 6c and left standing here. Same fix:
+# compare each candidate's device against the base's and drop the foreign ones.
+# `-x` is KEPT as well — belt and braces for anything mounted BELOW depth 1.
+#
+# 🔴 BOTH STAGES ARE `|| true`, AND THEY ARE TWO DIFFERENT ABORTS.
+#   (a) `find` exits 1 when an entry disappears between readdir and stat. On the
+#       host this was written for /tmp holds ~270,000 churning entries, and
+#       section 4's own counter calls those ENOENTs "benign, transient".
+#   (b) `xargs` exits 123 when ANY `du` it ran exited 1 — which is what happens
+#       when the entry vanishes a moment later, or is simply unreadable.
+# Either one is eaten by `2>/dev/null`, promoted by `pipefail` and fatal under
+# `set -e`: sections 6d-inodes, 7 and 8 never print and the report ends with no
+# error. MEASURED 2026-09-07: (a) rc 1, (b) rc 123, each reproducible on its own.
+# That is the same truncated-scan failure as E2BIG and SIGPIPE, reached by a
+# third and a fourth route. What is tolerated is per-ENTRY failure; a total
+# failure is still visible, as an empty section.
 size_breakdown() {
-  find "$1" -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
-    | xargs -0 -r du -sh -x 2>/dev/null | sort -rh | head_n 15
+  local base="$1" dev
+  dev=$(_dev_of "$base")
+  if ! _dev_is_valid "$dev"; then
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
+    return 0
+  fi
+  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0' 2>/dev/null || true; } \
+    | _on_device "$dev" \
+    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | sort -rh | head_n 15
 }
 
-# Inode count per top-level DIRECTORY of $1, largest first.
+# Inode count per top-level DIRECTORY of $1 that is on $1's OWN filesystem,
+# largest first.
 #
 # 🔴 NOT `xargs -I{} sh -c '… "{}" …'`. That substitutes the directory NAME into
 # a shell string, and /tmp is mode 1777, and this script demands sudo — so any
 # local process could plant a directory whose name is a command and get it run
 # AS ROOT. VERIFIED 2026-09-02: a dir named `evil";echo PWNED-AS-$(id -un) >&2;"x`
-# made the old pipeline print PWNED-AS-zach. -exec with "$1" passes the name as
-# an ARGUMENT, never as text to parse.
+# made the old pipeline print PWNED-AS-zach.
+#
+# `xargs -0 -r -n1 sh -c '…' _` is the SAFE xargs form and `-I{}` is the unsafe
+# one; the difference is not cosmetic. `-n1 … _` appends the name to sh's argv,
+# where it lands in "$1" and is never parsed as text. `-I{}` splices it into the
+# script STRING before sh ever sees it. This used to be `find … -exec sh -c '…'
+# _ {} \;`, which is equally safe; it changed only because the device filter has
+# to sit between the enumeration and the per-directory walk.
+#
+# 🔴 NO `2>/dev/null` ON THE xargs STAGE, deliberately. The inner `find` already
+# has its own; a blanket one here would swallow whatever the per-directory shell
+# writes to stderr — and the historical defect's own proof of execution was a
+# planted name printing `PWNED-AS-root` to STDERR. MEASURED: with `2>/dev/null`
+# added back, the injection mutant in the battery is scored WRONG-KILLER,
+# because the guard that watches for the expansion can no longer see it. A
+# `2>/dev/null` that hides the evidence for the guard above it is not tidiness.
+#
+# The device filter and the two `|| true`s are the same two defects as
+# `size_breakdown` above; read its comment.
 inode_breakdown() {
-  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d \
-    -exec sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ {} \; 2>/dev/null \
+  local base="$1" dev
+  dev=$(_dev_of "$base")
+  if ! _dev_is_valid "$dev"; then
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
+    return 0
+  fi
+  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '%D\t%p\0' 2>/dev/null || true; } \
+    | _on_device "$dev" \
+    | { xargs -0 -r -n1 sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ || true; } \
     | sort -rn | head_n 15
 }
 
-# Device id of $1, or empty. Its own function so the suite can substitute a
-# fixture-controlled device map without needing two real filesystems.
-_dev_of() { stat -c '%D' "$1" 2>/dev/null; }
+# The depth-1 entries of $1 that the two breakdowns above SKIPPED, because they
+# are on another filesystem.
+#
+# 🔴 THIS EXISTS BECAUSE THE DEVICE FILTER CREATED A BLIND SPOT. Excluding a
+# foreign mount is right — its size is not root-fs usage — but excluding it
+# SILENTLY is the exact failure this whole file catalogues: a floor presented as
+# a total. Section 6c already prints the same listing for /home, and its "none
+# found" branch is deliberately loud for the same reason. A section that drops
+# what it could not count without saying so is worse than one that never tried.
+foreign_entries() {
+  local base="$1" dev out
+  dev=$(_dev_of "$base")
+  if ! _dev_is_valid "$dev"; then
+    echo "  COULD NOT MEASURE: no device id for $base — NOT an absence of foreign mounts"
+    return 0
+  fi
+  out=$({ find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0' 2>/dev/null || true; } \
+        | _not_on_device "$dev" | tr '\0' '\n' | head_n 15)
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out" | sed 's/^/  /'
+  else
+    echo "  none — every depth-1 entry is on the same filesystem as $base"
+  fi
+}
 
-# Partition the directories under $1 by filesystem: on-root candidates into $2
-# (NUL-separated, ready for `xargs -0`), foreign ones into $3 (one per line).
-# $4 is the root device id.
+# Partition the directories under $1 by filesystem: on-root candidates into $2,
+# foreign ones into $3. BOTH are NUL-separated — $2 because it is fed to
+# `xargs -0`, $3 because it used to be one-per-line and a directory named with
+# an embedded newline then split into two garbled rows in the report. Wrong
+# report line rather than wrong execution, but /home is user-writable and this
+# script is run under sudo, so "the operator reads a line I chose" is not a
+# property worth leaving to chance. `report_foreign_mounts` reads it with
+# `read -r -d ''`. $4 is the root device id.
 #
 # 🔴 `du -x` only stops du CROSSING AWAY from its starting point. When the
 # starting point IS a foreign mount, du walks the whole thing: the 2026-09-01
@@ -172,7 +309,7 @@ split_by_device() {
     d=$(_dev_of "$p") || continue
     [ -n "$d" ] || continue
     if [ "$d" = "$root_dev" ]; then printf '%s\0' "$p" >> "$onroot"
-    else printf '%s\n' "$p" >> "$foreign"; fi
+    else printf '%s\0' "$p" >> "$foreign"; fi
   done
 }
 
@@ -182,7 +319,7 @@ split_by_device() {
 report_foreign_mounts() {
   local p
   if [ -s "$1" ]; then
-    while IFS= read -r p; do
+    while IFS= read -r -d '' p; do
       printf '  %-40s %s\n' "$p" "$(findmnt -n -o SOURCE,FSTYPE,SIZE,USED --target "$p" 2>/dev/null | head_n 1)"
     done < "$1"
   else
@@ -226,9 +363,14 @@ report_denials() {
 }
 
 # --- end of the sourceable seam ---------------------------------------------
-if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+# See the header for why this is `(return …)` and not `${BASH_SOURCE[0]}`, and
+# for what was measured. The `LSOF_BIN` override is deliberately INSIDE this
+# branch: only a sourced run may choose the binary.
+if (return 0 2>/dev/null); then
+  LSOF_BIN=${LSOF_BIN:-lsof}
   return 0
 fi
+LSOF_BIN=lsof
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "FATAL: must run as root — an unprivileged run silently skips the trees" >&2
@@ -333,9 +475,15 @@ echo "=== 5. k3s local-path PVCs (unreadable without root; the prior '1.7GB' cla
 if [ -d /var/lib/rancher/k3s/storage ]; then
   # Same NUL-safe enumeration as size_breakdown, for the same reason: a glob
   # expanded into `du` is an E2BIG waiting for the directory to grow, and this
-  # one is bounded only by how many PVCs the node happens to hold.
-  find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
-    | xargs -0 -r du -sh --exclude=/mnt 2>/dev/null | sort -rh | head_n 30
+  # one is bounded only by how many PVCs the node happens to hold. Same two
+  # `|| true`s too — find exits 1 on a PVC directory that is unlinked mid-scan,
+  # xargs exits 123 when a `du` under it does, and either kills the report.
+  #
+  # No device filter here, unlike section 6d: these are k3s local-path PVC
+  # directories, which are by construction on the node's own filesystem. If that
+  # ever stops being true this needs the same treatment.
+  { find /var/lib/rancher/k3s/storage -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null || true; } \
+    | { xargs -0 -r du -sh --exclude=/mnt 2>/dev/null || true; } | sort -rh | head_n 30
   echo "--- total ---"
   du -sh /var/lib/rancher/k3s/storage 2>/dev/null
   echo "--- inodes per PVC (top 15) ---"
@@ -377,7 +525,10 @@ ROOT_DEV=$(_dev_of /)
 ONROOT_LIST=$(mktemp) && FOREIGN_LIST=$(mktemp) || { rm -f "${ONROOT_LIST:-}"; exit 3; }
 trap 'rm -f "$DENIED_LOG" "$ONROOT_LIST" "$FOREIGN_LIST"' EXIT
 split_by_device /home "$ONROOT_LIST" "$FOREIGN_LIST" "$ROOT_DEV"
-xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null | sort -rh | head_n 15
+# `|| true` for the same reason as section 6d: xargs exits 123 when any `du` it
+# ran exited 1, which is what a /home directory unlinked mid-scan produces, and
+# `pipefail` + `set -e` would take the whole report with it.
+{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; } | sort -rh | head_n 15
 echo "--- NOT on the root filesystem, so NOT part of this accounting ---"
 report_foreign_mounts "$FOREIGN_LIST"
 
@@ -390,6 +541,8 @@ echo "--- top 15 by allocated size ---"
 size_breakdown /tmp
 echo "--- top 15 by inode count ---"
 inode_breakdown /tmp
+echo "--- NOT on the root filesystem, so EXCLUDED from the two lists above ---"
+foreign_entries /tmp
 echo "--- entry-name families (what is generating them) ---"
 ls -A /tmp 2>/dev/null | sed -E 's/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//' \
   | sort | uniq -c | sort -rn | head_n 20

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3939,6 +3939,19 @@ SHELL_TESTS=(
   # nothing. Watched red: mutating `APPLY=0` to `APPLY=1` fails it with
   # "the gate is bypassed".
   "scripts/tests/test_cleanup_disk_gate.sh"
+  # Registered in the SAME commit that adds it, for the reason the entries above
+  # exist. It covers `scripts/diagnose-disk-accounting.sh` — 282 lines of
+  # ROOT-PRIVILEGED bash that had no test file at all, in a repo with no
+  # shellcheck gate, which is precisely why a root COMMAND INJECTION (a planted
+  # /tmp directory name reaching `xargs -I{} sh -c`) and two silent
+  # whole-run aborts shipped invisibly. Nothing in it needs root: the script was
+  # given a sourceable seam (BASH_SOURCE[0] != $0 returns before the root check)
+  # and the suite drives the pure transforms against fixtures — an lsof header
+  # in two different column layouts, a directory literally named
+  # `evil";echo PWNED-AS-$(id -un) >&2;"x`, and a ~17,500-entry tree sized from
+  # the live ARG_MAX. It reaches no launcher, no network and no git.
+  # Watched red: `s += $col` -> `s += $8` fails it with "SIZE/OFF found at col 7".
+  "scripts/tests/test_diagnose_disk_accounting.sh"
 )
 # 🔴 THE SHELL TESTS ARE IN THE TIMING CENSUS TOO, and the reason is the census's
 # own honesty: it is presented as an accounting of the run, so a population it

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3940,16 +3940,24 @@ SHELL_TESTS=(
   # "the gate is bypassed".
   "scripts/tests/test_cleanup_disk_gate.sh"
   # Registered in the SAME commit that adds it, for the reason the entries above
-  # exist. It covers `scripts/diagnose-disk-accounting.sh` — 282 lines of
-  # ROOT-PRIVILEGED bash that had no test file at all, in a repo with no
-  # shellcheck gate, which is precisely why a root COMMAND INJECTION (a planted
-  # /tmp directory name reaching `xargs -I{} sh -c`) and two silent
-  # whole-run aborts shipped invisibly. Nothing in it needs root: the script was
-  # given a sourceable seam (BASH_SOURCE[0] != $0 returns before the root check)
-  # and the suite drives the pure transforms against fixtures — an lsof header
-  # in two different column layouts, a directory literally named
-  # `evil";echo PWNED-AS-$(id -un) >&2;"x`, and a ~17,500-entry tree sized from
-  # the live ARG_MAX. It reaches no launcher, no network and no git.
+  # exist. It covers `scripts/diagnose-disk-accounting.sh` — ROOT-PRIVILEGED
+  # bash that had no test file at all, in a repo with no shellcheck gate, which
+  # is precisely why a root COMMAND INJECTION (a planted /tmp directory name
+  # reaching `xargs -I{} sh -c`) and two silent whole-run aborts shipped
+  # invisibly. Nothing in it needs root: the script has a sourceable seam that
+  # returns before the root check, and the suite drives the pure transforms
+  # against fixtures — an lsof header in two different column layouts, a
+  # directory literally named `evil";echo PWNED-AS-$(id -un) >&2;"x`, and a
+  # ~17,500-entry tree sized from the live ARG_MAX. It reaches no launcher, no
+  # network and no git.
+  # 🔴 THIS COMMENT PREVIOUSLY SAID "282 lines" and described the seam as
+  # `BASH_SOURCE[0] != $0 returns before the root check`. Both were stale: 282
+  # was the count at the merge base (567 after round 1, 730 after round 2), and
+  # that BASH_SOURCE expression was MEASURED reachable from the environment,
+  # removed, and is now a banned pattern in the suite's own scanner — which only
+  # reads `diagnose-disk-accounting.sh`, so this copy survived it. A stale
+  # justification is why the wrong number is quoted downstream, so no line count
+  # is stated here at all any more.
   # Watched red: `s += $col` -> `s += $8` fails it with "SIZE/OFF found at col 7".
   "scripts/tests/test_diagnose_disk_accounting.sh"
 )

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3950,14 +3950,21 @@ SHELL_TESTS=(
   # directory literally named `evil";echo PWNED-AS-$(id -un) >&2;"x`, and a
   # ~17,500-entry tree sized from the live ARG_MAX. It reaches no launcher, no
   # network and no git.
-  # 🔴 THIS COMMENT PREVIOUSLY SAID "282 lines" and described the seam as
-  # `BASH_SOURCE[0] != $0 returns before the root check`. Both were stale: 282
-  # was the count at the merge base (567 after round 1, 730 after round 2), and
-  # that BASH_SOURCE expression was MEASURED reachable from the environment,
-  # removed, and is now a banned pattern in the suite's own scanner — which only
-  # reads `diagnose-disk-accounting.sh`, so this copy survived it. A stale
-  # justification is why the wrong number is quoted downstream, so no line count
-  # is stated here at all any more.
+  # 🔴 THIS COMMENT HAS NOW CARRIED A WRONG LINE COUNT TWICE, in the commit
+  # correcting the previous wrong one each time. It said "282 lines"; round 2
+  # replaced that with "282 at the merge base (567 after round 1, 730 after
+  # round 2)" — and 730 was false the moment it was typed (the file was 766).
+  # A count of a file that changes every round cannot be maintained in a comment
+  # in a different file, so none is stated here: run
+  # `wc -l scripts/diagnose-disk-accounting.sh`. The only figure that cannot go
+  # stale is anchored to a sha, and one is enough — the file entered this PR's
+  # history at 282 lines (`git show c1169e3b:scripts/diagnose-disk-accounting.sh
+  # | wc -l`) and has grown with each audit round since.
+  # The other half of the old stale claim: the seam was described as
+  # `BASH_SOURCE[0] != $0 returns before the root check`. That expression was
+  # MEASURED reachable from the environment, removed, and is now a banned
+  # pattern in the suite's own scanner — which only reads
+  # `diagnose-disk-accounting.sh`, so this copy survived it.
   # Watched red: `s += $col` -> `s += $8` fails it with "SIZE/OFF found at col 7".
   "scripts/tests/test_diagnose_disk_accounting.sh"
 )

--- a/scripts/tests/mutants-diagnose-disk-accounting.sh
+++ b/scripts/tests/mutants-diagnose-disk-accounting.sh
@@ -189,25 +189,159 @@ run lsof-assignment-rearms-set-e \
 # about executing a planted name and nothing else.
 run inject-xargs-I-substitution \
   'inode_breakdown does not execute the planted name' \
-  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d \
-    -exec sh -c '"'"'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"'"'"' _ {} \; 2>/dev/null \
-    | sort -rn | head_n 15' \
-  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
-    | xargs -I{} sh -c '"'"'printf "%12d  %s\n" "$(find "{}" -xdev -printf . 2>/dev/null | wc -c)" "{}"'"'"' \
-    | sort -rn | head_n 15'
+  '    | { xargs -0 -r -n1 sh -c '"'"'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"'"'"' _ || true; } \' \
+  '    | { xargs -0 -I{} sh -c '"'"'printf "%12d  %s\n" "$(find "{}" -xdev -printf . 2>/dev/null | wc -c)" "{}"'"'"' || true; } \'
 
 # --- defect 3: E2BIG --------------------------------------------------------
 run e2big-glob-expanded-into-du \
   'size_breakdown exited' \
-  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
-    | xargs -0 -r du -sh -x 2>/dev/null | sort -rh | head_n 15' \
-  '  du -sh -x "$1"/* 2>/dev/null | sort -rh | head_n 15'
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | _on_device "$dev" \
+    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | sort -rh | head_n 15' \
+  '  du -sh -x "$base"/* 2>/dev/null | sort -rh | head_n 15'
 
 # --- the SIGPIPE route to the same "truncated scan" failure ------------------
+# 🔴 TWO ROWS, ONE MUTATION. `head_n` is shared, so a single edit breaks both
+# breakdowns — but they are scored on DIFFERENT probes' guards, which is the
+# only way to show that the inode half is covered at all. It was not: the
+# fixture held 17,550 `touch`ed FILES and `inode_breakdown` filters `-type d`,
+# so its call in the probe returned zero rows and the whole row was killed by
+# `size_breakdown` alone.
 run sigpipe-head-closes-the-pipe \
   'the run died rc' \
   'head_n() { awk -v n="$1" '"'"'NR<=n'"'"'; }' \
   'head_n() { head -n "$1"; }'
+
+run sigpipe-head-closes-the-pipe-inode \
+  'the inode breakdown died rc' \
+  'head_n() { awk -v n="$1" '"'"'NR<=n'"'"'; }' \
+  'head_n() { head -n "$1"; }'
+
+# --- the `head` BAN WAS SPELLED, NOT STRUCTURAL ------------------------------
+# 🔴 The banned pattern read `| *head -[0-9]`, which demands a digit right after
+# `head -`. All three long-form spellings below SURVIVED a full green suite;
+# only `head -15` was caught. The pattern is now `| *head  *-`.
+run head-long-form-n-20 \
+  "no bare '| head -N' truncating a pipeline" \
+  '    | sort -rh | head_n 15' \
+  '    | sort -rh | head -n 20'
+
+run head-long-form-n-30 \
+  "no bare '| head -N' truncating a pipeline" \
+  '    | sort -rn | head_n 15' \
+  '    | sort -rn | head -n 30'
+
+run head-long-form-n-15-section-5 \
+  "no bare '| head -N' truncating a pipeline" \
+  '| sort -rh | head_n 30' \
+  '| sort -rh | head -n 15'
+
+# The spelling the OLD pattern already caught, kept as the contrast case: both
+# spellings must die, or the widening traded one blind spot for another.
+run head-short-form-15 \
+  "no bare '| head -N' truncating a pipeline" \
+  '    | sort -rh | head_n 15' \
+  '    | sort -rh | head -15'
+
+# --- routes 3 and 4: a find or a du that fails mid-scan ----------------------
+# 🔴 ISOLATED PER STAGE. Removing both `|| true`s at once would prove only that
+# "something" is tolerated; each row removes exactly one, and the two are killed
+# by fixtures that isolate one stage each (0400 dir -> find rc 1 with output;
+# mode-000 subdirectory -> du rc 1 -> xargs rc 123, find rc 0).
+run find-error-aborts-the-run \
+  'a failing find/du aborted the run' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | _on_device "$dev" \
+    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \' \
+  '  find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null \
+    | _on_device "$dev" \
+    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \'
+
+run du-failure-aborts-the-run \
+  'a failing find/du aborted the run' \
+  '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | sort -rh | head_n 15' \
+  '    | xargs -0 -r du -sh -x 2>/dev/null \
+    | sort -rh | head_n 15'
+
+run inode-find-error-aborts-the-run \
+  'a failing find/du aborted the run' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \' \
+  '  find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null \'
+
+# --- defect 7, the /tmp half: -xdev LISTS a foreign mountpoint at depth 1 -----
+run tmp-size-device-filter-dropped \
+  'size_breakdown DROPS every entry on a foreign device' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | _on_device "$dev" \' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | sed -z -n '"'"'s/^[0-9]*\t//p'"'"' \'
+
+run tmp-inode-device-filter-dropped \
+  'inode_breakdown DROPS every directory on a foreign device' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | _on_device "$dev" \' \
+  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+    | sed -z -n '"'"'s/^[0-9]*\t//p'"'"' \'
+
+# 🔴 STRUCTURAL PIN, and it is labelled as one. A second filesystem needs root,
+# so `du -x` cannot be checked behaviourally in this suite; a mutant dropping it
+# SURVIVED before the `required` row was added.
+run du-x-dropped-from-the-tmp-breakdown \
+  'du keeps -x in the /tmp size breakdown' \
+  '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \' \
+  '    | { xargs -0 -r du -sh 2>/dev/null || true; } \'
+
+run du-x-dropped-from-the-home-breakdown \
+  'du keeps -x in the /home size breakdown' \
+  '{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; }' \
+  '{ xargs -0 -r du -sh < "$ONROOT_LIST" 2>/dev/null || true; }'
+
+# The device READING itself: hex vs decimal is a silent total mis-classification.
+run dev-of-returns-hex-not-decimal \
+  '_dev_of / agrees with stat -c %d / (decimal)' \
+  "_dev_of() { stat -c '%d' \"\$1\" 2>/dev/null; }" \
+  "_dev_of() { stat -c '%D' \"\$1\" 2>/dev/null; }"
+
+# An empty device reading must REFUSE, not print an empty section.
+run absent-device-prints-an-empty-section \
+  'an unreadable base REFUSES rather than printing an empty size section' \
+  '    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
+    return 0
+  fi
+  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf' \
+  '    return 0
+  fi
+  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf'
+
+# 🔴 The device filter's own blind spot: excluding a foreign mount is right,
+# excluding it SILENTLY is the failure this file catalogues. Section 6c prints
+# the same listing for /home; 6d had no equivalent until the filter created the
+# need for one.
+run foreign-entries-lists-nothing \
+  '6d NAMES the entries it excluded (first)' \
+  '  if [ -n "$out" ]; then
+    printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"'' \
+  '  if false; then
+    printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"''
+
+run foreign-entries-inverted-filter \
+  '_not_on_device is the exact complement of _on_device' \
+  '_not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }' \
+  '_not_on_device() { sed -z -n "s/^[0-9]*\t//p"; }'
+
+run foreign-entries-none-branch-always \
+  'POSITIVE CONTROL: an all-on-device base prints the explicit' \
+  '  out=$({ find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
+        | _not_on_device "$dev" | tr '"'"'\0'"'"' '"'"'\n'"'"' | head_n 15)' \
+  '  out=$(printf '"'"'%s'"'"' "always-something")'
+
+# The digits predicate: it guards a value that reaches a `sed` SCRIPT.
+run dev-is-valid-accepts-anything-non-empty \
+  '_dev_is_valid accepted [/etc/passwd]' \
+  '_dev_is_valid() { case "$1" in '"''"'|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }' \
+  '_dev_is_valid() { case "$1" in '"''"') return 1 ;; *) return 0 ;; esac; }'
 
 # --- defect 7: the device comparison ----------------------------------------
 run home-device-comparison-dropped \
@@ -223,7 +357,7 @@ run home-device-comparison-dropped \
 run home-foreign-list-in-a-subshell \
   'foreign report names the first foreign mount' \
   '    if [ "$d" = "$root_dev" ]; then printf '"'"'%s\0'"'"' "$p" >> "$onroot"
-    else printf '"'"'%s\n'"'"' "$p" >> "$foreign"; fi
+    else printf '"'"'%s\0'"'"' "$p" >> "$foreign"; fi
   done
 }' \
   '    if [ "$d" = "$root_dev" ]; then printf '"'"'%s\0'"'"' "$p" >> "$onroot"
@@ -235,9 +369,20 @@ run home-foreign-list-in-a-subshell \
 run foreign-none-branch-always-taken \
   'foreign report names the first foreign mount' \
   '  if [ -s "$1" ]; then
-    while IFS= read -r p; do' \
+    while IFS= read -r -d '"''"' p; do' \
   '  if false; then
-    while IFS= read -r p; do'
+    while IFS= read -r -d '"''"' p; do'
+
+# --- the foreign list must be NUL-separated, like the on-root one ------------
+# 🔴 It was one-per-line, read with `while IFS= read -r`, so a directory name
+# containing a newline split into two rows in the report — the second of which
+# reads as a real path. /home is user-writable and this runs under sudo.
+# The killer is the guard's FAIL text, not its `pass` text — this row was scored
+# WRONG-KILLER first time round because the two are worded differently here.
+run foreign-list-one-per-line \
+  'the foreign list holds' \
+  '    else printf '"'"'%s\0'"'"' "$p" >> "$foreign"; fi' \
+  '    else printf '"'"'%s\n'"'"' "$p" >> "$foreign"; fi'
 
 # --- defect 5 + 8: denial accounting ----------------------------------------
 run grep-c-with-or-echo-zero \
@@ -270,12 +415,39 @@ run root-refusal-softened \
 
 run seam-runs-the-report-on-source \
   'sourcing produces no output at all beyond the marker' \
-  'if [ "${BASH_SOURCE[0]}" != "$0" ]; then
-  return 0
-fi' \
-  'if false; then
-  return 0
-fi'
+  'if (return 0 2>/dev/null); then' \
+  'if false; then'
+
+# 🔴 THE STRONGEST MUTANT IN THIS FILE: it reinstates the EXACT expression that
+# shipped, `[ "${BASH_SOURCE[0]}" != "$0" ]`. bash imports BASH_SOURCE from the
+# environment as a scalar, so an EXECUTED run with a stray BASH_SOURCE took the
+# sourced branch and hit `return` at top level — exit 2, no report, and 2 is
+# also this script's "you forgot sudo" status. Note the killer: the rc-2 check
+# still PASSES under this mutant, so only the guard that asserts the refusal
+# MESSAGE can see it. That is the whole reason the defect was invisible.
+run seam-reads-bash-source-again \
+  'the poisoned run refuses for the RIGHT reason' \
+  'if (return 0 2>/dev/null); then' \
+  'if [ "${BASH_SOURCE[0]}" != "$0" ]; then'
+
+# The same mutant, scored on the OTHER surface it breaks: `bash < script` leaves
+# BASH_SOURCE unset and `set -u` kills the guard's own line, rc 1. Base ran fine
+# that way, so this half is a genuine regression rather than a latent hazard.
+run seam-reads-bash-source-again-stdin \
+  'bash < script exited' \
+  'if (return 0 2>/dev/null); then' \
+  'if [ "${BASH_SOURCE[0]}" != "$0" ]; then'
+
+# --- the LSOF_BIN seam must not widen what a ROOT run executes ---------------
+# 🔴 `LSOF_BIN=${LSOF_BIN:-lsof}` used to sit ABOVE the seam, i.e. on the
+# EXECUTE path, so an inherited `LSOF_BIN=/anything` was what root would run.
+# Base hardcoded `lsof`. Nothing pinned it and the mutant SURVIVED.
+run lsof-bin-honoured-on-the-execute-path \
+  'the execute path DISCARDS an inherited LSOF_BIN' \
+  'LSOF_BIN=lsof
+' \
+  'LSOF_BIN=${LSOF_BIN:-lsof}
+'
 
 echo
 echo "== SURVIVES control — a behaviour-free edit must NOT kill anything =="

--- a/scripts/tests/mutants-diagnose-disk-accounting.sh
+++ b/scripts/tests/mutants-diagnose-disk-accounting.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Mutation battery for `scripts/tests/test_diagnose_disk_accounting.sh`.
+#
+# Not run by CI. An author/reviewer instrument, kept IN THE TREE so
+# "mutation-verified" can be RE-DERIVED instead of believed — the convention
+# `mutants-claim-work.sh` and `mutants-shared-clone-sync.sh` established.
+#
+#   bash scripts/tests/mutants-diagnose-disk-accounting.sh
+#
+# 🔴 IT NEVER TOUCHES YOUR WORKING TREE. The script under mutation and the suite
+# are copied into a `mktemp -d` and mutated THERE. In a repo whose rules are
+# built around shared checkouts and parallel agents, an EXIT-trap restore over a
+# tracked file is one SIGKILL away from a mutated file being staged by somebody
+# else.
+#
+# 🔴 EACH MUTANT NAMES THE GUARD THAT MUST KILL IT, and the row is scored on
+# whether THAT guard's own `FAIL:` line appears. "A test failed" is not enough:
+# with overlapping assertions a mutant can die to a DIFFERENT guard's error and
+# be scored as covered while its own assertion is unreachable. A mutant killed
+# only by some other guard reports 🔴 WRONG-KILLER, not ok.
+#
+# 🔴 EVERY MUTATION IS AN EXACT, SINGLE-OCCURRENCE REPLACEMENT, and the count is
+# CHECKED. A `sed` that silently fails to match reports the UNMUTATED file's
+# behaviour — i.e. "the guard held", the most flattering possible wrong answer,
+# and the way a previous sweep in this repo scored an unmutated baseline as
+# killed. A `count=1` replace on a pattern occurring twice is the same hazard
+# wearing the other face, so anything but exactly one occurrence is an error.
+#
+# 🔴 MUTATIONS ARE ISOLATED. Each edits the narrowest expression that can be
+# wrong — the column reference, the `-exec` form, the `head_n` body — never a
+# guard together with its enclosing condition, which dies for the wrong reason
+# and proves nothing about the guard.
+#
+# 🔴 CONTROLS, all three:
+#   * BASELINE — the unmutated copy must be green, or every row is meaningless.
+#   * NEGATIVE — a deliberately broken copy must be SEEN to go red, or the
+#     harness is not wired to the suite at all.
+#   * SURVIVES — a behaviour-free edit that must NOT kill anything, which is what
+#     proves the harness keys on BEHAVIOUR and not on the file's bytes.
+#
+# 🔴 PYTHONDONTWRITEBYTECODE=1 even though the file under mutation is BASH: the
+# mutator is Python, and a stale `.pyc` keyed on mtime-in-whole-seconds + size is
+# how a same-length edit gets scored SURVIVED without ever executing.
+set -uo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+CDPATH=
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" >/dev/null && pwd)"
+SRC="$(cd "$D/../.." >/dev/null && pwd)"
+
+T="$(mktemp -d /tmp/dda-mut-XXXXXX)"
+trap 'rm -rf "$T"' EXIT
+ROOT="$T/tree"
+mkdir -p "$ROOT/scripts/tests"
+cp -a "$SRC/scripts/diagnose-disk-accounting.sh" "$ROOT/scripts/"
+cp -a "$SRC/scripts/tests/test_diagnose_disk_accounting.sh" "$ROOT/scripts/tests/"
+
+SCRIPT="$ROOT/scripts/diagnose-disk-accounting.sh"
+SUITE="$ROOT/scripts/tests/test_diagnose_disk_accounting.sh"
+PRISTINE="$T/pristine.sh"
+cp -a "$SCRIPT" "$PRISTINE"
+LOG="$T/out.txt"
+MUTATOR="$T/mutate.py"
+
+cat > "$MUTATOR" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path, encoding="utf-8").read()
+n = s.count(old)
+if n != 1:
+    sys.stderr.write("occurrences=%d for %r\n" % (n, old[:70]))
+    sys.exit(3)
+open(path, "w", encoding="utf-8").write(s.replace(old, new, 1))
+PY
+
+restore() { cp -a "$PRISTINE" "$SCRIPT"; }
+suite_run() { bash "$SUITE" >"$LOG" 2>&1; }
+fails() { grep -c '^  FAIL: ' "$LOG"; }
+# Did THIS guard fail? -F, because guard names carry `+`, `/` and apostrophes.
+killed_by() { grep -qF "  FAIL: $1" "$LOG"; }
+
+RC=0
+apply() { # apply <old> <new>  -> 0 on an applied, single-occurrence edit
+  python3 "$MUTATOR" "$SCRIPT" "$1" "$2" 2>"$T/mut.err"
+}
+
+run() { # run <name> <killer-guard-prefix> <old> <new>
+  local name="$1" killer="$2"
+  restore
+  if ! apply "$3" "$4"; then
+    printf '  %-38s 🔴 MUTATION DID NOT APPLY (%s) — result meaningless\n' \
+      "$name" "$(tr -d '\n' < "$T/mut.err")"; RC=1; return
+  fi
+  if cmp -s "$PRISTINE" "$SCRIPT"; then
+    printf '  %-38s 🔴 MUTATION IS A NO-OP — result meaningless\n' "$name"; RC=1; return
+  fi
+  suite_run
+  local n; n="$(fails)"
+  if [ "$n" -eq 0 ]; then
+    printf '  %-38s 🔴 SURVIVED (0 FAIL lines)\n' "$name"; RC=1
+  elif killed_by "$killer"; then
+    printf '  %-38s KILLED   by its own guard (%s FAIL line(s))\n' "$name" "$n"
+  else
+    printf '  %-38s 🔴 WRONG-KILLER — %s FAIL line(s), none of them [%s]\n' "$name" "$n" "$killer"; RC=1
+  fi
+}
+
+survives() { # survives <name> <old> <new>   — must NOT kill anything
+  local name="$1"
+  restore
+  if ! apply "$2" "$3"; then
+    printf '  %-38s 🔴 MUTATION DID NOT APPLY — result meaningless\n' "$name"; RC=1; return
+  fi
+  suite_run
+  local n; n="$(fails)"
+  if [ "$n" -eq 0 ]; then
+    printf '  %-38s ok — behaviour-free edit did not kill\n' "$name"
+  else
+    printf '  %-38s 🔴 KILLED by a no-op edit (%s FAIL) — the suite keys on TEXT, not behaviour\n' "$name" "$n"; RC=1
+  fi
+}
+
+echo "== BASELINE: the unmutated copy must be green =="
+restore; suite_run
+echo "   FAIL-lines=$(fails)  ok-lines=$(grep -c '^  ok: ' "$LOG")  last=[$(tail -1 "$LOG")]"
+[ "$(fails)" -eq 0 ] || { echo "   🔴 baseline is RED — every row below is meaningless"; RC=1; }
+
+echo "== NEGATIVE CONTROL: a broken copy must be SEEN to go red =="
+# 🔴 The break must land INSIDE the sourceable seam. This control first APPENDED
+# the override to the end of the file and reported "the harness cannot observe a
+# failure at all" — correctly: the seam `return`s before the end of the file, so
+# a definition after it is never evaluated when sourced. An appended-at-the-end
+# negative control on a file with an early `return` tests nothing, and its
+# reassuring reading is "the suite is fine".
+restore
+apply '# --- end of the sourceable seam ---' \
+      'lsof_deleted_summary() { echo BROKEN; }
+# --- end of the sourceable seam ---' \
+  || { echo "   🔴 the negative control did not apply"; RC=1; }
+suite_run
+echo "   FAIL-lines=$(fails)  (must be non-zero)"
+[ "$(fails)" -gt 0 ] || { echo "   🔴 the harness cannot observe a failure at all"; RC=1; }
+restore
+
+echo
+echo "== mutants — every row must read KILLED by its own guard =="
+
+# --- defect 1: the lsof column is resolved from the HEADER, not an index -----
+run lsof-col-hardcoded-8 \
+  '+L1 shape: SIZE/OFF found at col 7' \
+  '{ n++; if (col) s += $col }' \
+  '{ n++; if (col) s += $8 }'
+
+run lsof-col-hardcoded-7 \
+  'plain -n -P shape: same bytes, col 9' \
+  '{ n++; if (col) s += $col }' \
+  '{ n++; if (col) s += $7 }'
+
+run lsof-lookup-by-position \
+  '+L1 shape: SIZE/OFF found at col 7' \
+  'if ($i == "SIZE/OFF") col=i' \
+  'if (i == 8) col=i'
+
+run lsof-absent-col-answers-anyway \
+  'absent SIZE/OFF refuses and names the row count' \
+  'if (!col) { printf "COULD NOT MEASURE: no SIZE/OFF column in lsof header (rows=%d) — NOT a zero\n", n+0; exit }' \
+  'if (0) { }'
+
+# --- defect 6: never negative; "did not run" is not "found nothing" ----------
+run lsof-empty-falls-through-to-awk \
+  "empty input: count=0 and lsof's exit status is carried" \
+  '  if [ -z "$out" ]; then
+    printf ' \
+  '  if false; then
+    printf '
+
+run lsof-missing-binary-reports-a-zero \
+  'lsof missing: COULD NOT MEASURE, not a count' \
+  'echo "COULD NOT MEASURE: lsof not on PATH — this is NOT a zero"' \
+  'echo "count=0 bytes=0.0 GiB"'
+
+run lsof-assignment-rearms-set-e \
+  'a non-zero lsof aborted the script under set -e' \
+  'out="$("$LSOF_BIN" +L1 2>/dev/null)" || rc=$?' \
+  'out="$("$LSOF_BIN" +L1 2>/dev/null)"; rc=$?'
+
+# --- defect 2: root command injection ---------------------------------------
+# 🔴 ISOLATED: only the traversal FORM changes. The find, the sort and the
+# truncation around it are byte-identical, so the guard that dies is the one
+# about executing a planted name and nothing else.
+run inject-xargs-I-substitution \
+  'inode_breakdown does not execute the planted name' \
+  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d \
+    -exec sh -c '"'"'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"'"'"' _ {} \; 2>/dev/null \
+    | sort -rn | head_n 15' \
+  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
+    | xargs -I{} sh -c '"'"'printf "%12d  %s\n" "$(find "{}" -xdev -printf . 2>/dev/null | wc -c)" "{}"'"'"' \
+    | sort -rn | head_n 15'
+
+# --- defect 3: E2BIG --------------------------------------------------------
+run e2big-glob-expanded-into-du \
+  'size_breakdown exited' \
+  '  find "$1" -xdev -mindepth 1 -maxdepth 1 -print0 2>/dev/null \
+    | xargs -0 -r du -sh -x 2>/dev/null | sort -rh | head_n 15' \
+  '  du -sh -x "$1"/* 2>/dev/null | sort -rh | head_n 15'
+
+# --- the SIGPIPE route to the same "truncated scan" failure ------------------
+run sigpipe-head-closes-the-pipe \
+  'the run died rc' \
+  'head_n() { awk -v n="$1" '"'"'NR<=n'"'"'; }' \
+  'head_n() { head -n "$1"; }'
+
+# --- defect 7: the device comparison ----------------------------------------
+run home-device-comparison-dropped \
+  'foreign list holds exactly the foreign-device dirs' \
+  'if [ "$d" = "$root_dev" ]; then printf' \
+  'if true; then printf'
+
+# --- defect 4: the accumulator must survive the loop ------------------------
+# 🔴 The HISTORICAL shape: a VARIABLE accumulator fed by a loop that is the head
+# of a pipeline, so every append lands in a subshell and the caller reads back
+# nothing. Only the accumulator moves; the device test above it is untouched, so
+# this cannot be scored on the previous mutant's guard.
+run home-foreign-list-in-a-subshell \
+  'foreign report names the first foreign mount' \
+  '    if [ "$d" = "$root_dev" ]; then printf '"'"'%s\0'"'"' "$p" >> "$onroot"
+    else printf '"'"'%s\n'"'"' "$p" >> "$foreign"; fi
+  done
+}' \
+  '    if [ "$d" = "$root_dev" ]; then printf '"'"'%s\0'"'"' "$p" >> "$onroot"
+    else FOREIGN="${FOREIGN:-}$p"; fi
+  done | cat
+  printf '"'"'%s'"'"' "${FOREIGN:-}" > "$foreign"
+}'
+
+run foreign-none-branch-always-taken \
+  'foreign report names the first foreign mount' \
+  '  if [ -s "$1" ]; then
+    while IFS= read -r p; do' \
+  '  if false; then
+    while IFS= read -r p; do'
+
+# --- defect 5 + 8: denial accounting ----------------------------------------
+run grep-c-with-or-echo-zero \
+  'empty denial log prints three clean zero lines' \
+  "denied=\$(grep -c 'Permission denied' \"\$log\" 2>/dev/null; true)" \
+  "denied=\$(grep -c 'Permission denied' \"\$log\" 2>/dev/null || echo 0)"
+
+run denial-count-pinned-to-zero \
+  '3 denials counted' \
+  "denied=\$(grep -c 'Permission denied' \"\$log\" 2>/dev/null; true)" \
+  'denied=0'
+
+run floors-warning-suppressed \
+  'denials make the counts FLOORS, loudly' \
+  '  if [ "$denied" -gt 0 ]; then
+    echo "!! Running as root' \
+  '  if false; then
+    echo "!! Running as root'
+
+run unclassified-folded-into-benign \
+  '1 unclassified error counted' \
+  'unclassified=$((total - denied - other))' \
+  'unclassified=0'
+
+# --- the root refusal and the sourceable seam -------------------------------
+run root-refusal-softened \
+  'non-root execution exited' \
+  '  exit 2' \
+  '  exit 0'
+
+run seam-runs-the-report-on-source \
+  'sourcing produces no output at all beyond the marker' \
+  'if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
+fi' \
+  'if false; then
+  return 0
+fi'
+
+echo
+echo "== SURVIVES control — a behaviour-free edit must NOT kill anything =="
+survives comment-reword \
+  '# Root-privileged disk accounting for the workbench root filesystem.' \
+  '# Root-privileged disk accounting for the workbench root filesystem. (reworded)'
+
+echo
+if [ "$RC" -eq 0 ]; then echo "mutation battery: every mutant killed by its own guard"
+else echo "mutation battery: PROBLEMS above"; fi
+exit "$RC"

--- a/scripts/tests/mutants-diagnose-disk-accounting.sh
+++ b/scripts/tests/mutants-diagnose-disk-accounting.sh
@@ -204,9 +204,9 @@ run inject-xargs-I-substitution \
 # none of them the rc one.
 run e2big-glob-expanded-into-du \
   'size_breakdown returned' \
-  '  out=$(_depth1_nul "$base" "$errf" \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" \
     | { _on_device "$dev" || true; } \
-    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | { xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true; } \
     | sort -rh | head_n 15)' \
   '  out=$(du -sh -x "$base"/* 2>/dev/null | sort -rh | head_n 15)'
 
@@ -271,9 +271,9 @@ run depth1-find-error-aborts-the-run \
 
 run du-failure-aborts-the-run \
   'a failing find/du aborted the run' \
-  '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+  '    | { xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true; } \
     | sort -rh | head_n 15)' \
-  '    | xargs -0 -r du -sh -x 2>/dev/null \
+  '    | xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" \
     | sort -rh | head_n 15)'
 
 # 🔴 THE F-1 MUTANT, and the one the round-1 fix would have SURVIVED. `%D` makes
@@ -289,10 +289,18 @@ run unstattable-count-pinned-to-zero \
   '  n=$(grep -c . "$1" 2>/dev/null; true)' \
   '  n=0'
 
+# 🔴 THE ANCHOR LINE ABOVE IS PART OF THE MUTATION, and it has to be: round 3
+# gave `_report_unreadable` the same `[ "$n" -gt 0 ] || return 0` guard, so the
+# bare expression now occurs TWICE and the battery correctly refused to apply it
+# (`occurrences=2`). The `local` line pins it to `_report_unstattable` alone —
+# a `count=1` replace on a two-occurrence pattern is the failure this file's
+# header is about, and the check is what caught it.
 run unstattable-report-suppressed \
   'route (a): inode_breakdown COUNTS the entries it could not stat' \
-  '  [ "$n" -gt 0 ] || return 0' \
-  '  [ "$n" -gt 0 ] && return 0'
+  '  local n="$1" base="$2" errf="$3"
+  [ "$n" -gt 0 ] || return 0' \
+  '  local n="$1" base="$2" errf="$3"
+  [ "$n" -gt 0 ] && return 0'
 
 # 🔴 THE AFFIRMATIVE "none" OVER A BLIND SCAN — the sentence the round-1 report
 # printed while three entries were missing from every list.
@@ -311,8 +319,8 @@ run foreign-entries-tr-flattened \
   '  while IFS= read -r -d '"''"' p; do
     n=$((n + 1))
     [ "$n" -gt 15 ] || printf '"'"'  %s\n'"'"' "$p"
-  done < <(_depth1_nul "$base" "$errf" | _not_on_device "$dev")' \
-  '  out=$(_depth1_nul "$base" "$errf" | _not_on_device "$dev" | tr '"'"'\0'"'"' '"'"'\n'"'"' | head_n 15)
+  done < <(_depth1_nul "$base" "$SCAN_ERRF" | _not_on_device "$dev")' \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" | _not_on_device "$dev" | tr '"'"'\0'"'"' '"'"'\n'"'"' | head_n 15)
   [ -z "$out" ] || { printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"'; n=1; }'
 
 # 🔴 THE CHECKED ASSIGNMENT. Three sites share the shape, so the mutation
@@ -391,16 +399,16 @@ run root-dev-reading-unguarded \
 # --- defect 7, the /tmp half: -xdev LISTS a foreign mountpoint at depth 1 -----
 run tmp-size-device-filter-dropped \
   'size_breakdown DROPS every entry on a foreign device' \
-  '  out=$(_depth1_nul "$base" "$errf" \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" \
     | { _on_device "$dev" || true; } \' \
-  '  out=$(_depth1_nul "$base" "$errf" \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" \
     | { sed -z -n '"'"'s/^[0-9]*\t//p'"'"' || true; } \'
 
 run tmp-inode-device-filter-dropped \
   'inode_breakdown DROPS every directory on a foreign device' \
-  '  out=$(_depth1_nul "$base" "$errf" -type d \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" -type d \
     | { _on_device "$dev" || true; } \' \
-  '  out=$(_depth1_nul "$base" "$errf" -type d \
+  '  out=$(_depth1_nul "$base" "$SCAN_ERRF" -type d \
     | { sed -z -n '"'"'s/^[0-9]*\t//p'"'"' || true; } \'
 
 # 🔴 STRUCTURAL PIN, and it is labelled as one. A second filesystem needs root,
@@ -408,13 +416,13 @@ run tmp-inode-device-filter-dropped \
 # SURVIVED before the `required` row was added.
 run du-x-dropped-from-the-tmp-breakdown \
   'du keeps -x AND its || true in the /tmp size breakdown' \
-  '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \' \
-  '    | { xargs -0 -r du -sh 2>/dev/null || true; } \'
+  '    | { xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true; } \' \
+  '    | { xargs -0 -r du -sh 2>>"$SCAN_DUERR" || true; } \'
 
 run du-x-dropped-from-the-home-breakdown \
   'du keeps -x AND its || true in the /home size breakdown' \
-  '{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; }' \
-  '{ xargs -0 -r du -sh < "$ONROOT_LIST" 2>/dev/null || true; }'
+  '{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>>"$DU_ERR" || true; }' \
+  '{ xargs -0 -r du -sh < "$ONROOT_LIST" 2>>"$DU_ERR" || true; }'
 
 # The device READING itself: hex vs decimal is a silent total mis-classification.
 run dev-of-returns-hex-not-decimal \
@@ -559,6 +567,84 @@ run lsof-bin-honoured-on-the-execute-path \
 ' \
   'LSOF_BIN=${LSOF_BIN:-lsof}
 '
+
+# --- round 3: du's stderr, the second and different blind spot ---------------
+# 🔴 ROUTE (b) KEEPS THE ENTRY AND SHORTENS ITS NUMBER, which is why these are
+# not scored on the route-(a) guards. MEASURED on the §4b-iii fixture: 8K
+# printed against a true 12K, with no marker of any kind while du's stderr went
+# to /dev/null.
+run du-stderr-discarded \
+  'route (b): size_breakdown REPORTS that du could not read a path' \
+  '    | { xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true; } \
+    | sort -rh | head_n 15)' \
+  '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
+    | sort -rh | head_n 15)'
+
+run du-blind-spot-not-reported \
+  "route (b): du's own error line is quoted, not just tallied" \
+  '  _report_unreadable "$base" "$SCAN_DUERR"' \
+  '  :'
+
+# 🔴 THE TWO SINKS ARE NOT INTERCHANGEABLE, and this is the mutant that says so:
+# handing the du report find's stderr yields a count of 0 over a fixture find can
+# stat completely, i.e. an affirmative silence.
+run du-report-reads-finds-stderr \
+  'route (b): size_breakdown REPORTS that du could not read a path' \
+  '  _report_unreadable "$base" "$SCAN_DUERR"' \
+  '  _report_unreadable "$base" "$SCAN_ERRF"'
+
+# --- round 3: the temp files nothing named and no trap covered ---------------
+run scan-temp-file-anonymous \
+  'a scan temp file is named [' \
+  '_scan_mktemp() { REPLY=$(mktemp "/tmp/disk-accounting-$1.XXXXXX") || { REPLY=; return 1; }; }' \
+  '_scan_mktemp() { REPLY=$(mktemp) || { REPLY=; return 1; }; }'
+
+# 🔴 THE HISTORICAL SHAPE, restored exactly: a cleanup that names the files
+# somebody thought of. Killed only by the SIGINT probe, because every other
+# guard here removes its own temp files on the happy path.
+run cleanup-forgets-the-scan-temps \
+  'an interrupt mid-breakdown leaked' \
+  '  rm -f "${DENIED_LOG:-}" "${DU_ERR:-}" "${ONROOT_LIST:-}" "${FOREIGN_LIST:-}" \
+        "${SCAN_ERRF:-}" "${SCAN_DUERR:-}"' \
+  '  rm -f "${DENIED_LOG:-}" "${ONROOT_LIST:-}" "${FOREIGN_LIST:-}"'
+
+# 🔴 STRUCTURAL PIN, labelled as one. The trap line is in the ROOT-ONLY region,
+# so no fixture can reach it; what the SIGINT probe measures is the FUNCTION, and
+# what this row proves is that the script really installs that function rather
+# than a hand-written list.
+run trap-named-as-a-fixed-list \
+  'the EXIT trap names a FUNCTION, not a fixed list of files' \
+  'trap _cleanup_temps EXIT' \
+  "trap 'rm -f \"\$DENIED_LOG\"' EXIT"
+
+# 🔴 THE ORDER HALF, scored on the ordering guard rather than the name pin: the
+# trap still names `_cleanup_temps`, so the `required` row above stays GREEN and
+# only the line-number comparison can see it.
+run trap-installed-after-the-first-mktemp \
+  'the EXIT trap is installed at line' \
+  'trap _cleanup_temps EXIT
+DENIED_LOG=$(mktemp /tmp/disk-accounting-denied.XXXXXX)' \
+  'DENIED_LOG=$(mktemp /tmp/disk-accounting-denied.XXXXXX)
+trap _cleanup_temps EXIT'
+
+run k3s-du-listing-stderr-discarded \
+  "section 5's PVC listing keeps du's stderr too" \
+  '| { xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true; } | sort -rh | head_n 30' \
+  '| { xargs -0 -r du -sh --exclude=/mnt 2>/dev/null || true; } | sort -rh | head_n 30'
+
+# --- round 3: the trailing-sort ledger, both directions ----------------------
+# 🔴 SHRINK AND GROW, because a ledger asserted only one way is half a ledger.
+# Neither of these is visible to the first-word sweep: the guarded form still
+# contains `||` and the added one is inside a `$(…)` in a printf argument.
+run sort-ledger-site-guarded-away \
+  'the sort ledger found' \
+  '| { xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true; } | sort -rh | head_n 30' \
+  '| { xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true; } | { sort -rh || true; } | head_n 30'
+
+run sort-ledger-site-added \
+  'the sort ledger found' \
+  "printf 'store paths     : %d\\n' \"\$(ls /nix/store/ 2>/dev/null | wc -l)\"" \
+  "printf 'store paths     : %d\\n' \"\$(ls /nix/store/ 2>/dev/null | sort | wc -l)\""
 
 echo
 echo "== SURVIVES control — a behaviour-free edit must NOT kill anything =="

--- a/scripts/tests/mutants-diagnose-disk-accounting.sh
+++ b/scripts/tests/mutants-diagnose-disk-accounting.sh
@@ -646,6 +646,48 @@ run sort-ledger-site-added \
   "printf 'store paths     : %d\\n' \"\$(ls /nix/store/ 2>/dev/null | wc -l)\"" \
   "printf 'store paths     : %d\\n' \"\$(ls /nix/store/ 2>/dev/null | sort | wc -l)\""
 
+# --- round 4: section 6's du printed a FLOOR with no marker ------------------
+# 🔴 TWO MUTANTS, ISOLATED, because the site has TWO ways to be wrong and one
+# guard each. Neither mutant touches the other's literal, so a row that goes red
+# proves its OWN assertion is reachable rather than that "something failed".
+# Section 6 is root-only, so both are INVARIANT PINS with no behavioural half —
+# what a fixture CAN show, and did (2026-09-08, a mode-000 subdirectory): the
+# expression prints 20K against a true 24K and now appends the marker, rc 0.
+run section6-du-status-not-read \
+  "section 6 BRANCHES on du's status instead of discarding it" \
+  $'    if du_out=$(du -sh -x "$d" 2>/dev/null); then du_mark=; else du_mark=\'  !! FLOOR — du could not read all of it\'; fi' \
+  $'    du_out=$(du -sh -x "$d" 2>/dev/null) || true; du_mark='
+
+# 🔴 The mirror: the branch stays, so the row above is still GREEN, and the only
+# thing that can see this is the pin on the printf's argument list. A marker
+# computed and never printed is the field-that-is-not-a-guard shape.
+run section6-marker-computed-but-not-printed \
+  'section 6 PRINTS the marker it computed' \
+  '"$(find "$d" -xdev -printf . 2>/dev/null | wc -c)" "$d" "$du_mark"' \
+  '"$(find "$d" -xdev -printf . 2>/dev/null | wc -c)" "$d"'
+
+# --- round 4: the `: > "$DU_ERR"` truncations, fatal and invisible ------------
+# 🔴 SCORED ON THE LEDGER, and nothing else in the suite can reach it: §7b's
+# first-word sweep cannot see a line headed by `:` and the sort ledger needs a
+# `| sort`, so before this ledger existed BOTH sites could lose their guard with
+# the suite fully green. Section 6c's copy is the one that matters — it fires
+# after sections 1..6b have printed.
+run duerr-truncation-unguarded-6c \
+  "not every ': > \$DU_ERR' truncation is guarded" \
+  ': > "$DU_ERR" || echo "COULD NOT MEASURE: could not truncate du'"'"'s stderr file — any PARTIALLY READ count below may include paths from an earlier section"
+{ xargs -0 -r du -sh -x < "$ONROOT_LIST"' \
+  ': > "$DU_ERR"
+{ xargs -0 -r du -sh -x < "$ONROOT_LIST"'
+
+# 🔴 THE OTHER DIRECTION OF THE SAME LEDGER — a NEW unguarded truncation, which
+# is the shape a future edit actually adds. It must go red for GROWTH too, or
+# the ledger is half a ledger.
+run duerr-truncation-added-unguarded \
+  "not every ': > \$DU_ERR' truncation is guarded" \
+  '  _report_unreadable /var/lib/rancher/k3s/storage "$DU_ERR"' \
+  '  _report_unreadable /var/lib/rancher/k3s/storage "$DU_ERR"
+  : > "$DU_ERR"'
+
 echo
 echo "== SURVIVES control — a behaviour-free edit must NOT kill anything =="
 survives comment-reword \

--- a/scripts/tests/mutants-diagnose-disk-accounting.sh
+++ b/scripts/tests/mutants-diagnose-disk-accounting.sh
@@ -193,13 +193,22 @@ run inject-xargs-I-substitution \
   '    | { xargs -0 -I{} sh -c '"'"'printf "%12d  %s\n" "$(find "{}" -xdev -printf . 2>/dev/null | wc -c)" "{}"'"'"' || true; } \'
 
 # --- defect 3: E2BIG --------------------------------------------------------
+# 🔴 THE KILLER MOVED, AND SAYING WHY IS THE POINT. It used to be
+# `size_breakdown exited`: the glob died E2BIG, the failure was the LAST thing
+# the function did, so its rc reached the caller. Round 2 put the pipeline in a
+# `out=$(…)` capture with four statements after it, so the function now returns
+# `rm`'s 0 whatever the pipeline did, and no rc assertion can ever see this
+# mutant. What it CANNOT do any more is quietly return a truncated list: the
+# empty `out` prints the explicit "none" line and the row-count guard sees 1 row
+# where it demands 15. MEASURED WRONG-KILLER under the old name, 15 FAIL lines,
+# none of them the rc one.
 run e2big-glob-expanded-into-du \
-  'size_breakdown exited' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | _on_device "$dev" \
+  'size_breakdown returned' \
+  '  out=$(_depth1_nul "$base" "$errf" \
+    | { _on_device "$dev" || true; } \
     | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
-    | sort -rh | head_n 15' \
-  '  du -sh -x "$base"/* 2>/dev/null | sort -rh | head_n 15'
+    | sort -rh | head_n 15)' \
+  '  out=$(du -sh -x "$base"/* 2>/dev/null | sort -rh | head_n 15)'
 
 # --- the SIGPIPE route to the same "truncated scan" failure ------------------
 # 🔴 TWO ROWS, ONE MUTATION. `head_n` is shared, so a single edit breaks both
@@ -249,52 +258,161 @@ run head-short-form-15 \
 # "something" is tolerated; each row removes exactly one, and the two are killed
 # by fixtures that isolate one stage each (0400 dir -> find rc 1 with output;
 # mode-000 subdirectory -> du rc 1 -> xargs rc 123, find rc 0).
-run find-error-aborts-the-run \
+# 🔴 ONE ROW, NOT TWO. There used to be `find-error-aborts-the-run` and
+# `inode-find-error-aborts-the-run`, one per breakdown. Round 2 consolidated the
+# three depth-1 enumerations into `_depth1_nul` — a predicate open-coded at three
+# sites was wrong at all three — so there is now ONE `|| true` to remove and one
+# mutant that removes it. Two rows applying the identical edit would have looked
+# like twice the coverage.
+run depth1-find-error-aborts-the-run \
   'a failing find/du aborted the run' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | _on_device "$dev" \
-    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \' \
-  '  find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null \
-    | _on_device "$dev" \
-    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \'
+  '  find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '"'"'%D\t%p\0'"'"' 2>"$errf" || true' \
+  '  find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '"'"'%D\t%p\0'"'"' 2>"$errf"'
 
 run du-failure-aborts-the-run \
   'a failing find/du aborted the run' \
   '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \
-    | sort -rh | head_n 15' \
+    | sort -rh | head_n 15)' \
   '    | xargs -0 -r du -sh -x 2>/dev/null \
-    | sort -rh | head_n 15'
+    | sort -rh | head_n 15)'
 
-run inode-find-error-aborts-the-run \
-  'a failing find/du aborted the run' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \' \
-  '  find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null \'
+# 🔴 THE F-1 MUTANT, and the one the round-1 fix would have SURVIVED. `%D` makes
+# find stat every entry; with the stderr at /dev/null an entry it cannot stat is
+# erased from all three sections at once and `foreign_entries` says "none".
+run depth1-stderr-discarded \
+  'route (a): size_breakdown COUNTS the entries it could not stat' \
+  'find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '"'"'%D\t%p\0'"'"' 2>"$errf" || true' \
+  'find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true'
+
+run unstattable-count-pinned-to-zero \
+  'route (a): foreign_entries COUNTS the entries it could not stat' \
+  '  n=$(grep -c . "$1" 2>/dev/null; true)' \
+  '  n=0'
+
+run unstattable-report-suppressed \
+  'route (a): inode_breakdown COUNTS the entries it could not stat' \
+  '  [ "$n" -gt 0 ] || return 0' \
+  '  [ "$n" -gt 0 ] && return 0'
+
+# 🔴 THE AFFIRMATIVE "none" OVER A BLIND SCAN — the sentence the round-1 report
+# printed while three entries were missing from every list.
+run foreign-none-outranks-its-blind-spot \
+  'route (a): foreign_entries does NOT claim every entry is on the same filesystem' \
+  '    if [ "$blind" -gt 0 ]; then' \
+  '    if false; then'
+
+# The F-3 shape, restored verbatim: a `tr`-flattened stream indented per LINE.
+# 🔴 The killer is the guard's FAIL text, not its `pass` text — the two are
+# worded differently here, and this row was scored WRONG-KILLER first time round
+# for exactly that reason, which is the SECOND time this file has made that
+# mistake (see `foreign-list-one-per-line` below).
+run foreign-entries-tr-flattened \
+  'foreign_entries emitted' \
+  '  while IFS= read -r -d '"''"' p; do
+    n=$((n + 1))
+    [ "$n" -gt 15 ] || printf '"'"'  %s\n'"'"' "$p"
+  done < <(_depth1_nul "$base" "$errf" | _not_on_device "$dev")' \
+  '  out=$(_depth1_nul "$base" "$errf" | _not_on_device "$dev" | tr '"'"'\0'"'"' '"'"'\n'"'"' | head_n 15)
+  [ -z "$out" ] || { printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"'; n=1; }'
+
+# 🔴 THE CHECKED ASSIGNMENT. Three sites share the shape, so the mutation
+# carries the line BELOW it to stay a single occurrence and to keep the edit
+# inside `size_breakdown` alone.
+run dev-assignment-rearms-set-e \
+  'an unreadable base killed the run under set -e' \
+  '  dev=$(_dev_of "$base") || dev=
+  if ! _dev_is_valid "$dev"; then
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (size breakdown)"' \
+  '  dev=$(_dev_of "$base")
+  if ! _dev_is_valid "$dev"; then
+    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (size breakdown)"'
+
+# An empty list must SAY it is empty; printing nothing is what a non-measurement
+# also does, and "an empty section is still visible" was a false claim.
+run size-empty-list-prints-nothing \
+  'size_breakdown SAYS its list is empty rather than printing nothing' \
+  '    echo "  none — no depth-1 entry of $base is on $base'"'"'s own filesystem (NOT zero bytes)"' \
+  '    :'
+
+run inode-empty-list-prints-nothing \
+  'inode_breakdown SAYS its list is empty rather than printing nothing' \
+  '    echo "  none — no depth-1 DIRECTORY of $base is on $base'"'"'s own filesystem (NOT zero inodes)"' \
+  '    :'
+
+# --- the `set -e` sweep: unguarded statements in the ROOT-ONLY region ---------
+# 🔴 These three sites cannot be reached without root, so they are scored on
+# STRUCTURAL guards — the `required` rows and section 7b's sweep. That is
+# labelled here rather than left for a reader to assume: the behaviour is
+# measured in section 4b (route (b)) and in the probes above; what these rows
+# prove is that the pins actually fire.
+run k3s-du-total-unguarded \
+  "section 5's du TOTAL is guarded, not bare" \
+  '  du -sh /var/lib/rancher/k3s/storage 2>/dev/null \
+    || echo "COULD NOT MEASURE: du failed under /var/lib/rancher/k3s/storage — any total it printed is a FLOOR"' \
+  '  du -sh /var/lib/rancher/k3s/storage 2>/dev/null'
+
+run dumpe2fs-pipeline-unguarded \
+  "section 1's dumpe2fs pipeline is guarded" \
+  'Last checked'"'"' \
+  || echo "COULD NOT MEASURE: dumpe2fs read no ext4 superblock fields from $DEV — set DEV=<device> if that is the wrong partition"' \
+  'Last checked'"'"
+
+# 🔴 THE ONE THE `required` TABLE DOES NOT PIN — only the 7b sweep sees it, which
+# is the whole reason 7b exists rather than a tenth `required` row.
+run tmp-name-families-unguarded \
+  'the set -e sweep found' \
+  '{ ls -A /tmp 2>/dev/null | sed -E '"'"'s/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//'"'"' \
+  | sort | uniq -c | sort -rn | head_n 20; } || true' \
+  'ls -A /tmp 2>/dev/null | sed -E '"'"'s/[0-9]{3,}.*$//; s/[A-Za-z0-9]{8,}$//'"'"' \
+  | sort | uniq -c | sort -rn | head_n 20'
+
+# --- the record-counted truncation that replaced `head_n 15` ------------------
+# 🔴 NEW EXPRESSION, NEW MUTANTS. `head_n 15` counted LINES; the loop counts
+# RECORDS, which is a different thing that can be off by one or forget to say it
+# truncated — and a listing that stops at 15 without saying so is the same
+# floor-presented-as-a-total this file is about.
+run foreign-truncation-off-by-one \
+  '20 foreign entries printed' \
+  '    [ "$n" -gt 15 ] || printf '"'"'  %s\n'"'"' "$p"' \
+  '    [ "$n" -gt 16 ] || printf '"'"'  %s\n'"'"' "$p"'
+
+run foreign-truncation-not-stated \
+  'the truncation is STATED, not silent' \
+  '  if [ "$n" -gt 15 ]; then
+    printf '"'"'  ... and %d more\n'"'"' "$((n - 15))"' \
+  '  if false; then
+    printf '"'"'  ... and %d more\n'"'"' "$((n - 15))"'
+
+run root-dev-reading-unguarded \
+  'the root device reading cannot kill the run' \
+  'ROOT_DEV=$(_dev_of /) || ROOT_DEV=' \
+  'ROOT_DEV=$(_dev_of /)'
 
 # --- defect 7, the /tmp half: -xdev LISTS a foreign mountpoint at depth 1 -----
 run tmp-size-device-filter-dropped \
   'size_breakdown DROPS every entry on a foreign device' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | _on_device "$dev" \' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | sed -z -n '"'"'s/^[0-9]*\t//p'"'"' \'
+  '  out=$(_depth1_nul "$base" "$errf" \
+    | { _on_device "$dev" || true; } \' \
+  '  out=$(_depth1_nul "$base" "$errf" \
+    | { sed -z -n '"'"'s/^[0-9]*\t//p'"'"' || true; } \'
 
 run tmp-inode-device-filter-dropped \
   'inode_breakdown DROPS every directory on a foreign device' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | _on_device "$dev" \' \
-  '  { find "$base" -xdev -mindepth 1 -maxdepth 1 -type d -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-    | sed -z -n '"'"'s/^[0-9]*\t//p'"'"' \'
+  '  out=$(_depth1_nul "$base" "$errf" -type d \
+    | { _on_device "$dev" || true; } \' \
+  '  out=$(_depth1_nul "$base" "$errf" -type d \
+    | { sed -z -n '"'"'s/^[0-9]*\t//p'"'"' || true; } \'
 
 # 🔴 STRUCTURAL PIN, and it is labelled as one. A second filesystem needs root,
 # so `du -x` cannot be checked behaviourally in this suite; a mutant dropping it
 # SURVIVED before the `required` row was added.
 run du-x-dropped-from-the-tmp-breakdown \
-  'du keeps -x in the /tmp size breakdown' \
+  'du keeps -x AND its || true in the /tmp size breakdown' \
   '    | { xargs -0 -r du -sh -x 2>/dev/null || true; } \' \
   '    | { xargs -0 -r du -sh 2>/dev/null || true; } \'
 
 run du-x-dropped-from-the-home-breakdown \
-  'du keeps -x in the /home size breakdown' \
+  'du keeps -x AND its || true in the /home size breakdown' \
   '{ xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true; }' \
   '{ xargs -0 -r du -sh < "$ONROOT_LIST" 2>/dev/null || true; }'
 
@@ -307,13 +425,9 @@ run dev-of-returns-hex-not-decimal \
 # An empty device reading must REFUSE, not print an empty section.
 run absent-device-prints-an-empty-section \
   'an unreadable base REFUSES rather than printing an empty size section' \
-  '    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory"
-    return 0
-  fi
-  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf' \
-  '    return 0
-  fi
-  { find "$base" -xdev -mindepth 1 -maxdepth 1 -printf'
+  '    echo "COULD NOT MEASURE: no device id for $base — NOT an empty directory (size breakdown)"
+    return 0' \
+  '    return 0'
 
 # 🔴 The device filter's own blind spot: excluding a foreign mount is right,
 # excluding it SILENTLY is the failure this file catalogues. Section 6c prints
@@ -321,21 +435,18 @@ run absent-device-prints-an-empty-section \
 # need for one.
 run foreign-entries-lists-nothing \
   '6d NAMES the entries it excluded (first)' \
-  '  if [ -n "$out" ]; then
-    printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"'' \
-  '  if false; then
-    printf '"'"'%s\n'"'"' "$out" | sed '"'"'s/^/  /'"'"''
+  '    [ "$n" -gt 15 ] || printf '"'"'  %s\n'"'"' "$p"' \
+  '    [ "$n" -gt 15 ] || :'
 
 run foreign-entries-inverted-filter \
   '_not_on_device is the exact complement of _on_device' \
   '_not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }' \
   '_not_on_device() { sed -z -n "s/^[0-9]*\t//p"; }'
 
-run foreign-entries-none-branch-always \
+run foreign-entries-none-branch-never \
   'POSITIVE CONTROL: an all-on-device base prints the explicit' \
-  '  out=$({ find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '"'"'%D\t%p\0'"'"' 2>/dev/null || true; } \
-        | _not_on_device "$dev" | tr '"'"'\0'"'"' '"'"'\n'"'"' | head_n 15)' \
-  '  out=$(printf '"'"'%s'"'"' "always-something")'
+  '  elif [ "$n" -eq 0 ]; then' \
+  '  elif false; then'
 
 # The digits predicate: it guards a value that reaches a `sed` SCRIPT.
 run dev-is-valid-accepts-anything-non-empty \

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -40,7 +40,12 @@ fail() { echo "  FAIL: $*"; FAILED=1; }
 pass() { echo "  ok: $*"; }
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# 🔴 `chmod -R u+rwX` BEFORE the `rm -rf`. Section 4b deliberately builds
+# unreadable fixture directories (mode 0400 / 000) so that `find` and `du` fail
+# for real, and `rm -rf` cannot unlink through them. Without this the temp tree
+# survives every run that dies before the fixture is chmodded back — a leak that
+# looks like nothing and accumulates.
+trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 # 🔴 Resolve the interpreter ONCE, absolutely, from the RUNNING shell. `$BASH`
 # is what is executing this file; `command -v bash` would resolve through the
@@ -89,7 +94,8 @@ set +e
 set -uo pipefail
 
 for fn in lsof_deleted_summary report_deleted_open_files size_breakdown \
-          inode_breakdown _dev_of split_by_device report_foreign_mounts \
+          inode_breakdown _dev_of _dev_is_valid _on_device _not_on_device \
+          foreign_entries split_by_device report_foreign_mounts \
           report_denials; do
   if declare -F "$fn" >/dev/null; then pass "helper $fn is sourceable"
   else fail "helper $fn is NOT defined after sourcing"; fi
@@ -106,6 +112,47 @@ else
   [ "$refuse_rc" -eq 2 ] && pass "non-root execution exits 2" \
     || fail "non-root execution exited $refuse_rc, expected 2"
   has "refusal names root on stderr" "$refuse_err" "must run as root"
+
+  # ------------------------------------------------------------------------- #
+  echo "== 1b. THE SEAM IS NOT REACHABLE FROM THE ENVIRONMENT =="
+  # 🔴 THE DEFECT: the seam used to be `[ "${BASH_SOURCE[0]}" != "$0" ]`, and the
+  # script's own header asserted that "the guard is not reachable from the
+  # environment". MEASURED FALSE. bash imports BASH_SOURCE from the environment
+  # as an ordinary scalar, so a stray `BASH_SOURCE` in the env made an EXECUTED
+  # run take the sourced branch and `return` at top level — rc 2, no report.
+  # rc 2 is also this script's "you forgot sudo" status, so the two causes were
+  # indistinguishable to the operator. `bash < script` was the mirror image:
+  # BASH_SOURCE unset under `set -u`, dead on the guard's own line, rc 1.
+  #
+  # 🔴 EACH CASE ASSERTS THE STATUS **AND** THE MESSAGE. rc 2 alone cannot tell
+  # "refused because not root" from "returned at top level", which is the whole
+  # reason this defect was invisible — so the refusal text is what discriminates.
+  env_err="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; env_rc=$?
+  [ "$env_rc" -eq 2 ] && pass "a poisoned BASH_SOURCE still reaches the root refusal (rc 2)" \
+    || fail "env BASH_SOURCE=... execution exited $env_rc, expected 2"
+  has "the poisoned run refuses for the RIGHT reason" "$env_err" "must run as root"
+  lacks "the poisoned run does not 'return' at top level" "$env_err" "can only 'return'"
+
+  # `bash < FILE` and `bash -s < FILE`: BASH_SOURCE is UNSET, so the old guard
+  # died on `set -u` before printing anything. Base ran fine this way, which
+  # makes this a genuine (narrow) regression the old form introduced.
+  stdin_err="$("$BASH_BIN" < "$SCRIPT" 2>&1 >/dev/null)"; stdin_rc=$?
+  [ "$stdin_rc" -eq 2 ] && pass "bash < script reaches the root refusal (rc 2)" \
+    || fail "bash < script exited $stdin_rc, expected 2"
+  has "the stdin run refuses for the RIGHT reason" "$stdin_err" "must run as root"
+  lacks "the stdin run does not die on an unbound BASH_SOURCE" "$stdin_err" "unbound variable"
+
+  dash_s_err="$("$BASH_BIN" -s < "$SCRIPT" 2>&1 >/dev/null)"; dash_s_rc=$?
+  [ "$dash_s_rc" -eq 2 ] && pass "bash -s < script reaches the root refusal (rc 2)" \
+    || fail "bash -s < script exited $dash_s_rc, expected 2"
+
+  # 🔴 THE OTHER HALF, or the fix above would be satisfied by a seam that never
+  # takes the sourced branch at all — which would silently make every helper
+  # assertion in this file a claim about a script that had already run the whole
+  # report. A poisoned BASH_SOURCE must NOT stop a genuine `source` working.
+  poisoned_src="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" -c "source '$SCRIPT' 2>&1; echo STILL-SOURCES")"
+  eq "a genuine source still no-ops, poisoned environment and all" \
+     "$poisoned_src" "STILL-SOURCES"
 fi
 
 # --------------------------------------------------------------------------- #
@@ -193,6 +240,31 @@ has "no-rows message is REACHABLE" "$probe_out" \
 has "the report continues past section 7" "$probe_out" "SECTION-8-WAS-REACHED"
 
 # --------------------------------------------------------------------------- #
+echo "== 2c. LSOF_BIN is a SOURCED-ONLY seam; a root run must not inherit it =="
+# 🔴 THE DEFECT: `LSOF_BIN=${LSOF_BIN:-lsof}` sat ABOVE the seam, so it was
+# honoured on the EXECUTE path too — an inherited `LSOF_BIN=/anything` was what
+# a ROOT run would then execute. Base hardcoded `lsof`. In a script whose whole
+# premise is that a local unprivileged process must not be able to influence a
+# root run, a TEST seam that widens what root executes is backwards.
+#
+# 🔴 OBSERVED THROUGH `bash -x`, because the execute path exits 2 at the root
+# check before it prints anything of its own. xtrace shows the assignment as it
+# is evaluated, so this is the REAL script executed exactly as an operator would
+# (minus sudo) — not a copy, not a stub.
+PWNED_LSOF="/pwned-lsof-$$"
+xt="$(env "LSOF_BIN=$PWNED_LSOF" "$BASH_BIN" -x "$SCRIPT" 2>&1 >/dev/null)"
+has "the execute path pins LSOF_BIN=lsof" "$xt" "LSOF_BIN=lsof"
+lacks "the execute path DISCARDS an inherited LSOF_BIN" "$xt" "$PWNED_LSOF"
+
+# 🔴 POSITIVE CONTROL. Without it, "the override is ignored" would also be
+# satisfied by a seam that ignores it EVERYWHERE — which would quietly make
+# section 2b's fake-lsof probe untestable rather than fixed.
+srcd_lsof="$(env "LSOF_BIN=$PWNED_LSOF" "$BASH_BIN" -c "source '$SCRIPT'; printf '%s' \"\${LSOF_BIN}\"")"
+eq "POSITIVE CONTROL: the SOURCED path still honours LSOF_BIN" "$srcd_lsof" "$PWNED_LSOF"
+srcd_default="$("$BASH_BIN" -c "unset LSOF_BIN; source '$SCRIPT'; printf '%s' \"\${LSOF_BIN}\"")"
+eq "the sourced path defaults to lsof when nothing overrides it" "$srcd_default" "lsof"
+
+# --------------------------------------------------------------------------- #
 echo "== 3. ROOT COMMAND INJECTION via a planted directory name =="
 # 🔴 THE DEFECT: `xargs -I{} sh -c '… "{}" …'` substitutes the filename into a
 # SHELL STRING. /tmp is mode 1777 and this script's header mandates sudo, so any
@@ -257,9 +329,24 @@ if [ "$NEED" -gt 60000 ]; then
   fail "COULD NOT MEASURE: ARG_MAX=$ARGMAX would need $NEED fixture files; refusing to build them. This guard did NOT run."
 else
   seq 1 "$NEED" | awk -v d="$BIG" -v p="$PAD" '{printf "%s/%s%06d\n", d, p, $1}' | xargs -d'\n' touch
+  # 🔴 THE FIXTURE MUST CONTAIN DIRECTORIES, and it used not to. It was
+  # `touch`ed FILES only, and `inode_breakdown` filters `-type d` — so it
+  # returned ZERO rows over this fixture, the `inode_breakdown "$BIG"` call in
+  # the SIGPIPE probe below measured nothing, and the whole battery row was
+  # killed by `size_breakdown` alone. Vacuous, and it read as coverage.
+  #
+  # 600 is not arbitrary: each row is ~12 + 2 + ~220 bytes, so 600 rows is
+  # ~140 KiB of `sort` output against a 64 KiB pipe buffer. Under 258 rows the
+  # whole output fits one write that completes before `head` exits and the
+  # SIGPIPE abort does NOT fire — the same size-dependence measured for
+  # `size_breakdown` at 40 vs 20,000 entries. A fixture under the buffer would
+  # certify the defect absent.
+  NDIRS=600
+  seq 1 "$NDIRS" | awk -v d="$BIG" -v p="$PAD" '{printf "%s/%sd%05d\n", d, p, $1}' | xargs -d'\n' mkdir -p
   made="$(find "$BIG" -mindepth 1 -maxdepth 1 | wc -l)"
-  [ "$made" -eq "$NEED" ] && pass "fixture built: $made top-level entries (ARG_MAX=$ARGMAX)" \
-    || fail "fixture build produced $made entries, wanted $NEED"
+  want=$(( NEED + NDIRS ))
+  [ "$made" -eq "$want" ] && pass "fixture built: $made top-level entries, $NDIRS of them directories (ARG_MAX=$ARGMAX)" \
+    || fail "fixture build produced $made entries, wanted $want"
 
   # 🔴 POSITIVE CONTROL. If the glob does NOT die here, the fixture is under the
   # limit and the assertion below proves nothing about E2BIG.
@@ -275,6 +362,16 @@ else
   [ "$big_lines" -eq 15 ] && pass "size_breakdown still returns its top-15 rows" \
     || fail "size_breakdown returned $big_lines rows, expected 15"
 
+  # 🔴 NON-VACUITY CHECK FOR THE FIXTURE ITSELF, not for the code. If this ever
+  # reads 0, every `inode_breakdown "$BIG"` in this file is measuring an empty
+  # pipeline and says nothing about `inode_breakdown`.
+  ino_out="$(inode_breakdown "$BIG" 2>&1)"; ino_rc=$?
+  [ "$ino_rc" -eq 0 ] && pass "inode_breakdown survives $made entries (rc 0)" \
+    || fail "inode_breakdown exited $ino_rc on $made entries"
+  ino_lines="$(printf '%s\n' "$ino_out" | grep -c . )"
+  [ "$ino_lines" -eq 15 ] && pass "inode_breakdown returns its top-15 rows over the big fixture" \
+    || fail "inode_breakdown returned $ino_lines rows, expected 15 — the fixture has no directories, so every inode_breakdown call over it is VACUOUS"
+
   # 🔴 THE SECOND ROUTE TO THE SAME FAILURE, and it is LIVE, not historical.
   # `<producer> | sort | head -N` under `pipefail` is a SIZE-DEPENDENT abort:
   # head exits after N lines, the producer blocks on its next write, takes
@@ -284,18 +381,97 @@ else
   # so a small-fixture test would have certified the defect as absent. The real
   # /tmp had 171,886 entries. This probe runs the script's own `set -euo
   # pipefail` over the big fixture and demands the marker AFTER it.
+  # 🔴 TWO PROBES, ONE PER BREAKDOWN. A single probe calling both would let
+  # `size_breakdown` kill every mutant on its own and leave `inode_breakdown`'s
+  # own truncation unguarded — which is exactly what the combined probe did
+  # while the fixture held no directories.
   cat > "$TMP/sigpipe-probe.sh" <<PROBE
 set -euo pipefail
 source "$SCRIPT"
 size_breakdown "$BIG" >/dev/null
-inode_breakdown "$BIG" >/dev/null
 echo "NEXT-SECTION-WAS-REACHED"
 PROBE
   sp_out="$("$BASH_BIN" "$TMP/sigpipe-probe.sh" 2>&1)"; sp_rc=$?
-  [ "$sp_rc" -eq 0 ] && pass "the breakdowns do not SIGPIPE the run away (rc 0 at $made entries)" \
+  [ "$sp_rc" -eq 0 ] && pass "the size breakdown does not SIGPIPE the run away (rc 0 at $made entries)" \
     || fail "the run died rc $sp_rc walking $made entries — a truncated scan with no message"
-  has "the report continues past the /tmp breakdown" "$sp_out" "NEXT-SECTION-WAS-REACHED"
+  has "the report continues past the /tmp size breakdown" "$sp_out" "NEXT-SECTION-WAS-REACHED"
+
+  cat > "$TMP/sigpipe-inode-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+inode_breakdown "$BIG" >/dev/null
+echo "INODE-SECTION-WAS-REACHED"
+PROBE
+  ip_out="$("$BASH_BIN" "$TMP/sigpipe-inode-probe.sh" 2>&1)"; ip_rc=$?
+  [ "$ip_rc" -eq 0 ] && pass "the inode breakdown does not SIGPIPE the run away (rc 0 over $NDIRS directories)" \
+    || fail "the inode breakdown died rc $ip_rc over $NDIRS directories — a truncated scan with no message"
+  has "the report continues past the /tmp inode breakdown" "$ip_out" "INODE-SECTION-WAS-REACHED"
 fi
+
+# --------------------------------------------------------------------------- #
+echo "== 4b. a find or a du that FAILS mid-scan must not kill the run =="
+# 🔴 THE THIRD AND FOURTH ROUTES to the same truncated-scan failure, and both
+# are LIVE on the host this script targets, where /tmp holds ~270,000 churning
+# top-level entries and section 4's own counter already calls the resulting
+# ENOENTs "vanished mid-scan (benign, transient)".
+#   (a) GNU `find` exits 1 when an entry disappears between readdir and stat.
+#   (b) `xargs` exits 123 when ANY command it ran exited 1-125 — the same
+#       vanished entry, one step later, reached through `du`.
+# `2>/dev/null` eats the message, `pipefail` promotes the status and `set -e`
+# kills the run: sections 6d-inodes, 7 and 8 never print and the report ends
+# with NO error. Same failure as E2BIG and SIGPIPE, two more ways in.
+#
+# 🔴 DETERMINISTIC FIXTURES — no background deleter, so no flake:
+#   ERRDIR is mode 0400. readdir succeeds (r) but stat of each entry needs x, so
+#   `find` errors per entry and exits 1. Isolates route (a).
+#   LOCKDIR holds a mode-000 subdirectory. `find` stats it fine and exits 0;
+#   `du` cannot read it and exits 1, so `xargs` exits 123 — while the readable
+#   sibling still produces a row. Isolates route (b), WITH partial output.
+# Both depend on not being root, which section 1 already refuses to paper over,
+# and each carries its own positive control below.
+ERRDIR="$TMP/find-errors"
+mkdir -p "$ERRDIR/sub-a" "$ERRDIR/sub-b"; touch "$ERRDIR/f"
+chmod 400 "$ERRDIR"
+LOCKDIR="$TMP/du-errors"
+mkdir -p "$LOCKDIR/locked" "$LOCKDIR/open"; touch "$LOCKDIR/open/f"
+chmod 000 "$LOCKDIR/locked"
+
+find "$ERRDIR" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0' >/dev/null 2>&1; a_rc=$?
+[ "$a_rc" -ne 0 ] && pass "POSITIVE CONTROL (a): find really exits $a_rc on the 0400 fixture" \
+  || fail "POSITIVE CONTROL (a) FAILED: find exited 0 over the 0400 fixture — every route-(a) assertion below is vacuous"
+du -sh -x "$LOCKDIR/locked" >/dev/null 2>&1; b_rc=$?
+[ "$b_rc" -ne 0 ] && pass "POSITIVE CONTROL (b): du really exits $b_rc on the mode-000 subdirectory" \
+  || fail "POSITIVE CONTROL (b) FAILED: du exited 0 on an unreadable directory — every route-(b) assertion below is vacuous"
+
+cat > "$TMP/finderr-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+size_breakdown "$ERRDIR" >/dev/null
+echo "PAST-SIZE-OVER-A-FAILING-FIND"
+inode_breakdown "$ERRDIR" >/dev/null
+echo "PAST-INODE-OVER-A-FAILING-FIND"
+size_breakdown "$LOCKDIR" >/dev/null
+echo "PAST-SIZE-OVER-A-FAILING-DU"
+inode_breakdown "$LOCKDIR" >/dev/null
+echo "PAST-INODE-OVER-A-FAILING-DU"
+PROBE
+fe_out="$("$BASH_BIN" "$TMP/finderr-probe.sh" 2>&1)"; fe_rc=$?
+# 🔴 The FAIL text must not share a prefix with section 4's SIGPIPE probe
+# ("the run died rc …"): the mutation battery scores each row on whether ITS OWN
+# guard's FAIL line appeared, matched as a fixed-string prefix, so two guards
+# with one prefix would let a mutant be credited to the wrong one.
+[ "$fe_rc" -eq 0 ] && pass "a failing find/du does not abort the run (rc 0)" \
+  || fail "a failing find/du aborted the run, rc $fe_rc — a truncated scan with no message"
+has "route (a): the report continues past a failing find in size_breakdown" "$fe_out" "PAST-SIZE-OVER-A-FAILING-FIND"
+has "route (a): the report continues past a failing find in inode_breakdown" "$fe_out" "PAST-INODE-OVER-A-FAILING-FIND"
+has "route (b): the report continues past a failing du in size_breakdown" "$fe_out" "PAST-SIZE-OVER-A-FAILING-DU"
+has "route (b): the report continues past a failing du in inode_breakdown" "$fe_out" "PAST-INODE-OVER-A-FAILING-DU"
+
+# 🔴 SURVIVING IS NOT ENOUGH — the readable entries must still be REPORTED, or
+# the tolerance would have turned one truncated scan into another.
+lock_out="$(size_breakdown "$LOCKDIR" 2>/dev/null)"
+has "route (b): the readable sibling still produces a row" "$lock_out" "$LOCKDIR/open"
+chmod 700 "$ERRDIR"; chmod 700 "$LOCKDIR/locked"
 
 # --------------------------------------------------------------------------- #
 echo "== 5. /home split by DEVICE, and the foreign list must survive the loop =="
@@ -313,28 +489,39 @@ echo "== 5. /home split by DEVICE, and the foreign list must survive the loop ==
 # The real-`stat` check runs FIRST, on purpose: the fixture cases below replace
 # `_dev_of`, and if that replacement came first this suite would be asserting
 # against its own stub and would pass with the script's implementation deleted.
-real_dev="$(stat -c '%D' / 2>/dev/null)"
-eq "_dev_of / agrees with stat -c %D /" "$(_dev_of /)" "$real_dev"
+#
+# 🔴 DECIMAL, NOT HEX. `_dev_of` is `stat -c '%d'` and the /tmp breakdowns
+# compare it against `find -printf '%D'`, which is decimal. `stat -c '%D'` is
+# HEX: had the helper kept it, every candidate would compare unequal and both
+# breakdowns would print an EMPTY section — the reassuring reading of a broken
+# instrument. So this checks the FORMAT, not just that the helper answers.
+real_dev="$(stat -c '%d' / 2>/dev/null)"
+eq "_dev_of / agrees with stat -c %d / (decimal)" "$(_dev_of /)" "$real_dev"
+eq "_dev_of agrees with find's own %D for the same path" \
+   "$(_dev_of "$TMP")" "$(find "$TMP" -maxdepth 0 -printf '%D')"
 mkdir -p "$TMP/sibling"
 eq "_dev_of is stable for two paths on one filesystem" \
-   "$(_dev_of "$TMP/sibling")" "$(stat -c '%D' "$TMP")"
+   "$(_dev_of "$TMP/sibling")" "$(stat -c '%d' "$TMP")"
 
 HOMEFIX="$TMP/homefix"
 mkdir -p "$HOMEFIX/zach/onroot-a" "$HOMEFIX/zach/foreign-b" \
          "$HOMEFIX/zach/.onroot-hidden" "$HOMEFIX/other/foreign-c"
 touch "$HOMEFIX/zach/a-plain-file"
-# Fixture device map. `801` is the real device id of /dev/sda1 on the host this
-# defect was measured on; `10308` is root's. Distinct from each other and from
-# any value `stat` could return for these paths, so a mutant that dropped the
-# comparison and kept everything (or dropped everything) is visibly wrong.
+# Fixture device map, in the DECIMAL form `_dev_of` really returns. The two
+# values are distinct from each other and far outside the range `stat` could
+# return for a real path here, so a mutant that dropped the comparison and kept
+# everything (or dropped everything) is visibly wrong. `999000001` is the
+# stand-in for a foreign disk, `999000002` for root.
+FOREIGN_DEV=999000001
+ROOTISH_DEV=999000002
 _dev_of() {
   case "$1" in
-    */foreign-b|*/foreign-c) printf '801\n' ;;
-    *) printf '10308\n' ;;
+    */foreign-b|*/foreign-c) printf '%s\n' "$FOREIGN_DEV" ;;
+    *) printf '%s\n' "$ROOTISH_DEV" ;;
   esac
 }
 ON="$TMP/onroot.lst"; FG="$TMP/foreign.lst"
-split_by_device "$HOMEFIX" "$ON" "$FG" "10308"
+split_by_device "$HOMEFIX" "$ON" "$FG" "$ROOTISH_DEV"
 
 # 🔴 `LC_ALL=C`. Under the host's en_US.UTF-8 collation `sort` ignores leading
 # punctuation, so `.onroot-hidden` sorts AFTER `onroot-a`; under the C locale
@@ -342,7 +529,7 @@ split_by_device "$HOMEFIX" "$ON" "$FG" "10308"
 # comparison passes on one tier and fails on the other — the config-blind-suite
 # failure, in the harness rather than the subject.
 on_list="$(tr '\0' '\n' < "$ON" | LC_ALL=C sort)"
-fg_list="$(LC_ALL=C sort < "$FG")"
+fg_list="$(tr '\0' '\n' < "$FG" | LC_ALL=C sort)"
 eq "on-root list holds exactly the root-device dirs (hidden included)" "$on_list" \
    "$(printf '%s\n%s\n' "$HOMEFIX/zach/.onroot-hidden" "$HOMEFIX/zach/onroot-a")"
 eq "foreign list holds exactly the foreign-device dirs" "$fg_list" \
@@ -355,6 +542,9 @@ lacks "a plain FILE is not treated as a directory" "$on_list$fg_list" "a-plain-f
 nul_count="$(tr -dc '\0' < "$ON" | wc -c)"
 [ "$nul_count" -eq 2 ] && pass "on-root list is NUL-separated (2 records)" \
   || fail "on-root list has $nul_count NUL separators, expected 2"
+fg_nul_count="$(tr -dc '\0' < "$FG" | wc -c)"
+[ "$fg_nul_count" -eq 2 ] && pass "foreign list is NUL-separated too (2 records)" \
+  || fail "foreign list has $fg_nul_count NUL separators, expected 2"
 
 # 🔴 THE ACCUMULATOR GUARD, stated behaviourally: with foreign mounts present the
 # report must NAME them. "none found" here was the subshell bug, and it is the
@@ -370,6 +560,122 @@ lacks "foreign report does NOT claim 'none found'" "$fm_out" "none found"
 none_out="$(report_foreign_mounts "$TMP/empty.lst" 2>/dev/null)"
 has "POSITIVE CONTROL: an empty list does print the loud 'none' line" \
     "$none_out" "none found — on a host with foreign mounts under /home this is a BUG"
+
+# --------------------------------------------------------------------------- #
+echo "== 5b. a directory name with a NEWLINE is ONE foreign record, not two =="
+# 🔴 THE DEFECT: `split_by_device` wrote the on-root list NUL-separated (it is
+# fed to `xargs -0`) but the FOREIGN list one-per-line, read back with
+# `while IFS= read -r`. A directory named with an embedded newline therefore
+# split into two rows in the report — and the second row is a fragment that
+# reads as a real path. /home is user-writable and this script runs under sudo,
+# so which lines the operator reads is not a thing to leave to chance.
+NLFIX="$TMP/nlfix"
+NLNAME="$(printf 'two\nlines')"
+mkdir -p "$NLFIX/u/$NLNAME"
+_dev_of() { case "$1" in "$NLFIX"/u/*) printf '%s\n' "$FOREIGN_DEV" ;; *) printf '%s\n' "$ROOTISH_DEV" ;; esac; }
+split_by_device "$NLFIX" "$TMP/nl-on.lst" "$TMP/nl-fg.lst" "$ROOTISH_DEV"
+nl_records="$(tr -dc '\0' < "$TMP/nl-fg.lst" | wc -c)"
+[ "$nl_records" -eq 1 ] && pass "one directory with a newline in its name is ONE record" \
+  || fail "the foreign list holds $nl_records records for a single directory — the name was split"
+nl_out="$(report_foreign_mounts "$TMP/nl-fg.lst" 2>/dev/null)"
+has "the foreign report prints the whole name, not a fragment" "$nl_out" "$NLFIX/u/$NLNAME"
+
+# --------------------------------------------------------------------------- #
+echo "== 5c. section 6d must DROP a foreign mount listed at depth 1 =="
+# 🔴 DEFECT 7, THE HALF THAT WAS LEFT STANDING. `-xdev` only stops find
+# DESCENDING past a mount; it still LISTS the mountpoint itself at depth 1. So a
+# mount under /tmp arrived as a STARTING POINT for `du -sh -x` — precisely the
+# case `du -x` cannot handle (see section 5(a)) — and its entire size landed in
+# a figure the report labels as root-fs /tmp usage. Section 6c fixed this for
+# /home; 6d, the section an operator actually acts on, did not.
+#
+# 🔴 A SECOND FILESYSTEM NEEDS ROOT, so what is stubbed is the device READING,
+# not the filesystem: `_dev_of` is the same seam section 5 uses, while
+# `find -printf '%D'` inside the helper still reports the fixture's REAL device.
+# Pointing `_dev_of` at a value no entry can have is therefore behaviourally
+# identical to every entry being a foreign mount — and pointing it at the real
+# `stat` reading is the on-root case. Both directions are asserted, so a mutant
+# that drops the filter AND a mutant that drops everything are both visible.
+DEVFIX="$TMP/devfix"
+mkdir -p "$DEVFIX/one" "$DEVFIX/two" "$DEVFIX/three"
+touch "$DEVFIX/one/f" "$DEVFIX/two/f" "$DEVFIX/three/f"
+UNREACHABLE_DEV=999000003
+
+# The redefinitions live inside the command substitutions, which are subshells,
+# so neither leaks into the rest of this file.
+kept_sz="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; size_breakdown "$DEVFIX" 2>/dev/null )"
+drop_sz="$( _dev_of() { printf '%s\n' "$UNREACHABLE_DEV"; }; size_breakdown "$DEVFIX" 2>/dev/null )"
+has "size_breakdown KEEPS an entry on the base's own device" "$kept_sz" "$DEVFIX/one"
+eq  "size_breakdown DROPS every entry on a foreign device" "$drop_sz" ""
+
+kept_ino="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; inode_breakdown "$DEVFIX" 2>/dev/null )"
+drop_ino="$( _dev_of() { printf '%s\n' "$UNREACHABLE_DEV"; }; inode_breakdown "$DEVFIX" 2>/dev/null )"
+has "inode_breakdown KEEPS a directory on the base's own device" "$kept_ino" "$DEVFIX/one"
+eq  "inode_breakdown DROPS every directory on a foreign device" "$drop_ino" ""
+
+# 🔴 AND A MISSING DEVICE READING MUST REFUSE, not print an empty section. With
+# the filter in place, "no rows" is the same output for "everything is foreign"
+# and "I could not read the base at all" — and the second is a non-measurement.
+nodev_sz="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; size_breakdown "$TMP/absent-$$" 2>/dev/null )"
+has "an unreadable base REFUSES rather than printing an empty size section" \
+    "$nodev_sz" "COULD NOT MEASURE: no device id for"
+nodev_ino="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; inode_breakdown "$TMP/absent-$$" 2>/dev/null )"
+has "an unreadable base REFUSES rather than printing an empty inode section" \
+    "$nodev_ino" "COULD NOT MEASURE: no device id for"
+
+# 🔴 EXCLUDING SILENTLY IS ITSELF A DEFECT. The device filter is right to drop a
+# foreign mount — its size is not root-fs usage — but a section that drops what
+# it could not count without saying so is the floor-presented-as-a-total failure
+# this whole file catalogues. 6c prints the same listing for /home, with a
+# deliberately loud "none" branch; 6d now does too.
+fe_foreign="$( _dev_of() { printf '%s\n' "$UNREACHABLE_DEV"; }; foreign_entries "$DEVFIX" 2>/dev/null )"
+has "6d NAMES the entries it excluded (first)" "$fe_foreign" "$DEVFIX/one"
+has "6d NAMES the entries it excluded (second)" "$fe_foreign" "$DEVFIX/two"
+lacks "6d does not claim 'none' while it is excluding things" "$fe_foreign" "none — every depth-1 entry"
+# POSITIVE CONTROL for the branch above: the "none" line CAN fire, so the
+# `lacks` is not an assertion about dead code.
+fe_none="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; foreign_entries "$DEVFIX" 2>/dev/null )"
+has "POSITIVE CONTROL: an all-on-device base prints the explicit 'none' line" \
+    "$fe_none" "none — every depth-1 entry is on the same filesystem as $DEVFIX"
+lacks "the 'none' case names no entry" "$fe_none" "$DEVFIX/one"
+fe_nodev="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; foreign_entries "$TMP/absent-$$" 2>/dev/null )"
+has "an unreadable base REFUSES rather than claiming no foreign mounts" \
+    "$fe_nodev" "NOT an absence of foreign mounts"
+
+# 🔴 THE DEVICE ID IS INTERPOLATED INTO A sed SCRIPT, so it must be digits, not
+# merely non-empty. `stat -c '%d'` cannot produce a `/` today; the predicate is
+# in one place so that stays true for all three callers rather than at two of
+# them.
+_dev_is_valid 12345 && pass "_dev_is_valid accepts a decimal device id" \
+  || fail "_dev_is_valid rejected a plain decimal device id"
+dev_bad_ok=1
+for bad in '' '/etc/passwd' '12*3' '12 3' 'abc' '0x8040'; do
+  if _dev_is_valid "$bad"; then fail "_dev_is_valid accepted [$bad]"; dev_bad_ok=0; fi
+done
+# 🔴 Conditional, not an unconditional `pass` after a loop that can fail — an
+# `ok:` line printed next to its own `FAIL:` reads as coverage while providing
+# none, which is the failure mode this whole suite is written against.
+[ "$dev_bad_ok" -eq 1 ] && pass "_dev_is_valid rejects empty, hex, and every sed-metacharacter shape tried"
+
+# The filter itself, driven directly: a NUL-separated `<device>\t<path>` stream.
+# Hand-built, so the assertion does not depend on find's behaviour at all.
+# 🔴 `printf '%s\t%s\0' a b …`, NEVER a single format string with `\0` in it.
+# `printf '111\t/a/keep\0222\t…'` reads `\0222` as the OCTAL escape 0o222, so
+# the record separator silently becomes byte 0x92 and the fixture stops being a
+# NUL stream at all — which is how this assertion was red on its first run.
+printf '%s\t%s\0' 111 /a/keep 222 /a/drop 111 '/a/keep two' > "$TMP/ondev.in"
+on_dev_out="$(_on_device 111 < "$TMP/ondev.in" | tr '\0' '\n')"
+eq "_on_device keeps exactly the wanted device, stripping the prefix" "$on_dev_out" \
+   "$(printf '/a/keep\n/a/keep two\n')"
+printf '%s\t%s\0' 111 "$NLNAME" 222 /b/x > "$TMP/ondev2.in"
+on_dev_nul="$(_on_device 111 < "$TMP/ondev2.in" | tr -dc '\0' | wc -c)"
+[ "$on_dev_nul" -eq 1 ] && pass "_on_device emits one NUL record for a path containing a newline" \
+  || fail "_on_device emitted $on_dev_nul records for one path with a newline"
+
+# The inverse, over the SAME stream: the two must partition it, so a mutant that
+# made one of them match everything is visible from either side.
+not_dev_out="$(_not_on_device 111 < "$TMP/ondev.in" | tr '\0' '\n')"
+eq "_not_on_device is the exact complement of _on_device" "$not_dev_out" "/a/drop"
 
 # --------------------------------------------------------------------------- #
 echo "== 6. denial accounting — a count with no denial figure is a FLOOR =="
@@ -438,7 +744,7 @@ grep -v '^[[:space:]]*#' "$SCRIPT" > "$CODE_FILE"
 # match is indistinguishable from a clean file, and both print "ok". Feed it a
 # line that MUST match every banned pattern before trusting a single zero.
 CANARY_FILE="$TMP/canary.txt"
-printf '%s\n' 'du -sh -x /tmp/* | xargs -I{} awk "{ s += $8 } END { print NR - 1 }" | head -15; X=$(lsof +L1); Y=$(grep -c foo bar || echo 0)' > "$CANARY_FILE"
+printf '%s\n' 'du -sh -x /tmp/* | xargs -I{} awk "{ s += $8 } END { print NR - 1 }" | head -n 20; X=$(lsof +L1); Y=$(grep -c foo bar || echo 0); if [ "${BASH_SOURCE[0]}" != "$0" ]; then :; fi' > "$CANARY_FILE"
 
 banned() { # name  BRE  why
   local name="$1" pat="$2" why="$3"
@@ -461,6 +767,20 @@ required() { # name  fixed-string  why
 # a `||` alternation guard and splitting on `|` shredded it into three fields on
 # this table's first run, which made the pattern a prefix that matched nothing
 # and reported the check as ok.
+#
+# 🔴 THE `head` PATTERN IS SPELLING-INSENSITIVE ON PURPOSE, and it used not to
+# be. It read `| *head -[0-9]`, which demands a DIGIT immediately after `head -`
+# — so `head -n 20`, the POSIX-preferred spelling, walked straight through.
+# MEASURED: `head -n 20`, `head -n 30` and `head -n 15` all SURVIVED the
+# mutation battery while `head -15` was caught. `| *head  *-` (BRE: `|`,
+# optional spaces, `head`, one-or-more spaces, `-`) matches every spelling and
+# still does not match `head_n`, which is the sanctioned helper. The canary line
+# above deliberately spells it `head -n 20`, so narrowing this pattern back
+# trips the SCANNER-BROKEN branch instead of silently reporting ok.
+#
+# 🔴 `BASH_SOURCE` is banned outright rather than pinned to a shape. A guard on
+# a specific expression is walkable by rewriting the expression; the hazard is
+# that the seam consults an environment-importable VARIABLE at all.
 while IFS='@' read -r name pat why; do
   [ -n "${name:-}" ] || continue
   banned "$name" "$pat" "$why"
@@ -471,7 +791,8 @@ no fixed column index summed out of lsof@s *+= *\$[0-9]@$8 under +L1 is NLINK, 0
 no NR-1 header strip (goes to -1 on empty input)@NR *- *1@NR is 0 with no output at all, and a negative count hides 'did not run'
 no 'grep -c ... || echo 0' (emits a two-line zero)@grep -c[^|]*|| *echo@grep -c prints 0 AND exits 1; the fallback then appends a second line
 no unchecked assignment from lsof under set -e@=\$(lsof@a command substitution in an assignment is CHECKED; lsof exits 1 when it finds nothing
-no bare '| head -N' truncating a pipeline (SIGPIPE 141)@| *head -[0-9]@head exits after N lines and the producer takes SIGPIPE; pipefail promotes 141 and set -e kills the run silently. Use head_n.
+no bare '| head -N' truncating a pipeline (SIGPIPE 141)@| *head  *-@head exits after N lines and the producer takes SIGPIPE; pipefail promotes 141 and set -e kills the run silently. Use head_n.
+no BASH_SOURCE seam test (reachable from the environment)@BASH_SOURCE@bash imports BASH_SOURCE from the env as a scalar, so an EXECUTED run took the sourced branch and returned at top level: rc 2, no report, indistinguishable from the not-root refusal
 BANNED
 
 while IFS='@' read -r name lit why; do
@@ -481,10 +802,16 @@ done <<'REQUIRED'
 section 2 keeps find's stderr instead of discarding it@2>>"$DENIED_LOG"@a scan reporting a number with no denial count is a floor presented as a total
 lsof column is resolved by NAME from the header@if ($i == "SIZE/OFF") col=i@the index is not stable: +L1 puts it at 7, plain -n -P at 9
 an absent SIZE/OFF column REFUSES rather than reporting a zero@COULD NOT MEASURE: no SIZE/OFF column in lsof header@a zero here is the reassuring reading of a broken instrument
-the /tmp inode walk passes the name as an ARGUMENT@-exec sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ {} \;@"$1" is an argv slot; "{}" is text the shell parses
-top-level enumeration is NUL-safe find|xargs, not a glob@find "$1" -xdev -mindepth 1 -maxdepth 1 -print0@the glob form dies E2BIG and set -euo pipefail takes the whole run with it
-candidates are compared by DEVICE, because du -x cannot do it@d=$(_dev_of "$p") || continue@du -x only stops du crossing AWAY from its start; started ON a foreign mount it walks all of it
+the /tmp inode walk passes the name as an ARGUMENT@xargs -0 -r -n1 sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _@"$1" is an argv slot; "{}" under xargs -I is text the shell parses
+top-level enumeration is NUL-safe find|xargs, not a glob@find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0'@the glob form dies E2BIG and set -euo pipefail takes the whole run with it
+/home candidates are compared by DEVICE, because du -x cannot do it@d=$(_dev_of "$p") || continue@du -x only stops du crossing AWAY from its start; started ON a foreign mount it walks all of it
+/tmp candidates are compared by DEVICE too (defect 7, section 6d)@| _on_device "$dev"@-xdev still LISTS a mountpoint at depth 1, so it reaches du as a starting point — the one case du -x cannot handle
+du keeps -x in the /tmp size breakdown@xargs -0 -r du -sh -x 2>/dev/null || true@INVARIANT PIN, not a regression guard: a second filesystem needs root, so -x cannot be checked behaviourally here. A mutant dropping it SURVIVED.
+du keeps -x in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true@same invariant pin for section 6c's call site
 truncation reads to EOF instead of closing the pipe@head_n() { awk -v n="$1" 'NR<=n'; }@awk consumes all input, so the upstream sort never takes SIGPIPE
+the seam reads no variable at all@if (return 0 2>/dev/null); then@`return` cannot be poisoned from the environment; ${BASH_SOURCE[0]} could
+section 6d reports what its device filter EXCLUDED@foreign_entries /tmp@dropping a foreign mount silently is the floor-presented-as-a-total failure this file exists to prevent
+the device id is validated as digits before it reaches sed@_dev_is_valid "$dev"@the value is interpolated into a sed script; a / or a * would change the expression rather than fail
 REQUIRED
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1185,8 +1185,10 @@ top-level enumeration is NUL-safe find|xargs, and KEEPS find's stderr@find "$bas
 /tmp candidates are compared by DEVICE too (defect 7, section 6d)@| { _on_device "$dev" || true; }@-xdev still LISTS a mountpoint at depth 1, so it reaches du as a starting point — the one case du -x cannot handle
 du keeps -x AND its || true in the /tmp size breakdown@xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true@INVARIANT PIN, not a regression guard, for the -x half: a second filesystem needs root, so -x cannot be checked behaviourally here and a mutant dropping it SURVIVED. The `|| true` half IS behaviourally covered, by route (b) in section 4b — this literal pins both, so read it as two claims. The redirection is part of the literal on purpose: it was `2>/dev/null` until round 3, and a du that cannot read a path is then an under-count with no marker (section 4b-iii).
 du keeps -x AND its || true in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>>"$DU_ERR" || true@same three claims for section 6c's call site; 6c is root-only, so its du-stderr capture is an INVARIANT PIN with no behavioural half
-section 5's PVC listing keeps du's stderr too@xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true@root-only INVARIANT PIN: the third du site, discarding its stderr the way the other two did until round 3
+section 5's PVC listing keeps du's stderr too@xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true@root-only INVARIANT PIN, about THIS pipeline and no other. A previous wording called it "the third du site", which asserted a COUNT of the file's du invocations; the count was wrong and the scope it implied was wider than any row here checks. `_report_unreadable`'s own comment declares which sites route du's stderr to a file and states that it says nothing about the rest.
 the du blind spot is REPORTED, not merely captured@_report_unreadable@capturing a stream nothing reads is worse than discarding it — it looks like coverage. Behaviourally covered for size_breakdown in section 4b-iii; this pins that the two root-only sites call it as well.
+section 6 BRANCHES on du's status instead of discarding it@if du_out=$(du -sh -x "$d" 2>/dev/null); then du_mark=; else du_mark=@a du that cannot read a tree prints a PARTIAL total and exits 1; this row rendered that floor exactly like a complete figure, and since `_report_unreadable` landed the absence of a marker reads as "nothing was missed". Root-only, so this is an INVARIANT PIN.
+section 6 PRINTS the marker it computed@"$(find "$d" -xdev -printf . 2>/dev/null | wc -c)" "$d" "$du_mark"@a variable that is set but never reaches the output is the field-that-is-not-a-guard shape: the branch above would look like coverage while every row still printed identically.
 every temp file this script opens carries an identifying name@mktemp "/tmp/disk-accounting-$1.XXXXXX"@a bare `mktemp` writes /tmp/tmp.XXXXXXXXXX — an unattributable file, in the directory this script exists to diagnose
 the EXIT trap names a FUNCTION, not a fixed list of files@trap _cleanup_temps EXIT@a trap naming a fixed LIST is an enumeration by eye: the three breakdown temp files were never in either version of it. This row pins the NAME only — the ORDER is a separate guard below, because a description wider than its check is how six guards in one session read as coverage while providing none.
 section 5's du TOTAL is guarded, not bare@|| echo "COULD NOT MEASURE: du failed under /var/lib/rancher/k3s/storage@it printed an under-counted total, exited 1 with its message already at /dev/null, and set -e then killed sections 6..8. Root-only, so this is an INVARIANT PIN; the failure itself is measured in section 4b route (b).
@@ -1211,6 +1213,26 @@ case "${trap_line:-x}${denied_line:-x}" in
   *) [ "$trap_line" -lt "$denied_line" ] \
        && pass "the EXIT trap is installed BEFORE the run's first mktemp (line $trap_line < $denied_line)" \
        || fail "the EXIT trap is installed at line $trap_line, AFTER the first mktemp at $denied_line — that file is uncovered on the exit path its own creation can take" ;;
+esac
+
+# 🔴 EVERY `: > "$DU_ERR"` TRUNCATION, NOT "a truncation" — a RELATIONSHIP, so
+# it fails when the set grows as well as when a guard is dropped. A redirection
+# failure on a SPECIAL BUILTIN is fatal under `set -e` (MEASURED 2026-09-08,
+# bash 5.3.15: `set -euo pipefail; : > /absent/x` ends the shell, rc 1), and
+# NEITHER ledger in 7b below can see this shape — the sweep keys on a line's
+# first word and this one's is `:`, and the line carries no `| sort`. A single
+# `required` row would go green with one of the two sites unguarded, which is
+# why this counts instead of pinning one literal. The numbers are DERIVED here,
+# never written down: what is asserted is that they are equal and non-zero.
+duerr_total="$(grep -cF ': > "$DU_ERR"' "$CODE_FILE" || true)"
+duerr_guarded="$(grep -cF ': > "$DU_ERR" || echo "COULD NOT MEASURE' "$CODE_FILE" || true)"
+case "${duerr_total:-x}${duerr_guarded:-x}" in
+  *[!0-9]*) fail "the DU_ERR truncation ledger cannot be read (total=[${duerr_total:-}] guarded=[${duerr_guarded:-}])" ;;
+  *) if [ "$duerr_total" -ge 1 ] && [ "$duerr_total" = "$duerr_guarded" ]; then
+       pass "every ': > \$DU_ERR' truncation carries a guard ($duerr_guarded of $duerr_total)"
+     else
+       fail "not every ': > \$DU_ERR' truncation is guarded ($duerr_guarded of $duerr_total) — an unguarded one is fatal under set -e, and at section 6c it fires AFTER sections 1..6b have already printed"
+     fi ;;
 esac
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -2,9 +2,13 @@
 # Regression guards for scripts/diagnose-disk-accounting.sh.
 #
 # WHY THIS EXISTS. That script is ROOT-PRIVILEGED bash that had no test file, in
-# a repo with no shellcheck gate. (It was 282 lines when this suite was written;
-# no line count is quoted here any more, because the last one went stale in one
-# round and was still being cited from run-tests.sh two rounds later.)
+# a repo with no shellcheck gate. (It was 282 lines at the merge base
+# `c1169e3b` — BEFORE this suite's own commit, which added the seam and most of
+# the comments. "When this suite was written" is the wrong anchor for that
+# figure and stood here for a round: by the end of that commit the file was 414
+# lines. No CURRENT count is quoted anywhere any more, because the last one went
+# stale within a round and was still being cited from run-tests.sh two rounds
+# later. `wc -l scripts/diagnose-disk-accounting.sh`.)
 # Every defect pinned below was real,
 # shipped, and invisible to the merge gate — including a root COMMAND INJECTION
 # reachable by any local process (via a planted /tmp directory name) and an
@@ -31,11 +35,16 @@
 # measurement (`dumpe2fs -h /dev/nvme0n1p2`, `find / -xdev` over root-only
 # trees, `findmnt /mnt/rootcheck`). Their numbers cannot be produced without
 # root on a real host, so their arithmetic is UNGUARDED here. Their `set -e`
-# EXPOSURE is a different question and IS covered, structurally: section 7b
-# sweeps the whole file for a statement whose failure would truncate the report,
-# which is how section 5's bare `du -sh` total was found. What is guarded
-# behaviourally is every defect the file's own comments record, all of which
-# live in the transforms below.
+# EXPOSURE is a different question and is covered structurally by section 7b —
+# but read that section's own header for what its scan can and cannot see. It
+# does NOT "sweep the whole file", which is what this sentence used to claim: it
+# keeps lines by their FIRST WORD and drops any line containing `||`, so a
+# pipeline headed by `for`/`done`/`printf` or guarded only in an early stage is
+# invisible to it. That is why 7b also carries a second, separate ledger over
+# the trailing `sort` stages, and why the script's own sweep comment lists five
+# deliberate exceptions rather than two. What is guarded behaviourally is every
+# defect the file's own comments record, all of which live in the transforms
+# below.
 set -uo pipefail
 
 # 🔴 `CDPATH=` and `>/dev/null` on the `cd`: with CDPATH set in the environment
@@ -132,7 +141,8 @@ set -uo pipefail
 for fn in lsof_deleted_summary report_deleted_open_files size_breakdown \
           inode_breakdown _dev_of _dev_is_valid _on_device _not_on_device \
           foreign_entries split_by_device report_foreign_mounts \
-          report_denials; do
+          report_denials _errline_count _report_unstattable _report_unreadable \
+          _scan_mktemp _cleanup_temps; do
   if declare -F "$fn" >/dev/null; then pass "helper $fn is sourceable"
   else fail "helper $fn is NOT defined after sourcing"; fi
 done
@@ -513,10 +523,17 @@ has "route (b): the readable sibling still produces a row" "$lock_out" "$LOCKDIR
 echo "== 4b-ii. ROUTE (a): an UNSTATTABLE entry must be COUNTED, not erased =="
 # 🔴 THE DEFECT, and it was introduced by the round-1 fix for route (a). `-print0`
 # still printed the NAME of an entry whose stat failed; `-printf '%D\t%p\0'`
-# forces a stat to format the record and emits NOTHING when it fails. MEASURED
-# 2026-09-07 over this very fixture, both `find` builds on this host, both rc 1:
-# `-print0` 116 B (GNU findutils 4.10.0, the bash PATH) / 119 B (4.11.0, the nix
-# dev shell); `-printf '%D\t%p\0'` **0 B** in both. So the entry left the size
+# forces a stat to format the record and emits NOTHING when it fails.
+#
+# RE-MEASURED 2026-09-07 (round 3), one fixture, three implementations — the
+# figures that stood here (116 B / 119 B, "both rc 1") could not all have been
+# true, because `-print0` emits the paths it FOUND, so two builds cannot
+# disagree about one fixture, and `-print0` needs no stat, so it does not error.
+# Over a 35-character 0400 base holding three entries: GNU findutils 4.10.0
+# (the bash PATH), 4.11.0 (the nix dev shell) and bfs 4.1.1 (the interactive
+# alias) all gave `-print0` **114 B, rc 0** and `-printf '%D\t%p\0'` **0 B,
+# rc 1**. The load-bearing half — 0 bytes under `%D` — is identical on all
+# three. So the entry left the size
 # breakdown, the inode breakdown AND the foreign-entry listing at once — and
 # `foreign_entries` then printed "none — every depth-1 entry is on the same
 # filesystem as …", an affirmative claim of absence produced by a blind scan.
@@ -571,6 +588,172 @@ has "POSITIVE CONTROL: a stattable fixture still lists its entries" "$ok_sz" "$O
 has "POSITIVE CONTROL: a stattable fixture DOES print the affirmative 'none'" \
     "$ok_fgn" "none — every depth-1 entry is on the same filesystem as $OK_DIR"
 chmod 700 "$ERRDIR"; chmod 700 "$LOCKDIR/locked"
+
+# --------------------------------------------------------------------------- #
+echo "== 4b-iii. ROUTE (b): a path du cannot READ is an UNDER-COUNT, not a total =="
+# 🔴 THE ASYMMETRY THAT MADE A PRE-EXISTING `2>/dev/null` WORTH FIXING NOW.
+# Route (a) ERASES an entry; route (b) keeps it and SHORTENS its number. §4b
+# above pins that route (b) does not kill the run and that the readable sibling
+# still produces a row — neither of which says anything about the figure printed
+# for the unreadable one. With du's stderr at /dev/null nothing did. And once
+# §4b-ii's `!! UNSTATTABLE` line existed, the ABSENCE of a blind-spot line
+# started reading as an affirmative "nothing was missed" — a floor presented as
+# a total, reached by trusting a report that never had the evidence.
+#
+# 🔴 THE POSITIVE CONTROL ASSERTS THE UNDER-COUNT ITSELF, not merely that du
+# exits non-zero. "The blind spot is reported" would otherwise be satisfiable on
+# a fixture where du in fact read everything. MEASURED over this fixture:
+# 8K reported for `locked` against a true 12K, a 33% shortfall.
+DUFIX="$TMP/du-partial"
+mkdir -p "$DUFIX/open" "$DUFIX/locked/inner"
+head -c 4096 /dev/zero > "$DUFIX/open/f"
+head -c 4096 /dev/zero > "$DUFIX/locked/inner/f"
+du_true="$(du -s -x --block-size=1K "$DUFIX/locked" 2>/dev/null | awk '{print $1}')"
+chmod 000 "$DUFIX/locked/inner"
+du_short="$(du -s -x --block-size=1K "$DUFIX/locked" 2>/dev/null | awk '{print $1}')"
+case "${du_true:-x}${du_short:-x}" in
+  *[!0-9]*) fail "POSITIVE CONTROL (du under-count): unparsable du output (true=[${du_true:-}] short=[${du_short:-}])" ;;
+  *) [ "$du_short" -lt "$du_true" ] \
+       && pass "POSITIVE CONTROL: du really under-counts the locked fixture (${du_short}K reported vs ${du_true}K true)" \
+       || fail "POSITIVE CONTROL FAILED: du reported ${du_short}K against a true ${du_true}K — no under-count, so every assertion below is vacuous" ;;
+esac
+
+du_out="$(size_breakdown "$DUFIX" 2>/dev/null)"
+has "route (b): size_breakdown REPORTS that du could not read a path" \
+    "$du_out" "!! PARTIALLY READ: du could not read 1 path(s) under $DUFIX."
+has "route (b): the under-counted figures are called FLOORS" \
+    "$du_out" "The sizes above are FLOORS for those paths, not totals."
+has "route (b): du's own error line is quoted, not just tallied" "$du_out" "cannot read directory"
+has "route (b): the readable sibling is still listed" "$du_out" "$DUFIX/open"
+# 🔴 THE TWO BLIND SPOTS MUST STAY TELLABLE APART. `find` can stat everything in
+# this fixture, so the route-(a) line must NOT appear: one message doing both
+# jobs would make both counts meaningless, and merging the two stderr sinks is
+# exactly how that would happen.
+lacks "route (b): a du failure is NOT reported as an unstattable entry" "$du_out" "UNSTATTABLE"
+
+# 🔴 POSITIVE CONTROL for the branch: on a fixture du can read completely, the
+# line is ABSENT — otherwise a function that printed it unconditionally would
+# satisfy every assertion above.
+ok_du="$(size_breakdown "$OK_DIR" 2>/dev/null)"
+lacks "POSITIVE CONTROL: a fully readable fixture reports NO du blind spot" "$ok_du" "PARTIALLY READ"
+has "POSITIVE CONTROL: that fixture still produced a size row" "$ok_du" "$OK_DIR/a"
+chmod 700 "$DUFIX/locked/inner"
+
+# --------------------------------------------------------------------------- #
+echo "== 4b-iv. TEMP FILES: identifiable names, and ONE trap that covers them all =="
+# 🔴 THE DEFECT. The three breakdown helpers opened `errf=$(mktemp)` — an
+# anonymous `/tmp/tmp.XXXXXXXXXX` — and NONE of the three was named in the
+# script's EXIT trap; only its own function's last statement removed it. The
+# realistic way this run ends is not an abort but SIGINT: the run it was written
+# for took ~3 h over 78 million entries. MEASURED 2026-09-07 on this host's
+# bash: an EXIT trap DOES run when the shell is killed by an untrapped SIGINT —
+# so the trap removed the NAMED $DENIED_LOG and left up to three unattributable
+# files in /tmp, the directory under diagnosis.
+# 🔴 `${REPLY:-}`, and a `declare -F` gate, so this section stays REPORTABLE
+# against a tree that has no `_scan_mktemp` at all. Without them the suite dies
+# on `set -u` at the first unset REPLY and every guard below it goes unmeasured
+# — which is exactly the truncated-run failure this file is about, in the file
+# that is about it. MEASURED: the red-at-`eb4e3a81` matrix stopped at 79 ok
+# before this gate, and reports the full set with it.
+REPLY=
+if declare -F _scan_mktemp >/dev/null; then
+  _scan_mktemp probe-4biv || fail "_scan_mktemp could not create a temp file"
+fi
+scan_path="${REPLY:-}"
+case "${scan_path##*/}" in
+  disk-accounting-probe-4biv.*) pass "a scan temp file is NAMED for this script and its purpose (${scan_path##*/})" ;;
+  *) fail "a scan temp file is named [${scan_path##*/}] — an operator cannot attribute it to this script" ;;
+esac
+[ -n "$scan_path" ] && [ -f "$scan_path" ] && pass "the named temp file really exists before cleanup" \
+  || fail "_scan_mktemp reported success without creating a file"
+[ -n "$scan_path" ] && rm -f "$scan_path"
+
+# 🔴 THE END-TO-END CASE, AND IT INTERRUPTS FOR REAL. The property is "a signal
+# arriving between the mktemp and the rm does not leak", so the probe stubs
+# `_report_unstattable` — which `size_breakdown` calls AFTER opening both temp
+# files and BEFORE removing them — to record the two paths and kill itself.
+# The trap is installed by the probe because it only exists on the script's ROOT
+# execute path, which this suite cannot reach; that the script really installs
+# THIS function is pinned separately in section 7 (`trap _cleanup_temps EXIT`).
+# What is measured here is the half a structural pin cannot reach: that the
+# function removes a file opened long after the trap went up.
+#
+# 🔴 THE PROBE FALLS BACK FROM SIGINT TO SIGTERM, AND THE FALLBACK IS THE POINT.
+# A first draft used `kill -INT` alone. It passed when this suite was run in the
+# foreground and produced THREE FAILs the moment the mutation battery ran it
+# from a `nohup … &` — bash sets SIGINT and SIGQUIT to SIG_IGN in a command
+# started asynchronously without job control, and a non-interactive shell
+# CANNOT reset a signal that was ignored on entry. MEASURED with a two-line
+# stand-in (`kill -INT $$; echo SURVIVED`): it dies silently when run in the
+# foreground and prints SURVIVED when run from `( … & wait )`. Left as-is, the
+# leak assertion would have gone VACUOUSLY GREEN in
+# exactly the runner that matters (0 files recorded as surviving because none
+# was ever opened for a signal that never arrived) — which is why the "was it
+# really interrupted" rows below are not decoration. SIGINT is still attempted
+# first, because it is the signal the defect is about; SIGTERM is delivered the
+# same way and reaches the same EXIT trap.
+SIGFIX="$TMP/sigint-fixture"
+mkdir -p "$SIGFIX/a"; touch "$SIGFIX/a/f"
+cat > "$TMP/sigint-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+if [ "\${1:-}" = "trapped" ]; then trap _cleanup_temps EXIT; fi
+_report_unstattable() {
+  printf '%s\n%s\n' "\$SCAN_ERRF" "\$SCAN_DUERR" > "$TMP/sigint-paths"
+  kill -INT \$\$
+  # Reached only when SIGINT was ignored on entry to this shell.
+  echo "SIGINT-IGNORED-USING-SIGTERM"
+  kill -TERM \$\$
+}
+size_breakdown "$SIGFIX" >/dev/null
+echo "NOT-INTERRUPTED"
+PROBE
+
+# POSITIVE CONTROL FIRST — the UNTRAPPED run must LEAK, or "the trapped run left
+# nothing behind" is indistinguishable from a probe that never opened a file.
+# `: >` rather than `rm -f`: a probe that failed to run at all must leave an
+# EMPTY ledger for the loops below to read, not a missing file — otherwise the
+# redirect fails and the count guards report on nothing.
+: > "$TMP/sigint-paths"
+si_untrapped="$("$BASH_BIN" "$TMP/sigint-probe.sh" untrapped 2>&1)"
+lacks "the probe really was interrupted (untrapped run)" "$si_untrapped" "NOT-INTERRUPTED"
+leaked=0; leak_names=""
+while IFS= read -r si_p; do
+  [ -n "$si_p" ] || continue
+  if [ -e "$si_p" ]; then leaked=$((leaked + 1)); leak_names="$leak_names ${si_p##*/}"; rm -f "$si_p"; fi
+done < "$TMP/sigint-paths"
+[ "$leaked" -eq 2 ] && pass "POSITIVE CONTROL: with no trap the signal leaks both temp files ($leak_names)" \
+  || fail "POSITIVE CONTROL FAILED: an untrapped signal leaked $leaked of 2 temp files — the trapped run below would prove nothing"
+# Informational, and it names which signal the harness could actually deliver —
+# a reader of a green run should not have to guess which half was exercised.
+case "$si_untrapped" in
+  *SIGINT-IGNORED-USING-SIGTERM*) pass "the interrupt was delivered as SIGTERM (SIGINT is SIG_IGN in this runner)" ;;
+  *) pass "the interrupt was delivered as SIGINT" ;;
+esac
+
+: > "$TMP/sigint-paths"
+si_trapped="$("$BASH_BIN" "$TMP/sigint-probe.sh" trapped 2>&1)"
+lacks "the probe really was interrupted (trapped run)" "$si_trapped" "NOT-INTERRUPTED"
+survivors=0; survivor_names=""
+while IFS= read -r si_p; do
+  [ -n "$si_p" ] || continue
+  if [ -e "$si_p" ]; then survivors=$((survivors + 1)); survivor_names="$survivor_names ${si_p##*/}"; rm -f "$si_p"; fi
+done < "$TMP/sigint-paths"
+[ "$survivors" -eq 0 ] && pass "an interrupt mid-breakdown leaves NO temp file behind in /tmp" \
+  || fail "an interrupt mid-breakdown leaked $survivors temp file(s) into /tmp:$survivor_names"
+
+# 🔴 AND EMPTY SLOTS MUST BE HARMLESS: `_cleanup_temps` runs on EVERY exit path,
+# including one taken before a single mktemp. MEASURED: `rm -f ""` is rc 0 and
+# silent, which is why the function needs no per-slot test — but a future
+# rewrite that added one and got it wrong would end the run on the trap.
+keepf="$TMP/not-a-scan-temp"; : > "$keepf"
+DENIED_LOG= ; DU_ERR= ; ONROOT_LIST= ; FOREIGN_LIST= ; SCAN_ERRF= ; SCAN_DUERR=
+cleanup_empty_out="$(_cleanup_temps 2>&1)"; cleanup_empty_rc=$?
+eq "_cleanup_temps with every slot empty is silent" "$cleanup_empty_out" ""
+[ "$cleanup_empty_rc" -eq 0 ] && pass "_cleanup_temps with every slot empty is rc 0" \
+  || fail "_cleanup_temps exited $cleanup_empty_rc with nothing to remove — the EXIT trap would rewrite the run's status"
+[ -f "$keepf" ] && pass "POSITIVE CONTROL: _cleanup_temps removes only what the run RECORDED" \
+  || fail "_cleanup_temps removed a file it was never given — it is an rm, not a cleanup"
 
 # --------------------------------------------------------------------------- #
 echo "== 4c. the refusal branches must be REACHABLE under the real set -e =="
@@ -1000,8 +1183,12 @@ the /tmp inode walk passes the name as an ARGUMENT@xargs -0 -r -n1 sh -c 'printf
 top-level enumeration is NUL-safe find|xargs, and KEEPS find's stderr@find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '%D\t%p\0' 2>"$errf"@the glob form dies E2BIG and set -euo pipefail takes the whole run with it; and %D forces a stat per entry, so 2>/dev/null here erases an unstattable entry from every list at once
 /home candidates are compared by DEVICE, because du -x cannot do it@d=$(_dev_of "$p") || continue@du -x only stops du crossing AWAY from its start; started ON a foreign mount it walks all of it
 /tmp candidates are compared by DEVICE too (defect 7, section 6d)@| { _on_device "$dev" || true; }@-xdev still LISTS a mountpoint at depth 1, so it reaches du as a starting point — the one case du -x cannot handle
-du keeps -x AND its || true in the /tmp size breakdown@xargs -0 -r du -sh -x 2>/dev/null || true@INVARIANT PIN, not a regression guard, for the -x half: a second filesystem needs root, so -x cannot be checked behaviourally here and a mutant dropping it SURVIVED. The `|| true` half IS behaviourally covered, by route (b) in section 4b — this literal pins both, so read it as two claims.
-du keeps -x AND its || true in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true@same pair of claims for section 6c's call site
+du keeps -x AND its || true in the /tmp size breakdown@xargs -0 -r du -sh -x 2>>"$SCAN_DUERR" || true@INVARIANT PIN, not a regression guard, for the -x half: a second filesystem needs root, so -x cannot be checked behaviourally here and a mutant dropping it SURVIVED. The `|| true` half IS behaviourally covered, by route (b) in section 4b — this literal pins both, so read it as two claims. The redirection is part of the literal on purpose: it was `2>/dev/null` until round 3, and a du that cannot read a path is then an under-count with no marker (section 4b-iii).
+du keeps -x AND its || true in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>>"$DU_ERR" || true@same three claims for section 6c's call site; 6c is root-only, so its du-stderr capture is an INVARIANT PIN with no behavioural half
+section 5's PVC listing keeps du's stderr too@xargs -0 -r du -sh --exclude=/mnt 2>>"$DU_ERR" || true@root-only INVARIANT PIN: the third du site, discarding its stderr the way the other two did until round 3
+the du blind spot is REPORTED, not merely captured@_report_unreadable@capturing a stream nothing reads is worse than discarding it — it looks like coverage. Behaviourally covered for size_breakdown in section 4b-iii; this pins that the two root-only sites call it as well.
+every temp file this script opens carries an identifying name@mktemp "/tmp/disk-accounting-$1.XXXXXX"@a bare `mktemp` writes /tmp/tmp.XXXXXXXXXX — an unattributable file, in the directory this script exists to diagnose
+the EXIT trap names a FUNCTION, not a fixed list of files@trap _cleanup_temps EXIT@a trap naming a fixed LIST is an enumeration by eye: the three breakdown temp files were never in either version of it. This row pins the NAME only — the ORDER is a separate guard below, because a description wider than its check is how six guards in one session read as coverage while providing none.
 section 5's du TOTAL is guarded, not bare@|| echo "COULD NOT MEASURE: du failed under /var/lib/rancher/k3s/storage@it printed an under-counted total, exited 1 with its message already at /dev/null, and set -e then killed sections 6..8. Root-only, so this is an INVARIANT PIN; the failure itself is measured in section 4b route (b).
 section 1's dumpe2fs pipeline is guarded@|| echo "COULD NOT MEASURE: dumpe2fs read no ext4 superblock fields@$DEV is a GUESS and grep exits 1 on no match, so a wrong device killed the whole report at section 1. Root-only: INVARIANT PIN.
 the root device reading cannot kill the run@ROOT_DEV=$(_dev_of /) || ROOT_DEV=@a bare VAR=$(...) is a CHECKED command under set -e; and an EMPTY root device makes split_by_device call every /home directory foreign
@@ -1011,6 +1198,20 @@ the seam reads no variable at all@if (return 0 2>/dev/null); then@`return` canno
 section 6d reports what its device filter EXCLUDED@foreign_entries /tmp@dropping a foreign mount silently is the floor-presented-as-a-total failure this file exists to prevent
 the device id is validated as digits before it reaches sed@_dev_is_valid "$dev"@the value is interpolated into a sed script; a / or a * would change the expression rather than fail
 REQUIRED
+
+# 🔴 ORDER, NOT JUST PRESENCE — the other half of the row above. A trap that
+# names the right function but goes up AFTER the first `mktemp` does not cover
+# that file on the exit path the `mktemp` line itself can take, and no
+# fixed-string pin can see the difference. Line numbers are read from the
+# comment-stripped copy, which is fine: only their ORDER is asserted.
+trap_line="$(grep -n 'trap _cleanup_temps EXIT' "$CODE_FILE" | head_n 1 | cut -d: -f1)"
+denied_line="$(grep -n 'DENIED_LOG=\$(mktemp' "$CODE_FILE" | head_n 1 | cut -d: -f1)"
+case "${trap_line:-x}${denied_line:-x}" in
+  *[!0-9]*) fail "the EXIT trap / first mktemp ordering cannot be read (trap=[${trap_line:-}] mktemp=[${denied_line:-}]) — one of them is gone" ;;
+  *) [ "$trap_line" -lt "$denied_line" ] \
+       && pass "the EXIT trap is installed BEFORE the run's first mktemp (line $trap_line < $denied_line)" \
+       || fail "the EXIT trap is installed at line $trap_line, AFTER the first mktemp at $denied_line — that file is uncovered on the exit path its own creation can take" ;;
+esac
 
 # --------------------------------------------------------------------------- #
 echo "== 7b. THE set -e SWEEP — an unguarded statement is a truncated report =="
@@ -1072,6 +1273,69 @@ sweep_n="$(printf '%s\n' "$sweep_hits" | grep -c . || true)"
   || fail "the set -e sweep found $sweep_n unguarded statement-level commands, expected the 1 pinned below — a new one truncates the report with no message: [$sweep_hits]"
 has "the one unguarded statement is section 2's process-substitution find" \
     "$sweep_hits" 'find "$d" -xdev -printf'
+
+# 🔴 A SECOND LEDGER, OVER WHAT THE SWEEP ABOVE STRUCTURALLY CANNOT SEE — and it
+# exists because the CLAIM and the SCAN disagreed. The script's sweep comment
+# read "Everything that scan reports is guarded above EXCEPT these" and then
+# listed the two `out=$(… | sort …)` captures, which a reader takes for the
+# complete inventory of deliberate `set -e` exposure. It is not: the sweep keys
+# on a line's FIRST WORD and drops any line containing `||`, so a pipeline
+# headed by `for`/`done`/`printf` is invisible to it, and so is one whose EARLY
+# stages are guarded while its LAST stage is not. THREE statement-level
+# pipelines ending in an unguarded `sort` were therefore never in either the
+# scan or the list.
+#
+# `sort` is deliberately never guarded — the whole point of `head_n` is that
+# `sort` never takes SIGPIPE, and MEASURED, a `|| true` on it breaks both
+# `sigpipe-head-closes-the-pipe` rows. So this ledger does not demand a guard.
+# It pins the NUMBER, failing when the set GROWS *or* SHRINKS, so the comment
+# and the code cannot drift apart again silently.
+#
+# The discriminator is positional and needs no guess: take the text AFTER the
+# LAST `sort` on the joined line, and treat the site as guarded only if a `||`
+# appears there. Section 6d's entry-name families is the one line where it does
+# (`{ … | sort | uniq -c | sort -rn | head_n 20; } || true`).
+sort_sites() { # $1 = file -> joined lines whose LAST sort stage carries no ||
+  local l
+  grep -v '^[[:space:]]*#' "$1" \
+    | sed -e ':a' -e '/\\$/N' -e 's/\\\n/ /' -e 'ta' \
+    | grep -E '\| *sort[[:space:]]' \
+    | while IFS= read -r l; do
+        case "${l##*sort}" in *'||'*) : ;; *) printf '%s\n' "$l" ;; esac
+      done
+}
+
+# 🔴 THE CANARY EXERCISES BOTH BRANCHES, so one file is the positive control AND
+# the negative one: two unguarded sort stages (a statement-level pipeline the
+# first-word sweep would miss, and a multi-line `out=$(…)` capture), one guarded
+# group that must be EXCLUDED, one sort-free line, one commented sort.
+SORT_CANARY="$TMP/sort-canary.txt"
+{
+  printf '%s\n' 'done | sort -rn | head_n 5'
+  printf '%s\n' 'out=$(find /b \'
+  printf '%s\n' '  | sort -rh | head_n 15)'
+  printf '%s\n' '{ ls /c | sort -rn | head_n 5; } || true'
+  printf '%s\n' 'ls /d | wc -l'
+  printf '%s\n' '# ls /e | sort -rn'
+} > "$SORT_CANARY"
+sort_canary_hits="$(sort_sites "$SORT_CANARY" || true)"
+sort_canary_n="$(printf '%s\n' "$sort_canary_hits" | grep -c . || true)"
+[ "$sort_canary_n" -eq 2 ] && pass "POSITIVE CONTROL: the sort ledger finds both unguarded canary sort stages (2)" \
+  || fail "POSITIVE CONTROL FAILED: the sort ledger found $sort_canary_n unguarded sort stages in a canary holding exactly 2 — its count over the real script would mean nothing"
+lacks "the sort ledger EXCLUDES a sort inside a { … } || true group" "$sort_canary_hits" "/c"
+lacks "the sort ledger does NOT flag a commented sort" "$sort_canary_hits" "/e"
+
+sort_hits="$(sort_sites "$SCRIPT" || true)"
+sort_n="$(printf '%s\n' "$sort_hits" | grep -c . || true)"
+[ "$sort_n" -eq 5 ] && pass "exactly five unguarded sort stages, as the script's sweep comment now says" \
+  || fail "the sort ledger found $sort_n unguarded sort stages, expected the 5 the script's sweep comment enumerates — a new one is an exposure nobody wrote down: [$sort_hits]"
+# Named individually, because a bare 5 could be any five. The three below are
+# precisely the ones the first-word sweep cannot reach.
+has "the sort ledger names section 5's PVC listing" "$sort_hits" 'du -sh --exclude=/mnt'
+has "the sort ledger names section 5's inodes-per-PVC loop" "$sort_hits" 'done | sort -rn | head_n 15'
+has "the sort ledger names section 6c's /home listing" "$sort_hits" '< "$ONROOT_LIST"'
+has "the sort ledger names the size-breakdown capture" "$sort_hits" 'du -sh -x 2>>"$SCAN_DUERR"'
+has "the sort ledger names the inode-breakdown capture" "$sort_hits" '| sort -rn | head_n 15)'
 
 # --------------------------------------------------------------------------- #
 # 🔴 DO NOT print `RESULT: PASS (exit=0)` here — that grammar is RESERVED to

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -225,9 +225,14 @@ lacks "inode_breakdown does not execute the planted name" "$inj_out" "$EXPANSION
 has "the planted directory is still listed, byte-for-byte" "$inj_out" "$INJ/$EVIL"
 has "the benign directory's inodes are counted" "$inj_out" "$INJ/benign"
 
-# The size half of section 6d walks the same attacker-writable directory.
+# The size half of section 6d walks the same attacker-writable directory. Its
+# 🔴 INVARIANT GUARD, labelled as one and NOT counted as regression coverage:
+# `du` never starts a shell, so no mutation of `size_breakdown` short of adding
+# `sh -c` could make this go red. It pins that the pipeline stays shell-free —
+# real, but it is not a test of a bug that existed. The line below it IS a
+# regression guard: a `du` fed a mangled name reports the wrong directory.
 size_out="$(size_breakdown "$INJ" 2>&1)"
-lacks "size_breakdown does not execute the planted name" "$size_out" "$EXPANSION"
+lacks "INVARIANT: size_breakdown starts no shell for the planted name" "$size_out" "$EXPANSION"
 has "size_breakdown lists the planted directory verbatim" "$size_out" "$INJ/$EVIL"
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Regression guards for scripts/diagnose-disk-accounting.sh.
 #
-# WHY THIS EXISTS. That script is 282 lines of ROOT-PRIVILEGED bash with no test
-# file, in a repo with no shellcheck gate. Every defect pinned below was real,
+# WHY THIS EXISTS. That script is ROOT-PRIVILEGED bash that had no test file, in
+# a repo with no shellcheck gate. (It was 282 lines when this suite was written;
+# no line count is quoted here any more, because the last one went stale in one
+# round and was still being cited from run-tests.sh two rounds later.)
+# Every defect pinned below was real,
 # shipped, and invisible to the merge gate — including a root COMMAND INJECTION
 # reachable by any local process (via a planted /tmp directory name) and an
 # E2BIG abort that silently truncated the report it exists to produce. The two
@@ -17,15 +20,22 @@
 # cover it in a gate that runs as an ordinary user is to drive the pure
 # transforms and the traversal helpers directly. `diagnose-disk-accounting.sh`
 # was refactored to make them callable: sourcing it defines the helpers and runs
-# nothing (BASH_SOURCE[0] != $0). The header of that file marks the seam.
+# nothing. The header of that file marks the seam. (This sentence used to quote
+# the seam as `BASH_SOURCE[0] != $0`. That expression was MEASURED reachable
+# from the environment and removed a round ago; the scanner in section 7 bans it
+# — but the scanner only reads the SCRIPT, so this copy of the stale claim, and
+# an identical one in run-tests.sh, both walked straight past it.)
 #
 # 🔴 WHAT THIS SUITE CANNOT COVER, stated once so nobody reads it as more than
 # it is: sections 1-3, 5, 6, 6b and 8 do privileged whole-filesystem
 # measurement (`dumpe2fs -h /dev/nvme0n1p2`, `find / -xdev` over root-only
 # trees, `findmnt /mnt/rootcheck`). Their numbers cannot be produced without
-# root on a real host, so their arithmetic is UNGUARDED here. What is guarded is
-# every defect the file's own comments record, all of which live in the
-# transforms below.
+# root on a real host, so their arithmetic is UNGUARDED here. Their `set -e`
+# EXPOSURE is a different question and IS covered, structurally: section 7b
+# sweeps the whole file for a statement whose failure would truncate the report,
+# which is how section 5's bare `du -sh` total was found. What is guarded
+# behaviourally is every defect the file's own comments record, all of which
+# live in the transforms below.
 set -uo pipefail
 
 # 🔴 `CDPATH=` and `>/dev/null` on the `cd`: with CDPATH set in the environment
@@ -57,6 +67,32 @@ BASH_BIN="${BASH:-}"
 [ -x "$BASH_BIN" ] || { echo "  FAIL: cannot resolve the running bash"; exit 1; }
 
 [ -f "$SCRIPT" ] || { echo "  FAIL: $SCRIPT does not exist"; exit 1; }
+
+# 🔴 ABORT AS ROOT — do not `fail` and carry on. This check used to live inside
+# section 1 and only guarded the sections nested under it; §2c, which EXECUTES
+# the real script under `bash -x`, sat at top level and ran regardless. Under
+# root that is not a failed assertion, it is the whole privileged report:
+# `dumpe2fs`, `find / -xdev` over every top-level directory, `du -sh -x
+# /var/lib/docker`, and `size_breakdown`/`inode_breakdown` over /tmp — with the
+# xtrace accumulating in a shell variable.
+#
+# MEASURED 2026-09-07 under `unshare -r` (uid 0 in a user namespace): the base
+# suite printed its `FAIL: … AS ROOT` line and RAN ON, through §2c and all the
+# way to section 7, rc 1 — 24.95 s here versus 22 s unprivileged, because this
+# host's / is still EACCES to a userns root and its /tmp is small. What is
+# therefore MEASURED is the mechanism, not a duration: the guard did not stop
+# the run and the report did execute. The cost is whatever the host's /tmp
+# costs, and on the host this script targets that was 78 million entries. At
+# HEAD the same command takes 0.01 s.
+#
+# Every fixture below also DEPENDS on not being root (the 0400 and mode-000
+# directories are readable by uid 0), so a root run makes the guards vacuous
+# even where it does terminate.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  FAIL: this suite is running AS ROOT. Nothing here needs root and several"
+  echo "        fixtures are inert under it. Re-run unprivileged."
+  exit 1
+fi
 
 # assert stdout (arg 2) equals expected (arg 3), byte for byte
 eq() {
@@ -105,55 +141,56 @@ done
 echo "== 1. ROOT REFUSAL: an unprivileged EXECUTION must refuse, rc 2 =="
 # The whole premise of the script — an unprivileged run silently skips the trees
 # it exists to measure — so a soft-fail here is worse than no script.
-if [ "$(id -u)" -eq 0 ]; then
-  fail "this suite is running AS ROOT; the refusal check below cannot fire. Run it unprivileged."
-else
-  refuse_err="$("$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; refuse_rc=$?
-  [ "$refuse_rc" -eq 2 ] && pass "non-root execution exits 2" \
-    || fail "non-root execution exited $refuse_rc, expected 2"
-  has "refusal names root on stderr" "$refuse_err" "must run as root"
+#
+# 🔴 NO `if [ "$(id -u)" -eq 0 ]` WRAPPER HERE ANY MORE. It used to open one
+# that closed at the end of §1b, which read as "the suite is root-guarded" while
+# guarding only two sections; the root abort now sits at the top of the file, so
+# nothing below it can run privileged. See the comment there.
+refuse_err="$("$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; refuse_rc=$?
+[ "$refuse_rc" -eq 2 ] && pass "non-root execution exits 2" \
+  || fail "non-root execution exited $refuse_rc, expected 2"
+has "refusal names root on stderr" "$refuse_err" "must run as root"
 
-  # ------------------------------------------------------------------------- #
-  echo "== 1b. THE SEAM IS NOT REACHABLE FROM THE ENVIRONMENT =="
-  # 🔴 THE DEFECT: the seam used to be `[ "${BASH_SOURCE[0]}" != "$0" ]`, and the
-  # script's own header asserted that "the guard is not reachable from the
-  # environment". MEASURED FALSE. bash imports BASH_SOURCE from the environment
-  # as an ordinary scalar, so a stray `BASH_SOURCE` in the env made an EXECUTED
-  # run take the sourced branch and `return` at top level — rc 2, no report.
-  # rc 2 is also this script's "you forgot sudo" status, so the two causes were
-  # indistinguishable to the operator. `bash < script` was the mirror image:
-  # BASH_SOURCE unset under `set -u`, dead on the guard's own line, rc 1.
-  #
-  # 🔴 EACH CASE ASSERTS THE STATUS **AND** THE MESSAGE. rc 2 alone cannot tell
-  # "refused because not root" from "returned at top level", which is the whole
-  # reason this defect was invisible — so the refusal text is what discriminates.
-  env_err="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; env_rc=$?
-  [ "$env_rc" -eq 2 ] && pass "a poisoned BASH_SOURCE still reaches the root refusal (rc 2)" \
-    || fail "env BASH_SOURCE=... execution exited $env_rc, expected 2"
-  has "the poisoned run refuses for the RIGHT reason" "$env_err" "must run as root"
-  lacks "the poisoned run does not 'return' at top level" "$env_err" "can only 'return'"
+# ------------------------------------------------------------------------- #
+echo "== 1b. THE SEAM IS NOT REACHABLE FROM THE ENVIRONMENT =="
+# 🔴 THE DEFECT: the seam used to be `[ "${BASH_SOURCE[0]}" != "$0" ]`, and the
+# script's own header asserted that "the guard is not reachable from the
+# environment". MEASURED FALSE. bash imports BASH_SOURCE from the environment
+# as an ordinary scalar, so a stray `BASH_SOURCE` in the env made an EXECUTED
+# run take the sourced branch and `return` at top level — rc 2, no report.
+# rc 2 is also this script's "you forgot sudo" status, so the two causes were
+# indistinguishable to the operator. `bash < script` was the mirror image:
+# BASH_SOURCE unset under `set -u`, dead on the guard's own line, rc 1.
+#
+# 🔴 EACH CASE ASSERTS THE STATUS **AND** THE MESSAGE. rc 2 alone cannot tell
+# "refused because not root" from "returned at top level", which is the whole
+# reason this defect was invisible — so the refusal text is what discriminates.
+env_err="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; env_rc=$?
+[ "$env_rc" -eq 2 ] && pass "a poisoned BASH_SOURCE still reaches the root refusal (rc 2)" \
+  || fail "env BASH_SOURCE=... execution exited $env_rc, expected 2"
+has "the poisoned run refuses for the RIGHT reason" "$env_err" "must run as root"
+lacks "the poisoned run does not 'return' at top level" "$env_err" "can only 'return'"
 
-  # `bash < FILE` and `bash -s < FILE`: BASH_SOURCE is UNSET, so the old guard
-  # died on `set -u` before printing anything. Base ran fine this way, which
-  # makes this a genuine (narrow) regression the old form introduced.
-  stdin_err="$("$BASH_BIN" < "$SCRIPT" 2>&1 >/dev/null)"; stdin_rc=$?
-  [ "$stdin_rc" -eq 2 ] && pass "bash < script reaches the root refusal (rc 2)" \
-    || fail "bash < script exited $stdin_rc, expected 2"
-  has "the stdin run refuses for the RIGHT reason" "$stdin_err" "must run as root"
-  lacks "the stdin run does not die on an unbound BASH_SOURCE" "$stdin_err" "unbound variable"
+# `bash < FILE` and `bash -s < FILE`: BASH_SOURCE is UNSET, so the old guard
+# died on `set -u` before printing anything. Base ran fine this way, which
+# makes this a genuine (narrow) regression the old form introduced.
+stdin_err="$("$BASH_BIN" < "$SCRIPT" 2>&1 >/dev/null)"; stdin_rc=$?
+[ "$stdin_rc" -eq 2 ] && pass "bash < script reaches the root refusal (rc 2)" \
+  || fail "bash < script exited $stdin_rc, expected 2"
+has "the stdin run refuses for the RIGHT reason" "$stdin_err" "must run as root"
+lacks "the stdin run does not die on an unbound BASH_SOURCE" "$stdin_err" "unbound variable"
 
-  dash_s_err="$("$BASH_BIN" -s < "$SCRIPT" 2>&1 >/dev/null)"; dash_s_rc=$?
-  [ "$dash_s_rc" -eq 2 ] && pass "bash -s < script reaches the root refusal (rc 2)" \
-    || fail "bash -s < script exited $dash_s_rc, expected 2"
+dash_s_err="$("$BASH_BIN" -s < "$SCRIPT" 2>&1 >/dev/null)"; dash_s_rc=$?
+[ "$dash_s_rc" -eq 2 ] && pass "bash -s < script reaches the root refusal (rc 2)" \
+  || fail "bash -s < script exited $dash_s_rc, expected 2"
 
-  # 🔴 THE OTHER HALF, or the fix above would be satisfied by a seam that never
-  # takes the sourced branch at all — which would silently make every helper
-  # assertion in this file a claim about a script that had already run the whole
-  # report. A poisoned BASH_SOURCE must NOT stop a genuine `source` working.
-  poisoned_src="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" -c "source '$SCRIPT' 2>&1; echo STILL-SOURCES")"
-  eq "a genuine source still no-ops, poisoned environment and all" \
-     "$poisoned_src" "STILL-SOURCES"
-fi
+# 🔴 THE OTHER HALF, or the fix above would be satisfied by a seam that never
+# takes the sourced branch at all — which would silently make every helper
+# assertion in this file a claim about a script that had already run the whole
+# report. A poisoned BASH_SOURCE must NOT stop a genuine `source` working.
+poisoned_src="$(env 'BASH_SOURCE=(nope)' "$BASH_BIN" -c "source '$SCRIPT' 2>&1; echo STILL-SOURCES")"
+eq "a genuine source still no-ops, poisoned environment and all" \
+   "$poisoned_src" "STILL-SOURCES"
 
 # --------------------------------------------------------------------------- #
 echo "== 2. lsof column resolution — resolved from the HEADER, never an index =="
@@ -471,7 +508,152 @@ has "route (b): the report continues past a failing du in inode_breakdown" "$fe_
 # the tolerance would have turned one truncated scan into another.
 lock_out="$(size_breakdown "$LOCKDIR" 2>/dev/null)"
 has "route (b): the readable sibling still produces a row" "$lock_out" "$LOCKDIR/open"
+
+# --------------------------------------------------------------------------- #
+echo "== 4b-ii. ROUTE (a): an UNSTATTABLE entry must be COUNTED, not erased =="
+# 🔴 THE DEFECT, and it was introduced by the round-1 fix for route (a). `-print0`
+# still printed the NAME of an entry whose stat failed; `-printf '%D\t%p\0'`
+# forces a stat to format the record and emits NOTHING when it fails. MEASURED
+# 2026-09-07 over this very fixture, both `find` builds on this host, both rc 1:
+# `-print0` 116 B (GNU findutils 4.10.0, the bash PATH) / 119 B (4.11.0, the nix
+# dev shell); `-printf '%D\t%p\0'` **0 B** in both. So the entry left the size
+# breakdown, the inode breakdown AND the foreign-entry listing at once — and
+# `foreign_entries` then printed "none — every depth-1 entry is on the same
+# filesystem as …", an affirmative claim of absence produced by a blind scan.
+#
+# 🔴 WHAT THIS CANNOT PIN, stated so it is not read as more than it is: route
+# (b)'s "the readable sibling still produces a row" has no analogue here,
+# because a fixture with SOME depth-1 entries stattable and some not is not
+# constructible without root — `find` needs `x` on the parent to stat any entry,
+# so mode 0400 makes ALL of them unstattable at once. What is pinned instead is
+# the blind-spot report itself: the count, and the refusal to say "none".
+ERR_SZ="$(size_breakdown "$ERRDIR" 2>/dev/null)"
+ERR_INO="$(inode_breakdown "$ERRDIR" 2>/dev/null)"
+ERR_FGN="$(foreign_entries "$ERRDIR" 2>/dev/null)"
+# The fixture holds three entries (sub-a, sub-b, f) and find can stat none.
+has "route (a): size_breakdown COUNTS the entries it could not stat" \
+    "$ERR_SZ" "!! UNSTATTABLE: 3 depth-1 entries of $ERRDIR reached NO list above."
+has "route (a): size_breakdown calls its own figures a FLOOR" "$ERR_SZ" "is a FLOOR, not a total"
+# 🔴 NO EXACT COUNT FOR THE INODE HALF, on purpose. Its enumeration adds
+# `-type d`, and MEASURED here GNU find answers that test from readdir's
+# `d_type` where the filesystem supplies one — so the plain file `f` is filtered
+# out BEFORE a stat is attempted and only two errors appear, while on a
+# filesystem without `d_type` all three would. Pinning 3 (or 2) would make this
+# guard a claim about $TMPDIR's filesystem. The count is pinned exactly on the
+# two enumerations that have no type filter, above and below.
+has "route (a): inode_breakdown COUNTS the entries it could not stat" \
+    "$ERR_INO" "depth-1 entries of $ERRDIR reached NO list above."
+ino_blind="$(printf '%s\n' "$ERR_INO" | sed -n 's/^  !! UNSTATTABLE: \([0-9][0-9]*\) .*/\1/p')"
+case "${ino_blind:-x}" in
+  ''|*[!0-9]*) fail "route (a): inode_breakdown printed no parsable UNSTATTABLE count" ;;
+  *) [ "$ino_blind" -gt 0 ] && pass "route (a): inode_breakdown's unstattable count is a positive integer ($ino_blind)" \
+       || fail "route (a): inode_breakdown reported an unstattable count of $ino_blind over a fixture find cannot stat" ;;
+esac
+has "route (a): foreign_entries COUNTS the entries it could not stat" \
+    "$ERR_FGN" "!! UNSTATTABLE: 3 depth-1 entries of $ERRDIR reached NO list above."
+# 🔴 THE HEADLINE: the affirmative "none" must NOT be printed over a blind scan.
+lacks "route (a): foreign_entries does NOT claim every entry is on the same filesystem" \
+      "$ERR_FGN" "none — every depth-1 entry is on the same filesystem"
+has "route (a): foreign_entries says only that none is VISIBLE" \
+    "$ERR_FGN" "none VISIBLE"
+# The denial lines themselves are surfaced, not just tallied.
+has "route (a): the blind-spot report quotes find's own error" "$ERR_SZ" "Permission denied"
+
+# 🔴 POSITIVE CONTROL for the whole block: on a fixture find CAN stat, none of
+# the above fires — otherwise "UNSTATTABLE is reported" would also be satisfied
+# by a function that printed it unconditionally.
+OK_DIR="$TMP/stattable"
+mkdir -p "$OK_DIR/a" "$OK_DIR/b"; touch "$OK_DIR/a/f"
+ok_sz="$(size_breakdown "$OK_DIR" 2>/dev/null)"
+ok_fgn="$(foreign_entries "$OK_DIR" 2>/dev/null)"
+lacks "POSITIVE CONTROL: a stattable fixture reports NO blind spot" "$ok_sz" "UNSTATTABLE"
+has "POSITIVE CONTROL: a stattable fixture still lists its entries" "$ok_sz" "$OK_DIR/a"
+has "POSITIVE CONTROL: a stattable fixture DOES print the affirmative 'none'" \
+    "$ok_fgn" "none — every depth-1 entry is on the same filesystem as $OK_DIR"
 chmod 700 "$ERRDIR"; chmod 700 "$LOCKDIR/locked"
+
+# --------------------------------------------------------------------------- #
+echo "== 4c. the refusal branches must be REACHABLE under the real set -e =="
+# 🔴 THE DEFECT: `dev=$(_dev_of "$base")` is a command substitution in an
+# assignment, i.e. a CHECKED command under `set -e`. When `stat` fails the run
+# died ON THAT LINE and the `COULD NOT MEASURE: no device id` branch below it —
+# added in round 1 precisely so a non-measurement could not read as an empty
+# directory — never printed. Exactly the `OUT=$(lsof …)` defect this file
+# already records, one round later and three functions over.
+#
+# 🔴 AND THE SUITE COULD NOT SEE IT. Sourcing this script turns `set -e` on, so
+# the suite turns it back OFF immediately after sourcing, to run at all; every §5c assertion
+# about the refusal branch therefore ran WITHOUT the option that made the branch
+# unreachable. Same shape as §2b: only a probe that re-enables `set -euo
+# pipefail` for real can observe it.
+cat > "$TMP/nodev-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+size_breakdown "$TMP/no-such-base"
+echo "PAST-SIZE-REFUSAL"
+inode_breakdown "$TMP/no-such-base"
+echo "PAST-INODE-REFUSAL"
+foreign_entries "$TMP/no-such-base"
+echo "PAST-FOREIGN-REFUSAL"
+PROBE
+nd_out="$("$BASH_BIN" "$TMP/nodev-probe.sh" 2>&1)"; nd_rc=$?
+[ "$nd_rc" -eq 0 ] && pass "an unreadable base does not abort the run under set -e (rc 0)" \
+  || fail "an unreadable base killed the run under set -e, rc $nd_rc — the refusal branch is unreachable"
+has "the size refusal is REACHABLE under set -e" "$nd_out" "COULD NOT MEASURE: no device id for $TMP/no-such-base — NOT an empty directory (size breakdown)"
+has "the inode refusal is REACHABLE under set -e" "$nd_out" "COULD NOT MEASURE: no device id for $TMP/no-such-base — NOT an empty directory (inode breakdown)"
+has "the foreign refusal is REACHABLE under set -e" "$nd_out" "NOT an absence of foreign mounts"
+has "the report continues past the size refusal" "$nd_out" "PAST-SIZE-REFUSAL"
+has "the report continues past the inode refusal" "$nd_out" "PAST-INODE-REFUSAL"
+has "the report continues past the foreign refusal" "$nd_out" "PAST-FOREIGN-REFUSAL"
+# 🔴 THE TWO REFUSALS MUST BE TELLABLE APART, and the two `has` rows above are
+# what pins it: before this round both printed the byte-identical string
+# `COULD NOT MEASURE: no device id for <base> — NOT an empty directory`, so a
+# reader of a real report could not tell which section had refused. Each row
+# now names its own section, and each `has` fails if that suffix is missing.
+# (An earlier draft added a third `lacks` here for a DUPLICATED size line. It
+# was vacuous — the probe prints a marker between the two refusals, so the two
+# lines are never adjacent and the needle could not match either way.)
+
+# --------------------------------------------------------------------------- #
+echo "== 4d. a foreign entry whose NAME contains a newline is ONE row =="
+# 🔴 THE DEFECT: `foreign_entries` ended `| tr '\0' '\n' | head_n 15`, which is
+# the F7 defect `split_by_device` was fixed for IN THE SAME COMMIT. /tmp is mode
+# 1777, so any local process can plant a directory whose name contains a
+# newline; `tr` turns it into two report rows — the second a fragment that reads
+# as a real path — and `head_n` counts LINES, so one name eats two of fifteen
+# slots. `report_foreign_mounts` reads its list with `read -r -d ''`; this
+# function now emits one row per NUL record for the same reason.
+#
+# 🔴 THE DISCRIMINATOR IS THE INDENTATION, NOT THE LINE COUNT. Both forms print
+# three lines for this fixture — the old one indented all three (`sed 's/^/  /'`
+# over a `tr`-flattened stream), the fixed one indents one per RECORD, so the
+# fragment `beta` arrives unindented as part of its own name. A line count
+# cannot tell them apart; the count of INDENTED lines can.
+NLDEV="$TMP/nl-foreign"
+NLNAME_6D="$(printf 'alpha\nbeta')"
+FGN_DEV_6D=999000004
+mkdir -p "$NLDEV/$NLNAME_6D" "$NLDEV/plain"
+nl_fgn="$( _dev_of() { printf '%s\n' "$FGN_DEV_6D"; }; foreign_entries "$NLDEV" 2>/dev/null )"
+nl_records="$(printf '%s\n' "$nl_fgn" | grep -c '^  ')"
+[ "$nl_records" -eq 2 ] && pass "two foreign directories are TWO indented records, newline name and all" \
+  || fail "foreign_entries emitted $nl_records indented records for 2 entries — a name was split into an extra row"
+has "the whole newline name is present, indented once" "$nl_fgn" "$(printf '  %s' "$NLDEV/$NLNAME_6D")"
+has "the plain sibling is still listed" "$nl_fgn" "  $NLDEV/plain"
+
+# 🔴 THE TRUNCATION IS NEW CODE, SO IT GETS ITS OWN GUARD. `head_n 15` counted
+# LINES; the replacement counts RECORDS in the loop, which is a different
+# expression that can be off by one, stop early, or forget to say it truncated.
+# 20 entries: 15 printed, and the report must SAY there are 5 more rather than
+# silently ending at 15 — that is the same floor-as-total failure one more time.
+MANYDEV="$TMP/many-foreign"
+mkdir -p "$MANYDEV"
+for i in $(seq -w 1 20); do mkdir -p "$MANYDEV/entry-$i"; done
+many_fgn="$( _dev_of() { printf '%s\n' "$FGN_DEV_6D"; }; foreign_entries "$MANYDEV" 2>/dev/null )"
+many_rows="$(printf '%s\n' "$many_fgn" | grep -c '^  /')"
+[ "$many_rows" -eq 15 ] && pass "20 foreign entries print exactly 15 rows" \
+  || fail "20 foreign entries printed $many_rows rows, expected 15"
+has "the truncation is STATED, not silent" "$many_fgn" "... and 5 more"
+lacks "the truncated listing does not also claim 'none'" "$many_fgn" "none"
 
 # --------------------------------------------------------------------------- #
 echo "== 5. /home split by DEVICE, and the foreign list must survive the loop =="
@@ -603,15 +785,27 @@ UNREACHABLE_DEV=999000003
 
 # The redefinitions live inside the command substitutions, which are subshells,
 # so neither leaks into the rest of this file.
+#
+# 🔴 AN EMPTY LIST MUST SAY SO IN WORDS. These two used to assert the dropped
+# case produced the EMPTY STRING — which is what a section that measured nothing
+# also produces, and "an empty section is still visible" was the false claim the
+# script's own comment made about it. So the assertion is now: the excluded
+# entries are absent (the filter works) AND the section says it is empty (the
+# floor is labelled). The guard NAMES are unchanged, because the mutation
+# battery scores `tmp-size-device-filter-dropped` / `tmp-inode-…` on them.
 kept_sz="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; size_breakdown "$DEVFIX" 2>/dev/null )"
 drop_sz="$( _dev_of() { printf '%s\n' "$UNREACHABLE_DEV"; }; size_breakdown "$DEVFIX" 2>/dev/null )"
 has "size_breakdown KEEPS an entry on the base's own device" "$kept_sz" "$DEVFIX/one"
-eq  "size_breakdown DROPS every entry on a foreign device" "$drop_sz" ""
+lacks "size_breakdown DROPS every entry on a foreign device" "$drop_sz" "$DEVFIX/one"
+has "size_breakdown SAYS its list is empty rather than printing nothing" \
+    "$drop_sz" "none — no depth-1 entry of $DEVFIX is on $DEVFIX's own filesystem (NOT zero bytes)"
 
 kept_ino="$( _dev_of() { stat -c '%d' "$1" 2>/dev/null; }; inode_breakdown "$DEVFIX" 2>/dev/null )"
 drop_ino="$( _dev_of() { printf '%s\n' "$UNREACHABLE_DEV"; }; inode_breakdown "$DEVFIX" 2>/dev/null )"
 has "inode_breakdown KEEPS a directory on the base's own device" "$kept_ino" "$DEVFIX/one"
-eq  "inode_breakdown DROPS every directory on a foreign device" "$drop_ino" ""
+lacks "inode_breakdown DROPS every directory on a foreign device" "$drop_ino" "$DEVFIX/one"
+has "inode_breakdown SAYS its list is empty rather than printing nothing" \
+    "$drop_ino" "none — no depth-1 DIRECTORY of $DEVFIX is on $DEVFIX's own filesystem (NOT zero inodes)"
 
 # 🔴 AND A MISSING DEVICE READING MUST REFUSE, not print an empty section. With
 # the filter in place, "no rows" is the same output for "everything is foreign"
@@ -803,16 +997,81 @@ section 2 keeps find's stderr instead of discarding it@2>>"$DENIED_LOG"@a scan r
 lsof column is resolved by NAME from the header@if ($i == "SIZE/OFF") col=i@the index is not stable: +L1 puts it at 7, plain -n -P at 9
 an absent SIZE/OFF column REFUSES rather than reporting a zero@COULD NOT MEASURE: no SIZE/OFF column in lsof header@a zero here is the reassuring reading of a broken instrument
 the /tmp inode walk passes the name as an ARGUMENT@xargs -0 -r -n1 sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _@"$1" is an argv slot; "{}" under xargs -I is text the shell parses
-top-level enumeration is NUL-safe find|xargs, not a glob@find "$base" -xdev -mindepth 1 -maxdepth 1 -printf '%D\t%p\0'@the glob form dies E2BIG and set -euo pipefail takes the whole run with it
+top-level enumeration is NUL-safe find|xargs, and KEEPS find's stderr@find "$base" -xdev -mindepth 1 -maxdepth 1 "$@" -printf '%D\t%p\0' 2>"$errf"@the glob form dies E2BIG and set -euo pipefail takes the whole run with it; and %D forces a stat per entry, so 2>/dev/null here erases an unstattable entry from every list at once
 /home candidates are compared by DEVICE, because du -x cannot do it@d=$(_dev_of "$p") || continue@du -x only stops du crossing AWAY from its start; started ON a foreign mount it walks all of it
-/tmp candidates are compared by DEVICE too (defect 7, section 6d)@| _on_device "$dev"@-xdev still LISTS a mountpoint at depth 1, so it reaches du as a starting point — the one case du -x cannot handle
-du keeps -x in the /tmp size breakdown@xargs -0 -r du -sh -x 2>/dev/null || true@INVARIANT PIN, not a regression guard: a second filesystem needs root, so -x cannot be checked behaviourally here. A mutant dropping it SURVIVED.
-du keeps -x in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true@same invariant pin for section 6c's call site
+/tmp candidates are compared by DEVICE too (defect 7, section 6d)@| { _on_device "$dev" || true; }@-xdev still LISTS a mountpoint at depth 1, so it reaches du as a starting point — the one case du -x cannot handle
+du keeps -x AND its || true in the /tmp size breakdown@xargs -0 -r du -sh -x 2>/dev/null || true@INVARIANT PIN, not a regression guard, for the -x half: a second filesystem needs root, so -x cannot be checked behaviourally here and a mutant dropping it SURVIVED. The `|| true` half IS behaviourally covered, by route (b) in section 4b — this literal pins both, so read it as two claims.
+du keeps -x AND its || true in the /home size breakdown@xargs -0 -r du -sh -x < "$ONROOT_LIST" 2>/dev/null || true@same pair of claims for section 6c's call site
+section 5's du TOTAL is guarded, not bare@|| echo "COULD NOT MEASURE: du failed under /var/lib/rancher/k3s/storage@it printed an under-counted total, exited 1 with its message already at /dev/null, and set -e then killed sections 6..8. Root-only, so this is an INVARIANT PIN; the failure itself is measured in section 4b route (b).
+section 1's dumpe2fs pipeline is guarded@|| echo "COULD NOT MEASURE: dumpe2fs read no ext4 superblock fields@$DEV is a GUESS and grep exits 1 on no match, so a wrong device killed the whole report at section 1. Root-only: INVARIANT PIN.
+the root device reading cannot kill the run@ROOT_DEV=$(_dev_of /) || ROOT_DEV=@a bare VAR=$(...) is a CHECKED command under set -e; and an EMPTY root device makes split_by_device call every /home directory foreign
+the three /tmp helpers survive an unreadable base@dev=$(_dev_of "$base") || dev=@same checked-assignment defect: without the `||` the run died before the COULD NOT MEASURE branch it was supposed to reach (behaviourally covered in section 4c)
 truncation reads to EOF instead of closing the pipe@head_n() { awk -v n="$1" 'NR<=n'; }@awk consumes all input, so the upstream sort never takes SIGPIPE
 the seam reads no variable at all@if (return 0 2>/dev/null); then@`return` cannot be poisoned from the environment; ${BASH_SOURCE[0]} could
 section 6d reports what its device filter EXCLUDED@foreign_entries /tmp@dropping a foreign mount silently is the floor-presented-as-a-total failure this file exists to prevent
 the device id is validated as digits before it reaches sed@_dev_is_valid "$dev"@the value is interpolated into a sed script; a / or a * would change the expression rather than fail
 REQUIRED
+
+# --------------------------------------------------------------------------- #
+echo "== 7b. THE set -e SWEEP — an unguarded statement is a truncated report =="
+# 🔴 WHY A SCANNER AND NOT MORE `required` ROWS. Twice now the set of "commands
+# whose failure kills the report" was enumerated BY EYE and came up short: round
+# 1 guarded the two pipelines in section 5 and left the bare `du -sh` total two
+# lines below them, under a comment describing the treatment it did not have.
+# A `required` row pins the site you already thought of; this pins the SHAPE, so
+# the site nobody thought of is the one it catches.
+#
+# The scan: strip whole-line comments, join backslash continuations, keep every
+# line whose FIRST word is a failure-prone external, drop those containing `||`.
+# Under `set -euo pipefail` every one of those is fatal — including a pipeline
+# whose LAST stage succeeds, because `pipefail` promotes any stage's status.
+#
+# 🔴 WHAT IT DOES NOT COVER, so nobody reads it as wider than it is: it looks at
+# the first WORD only, so `VAR=$(cmd)` assignments (also checked under `set -e`)
+# are invisible to it, and so is a fatal command that is not the head of its
+# line. Those are handled by the `required` rows above and by the sweep comment
+# in the script's own executable region, which lists the categories left open on
+# purpose and why. This is a net, not a proof.
+SWEEP_EXT='(find|du|ls|dumpe2fs|findmnt|lsof|stat|xargs|grep|sed|sort|uniq|wc|tr|awk|mktemp|seq|dd|id)'
+sweep() { # $1 = file -> every unguarded statement-level external, one per line
+  grep -v '^[[:space:]]*#' "$1" \
+    | sed -e ':a' -e '/\\$/N' -e 's/\\\n/ /' -e 'ta' \
+    | grep -E "^[[:space:]]*(\{ )?$SWEEP_EXT[[:space:]]" \
+    | grep -v '||'
+}
+
+# 🔴 POSITIVE CONTROL FIRST, and built from lines shaped like the REAL defect —
+# a bare `du -sh`, and a multi-line pipeline whose `||` would have to be on a
+# continuation line. A scanner that returns "no unguarded statements" is
+# indistinguishable from one wired to nothing until it has been watched to
+# return a non-zero count.
+SWEEP_CANARY="$TMP/sweep-canary.txt"
+{
+  printf '%s\n' 'du -sh /var/lib/x 2>/dev/null'
+  printf '%s\n' '  ls -A /tmp 2>/dev/null | sed -E "s/x//" \'
+  printf '%s\n' '    | sort | uniq -c'
+  printf '%s\n' 'du -sh /guarded 2>/dev/null || echo "COULD NOT MEASURE"'
+  printf '%s\n' '# du -sh /this-is-a-comment'
+} > "$SWEEP_CANARY"
+canary_hits="$(sweep "$SWEEP_CANARY" || true)"
+canary_n="$(printf '%s\n' "$canary_hits" | grep -c . || true)"
+[ "$canary_n" -eq 2 ] && pass "POSITIVE CONTROL: the sweep finds both unguarded canary statements (2)" \
+  || fail "POSITIVE CONTROL FAILED: the sweep found $canary_n unguarded lines in a canary holding exactly 2 — its zero over the real script would mean nothing"
+lacks "the sweep does NOT flag a guarded canary line" "$canary_hits" "/guarded"
+lacks "the sweep does NOT flag a commented canary line" "$canary_hits" "/this-is-a-comment"
+
+# 🔴 A LEDGER, failing when the set GROWS *or* SHRINKS. One line in the script
+# is reported and is deliberately NOT guarded: section 2's
+# `find "$d" … | awk …` is the body of a `read … < <(…)` process substitution,
+# and MEASURED 2026-09-07 a process substitution's status is NOT checked by
+# `set -e` — which is exactly why denials in section 2 do not kill the run. If
+# that line ever moves out of the process substitution, this ledger goes red.
+sweep_hits="$(sweep "$SCRIPT" || true)"
+sweep_n="$(printf '%s\n' "$sweep_hits" | grep -c . || true)"
+[ "$sweep_n" -eq 1 ] && pass "exactly one statement-level external is unguarded, as pinned" \
+  || fail "the set -e sweep found $sweep_n unguarded statement-level commands, expected the 1 pinned below — a new one truncates the report with no message: [$sweep_hits]"
+has "the one unguarded statement is section 2's process-substitution find" \
+    "$sweep_hits" 'find "$d" -xdev -printf'
 
 # --------------------------------------------------------------------------- #
 # 🔴 DO NOT print `RESULT: PASS (exit=0)` here — that grammar is RESERVED to

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+# Regression guards for scripts/diagnose-disk-accounting.sh.
+#
+# WHY THIS EXISTS. That script is 282 lines of ROOT-PRIVILEGED bash with no test
+# file, in a repo with no shellcheck gate. Every defect pinned below was real,
+# shipped, and invisible to the merge gate — including a root COMMAND INJECTION
+# reachable by any local process (via a planted /tmp directory name) and an
+# E2BIG abort that silently truncated the report it exists to produce. The two
+# facts compose: nothing here was ever executed by a gate, so nothing here was
+# ever wrong in a way anybody could see.
+#
+#   run: bash scripts/tests/test_diagnose_disk_accounting.sh
+#   (registered in run-tests.sh SHELL_TESTS — an unrun shell test is not a gate)
+#
+# 🔴 NOTHING HERE NEEDS ROOT, and that is a design constraint, not a convenience.
+# The script refuses to run as non-root (rc 2) by design, so the only way to
+# cover it in a gate that runs as an ordinary user is to drive the pure
+# transforms and the traversal helpers directly. `diagnose-disk-accounting.sh`
+# was refactored to make them callable: sourcing it defines the helpers and runs
+# nothing (BASH_SOURCE[0] != $0). The header of that file marks the seam.
+#
+# 🔴 WHAT THIS SUITE CANNOT COVER, stated once so nobody reads it as more than
+# it is: sections 1-3, 5, 6, 6b and 8 do privileged whole-filesystem
+# measurement (`dumpe2fs -h /dev/nvme0n1p2`, `find / -xdev` over root-only
+# trees, `findmnt /mnt/rootcheck`). Their numbers cannot be produced without
+# root on a real host, so their arithmetic is UNGUARDED here. What is guarded is
+# every defect the file's own comments record, all of which live in the
+# transforms below.
+set -uo pipefail
+
+# 🔴 `CDPATH=` and `>/dev/null` on the `cd`: with CDPATH set in the environment
+# (it is, on this host) `cd` ECHOES its target, so a bare `$(cd … && pwd)`
+# captures two lines. Same reasoning as test_cleanup_disk_gate.sh, which was red
+# on its first run for exactly this.
+ROOT="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
+SCRIPT="$ROOT/scripts/diagnose-disk-accounting.sh"
+FAILED=0
+
+fail() { echo "  FAIL: $*"; FAILED=1; }
+pass() { echo "  ok: $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# 🔴 Resolve the interpreter ONCE, absolutely, from the RUNNING shell. `$BASH`
+# is what is executing this file; `command -v bash` would resolve through the
+# stub dir `run-tests.sh` prepends to PATH for the whole gate run. A path that
+# turns out unfindable dies rc 127, which reads as "the script under test
+# failed" rather than "the harness broke" — the exact misreading
+# test_cleanup_disk_gate.sh records.
+BASH_BIN="${BASH:-}"
+[ -x "$BASH_BIN" ] || { echo "  FAIL: cannot resolve the running bash"; exit 1; }
+
+[ -f "$SCRIPT" ] || { echo "  FAIL: $SCRIPT does not exist"; exit 1; }
+
+# assert stdout (arg 2) equals expected (arg 3), byte for byte
+eq() {
+  if [ "$2" = "$3" ]; then pass "$1"; else
+    fail "$1"; printf '     expected: [%s]\n     actual:   [%s]\n' "$3" "$2"
+  fi
+}
+# assert haystack (arg 2) contains needle (arg 3) as a substring
+has() {
+  case "$2" in *"$3"*) pass "$1" ;;
+    *) fail "$1"; printf '     missing: [%s]\n     in:      [%s]\n' "$3" "$2" ;;
+  esac
+}
+# assert haystack (arg 2) does NOT contain needle (arg 3)
+lacks() {
+  case "$2" in *"$3"*) fail "$1"; printf '     unexpected: [%s]\n     in: [%s]\n' "$3" "$2" ;;
+    *) pass "$1" ;;
+  esac
+}
+
+# --------------------------------------------------------------------------- #
+echo "== 0. THE SEAM: sourcing defines helpers and MEASURES NOTHING =="
+# A source that ran the report would (a) take hours and (b) make every assertion
+# below a claim about a live filesystem instead of a fixture.
+src_out="$(set -uo pipefail; source "$SCRIPT" 2>&1; echo "SOURCED-OK")"
+eq "sourcing produces no output at all beyond the marker" "$src_out" "SOURCED-OK"
+
+# shellcheck source=/dev/null
+source "$SCRIPT"
+# 🔴 The script's own `set -euo pipefail` executed during that source and is now
+# ACTIVE IN THIS SHELL. Left alone, the first assertion whose command returns
+# non-zero would abort the suite mid-run and report a truncated PASS list —
+# which is this very script's headline failure mode, reproduced in its test.
+set +e
+set -uo pipefail
+
+for fn in lsof_deleted_summary report_deleted_open_files size_breakdown \
+          inode_breakdown _dev_of split_by_device report_foreign_mounts \
+          report_denials; do
+  if declare -F "$fn" >/dev/null; then pass "helper $fn is sourceable"
+  else fail "helper $fn is NOT defined after sourcing"; fi
+done
+
+# --------------------------------------------------------------------------- #
+echo "== 1. ROOT REFUSAL: an unprivileged EXECUTION must refuse, rc 2 =="
+# The whole premise of the script — an unprivileged run silently skips the trees
+# it exists to measure — so a soft-fail here is worse than no script.
+if [ "$(id -u)" -eq 0 ]; then
+  fail "this suite is running AS ROOT; the refusal check below cannot fire. Run it unprivileged."
+else
+  refuse_err="$("$BASH_BIN" "$SCRIPT" 2>&1 >/dev/null)"; refuse_rc=$?
+  [ "$refuse_rc" -eq 2 ] && pass "non-root execution exits 2" \
+    || fail "non-root execution exited $refuse_rc, expected 2"
+  has "refusal names root on stderr" "$refuse_err" "must run as root"
+fi
+
+# --------------------------------------------------------------------------- #
+echo "== 2. lsof column resolution — resolved from the HEADER, never an index =="
+# 🔴 THE DEFECT: the original summed \$8. Under `+L1` that is NLINK, which is 0
+# for every row BY THE DEFINITION of +L1, so it printed a hard `bytes=0.0 GiB`
+# forever — the reassuring reading, in the section rewritten to stop emitting a
+# misleading number. MEASURED on this host: \$8 -> 0.0 GiB; header-driven -> 2.5
+# GiB over 2,440 rows.
+#
+# 🔴 TWO FIXTURES, NOT ONE, and the reason is mechanical: `lsof +L1` puts
+# SIZE/OFF at column 7 here, while plain `lsof -n -P` on the SAME host emits TID
+# and TASKCMD too and puts it at column 9. A single fixture cannot tell a
+# header-driven lookup from a hardcoded index that happens to match it. Every
+# other column in both fixtures sums to 0.0 GiB (NLINK is 0, PID/NODE are small,
+# DEVICE and the text columns are non-numeric), so 2.5 is reachable ONLY from
+# the right column — the fixture values are deliberately far from the constant.
+L1_HEADER='COMMAND PID USER FD TYPE DEVICE SIZE/OFF NLINK NODE NAME'
+L1_ROWS='bash 1234 zach 3r REG 259,8 1073741824 0 111 /tmp/gone-1 (deleted)
+node 5678 zach 7u REG 259,8 1610612736 0 222 /tmp/gone-2 (deleted)'
+
+out="$(printf '%s\n%s\n' "$L1_HEADER" "$L1_ROWS" | lsof_deleted_summary 0)"
+eq "+L1 shape: SIZE/OFF found at col 7, 2.5 GiB over 2 rows" "$out" \
+   "count=2 bytes=2.5 GiB (SIZE/OFF=col 7, resolved from the header)"
+
+# The SAME two sizes, shifted two columns right by TID/TASKCMD. A fixed index
+# gives 0.0 here; only a name lookup still reports 2.5.
+PLAIN_HEADER='COMMAND PID TID TASKCMD USER FD TYPE DEVICE SIZE/OFF NODE NAME'
+PLAIN_ROWS='bash 1234 1234 bash zach 3r REG 259,8 1073741824 111 /tmp/a
+node 5678 5679 node zach 7u REG 259,8 1610612736 222 /tmp/b'
+out="$(printf '%s\n%s\n' "$PLAIN_HEADER" "$PLAIN_ROWS" | lsof_deleted_summary 0)"
+eq "plain -n -P shape: same bytes, col 9" "$out" \
+   "count=2 bytes=2.5 GiB (SIZE/OFF=col 9, resolved from the header)"
+
+# 🔴 REFUSAL, not a zero. A header with no SIZE/OFF at all is the version-skew
+# case the name lookup exists for; answering it with a number would be worse
+# than the fixed index it replaced.
+NO_SIZE_HEADER='COMMAND PID USER FD TYPE DEVICE NLINK NODE NAME'
+out="$(printf '%s\nbash 1 z 3r REG 259,8 0 111 /tmp/a\nnode 2 z 4r REG 259,8 0 112 /tmp/b\nsh 3 z 5r REG 259,8 0 113 /tmp/c\n' \
+       "$NO_SIZE_HEADER" | lsof_deleted_summary 0)"
+eq "absent SIZE/OFF refuses and names the row count" "$out" \
+   "COULD NOT MEASURE: no SIZE/OFF column in lsof header (rows=3) — NOT a zero"
+lacks "refusal emits NO byte figure at all" "$out" "bytes="
+
+# 🔴 NEVER NEGATIVE. The 2026-09-01 run printed `count=-1` because the awk did
+# NR-1 to drop the header and NR is 0 on empty input. A negative count also hid
+# "lsof found nothing" vs "lsof did not run" — and the zero is the reassuring
+# one, so the two must be told apart in WORDS, not by a number.
+out="$(printf '' | lsof_deleted_summary 1)"
+eq "empty input: count=0 and lsof's exit status is carried" "$out" \
+   "count=0 bytes=0.0 GiB  (lsof exited 1 with no rows — no deleted-but-open files)"
+lacks "empty input never prints a negative count" "$out" "count=-"
+
+out="$(printf '%s\n' "$L1_HEADER" | lsof_deleted_summary 0)"
+eq "header-only input: count=0, not -1" "$out" \
+   "count=0 bytes=0.0 GiB (SIZE/OFF=col 7, resolved from the header)"
+
+# --------------------------------------------------------------------------- #
+echo "== 2b. section 7's own branches: not-on-PATH, and the set -e trap =="
+# `command -v` on a name that cannot exist. This is the branch that must never
+# be confused with a zero.
+out="$(LSOF_BIN="lsof-does-not-exist-$$" report_deleted_open_files 2>&1)"
+eq "lsof missing: COULD NOT MEASURE, not a count" "$out" \
+   "COULD NOT MEASURE: lsof not on PATH — this is NOT a zero"
+
+# 🔴 THE NO-ROWS MESSAGE USED TO BE UNREACHABLE. lsof documents exit 1 when it
+# finds nothing — the ordinary case — and `OUT=$(lsof …); RC=$?` is a CHECKED
+# command under `set -e`, so the script died on that line, mid-report, with the
+# message already eaten by `2>/dev/null`. Sections 7 and 8 never printed and the
+# run ended looking complete. This probe runs the real `set -euo pipefail`
+# and asserts the script gets PAST section 7 — the marker is the whole point.
+cat > "$TMP/lsof-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+fake_lsof() { return 1; }   # exits non-zero with no output, exactly like lsof
+LSOF_BIN=fake_lsof
+report_deleted_open_files
+echo "SECTION-8-WAS-REACHED"
+PROBE
+probe_out="$("$BASH_BIN" "$TMP/lsof-probe.sh" 2>&1)"; probe_rc=$?
+[ "$probe_rc" -eq 0 ] && pass "a non-zero lsof does not kill the run (rc 0)" \
+  || fail "a non-zero lsof aborted the script under set -e (rc $probe_rc)"
+has "no-rows message is REACHABLE" "$probe_out" \
+    "count=0 bytes=0.0 GiB  (lsof exited 1 with no rows"
+has "the report continues past section 7" "$probe_out" "SECTION-8-WAS-REACHED"
+
+# --------------------------------------------------------------------------- #
+echo "== 3. ROOT COMMAND INJECTION via a planted directory name =="
+# 🔴 THE DEFECT: `xargs -I{} sh -c '… "{}" …'` substitutes the filename into a
+# SHELL STRING. /tmp is mode 1777 and this script's header mandates sudo, so any
+# local process could plant a directory whose name is a command and have it run
+# AS ROOT. `find -exec sh -c '… "$1"' _ {} \;` passes the name as an ARGUMENT.
+#
+# 🔴 GREP FOR THE EXPANSION, NEVER THE WORD. The fixture's own name contains the
+# string `PWNED`, so grepping for that gives a guaranteed false red. The only
+# thing that distinguishes execution from mere printing is `$(id -un)` having
+# been REPLACED by the user's name.
+INJ="$TMP/inj"
+EVIL='evil";echo PWNED-AS-$(id -un) >&2;"x'
+mkdir -p "$INJ/$EVIL" "$INJ/benign"
+touch "$INJ/benign/f1" "$INJ/benign/f2"
+WHO="$(id -un)"
+EXPANSION="PWNED-AS-$WHO"
+
+# 🔴 POSITIVE CONTROL FIRST. A "no injection observed" result is worthless
+# unless this instrument has been watched to observe one. The old, vulnerable
+# pipeline is run here verbatim against the SAME fixture; if it does not leak
+# the expansion, the fixture is inert and every assertion below is vacuous.
+vuln_out="$(find "$INJ" -xdev -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
+  | xargs -I{} sh -c 'printf "%12d  %s\n" "$(find "{}" -xdev -printf . 2>/dev/null | wc -c)" "{}"' 2>&1)"
+has "POSITIVE CONTROL: the OLD xargs -I{} form DOES expand \$(id -un)" \
+    "$vuln_out" "$EXPANSION"
+
+inj_out="$(inode_breakdown "$INJ" 2>&1)"
+lacks "inode_breakdown does not execute the planted name" "$inj_out" "$EXPANSION"
+# ... and it still does its job: the name survives VERBATIM, quotes and all.
+has "the planted directory is still listed, byte-for-byte" "$inj_out" "$INJ/$EVIL"
+has "the benign directory's inodes are counted" "$inj_out" "$INJ/benign"
+
+# The size half of section 6d walks the same attacker-writable directory.
+size_out="$(size_breakdown "$INJ" 2>&1)"
+lacks "size_breakdown does not execute the planted name" "$size_out" "$EXPANSION"
+has "size_breakdown lists the planted directory verbatim" "$size_out" "$INJ/$EVIL"
+
+# --------------------------------------------------------------------------- #
+echo "== 4. E2BIG: a top-level glob aborts on a real /tmp; find -print0 does not =="
+# 🔴 THE DEFECT: `du -sh -x /tmp/*` on this host. MEASURED 2026-09-02: 171,886
+# top-level entries = ~4.32 MiB of argv against ARG_MAX 2,097,152, so the glob
+# dies E2BIG; `2>/dev/null` swallows the message and `set -euo pipefail` then
+# kills the WHOLE SCRIPT mid-section. Sections 6d-inodes, 7 and 8 never run and
+# the report ends with no error — a truncated scan reported as a total, which is
+# the failure this script exists to prevent.
+#
+# The fixture is sized from the LIVE ARG_MAX rather than a magic number, so it
+# stays a real E2BIG on a host with a different limit instead of quietly
+# becoming a no-op.
+ARGMAX="$(getconf ARG_MAX 2>/dev/null || echo 2097152)"
+PAD="$(printf 'x%.0s' $(seq 1 200))"
+NAMELEN=$(( ${#TMP} + 220 ))
+NEED=$(( (ARGMAX * 2 / NAMELEN) + 1 ))
+BIG="$TMP/big"
+mkdir -p "$BIG"
+if [ "$NEED" -gt 60000 ]; then
+  fail "COULD NOT MEASURE: ARG_MAX=$ARGMAX would need $NEED fixture files; refusing to build them. This guard did NOT run."
+else
+  seq 1 "$NEED" | awk -v d="$BIG" -v p="$PAD" '{printf "%s/%s%06d\n", d, p, $1}' | xargs -d'\n' touch
+  made="$(find "$BIG" -mindepth 1 -maxdepth 1 | wc -l)"
+  [ "$made" -eq "$NEED" ] && pass "fixture built: $made top-level entries (ARG_MAX=$ARGMAX)" \
+    || fail "fixture build produced $made entries, wanted $NEED"
+
+  # 🔴 POSITIVE CONTROL. If the glob does NOT die here, the fixture is under the
+  # limit and the assertion below proves nothing about E2BIG.
+  glob_err="$( { du -sh -x "$BIG"/* >/dev/null; } 2>&1 )"; glob_rc=$?
+  [ "$glob_rc" -ne 0 ] && pass "POSITIVE CONTROL: the glob form really does die (rc $glob_rc)" \
+    || fail "POSITIVE CONTROL FAILED: the glob survived $made entries — the E2BIG assertion below is vacuous"
+  has "POSITIVE CONTROL names the E2BIG error" "$glob_err" "Argument list too long"
+
+  big_out="$(size_breakdown "$BIG" 2>&1)"; big_rc=$?
+  [ "$big_rc" -eq 0 ] && pass "size_breakdown survives $made entries (rc 0)" \
+    || fail "size_breakdown exited $big_rc on $made entries"
+  big_lines="$(printf '%s\n' "$big_out" | grep -c . )"
+  [ "$big_lines" -eq 15 ] && pass "size_breakdown still returns its top-15 rows" \
+    || fail "size_breakdown returned $big_lines rows, expected 15"
+
+  # 🔴 THE SECOND ROUTE TO THE SAME FAILURE, and it is LIVE, not historical.
+  # `<producer> | sort | head -N` under `pipefail` is a SIZE-DEPENDENT abort:
+  # head exits after N lines, the producer blocks on its next write, takes
+  # SIGPIPE and exits 141, and `set -e` kills the run with NO message at all.
+  # MEASURED AT TWO POINTS on this host — 40 entries survive rc 0 (sort's whole
+  # output fits one write that completes before head exits), 20,000 die rc 141 —
+  # so a small-fixture test would have certified the defect as absent. The real
+  # /tmp had 171,886 entries. This probe runs the script's own `set -euo
+  # pipefail` over the big fixture and demands the marker AFTER it.
+  cat > "$TMP/sigpipe-probe.sh" <<PROBE
+set -euo pipefail
+source "$SCRIPT"
+size_breakdown "$BIG" >/dev/null
+inode_breakdown "$BIG" >/dev/null
+echo "NEXT-SECTION-WAS-REACHED"
+PROBE
+  sp_out="$("$BASH_BIN" "$TMP/sigpipe-probe.sh" 2>&1)"; sp_rc=$?
+  [ "$sp_rc" -eq 0 ] && pass "the breakdowns do not SIGPIPE the run away (rc 0 at $made entries)" \
+    || fail "the run died rc $sp_rc walking $made entries — a truncated scan with no message"
+  has "the report continues past the /tmp breakdown" "$sp_out" "NEXT-SECTION-WAS-REACHED"
+fi
+
+# --------------------------------------------------------------------------- #
+echo "== 5. /home split by DEVICE, and the foreign list must survive the loop =="
+# 🔴 TWO DEFECTS MEET HERE.
+#  (a) `du -x` does NOT mean "only this filesystem" — it stops du crossing AWAY
+#      from its starting point, so started ON a foreign mount it walks the whole
+#      thing. The 2026-09-01 run reported 12T for /home/zach/hdd-20tb under a
+#      1.8T root filesystem, and walking 13T of external disk is what made that
+#      run take ~3 hours. The fix compares `stat -c '%D'` per candidate.
+#  (b) The loop was the HEAD OF A PIPELINE with a VARIABLE accumulator, so the
+#      foreign list was assigned in a SUBSHELL and read back empty — the report
+#      printed a confident "none" on a host with foreign mounts under /home.
+#      SC2030/SC2031; no shellcheck gate here, so nothing caught it.
+#
+# The real-`stat` check runs FIRST, on purpose: the fixture cases below replace
+# `_dev_of`, and if that replacement came first this suite would be asserting
+# against its own stub and would pass with the script's implementation deleted.
+real_dev="$(stat -c '%D' / 2>/dev/null)"
+eq "_dev_of / agrees with stat -c %D /" "$(_dev_of /)" "$real_dev"
+mkdir -p "$TMP/sibling"
+eq "_dev_of is stable for two paths on one filesystem" \
+   "$(_dev_of "$TMP/sibling")" "$(stat -c '%D' "$TMP")"
+
+HOMEFIX="$TMP/homefix"
+mkdir -p "$HOMEFIX/zach/onroot-a" "$HOMEFIX/zach/foreign-b" \
+         "$HOMEFIX/zach/.onroot-hidden" "$HOMEFIX/other/foreign-c"
+touch "$HOMEFIX/zach/a-plain-file"
+# Fixture device map. `801` is the real device id of /dev/sda1 on the host this
+# defect was measured on; `10308` is root's. Distinct from each other and from
+# any value `stat` could return for these paths, so a mutant that dropped the
+# comparison and kept everything (or dropped everything) is visibly wrong.
+_dev_of() {
+  case "$1" in
+    */foreign-b|*/foreign-c) printf '801\n' ;;
+    *) printf '10308\n' ;;
+  esac
+}
+ON="$TMP/onroot.lst"; FG="$TMP/foreign.lst"
+split_by_device "$HOMEFIX" "$ON" "$FG" "10308"
+
+# 🔴 `LC_ALL=C`. Under the host's en_US.UTF-8 collation `sort` ignores leading
+# punctuation, so `.onroot-hidden` sorts AFTER `onroot-a`; under the C locale
+# the nix build sandbox uses, it sorts before. Left to the ambient locale this
+# comparison passes on one tier and fails on the other — the config-blind-suite
+# failure, in the harness rather than the subject.
+on_list="$(tr '\0' '\n' < "$ON" | LC_ALL=C sort)"
+fg_list="$(LC_ALL=C sort < "$FG")"
+eq "on-root list holds exactly the root-device dirs (hidden included)" "$on_list" \
+   "$(printf '%s\n%s\n' "$HOMEFIX/zach/.onroot-hidden" "$HOMEFIX/zach/onroot-a")"
+eq "foreign list holds exactly the foreign-device dirs" "$fg_list" \
+   "$(printf '%s\n%s\n' "$HOMEFIX/other/foreign-c" "$HOMEFIX/zach/foreign-b")"
+lacks "a plain FILE is not treated as a directory" "$on_list$fg_list" "a-plain-file"
+# The two `eq`s above are also the `.`/`..` guard: without the case-skip, the
+# `/home/*/.*` half of the glob puts `$HOMEFIX/zach/.` and `$HOMEFIX/zach/..`
+# (both real directories) into the on-root list and both comparisons go red.
+# NUL separation is what makes `xargs -0` safe for names with spaces/newlines.
+nul_count="$(tr -dc '\0' < "$ON" | wc -c)"
+[ "$nul_count" -eq 2 ] && pass "on-root list is NUL-separated (2 records)" \
+  || fail "on-root list has $nul_count NUL separators, expected 2"
+
+# 🔴 THE ACCUMULATOR GUARD, stated behaviourally: with foreign mounts present the
+# report must NAME them. "none found" here was the subshell bug, and it is the
+# reassuring reading.
+fm_out="$(report_foreign_mounts "$FG" 2>/dev/null)"
+has "foreign report names the first foreign mount" "$fm_out" "$HOMEFIX/zach/foreign-b"
+has "foreign report names the second foreign mount" "$fm_out" "$HOMEFIX/other/foreign-c"
+lacks "foreign report does NOT claim 'none found'" "$fm_out" "none found"
+
+# POSITIVE CONTROL for the branch above: it CAN say none, so the `lacks` is not
+# an assertion about a branch that never fires.
+: > "$TMP/empty.lst"
+none_out="$(report_foreign_mounts "$TMP/empty.lst" 2>/dev/null)"
+has "POSITIVE CONTROL: an empty list does print the loud 'none' line" \
+    "$none_out" "none found — on a host with foreign mounts under /home this is a BUG"
+
+# --------------------------------------------------------------------------- #
+echo "== 6. denial accounting — a count with no denial figure is a FLOOR =="
+# 🔴 DEFECT: `grep -c` prints `0` AND exits 1, so `$(grep -c … || echo 0)` yields
+# a TWO-LINE "0\n0" and every later integer test dies with "integer expected" —
+# a guard that fails precisely when it has something to report.
+: > "$TMP/denied-empty.log"
+d_out="$(report_denials "$TMP/denied-empty.log" 2>"$TMP/d.err")"; d_rc=$?
+d_err="$(cat "$TMP/d.err")"
+[ "$d_rc" -eq 0 ] && pass "empty denial log: rc 0" || fail "empty denial log: rc $d_rc"
+eq "empty denial log prints three clean zero lines" "$d_out" \
+   "$(printf 'directories find could not read      : 0\nvanished mid-scan (benign, transient): 0\nOTHER, unclassified                  : 0')"
+eq "empty denial log writes NOTHING to stderr" "$d_err" ""
+lacks "empty denial log does not trip the broken-counter guard" "$d_out" "denial counter is broken"
+
+cat > "$TMP/denied.log" <<'EOF'
+find: ‘/var/lib/kubelet/pods/x’: Permission denied
+find: ‘/var/lib/docker/overlay2/y’: Permission denied
+find: ‘/root/.cache/z’: Permission denied
+find: ‘/tmp/vanished-1’: No such file or directory
+find: ‘/tmp/vanished-2’: No such file or directory
+find: ‘/proc/9999/task’: Input/output error
+EOF
+d_out="$(report_denials "$TMP/denied.log" 2>&1)"
+has "3 denials counted" "$d_out" "directories find could not read      : 3"
+has "2 transient vanishings counted" "$d_out" "vanished mid-scan (benign, transient): 2"
+has "1 unclassified error counted" "$d_out" "OTHER, unclassified                  : 1"
+has "denials make the counts FLOORS, loudly" "$d_out" \
+    "!! Running as root and STILL denied — the counts above are FLOORS, not totals."
+has "the denied paths are listed, not just counted" "$d_out" "/var/lib/kubelet/pods/x"
+has "the unclassified error is surfaced verbatim" "$d_out" "Input/output error"
+lacks "a known-benign line is not reported as unclassified" "$d_out" \
+      "$(printf -- '-- unclassified errors (read these; they are not known-benign) --\nfind: ‘/tmp/vanished-1’')"
+
+# POSITIVE CONTROL: the broken-counter branch CAN fire, so the `lacks` above is
+# not an assertion about dead code. A missing log makes `grep -c` print nothing.
+d_out="$(report_denials "$TMP/no-such-log-$$" 2>/dev/null)"
+has "POSITIVE CONTROL: an unreadable log trips the broken-counter guard" \
+    "$d_out" "!! denial counter is broken — treat every count above as UNVERIFIED"
+
+# --------------------------------------------------------------------------- #
+echo "== 7. SOURCE GUARDS — the anti-patterns must not reappear ANYWHERE =="
+# These are structural, and they are deliberately a second net rather than the
+# primary one: a behavioural guard covers the helper it was extracted from, but
+# the script has six more traversals a future edit could rebuild the same defect
+# in. Each pin names the whole normalised expression, not a keyword.
+# 🔴 COMMENTS ARE STRIPPED FIRST. Every defect below is DESCRIBED in a comment
+# in the script ("NOT `du -sh -x /tmp/*`", "NOT `xargs -I{} …`"), so a scan over
+# the raw file matches its own documentation and reports the defect present in a
+# clean file — a guaranteed red that would be "fixed" by deleting the comments.
+# Only whole-line comments are removed; a trailing comment on a code line stays,
+# which errs toward a false red rather than a false green.
+#
+# 🔴 THE STRIPPED SOURCE GOES TO A FILE, AND THE SCANS READ THE FILE. The obvious
+# `printf '%s\n' "$CODE" | grep -q …` is a RACE under `pipefail`: `grep -q` exits
+# on its FIRST match, and if it wins that race `printf` takes SIGPIPE, the
+# pipeline reports 141 and the `if` reads a successful match as "not found".
+# Measured here — the same unmodified tree returned 71 ok on one run and one
+# spurious FAIL ("the script no longer contains …") on the next. A flaky guard
+# whose failure mode is "the thing you are looking for is missing" is worse than
+# no guard: it trains a reader to re-run until green. No pipe, no race.
+CODE_FILE="$TMP/code-no-comments.txt"
+grep -v '^[[:space:]]*#' "$SCRIPT" > "$CODE_FILE"
+
+# 🔴 POSITIVE CONTROL FOR THE SCANNER ITSELF. A `banned` check that can never
+# match is indistinguishable from a clean file, and both print "ok". Feed it a
+# line that MUST match every banned pattern before trusting a single zero.
+CANARY_FILE="$TMP/canary.txt"
+printf '%s\n' 'du -sh -x /tmp/* | xargs -I{} awk "{ s += $8 } END { print NR - 1 }" | head -15; X=$(lsof +L1); Y=$(grep -c foo bar || echo 0)' > "$CANARY_FILE"
+
+banned() { # name  BRE  why
+  local name="$1" pat="$2" why="$3"
+  if ! grep -q -- "$pat" "$CANARY_FILE"; then
+    fail "$name — SCANNER BROKEN: the pattern [$pat] does not even match the canary line, so its zero means nothing"
+    return
+  fi
+  if grep -q -- "$pat" "$CODE_FILE"; then
+    fail "$name — matched [$pat] in code: $why"
+  else
+    pass "$name"
+  fi
+}
+required() { # name  fixed-string  why
+  if grep -qF -- "$2" "$CODE_FILE"; then pass "$1"
+  else fail "$1 — the script no longer contains [$2]: $3"; fi
+}
+
+# 🔴 The field separator is `@`, NOT `|` — one of the banned patterns is itself
+# a `||` alternation guard and splitting on `|` shredded it into three fields on
+# this table's first run, which made the pattern a prefix that matched nothing
+# and reported the check as ok.
+while IFS='@' read -r name pat why; do
+  [ -n "${name:-}" ] || continue
+  banned "$name" "$pat" "$why"
+done <<'BANNED'
+no 'xargs -I' anywhere (root command injection)@xargs -I@-I substitutes a filename into a SHELL STRING; /tmp is 1777 and this script demands sudo
+no glob expanded into du (E2BIG)@du [^#]*\*@a top-level glob over /tmp is ~4.3 MiB of argv against ARG_MAX 2097152
+no fixed column index summed out of lsof@s *+= *\$[0-9]@$8 under +L1 is NLINK, 0 by definition — a hard 0.0 GiB forever
+no NR-1 header strip (goes to -1 on empty input)@NR *- *1@NR is 0 with no output at all, and a negative count hides 'did not run'
+no 'grep -c ... || echo 0' (emits a two-line zero)@grep -c[^|]*|| *echo@grep -c prints 0 AND exits 1; the fallback then appends a second line
+no unchecked assignment from lsof under set -e@=\$(lsof@a command substitution in an assignment is CHECKED; lsof exits 1 when it finds nothing
+no bare '| head -N' truncating a pipeline (SIGPIPE 141)@| *head -[0-9]@head exits after N lines and the producer takes SIGPIPE; pipefail promotes 141 and set -e kills the run silently. Use head_n.
+BANNED
+
+while IFS='@' read -r name lit why; do
+  [ -n "${name:-}" ] || continue
+  required "$name" "$lit" "$why"
+done <<'REQUIRED'
+section 2 keeps find's stderr instead of discarding it@2>>"$DENIED_LOG"@a scan reporting a number with no denial count is a floor presented as a total
+lsof column is resolved by NAME from the header@if ($i == "SIZE/OFF") col=i@the index is not stable: +L1 puts it at 7, plain -n -P at 9
+an absent SIZE/OFF column REFUSES rather than reporting a zero@COULD NOT MEASURE: no SIZE/OFF column in lsof header@a zero here is the reassuring reading of a broken instrument
+the /tmp inode walk passes the name as an ARGUMENT@-exec sh -c 'printf "%12d  %s\n" "$(find "$1" -xdev -printf . 2>/dev/null | wc -c)" "$1"' _ {} \;@"$1" is an argv slot; "{}" is text the shell parses
+top-level enumeration is NUL-safe find|xargs, not a glob@find "$1" -xdev -mindepth 1 -maxdepth 1 -print0@the glob form dies E2BIG and set -euo pipefail takes the whole run with it
+candidates are compared by DEVICE, because du -x cannot do it@d=$(_dev_of "$p") || continue@du -x only stops du crossing AWAY from its start; started ON a foreign mount it walks all of it
+truncation reads to EOF instead of closing the pipe@head_n() { awk -v n="$1" 'NR<=n'; }@awk consumes all input, so the upstream sort never takes SIGPIPE
+REQUIRED
+
+# --------------------------------------------------------------------------- #
+# 🔴 DO NOT print `RESULT: PASS (exit=0)` here — that grammar is RESERVED to
+# run-tests.sh's EXIT trap, and a second writer of it lets a red run report green
+# through the gate's own truth-telling channel. See test_result_grammar_is_reserved.py.
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "diagnose-disk-accounting guards: all checks passed"; exit 0
+else
+  echo "diagnose-disk-accounting guards: FAILURES above"; exit 1
+fi

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -216,16 +216,29 @@ def test_the_non_pytest_targets_are_covered_and_named():
     # transforms against fixtures under a mktemp dir — an lsof header in two
     # column layouts, a planted directory name, and a large flat tree sized from
     # the live ARG_MAX. The only binaries it reaches are find/du/stat/sort/awk/sh
-    # over that mktemp dir.
-    # 🔴 THIS PREVIOUSLY SAID "It does execute the script itself ONCE". Wrong,
-    # and wrong in the direction that stops a reader counting: the suite runs the
-    # interpreter on the script FIVE times on the EXECUTE path (the plain refusal
-    # check, three seam-reachability cases in §1b, and §2c's `bash -x` xtrace
-    # read) and SOURCES it ten more times, counting the four probe scripts. Every
-    # one of the five exits 2 at the root check before the script opens a temp
-    # file or touches the filesystem — that is the property this entry rests on,
-    # and it does not depend on the count. The suite now ABORTS if it is itself
-    # running as root, so the root check is always the branch those five reach.
+    # over that mktemp dir. (That list used to read "find/du/stat/sort/awk/sh",
+    # which was already short of mkdir/touch/chmod/tr/grep/sed/wc; what the
+    # entry actually rests on is the negative — nothing it reaches launches an
+    # agent, opens the network, or runs git.)
+    # 🔴 THIS SENTENCE HAS NOW BEEN WRONG TWICE, each time in the commit that
+    # corrected the previous version. It said "It does execute the script itself
+    # ONCE"; round 2 replaced that with a count that named "the four probe
+    # scripts" while the same commit added a FIFTH (`nodev-probe.sh`, joining
+    # `lsof-`, `sigpipe-`, `sigpipe-inode-` and `finderr-`). So no count is
+    # stated here any more, and no grep recipe is offered either: the obvious
+    # ones are wrong in opposite directions (`grep -c 'source "$SCRIPT"'`
+    # misses the `bash -c "source '$SCRIPT'"` spellings; `grep -c '"$BASH_BIN"'`
+    # counts probe scripts as if they were the script). Read the suite.
+    #
+    # What holds regardless of the numbers, and is the only thing this entry
+    # rests on: the suite reaches the script by two routes and NEITHER measures
+    # anything. It SOURCES it — directly, and once more inside each probe script
+    # it writes — which takes the seam's no-op branch. And it EXECUTES it on the
+    # non-root refusal path (the plain refusal check, the seam-reachability
+    # cases in §1b, and §2c's `bash -x` xtrace read), where every run exits 2 at
+    # the root check before the script opens a temp file or touches the
+    # filesystem. The suite now ABORTS if it is itself running as root, so the
+    # root check is always the branch the executing runs reach.
     assert shells == [
         "scripts/tests/test_release_wrapper.sh",
         "scripts/tests/test_resume_state.sh",

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -209,11 +209,22 @@ def test_the_non_pytest_targets_are_covered_and_named():
     # such a mutant really deleted a file during the guard run. Corrected here
     # because a pinned entry's stated reason is the thing the pin rests on, and a
     # reader who believes the old wording stops looking.
+    # Fifth entry: `test_diagnose_disk_accounting.sh`, registered when it landed,
+    # like the third and fourth. It touches no launcher, no spool and no git: it
+    # sources `scripts/diagnose-disk-accounting.sh` (whose sourceable seam
+    # returns before the root check, so nothing is measured) and drives the pure
+    # transforms against fixtures under a mktemp dir — an lsof header in two
+    # column layouts, a planted directory name, and a large flat tree sized from
+    # the live ARG_MAX. The only binaries it reaches are find/du/stat/sort/awk/sh
+    # over that mktemp dir. It does execute the script itself ONCE, to assert the
+    # non-root refusal (rc 2), which exits before the script opens a temp file or
+    # touches the filesystem.
     assert shells == [
         "scripts/tests/test_release_wrapper.sh",
         "scripts/tests/test_resume_state.sh",
         "scripts/tests/test_base_clone_staleness.sh",
         "scripts/tests/test_cleanup_disk_gate.sh",
+        "scripts/tests/test_diagnose_disk_accounting.sh",
     ], shells
     for rel in hooks + shells:
         assert (REPO_ROOT / rel).is_file(), f"{rel} is listed but does not exist"

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -216,9 +216,16 @@ def test_the_non_pytest_targets_are_covered_and_named():
     # transforms against fixtures under a mktemp dir — an lsof header in two
     # column layouts, a planted directory name, and a large flat tree sized from
     # the live ARG_MAX. The only binaries it reaches are find/du/stat/sort/awk/sh
-    # over that mktemp dir. It does execute the script itself ONCE, to assert the
-    # non-root refusal (rc 2), which exits before the script opens a temp file or
-    # touches the filesystem.
+    # over that mktemp dir.
+    # 🔴 THIS PREVIOUSLY SAID "It does execute the script itself ONCE". Wrong,
+    # and wrong in the direction that stops a reader counting: the suite runs the
+    # interpreter on the script FIVE times on the EXECUTE path (the plain refusal
+    # check, three seam-reachability cases in §1b, and §2c's `bash -x` xtrace
+    # read) and SOURCES it ten more times, counting the four probe scripts. Every
+    # one of the five exits 2 at the root check before the script opens a temp
+    # file or touches the filesystem — that is the property this entry rests on,
+    # and it does not depend on the count. The suite now ABORTS if it is itself
+    # running as root, so the root check is always the branch those five reach.
     assert shells == [
         "scripts/tests/test_release_wrapper.sh",
         "scripts/tests/test_resume_state.sh",


### PR DESCRIPTION
`scripts/diagnose-disk-accounting.sh` is **root-privileged** bash that had **no test file**, in a repo with **no shellcheck gate**. That combination is why an E2BIG abort and a hard `0.0 GiB` shipped invisibly — nothing here was ever executed by a gate, so nothing here could ever be *seen* to be wrong.

This adds `scripts/tests/test_diagnose_disk_accounting.sh`, registers it in `run-tests.sh` `SHELL_TESTS`, and ships `scripts/tests/mutants-diagnose-disk-accounting.sh` so the "mutation-verified" claim below can be re-derived rather than believed.

> **No line count is quoted anywhere in this PR any more.** Three separate places carried one, in three different files, and each went stale within a round while still being cited from the others. The only figure that cannot go stale is anchored to a sha: the file was **282 lines at the merge base `c1169e3b`** (`git show c1169e3b:scripts/diagnose-disk-accounting.sh | wc -l`). For the current figure, run `wc -l`.

> **The title used to read "127 guards for 282 lines"** — both numbers stale, in a title. It now names no count at all.

> **Four audit rounds have run on this branch.** Each found something the *previous* round's fix introduced or left standing, and in every one of them at least one finding was a **false sentence written by the round that was correcting a false sentence** — round 4 almost entirely so, which is why it deletes claims instead of rewriting them. Every ✏️ block below is a claim this PR previously made and later measured false; they are kept rather than deleted, because a reader who believes the old wording stops looking.

---

## ✏️ Correction 1 — this PR did **not** fix the root command injection

An earlier revision listed *"root command injection"* among the defects this PR fixed. **It was already fixed before this PR.** Measured on the merge base `c1169e3b`: the file contains **zero** `xargs -I` occurrences in code — the only match is inside a comment *describing* the historical defect — and the inode walk was already `find … -exec sh -c '…' _ {} \;`. The fix landed in `d8fe0bc` (#1227).

What this PR adds is the **test** for it: a fixture directory literally named `evil";echo PWNED-AS-$(id -un) >&2;"x`, asserted against the *expansion* `PWNED-AS-<whoami>` and never the word `PWNED` (the filename contains it), with the old vulnerable `xargs -I{}` pipeline run **first as a positive control** and confirmed to leak the expansion.

That guard earned its keep in round 1: adding a `2>/dev/null` to the new `xargs` stage silently disarmed it — the historical defect's own proof of execution is a planted name printing to **stderr** — and the mutation battery caught it as `WRONG-KILLER` while the suite stayed green.

## ✏️ Correction 2 — the seam **was** reachable from the environment

This description used to quote the seam as `[ "${BASH_SOURCE[0]}" != "$0" ]` and claim *"the guard is not reachable from the environment"*. **Measured false.** bash imports `BASH_SOURCE` from the environment as an ordinary scalar:

* `env 'BASH_SOURCE=(nope)' bash scripts/diagnose-disk-accounting.sh` → takes the **sourced** branch, `return`s at top level, **rc 2, no report at all** — and rc 2 is this script's own *"you forgot sudo"* status, so two unrelated causes shared one exit code. Only a guard asserting the refusal **message** can tell them apart.
* `bash < script` / `bash -s` → `BASH_SOURCE` **unset**, `set -u`, dead on the guard's own line, rc 1 — a genuine (narrow) regression the refactor introduced.

It is now `if (return 0 2>/dev/null); then`, which reads no variable, and `BASH_SOURCE` is a **banned pattern** in the suite's own scanner.

## ✏️ Correction 3 — section 5 is not a verbatim move

This description said *"Everything else in the diff is a verbatim move into a helper."* Not quite. Section 5's enumeration changed from a glob to `find … -print0 | xargs -0`, and **`find` enumerates dotfiles that the glob skipped**. That is a behaviour change — an improvement for an accounting tool, and it is **kept**, but it should not have been filed under "verbatim".

## ✏️ Correction 4 — the `%D` cross-implementation evidence disagreed with itself

Round 2's evidence for the `%D` defect was quoted in three places and no two agreed: the script said *"the **two** GNU findutils builds … (Not measured on `bfs`)"*, the round-2 commit message said *"Measured on **two** implementations"* while printing **bfs** numbers, and a PR comment said **three**. The byte counts could not all have been true either — *"`-print0` 116 B (4.10.0) / 119 B (4.11.0)"* over **one** fixture, when `-print0` emits the paths it *found*, not the binary's path.

**Re-measured in round 3** — one fixture (a 35-character mode-0400 base holding three entries), three implementations, each run twice:

| implementation | `-print0` | `-printf '%D\t%p\0'` |
|---|---|---|
| GNU findutils 4.10.0 (what a non-interactive `bash`, and so a `sudo` run, resolves) | **114 B, rc 0** | **0 B, rc 1** |
| GNU findutils 4.11.0 (the nix dev shell) | **114 B, rc 0** | **0 B, rc 1** |
| bfs 4.1.1 (the interactive alias) | **114 B, rc 0** | **0 B, rc 1** |

Two things were wrong, not one: the builds **agree** (114 B is a figure about that fixture's path length and nothing else), and `-print0` exits **0**, not 1 — it needs no `stat`, which is exactly why it still emits the names. The load-bearing half — **0 bytes under `%D`** — reproduces identically on all three and was never in doubt. The script and the suite now carry these figures; the round-2 commit message is immutable and is superseded by them.

---

## The seam I refactored

The script refuses to run as non-root (rc 2) **by design**, so the only way to gate it as an ordinary user is to make the transforms callable. Sourcing it defines the helpers and takes the `(return 0 2>/dev/null)` branch, running nothing. `LSOF_BIN` exists so the suite can drive both the not-on-PATH branch and the rows branch without planting a binary — and it is **inside** the sourced branch only (round 1, F4).

## Defects the suite covers

All eight from `claudedocs/handoff-nix-disk-cleanup.md` rank 5 / cairn `devrc/diagnose-disk-accounting`:

1. **lsof column resolved from the HEADER** — pinned with **two** fixtures: `+L1` puts `SIZE/OFF` at col 7, plain `lsof -n -P` puts it at col 9. Both carry the same two sizes summing to 2.5 GiB and **every other column in both sums to 0.0**, so 2.5 is reachable only from the right column. Plus: an absent `SIZE/OFF` column must **refuse**.
2. **Root command injection** — pre-existing fix, newly guarded; see Correction 1.
3. **E2BIG** — a fixture sized from the **live `getconf ARG_MAX`**, with the glob form run as a positive control and confirmed to die `Argument list too long`.
4. **Subshell accumulator** — behavioural: with foreign mounts present the report must *name* them and must not print `none found`, plus a positive control that the `none` branch can fire at all.
5. **`grep -c` prints 0 and exits 1** — an empty denial log must produce exactly three clean zero lines and must not trip the broken-counter guard.
6. **`NR-1` → −1** — empty input, header-only input and a missing `lsof` binary are three *different* answers, none of them a bare zero.
7. **`du -x` is not "only this filesystem"** — per-candidate device comparison, in **both** section 6c and section 6d.
8. **A count with no denial figure is a floor** — denials counted, paths listed, `FLOORS, not totals` asserted.

## Round 1 — defects found while writing the tests

**(a) The no-rows message in section 7 was unreachable dead code.** `LSOF_OUT=$(lsof +L1 2>/dev/null); LSOF_RC=$?` is a *checked* command under `set -e`, and lsof documents exit 1 when it finds nothing — the ordinary case. Now `|| rc=$?`, with a probe that runs the real `set -euo pipefail` and demands a marker printed *after* section 7.

**(b) `<producer> | sort | head -N` under `pipefail` is a live, size-dependent abort.** Measured at two points: **40 entries survive rc 0**, **20,000 die rc 141**. The real `/tmp` had 171,886. Fixed with `head_n() { awk -v n="$1" 'NR<=n'; }`.

**(F1) A vanished entry mid-scan killed the whole run — two routes, not one.** GNU `find` exits **1** when an entry disappears between readdir and stat; `xargs` exits **123** when any `du` it ran exited 1. Both are promoted by `pipefail` and fatal under `set -e`. Two deterministic fixtures isolate one route each (a mode-`0400` directory; a directory holding a mode-`000` subdirectory), so neither guard is scored on the other's failure and neither needs a concurrent deleter.

**(F5) Defect 7 was fixed at `/home` and left standing at `/tmp`.** `-xdev` only stops `find` **descending** past a mount — it still **lists** the mountpoint at depth 1, so it arrived as a *starting point* for `du -sh -x`, the one case `du -x` cannot handle. Section 6d now applies the same per-candidate device comparison, through a single `_on_device` filter over `find -printf '%D\t%p\0'`. `_dev_of` moved from `stat -c '%D'` (**hex**) to `stat -c '%d'` (**decimal**) to match find's own `%D`.

**(F2a) The `head` ban was SPELLED, not structural.** The banned pattern was `| *head -[0-9]`, demanding a **digit** after `head -` — so `head -n 20`, `head -n 30` and `head -n 15` all **SURVIVED** a fully green suite. Widened to `| *head  *-`, with all four spellings in the battery.

**(F2b) The E2BIG fixture was files-only, so `inode_breakdown` measured nothing.** It filters `-type d` and the fixture was 17,550 `touch`ed **files**, so its probe call returned zero rows and the whole SIGPIPE battery row was killed by `size_breakdown` alone. The fixture now also builds 600 directories, the probes are split one per breakdown, and a non-vacuity assertion fails loudly if the row count returns to 0.

## Round 2 — the round-1 fix created the headline defect

**(🔴 F-1) `-printf '%D\t%p\0'` emits NOTHING for an unstattable entry.** Round 1 swapped `-print0` for `-printf '%D\t%p\0'` to get the device id for the new filter. `%D` forces a `stat` per entry, and a failed stat emits **no record at all** where `-print0` still emitted the name. So an entry root cannot stat — a FUSE mountpoint without `allow_other`, gvfs, sshfs, or a device answering ESTALE/EIO — vanished from `size_breakdown`, `inode_breakdown` **and** `foreign_entries` at once, and `foreign_entries` then printed the affirmative *"none — every depth-1 entry is on the same filesystem"*. Fixed by keeping each enumeration's stderr in a file, counting it, reporting it (`!! UNSTATTABLE`), and downgrading the affirmative "none" to "none VISIBLE". Numbers in Correction 4.

**(🔴 F-2) A bare statement-level `du -sh` under `set -e`.** Section 5's total sat directly beneath two carefully `|| true`-guarded pipelines, under a comment describing the treatment it did not have. Round 1's site enumeration was done **by eye** and missed it; round 2 replaced that with a mechanical sweep, which is now section 7b of the suite.

**(🟡 F-3) `foreign_entries` reintroduced F7 in the commit that fixed F7** — `| tr '\0' '\n' | head_n 15` turned a directory name containing a newline into two report rows. Now one row per NUL record.

**(🟡 F-4/F-5) Two stale claims, each in a file the scanner cannot see** — `run-tests.sh` and `test_no_real_launchers_all_targets.py`. The banned-pattern scanner only reads `diagnose-disk-accounting.sh`, so both copies walked past it.

## Round 3 — this round

**(🟡 1) Three `mktemp` files in NO trap, opened into the directory under diagnosis.** `size_breakdown`, `inode_breakdown` and `foreign_entries` each opened `errf=$(mktemp)` — an anonymous `/tmp/tmp.XXXXXXXXXX` — removed only by that function's last statement. The realistic way this run ends is **SIGINT**, not an abort: the run it was written for took ~3 h over 78 million entries. MEASURED: an EXIT trap **does** run when bash is killed by an untrapped SIGINT, so the trap removed the *named* `$DENIED_LOG` and left up to three unattributable files in `/tmp`.

Fixed structurally rather than by extending a list: every temp file now goes through `_scan_mktemp <kind>` (template `/tmp/disk-accounting-<kind>.XXXXXX`) and is removed by `_cleanup_temps`, which reads its variables at **call** time — so one `trap _cleanup_temps EXIT`, installed **before** the first `mktemp`, covers every file opened later. That also deletes the hand-widened second trap at section 6c, which is the mechanism the three files fell out of in the first place.

Guarded end-to-end: a probe stubs `_report_unstattable` (called after both `mktemp`s and before the `rm`) to record the paths and signal itself. **The positive control runs first and must LEAK** — with no trap, both files survive — because a "nothing was left behind" assertion is otherwise indistinguishable from a probe that never opened a file. That control caught a real harness bug: a first draft used `kill -INT` alone and produced three FAILs the moment the mutation battery ran the suite from `nohup … &`, since bash sets SIGINT to `SIG_IGN` for a command started asynchronously without job control and a non-interactive shell cannot reset a signal ignored on entry. The probe now falls back to SIGTERM and says which signal it delivered.

**(🟡 5) `du`'s stderr was still discarded, and the new blind-spot report made the silence mean something it hadn't.** `_report_unstattable` fires only when **find's** stderr is non-empty. An entry `find` can stat but `du` cannot fully read is listed with an under-counted figure and no marker of any kind — and once `!! UNSTATTABLE` existed, the *absence* of a blind-spot line started reading as "nothing was missed". MEASURED on `base/{open,locked/inner}`, each holding one 4 KiB file with `inner` mode 000: `du -sh -x` prints **8.0K** for `locked` against a true **12K** — a **33% under-count presented as a total** — and exits 1.

du's stderr is now captured the way find's is at the sites that call `_report_unreadable` — `size_breakdown`'s own capture, section 5's PVC listing and section 6c's `/home` listing — and reported as `!! PARTIALLY READ: du could not read N path(s)`. *(This sentence used to read "at all **three** `du` sites", which asserted a count of the file's `du` invocations and was wrong; see round 4 🟡 A below. The scope is now stated structurally, and `_report_unreadable`'s own comment declares that it says nothing about any other `du` in the file.)* The two sinks are deliberately **separate files**: one blind spot erases an entry, the other shortens its number, and a merged count would be one number standing for two different claims. A mutant that points the du report at find's stderr is in the battery for exactly that.

**(🟢 1) The sweep's framing was wider than what the sweep can see.** The script's comment read *"Everything that scan reports is guarded above EXCEPT these"* and listed only the two `out=$(… | sort …)` captures; the suite header said 7b *"sweeps the whole file"*. The scan keys on a line's **first word** and drops any line containing `||`, so a pipeline headed by `for`/`done`/`printf` is invisible to it, and so is one whose *early* stages are guarded while its **last** stage is not. **Five** trailing `sort` stages are unguarded, not two — three of them statement-level pipelines the sweep cannot reach.

Both halves fixed: the claims are narrowed to what the scan actually does, and §7b gained a **second ledger** over trailing `sort` stages that fails when the set GROWS *or* SHRINKS, with its own canary exercising both branches (a guarded `{ … } || true` group must be excluded). Nothing here is a live bug — `sort` over ≤30 lines will not spill — but the exception list read as exhaustive and was not.

**(🟡 2, 🟡 3) The round's own corrective prose was false, twice.** `run-tests.sh` said *"282 at the merge base (567 after round 1, **730** after round 2)"* — the file was **766**, i.e. the sentence explaining that stale counts get quoted downstream carried a stale count. And `test_no_real_launchers_all_targets.py` said the suite sources the script *"ten more times, counting the **four** probe scripts"* — there are **five**, and `nodev-probe.sh` was added by the same commit. Both now state no drifting count at all: the historical figure is anchored to a sha, and the current ones are re-derivable with `wc -l` / `grep -c`.

While correcting them I found a third of the same kind, in the suite's own header: *"It was 282 lines when this suite was written"* — 282 is the count at the **merge base**, *before* this suite's commit; by the end of that commit the file was 414.

**(Out of range, declared not fixed) `split_by_device` is a known fourth site.** Its `[ -d "$p" ] || continue` silently drops a directory root cannot stat, with no count, feeding `report_foreign_mounts`. Round 2's comment claimed *"every caller reports the count"*, which is true of `_depth1_nul`'s three callers only; that over-claim is corrected. The site itself is **recorded, not fixed**: `[ -d "$p" ]` says no for three different reasons — not a directory, stat refused, or an unmatched glob left its own pattern — and bash's file tests cannot separate them, so a count needs a different enumeration. Inventing one inside an audit-fix round is precisely how each round of this ladder produced the next round's finding. What limits it is that `report_foreign_mounts`'s empty branch already tells the reader an empty list is a BUG rather than a clean result.

## Round 4 — this round

No 🔴: one 🟡 and three 🟢, and nearly all of it is again **this ladder's own corrective prose being wrong** — the fifth consecutive round in which that is the most reliable finding. So this round **removes** claims rather than restating them. Where a sentence needed a number to be true, the number is gone and the command that derives it is in its place.

**(🟡 A) "du's stderr is kept at all three `du` sites" was false — and one of the uncovered sites printed a figure with no marker at all.** The file has more `du` invocations than the ones that route stderr into a file. Some of the others at least print a `|| echo` fallback. Section 6's per-tree row printed nothing: `"$(du -sh -x "$d" 2>/dev/null | awk '{print $1}')"` renders a partial total exactly like a complete one, which is what a stale NFS/CSI mount under `/var/lib/kubelet` produces. Since `_report_unreadable` landed, the *absence* of a marker reads as an affirmative "nothing was missed" — its own thesis — so that site was **more misleading after round 3 than before it**, at a site the round's prose said was covered.

Two fixes, and neither is a new count. The claim is narrowed to the callers of `_report_unreadable`, named structurally; the rest are **declared** in that function's comment the way `split_by_device`'s blind spot is declared, with the `grep`s that derive both sets instead of a figure that goes stale. And section 6 now branches on du's status — `if du_out=$(du …); then du_mark=; else du_mark='  !! FLOOR — du could not read all of it'; fi` — with the marker printed as part of the row. MEASURED 2026-09-08 over a fixture holding a mode-000 subdirectory: **20K printed against a true 24K**, now marked, and the run continues. `if VAR=$(…)` rather than a bare assignment, because a command in an `if` condition is not checked by `set -e`.

Guarded by two *separate* `required` rows with two *isolated* mutants, because the site has two independent ways to be wrong: the branch can be removed, or the marker can be computed and never reach the output. Section 6 is root-only, so both are **INVARIANT PINS**; the fixture above exercises the expression, not the script's own line, and is reported as such.

**(🟢 D) `: > "$DU_ERR"` is `set -e`-fatal and was invisible to both ledgers.** A redirection failure on a special builtin ends the shell — MEASURED 2026-09-08, bash 5.3.15: `set -euo pipefail; : > /absent/x` exits 1 with nothing after it running; the same line with `||` is caught and the run continues. The line is headed by `:`, so 7b's first-word sweep cannot see it, and it carries no `| sort`, so the trailing-`sort` ledger cannot either. It was in **neither** ledger and absent from the "left open on purpose" list — and round 3's own 🟢 1 was *"the exception list read as exhaustive and was not"*, in the same commit that added this site. Section 6c's copy fires **after** sections 1–6b have printed, which fails the file's own criterion for leaving a site unguarded.

Guarded rather than listed, so the exception list does not have to grow: `: > "$DU_ERR" || echo "COULD NOT MEASURE: …"`. Deliberately not `|| true` — a file that did not truncate still holds an earlier site's paths, and `_report_unreadable` would then attribute them here. Pinned as a **relationship rather than a literal**: the suite counts `: > "$DU_ERR"` lines and guarded ones and asserts they are equal and non-zero, so it goes red when a guard is dropped *and* when a new unguarded truncation is added. Both directions have a mutant; a single `required` row would have stayed green with one of the two sites unguarded.

**(🟢 B) The recorded cost of hardcoding `/tmp` said "empty", and omitted the consequence that matters.** MEASURED 2026-09-08 on this host: leftovers of both kinds were sitting in `/tmp` and **not all of them were empty** — some held a fixture's captured stderr (`du: cannot read directory '/tmp/tmp.XXXXXXXXXX/du-errors/locked': Permission denied`). Mode 0600, so "harmless" holds; "empty" did not. The comment now says so, and quotes `ls -l /tmp/disk-accounting-*` rather than a number, because the number is whatever the last interrupted sweep happened to leave.

The half that was never recorded: hardcoding `/tmp` also removes `TMPDIR` as an **escape route**, on exactly the failure this script is pointed at. `$DENIED_LOG` and `$DU_ERR` are opened unguarded at the top of the executable region, so a root filesystem out of inodes ends the run on those lines with a blank report — which the exception list accepts as the honest outcome. What it did not say, and now does, is that the bare `mktemp` this replaced would have honoured an inherited `$TMPDIR` and the template cannot: pointing this run's scratch at another filesystem now means editing the file.

**(🟢 C) The control in "the pytest tier is RED" miscounted the tests and files it rests on.** Fixed above, by deleting the counts and pointing at the table. The conclusion is unchanged and is now stated in terms the table itself carries.

## Red-at-old-code / green-at-HEAD

The current suite run against each earlier revision of the script, unmodified:

```
suite vs scripts/diagnose-disk-accounting.sh @ 491fc447 (pre-audit) :  96 FAIL, 106 ok
suite vs                                     @ 4d8228c3 (round 1)   :  55 FAIL, 147 ok
suite vs                                     @ eb4e3a81 (round 2)   :  23 FAIL, 179 ok
suite vs                                     @ 530a5c56 (round 3)   :   3 FAIL, 199 ok
suite vs HEAD                                                       :   0 FAIL, 202 ok
```

Every row was **re-run with the round-4 suite**, not quoted from a previous round — which is why the first three are each three higher than the figures round 3 published (`93 / 52 / 20`): round 4's three new guards are red at every earlier revision too. The three red at `530a5c56` are exactly those guards, one per fix — section 6's branch on du's status, section 6's *printed* marker, and the `: > "$DU_ERR"` ledger, which reports `0 of 2` guarded there.

The 20 red at `eb4e3a81` **as round 3's suite reported them** — the table above now reads 23 there, the extra three being round 4's guards — are exactly round 3's new guards, and they account for all of it: **4** absent helpers (`_errline_count`, `_report_unreadable`, `_scan_mktemp`, `_cleanup_temps`), **3** route-(b) `du` assertions, **5** temp-file rows (the name, the file's existence, the leak positive control, and the two `_cleanup_temps` empty-slot rows), **7** structural pins in section 7, and **1** sort-ledger row.

One of them is worth naming: *"an interrupt mid-breakdown leaves NO temp file behind"* **passes** at `eb4e3a81` — vacuously, because the probe records no paths there. Its positive control is what goes red. A leak assertion without one is a claim about a probe that never ran.

## Mutation battery

`bash scripts/tests/mutants-diagnose-disk-accounting.sh` — one row per mutant plus a SURVIVES control, each an **exact single-occurrence replacement whose application is checked**, each scored on whether **its own guard's `FAIL:` line** appears. A mutant killed only by some other guard reports `WRONG-KILLER`, not ok. *(The roster size used to be written here as a number and is not any more: it is one of the counts that drifts every round. Run the battery — it prints one line per mutant.)*

```
== BASELINE ==            FAIL-lines=0  ok-lines=199   (green)
== NEGATIVE CONTROL ==    FAIL-lines=6                 (the harness can go red)
== 64 mutants ==          every row KILLED by its own guard
== SURVIVES control ==    comment-reword — behaviour-free edit killed nothing
```

Round 3's ten new rows, all `KILLED by its own guard`:

```
du-stderr-discarded                 du's stderr back to /dev/null
du-blind-spot-not-reported          _report_unreadable call removed
du-report-reads-finds-stderr        the two stderr sinks swapped
scan-temp-file-anonymous            named mktemp -> bare mktemp
cleanup-forgets-the-scan-temps      the historical fixed-list cleanup, restored
trap-named-as-a-fixed-list          trap _cleanup_temps -> trap 'rm -f "$DENIED_LOG"'
trap-installed-after-the-first-mktemp   the two lines swapped; the NAME pin stays green
k3s-du-listing-stderr-discarded     section 5's du stderr back to /dev/null
sort-ledger-site-guarded-away       a sort stage guarded -> ledger shrinks
sort-ledger-site-added              a sort stage added    -> ledger grows
```

Round 4's new rows, all `KILLED by its own guard`, and deliberately isolated in pairs:

```
section6-du-status-not-read              the branch removed; the printf pin stays green
section6-marker-computed-but-not-printed the marker dropped from the argument list;
                                         the branch pin stays green
duerr-truncation-unguarded-6c            section 6c's guard removed  -> ledger 1 of 2
duerr-truncation-added-unguarded         a new unguarded truncation  -> ledger 2 of 3
```

**The occurrence check earned its keep again, on this round's own edit.** A first draft of section 6's new comment quoted `ROOT_DEV=$(_dev_of /) || ROOT_DEV=` verbatim while explaining the checked-assignment reasoning. The mutator matches **raw** text, so that made an *existing* mutant ambiguous: `root-dev-reading-unguarded` reported `occurrences=2` and scored `MUTATION DID NOT APPLY`. Without that check it would have silently measured the unmutated file — "the guard held", the most flattering possible wrong answer. The comment now paraphrases, and says why.

It also earned it in round 3: `unstattable-report-suppressed` reported `occurrences=2` the moment `_report_unreadable` gained the same `[ "$n" -gt 0 ] || return 0` line, so the mutation now carries the `local` line above it as an anchor. A `count=1` replace on a two-occurrence pattern would have scored the wrong function.

## Both tiers, read as counts rather than as "BUILD OK"

| tier | command | result |
|---|---|---|
| dev-host · pytest | `nix develop … -c scripts/gate.sh --tier both` | `TOTAL collected=22003 passed=21992 skipped=3 failed=8`, `RESULT: FAIL (exit=1)`. **`PASS scripts/tests/test_diagnose_disk_accounting.sh (script)` — 202 `ok:`, 0 `FAIL:`, read from the gate's own log.** |
| dev-host · node | same run | `TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0 skipped=0` (floor 1367), `RESULT: PASS (exit=0)` |
| sandbox · pytest | `nix build -L .#checks.x86_64-linux.pytests` | `TOTAL collected=22003 passed=22000 skipped=3 failed=0`, `RESULT: PASS (exit=0)`. **My suite ran here too: 202 `ok:`, 0 `FAIL:`.** |
| sandbox · node | `nix build -L .#checks.x86_64-linux.nodetests` | `TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0 skipped=0`, `RESULT: PASS (exit=0)` |

Both `nix build`s were run with **`-L`**, so the counts above were read from the streamed build log rather than from a silent exit 0 — a quiet `nix build` is *cached*, not a verdict.

### 🔴 The pytest tier is RED, and none of it is this PR

The two tiers disagree, and the disagreement is itself the useful reading: the dev host is red, the sandbox is **fully green** (`failed=0`), and every dev-host failure is a toolchain the sandbox pins away. *(Round 4 update: the sandbox previously reported one failure — `test_git_repo_isolation.py::test_live_cotenants…`, called a flake at the time. It did not recur in this round's sandbox run, which is the only evidence available that the "flake" reading was right; it is still the reading, not a proof.)*

| failure | tier | control |
|---|---|---|
| `test_analyze_service_index_escrow_verify.py::test_a_TAMPERED_or_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_not_EMPTY` ×3 | dev-host only | **reproduced at `eb4e3a81`** |
| `…::test_every_decrypt_family_VERDICT_is_pinned_WHOLE` | dev-host only | **reproduced at `eb4e3a81`** |
| `test_analyze_service_index_backup.py::test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret` | dev-host only | **reproduced at `eb4e3a81`** |
| `…::test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr` | dev-host only | **reproduced at `eb4e3a81`** |
| `test_opencode_engine.py::test_engine_is_the_version_every_measurement_is_keyed_to` | dev-host only | **reproduced at `eb4e3a81`** |
| `test_browser_agent.py::test_the_release_handler_EXITS_rather_than_resuming[INT]` | dev-host only | known signal race under load; 0 files of this PR touch browser-bridge |
| `test_git_repo_isolation.py::test_live_cotenants_sees_another_process_in_the_repo` | sandbox only, and **did not recur in round 4's sandbox run** | known flake |

The control was run properly rather than reasoned about: `git archive eb4e3a81 | tar -x` into a scratch directory — no worktree, no shared-repo write — then the dev-host rows re-run there. Each one reproduced, which is what the table's `control` column records row by row. *(Round 4 correction: this paragraph used to summarise that as "the **six** named tests … the **two** test files involved are byte-identical", and neither number matched the table directly above it — "six" is only reachable by counting table rows, which would include the `[INT]` row the table itself calls a signal race, and that reading gives four files. The counts are gone; the table is the record.)* The visible causes are toolchain drift the dev host has and the sandbox pins: `age` 1.3.1 → **1.3.2** changed the stderr these guards assert on, and `opencode` is **1.18.29** against a pinned 1.18.21.

No file in that table is one this PR touches — `git diff --name-only c1169e3b..HEAD` lists `scripts/diagnose-disk-accounting.sh`, `scripts/run-tests.sh`, `scripts/tests/test_diagnose_disk_accounting.sh`, `scripts/tests/mutants-diagnose-disk-accounting.sh` and `scripts/tests/test_no_real_launchers_all_targets.py`, and nothing else. This PR does not fix these failures, and it should not be read as having made the gate green.

## What I could NOT cover without root

Sections **1, 2, 3, 5, 6, 6b and 8** do privileged whole-filesystem measurement — `dumpe2fs -h /dev/nvme0n1p2`, `find / -xdev` across `/root`, `/var/lib/docker`, `/var/lib/kubelet`, `/var/lib/private`, `/var/lib/rancher/k3s/storage`, `findmnt /mnt/rootcheck`. Their **arithmetic** is unguarded here: the hardlink dedup in section 2's awk, the residual subtraction in section 3, the inode-table arithmetic in section 1. `du -x` is in the same category, which is why its pin is structural and labelled as such — as are section 5's and section 6c's du-stderr captures, section 6's FLOOR marker, and the `: > "$DU_ERR"` ledger.

**Reported, not fixed:** `stat -f /` measures the real root filesystem while `dumpe2fs` measures `$DEV`, and nothing cross-checks that they are the same filesystem. `split_by_device`'s silent drop, above — declared, not closed. And the `du` invocations outside `_report_unreadable`'s callers still send stderr to `/dev/null` and produce no path count. That scope is declared in `_report_unreadable`'s comment, with the two `grep`s that derive it, rather than counted anywhere.

## Registration

`SHELL_TESTS` in `run-tests.sh`, plus the deliberate ledger in `test_no_real_launchers_all_targets.py`. The suite touches no launcher, no spool and no git: it sources the script — directly, and once inside each probe script it writes — and executes it only on the non-root refusal path, where every run exits 2 at the root check before the script opens a temp file. The suite **aborts** if it is itself running as root, since several fixtures are inert under uid 0. Its `EXIT` trap `chmod -R u+rwX`s before `rm -rf`, because section 4b deliberately builds unreadable fixture directories.

