### PR TITLE
docs(obs-read): guarded cairn prior-work recall, scoped deterministically by --cluster

### DIFF
--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -23,6 +23,41 @@ genuinely 0 renders normally.
 - Read-only (query APIs only). Bounded timeouts; the port-forward is torn down on
   success, error, and signal.
 
+## Prior work first — the store is keyed the way your query is
+Before an incident/perf dig (not before a one-off number read), ask what a past
+session already diagnosed. The subsystem store is keyed by **metric / service /
+namespace** — exactly what `--preset` and `--query` name — so obs-read's own
+arguments ARE the retrieval keys. Scope is a **function of `--cluster`**, never a
+judgement call:
+
+```bash
+CLUSTER=dpprod                          # the same --cluster you are about to pass
+Q='node_network_receive_drop_total'     # the metric / service / namespace you are about to query
+case "$CLUSTER" in
+  dpprod)                    SCOPE=datapacket-talos ;;
+  homelab|workbench|nebula)  SCOPE=homelab-talos ;;
+esac
+if command -v cairn >/dev/null; then cairn search "$Q" --scope "$SCOPE"; else echo "skipped: cairn unavailable"; fi
+```
+
+- 🔴 **Keep the `if … then … else … fi` form.** `command -v cairn && …` exits
+  non-zero when cairn is absent (1 in bash/zsh, **127 in dash**) and reads as the
+  observability step failing; a bare `if` with no `else` skips SILENTLY. The `else`
+  echo is load-bearing.
+- **No `cairn sync` prefix** — `cairn search` syncs itself; a prefix fetches the
+  whole store twice.
+- 🔴 **Explicit `--scope`, never `--all-scopes`.** `--all-scopes` derives a scope
+  from the cwd's git repo and exits **rc 2** outside one (obs-read is documented to
+  run from any cwd), and it would answer a homelab question out of a CLIENT
+  cluster's scope — §Safety's wrong-cluster trap through a new door. `--scope`
+  needs no git cwd.
+- An empty result is a fact about the QUERY before it is a fact about the store:
+  try the metric, then the service/namespace, then the subsystem (`monitoring`,
+  `prom-stack`, `pyroscope`, `prometheus-stack`) before concluding nothing is recorded.
+- Everything returned is `RECALL, NOT LIVE OBSERVATION` — a remedy that has since
+  landed reads exactly like one that has not. It is a pointer to verify with the
+  query you were going to run anyway, not a substitute for it.
+
 ## Usage
 
 🔴 **Use the ABSOLUTE path — `obs-read` is NOT on `$PATH`, and it lives in the


### PR DESCRIPTION
## What

Adds a **prior-work recall** step to the `obs-read` skill: before an incident/perf
dig, ask the subsystem store what a past session already diagnosed about this
metric/service. Modelled on the step shipped for `investigate-alert`
(talos-infra #1444). Frontmatter — including `description` — is untouched; this is
a 35-line body addition.

## Why obs-read and not another skill: the retrieval keys line up

For `investigate-alert` the keys did **not** meet — the store's content is keyed by
**metric/service** (it was written by sessions *authoring* rules), while an on-call
arrives holding an **alert title**. Only 9 of 35 catalog titles matched anything.

obs-read's arguments *are* metric and service names, so the key alignment is native.
Measured against the live store (221 entries) on 2026-09-07:

| query | scope | hunks |
|---|---|---|
| `node_network_receive_drop_total` | `datapacket-talos` | **3** |
| `prometheus` | `homelab-talos` | **10 of 26** |
| `loki` | `homelab-talos` | 10 of 21 |
| `monitoring` | `datapacket-talos` | 10 of 19 |
| `pyroscope` | `datapacket-talos` | 6 |

## Scope selection is deterministic, not prose

obs-read is cross-cluster, so the block picks the scope with a `case` on the same
`--cluster` you are about to pass — no judgement call:

- `dpprod` → `datapacket-talos`
- `homelab` / `workbench` / `nebula` → `homelab-talos`

All three of the latter kubeconfigs are homelab-talos artifacts
(`$KC_HOMELAB`/`$KC_WORKBENCH` live in that repo, `$KC_NEBULA` is the homelab
cluster over nebula), so the mapping is a fact about the wiring, not a preference.

## Controls run (not just "it returned something")

- **Positive control, dpprod arm** — block run verbatim from a git cwd:
  `node_network_receive_drop_total` → `3 of 3 hunks` from
  `datapacket-talos/monitoring.md`, including the bullet recording the
  investigate-alert key-mismatch measurement.
- **Positive control, homelab arm** — `prometheus` → `10 of 26 hunks` from
  `homelab-talos/prom-stack.md`. Both branches of the `case` measured, not one.
- **Guard-absent control** — `env PATH=/usr/bin:/bin sh <block>` prints
  `skipped: cairn unavailable`, **rc 0**. Same under real `dash`: rc 0.
- **Negative control on the rejected form** — `command -v cairn && …` with cairn
  off PATH exits **1** under bash and **127** under dash. That is why the
  `if/then/else/fi` shape is mandated in the text and why the `else` echo is
  load-bearing: a bare `if` with no else skips silently, which is the exact failure
  the guard exists to prevent.
- **`--all-scopes` from a non-git cwd** exits **rc 2** with a scope-derivation
  error. The explicit `--scope` therefore also removes a cwd dependency obs-read
  does not otherwise have (it is documented to run from any cwd), and prevents
  answering a homelab question out of a client cluster's scope.
- No `cairn sync` prefix — `cairn search` already syncs; a prefix fetches twice.
- `scripts/opencode/generate-commands.py` still generates cleanly with the new
  fenced block (38 commands, 0 skipped; the block carries through to the opencode
  command).

## Gate — both tiers, merged tree

Base sha **`969f05816cfc5abfd382bd618f91159f4cb2dd8a`** (`origin/main`); the branch
is a fast-forward from it, so the merged tree is the branch tree.

- `scripts/gate.sh --tier both` (dev host, run inside `nix develop` — the opencode
  direnv lacks `logrotate`/`dash` and the runner correctly refuses to skip past that):
  `GATE: RESULT=PASS exit=0` — pytest `TOTAL collected=22003 passed=22000 skipped=3 failed=0 (floor 21196)`, node `TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0 (floor 1367)`.
- `nix build .#checks.x86_64-linux.pytests` (sandbox tier, built alone):
  `RESULT: PASS (exit=0)`, same 22003/22000 totals.
- `nix build .#checks.x86_64-linux.nodetests` (sandbox tier, built alone):
  `RESULT: PASS (exit=0)`, 1449/1449.

Verdicts read from the runners' own `RESULT:` lines (via `nix log` for the
derivations), not from a piped exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127Gyg7Jrg9YakoKdq7bShM
