### PR TITLE
feat(mention): offer every repo you contribute to in the picker, and converge it daily

### DIFF
--- a/claudedocs/handoff-mention-system-repos.md
+++ b/claudedocs/handoff-mention-system-repos.md
@@ -22,21 +22,34 @@ Expand the mention system (`mention-open.py`) so clicking `repo#N` in Alacritty 
 copy-on-select · `#1328` (`3f4d9c0f`) local-first click path · `#1336` (`d790786a`)
 disclosure guard on KEYS + `audit-pr N` clickable · `#1331` (`8b173b05`) handoff.
 
-Both hosts converged and **compared** at `8b173b05`; `ship.sh` reported `NO dirty path is
-read by nix`. ⚠ `main` has since moved to `3f8c81bb` via OTHER sessions' work — that is not
-this effort's and needs no action here.
+**IN FLIGHT — rank 9, the picker universe (2026-09-07).** Branch `feat/picker-universe`,
+commit `41590742`, pushed, merged tree on `969f0581` (`merge-base --is-ancestor` CONFIRMED,
+not assumed). **No PR opened yet.** Claim `mention-system-repos-9` is HELD — release it
+when the PR lands. Operator asked for "all repos i contribute to (cached list +
+periodically query for new ones) so i can fuzzy search"; breadth and cadence were chosen by
+the operator (full 388 incl. archived+forks; daily).
 
-**Two full audit ladders ran, each to a clean stop.** #1313: round 1 → 5 findings → fix →
-round 2 safe-to-merge. #1328/#1336: round 1 → 3 findings → fix → round 2 found one 🔴 (below)
-→ fixed → merged.
+⚠ **GATE NOT FINISHED — do not read this as verified.** `scripts/gate.sh --tier both` was
+still running in the background when the session ended; the **nix sandbox tier has not been
+run at all**. Both tiers must be green on the merged tree before merge. First attempt
+failed `exit=3` = MISSING ENVIRONMENT (not a code failure) because the worktree's `.envrc`
+is `use opencode`; re-run inside `nix develop <worktree>`.
 
-**Measured on the deployed artifact:** `dashboard#12` **4.26 s → 0.086 s**.
-`talos-infra#1065` opens; bare `#1291` → clawgate task; `#282828` names the colour reason.
+**Measured live on the workbench 2026-09-07:**
+picker universe **392 rows, 52 reachable ONLY via the picker** (was 339 of 388).
+Mapping unchanged at 370 keys. `regen-known-repos.py --print` on a PATH with no `gh` → **rc 4**.
 
-⚠ **What is NOT verified**: the `repo_source == "default"` picker suppression could not be
-confirmed on the deployed copy, because `--print` prints candidates and never shows a
-picker — it cannot distinguish auto-open from one-row-picker. It was verified by the fix
-round and independently by the round-2 auditor, but not end-to-end by a human click.
+**Earlier, still true:** `dashboard#12` 4.26 s → 0.086 s; `talos-infra#1065` opens;
+bare `#1291` → clawgate task; `#282828` names the colour reason.
+
+⚠ **What is NOT verified**: the `repo_source == "default"` picker suppression, unchanged
+here — `--print` prints candidates and never shows a picker, so it cannot distinguish
+auto-open from a one-row picker. Needs a human click.
+
+**This session resolved no clawgate task** — `clawgate_handoff.sh resolve` exited 5 with its
+positive control passing (11 links for another session, so the board IS reachable). 🔴 That
+is NOT evidence this session touched no task: a wrong session id also answers 200 with an
+empty array. No `clawgate-task:` field was written.
 
 ## Open investigations — live diagnosis state
 (none — the disclosure is a known, measured state awaiting an operator decision, not a
@@ -52,6 +65,8 @@ diagnosis in progress.)
    🔴 NEEDS A HUMAN — clicking raises windows, a `pkill`-class action for an agent.
    forcing: none
 2. ~~Staleness signal for `known_repos.json`~~ — **DONE in #1328**, as a SIGNAL not a timer.
+   ⚠ Rank 9 CHANGED its meaning: a daily timer now converges the file, so the note is a
+   DEADMAN for that timer rather than a reminder to run the generator.
    forcing: none
 3. ~~Commit the `save_to_clipboard` WIP~~ — **DONE in #1322** (`a75ffc6a`).
    forcing: none
@@ -64,15 +79,11 @@ diagnosis in progress.)
    forcing: none
 7. **Clear the four 🟢 left by #1336's round-2 audit** (devrc; `scripts/tests/
    test_mention_open.py`, `scripts/collector/mention_scan.py`, `test_session_tailer.py`).
-   All prose/coverage-claim, no behaviour: (a) `test_the_one_row_picker_..._SAYS_WHY`
-   claims the note "NEVER names a repository" but only checks universe tokens — a mutant
-   naming the *pane-guessed* repo leaves all 401 tests green; (b) counts that do not
-   resolve — "Four tests drive `_run()`" is five then seven, a `mention-open.py:135`
-   reference that is now 141, and a `` `_load_handler` `` that does not exist anywhere;
-   (c) a comment claiming three sinks are "the WHOLE list" thirty lines after another says
-   the note "goes to rofi"; (d) the autouse fixture closes `MENTION_OPEN_KNOWN_REPOS` for
-   subprocesses but `DEVRC_WORKSPACE` is still per-test — the next `_run()` test with digits
-   and no `--no-discovery` fans out over the real `~/workspace`.
+   RE-VERIFIED 2026-09-07: all four still open. ⚠ **(d) is now CLOSED by rank 9** — the
+   autouse fixture pins `DEVRC_WORKSPACE` as well as the two mapping paths. (b) is
+   PARTLY closed: the `mention-open.py:135` citation is fixed (it pointed at a DIFFERENT
+   variable, `WORKSPACE`, while reading as precise), the `_load_handler` reference at
+   `:1653` and the "four tests drive `_run()`" count are NOT.
    forcing: none
 8. **Fix or retire Tekton's `devrc-pytests` leg** (not this effort's; needs an owner).
    MEASURED 2026-09-05: red on `test_mjs_parses[attachments.mjs]` for PR #1328 **and** for
@@ -81,6 +92,26 @@ diagnosis in progress.)
    environments. #1328 was merged past it.
    forcing: gate — a check red for every PR trains everyone to click through, which this
    session then did; `claude/RULES.md` calls a permanently-red gate worse than none.
+9. **Finish and land the picker-universe PR** — `feat/picker-universe` @ `41590742`,
+   IN FLIGHT, claim `mention-system-repos-9` HELD. Remaining, in order: (a) finish
+   `nix develop <worktree> -c bash scripts/gate.sh --tier both`; (b) run the sandbox tier
+   `nix build .#checks.x86_64-linux.pytests` and `.nodetests` **ONE AT A TIME** (a combined
+   invocation produces FALSE failures); (c) `gh pr create`, re-sweeping `gh pr list` first;
+   (d) merge, `ship.sh`, then `systemctl --user list-timers mention-known-repos-refresh` on
+   BOTH hosts. 🔴 The timer only exists after a `home-manager switch` — `git pull` changes
+   nothing nix manages.
+   forcing: gate — nothing blocks a merge in this repo, so the two-tier local run IS the gate.
+10. **Make the disclosure guard's own threshold non-fragile** (devrc;
+   `scripts/tests/test_regen_known_repos.py`). MEASURED 2026-09-07: the file sat at **19
+   distinct keys against its own threshold of 20**, so ONE new fixture key reddened a
+   DISCLOSURE guard. Worked around by reusing an existing key (`mirror`); the next person
+   adding a fixture hits it again, and the tempting fix under pressure — raise the
+   threshold, or exclude the file — guts the guard. The structural fix is the one already
+   used for the universe arm: count a single dict/list LITERAL, not distinct pairs
+   scattered across a 700-line file. 🔴 Deliberately NOT done inside the feature PR:
+   the text detector catches shapes the structural one would not, and narrowing a
+   disclosure guard as a side effect of a feature is how the original incident happened.
+   forcing: none
 
 ## Gotchas / decisions / dead-ends
 - `--no-discovery` flag intentionally skips the static mapping (Pass 2 only). This is by design: the flag means "resolve only what the text itself carries."
@@ -328,22 +359,105 @@ diagnosis in progress.)
   so a single URL is consistent with BOTH auto-open and a one-row picker. Any claim about
   that distinction needs the interactive path, which raises a window.
 
+- 🔴 **A DISPLAY LIST READ OUT OF A LOOKUP TABLE INHERITS THE LOOKUP'S FILTERS — AND THAT
+  IS THE WHOLE RANK-9 BUG.** `repo_universe()` was `sorted(discover_repos().values())`, so
+  the fuzzy picker silently obeyed both filters the RESOLUTION mapping needs: drop a repo
+  whose issues are disabled, drop a bare name two owners share. Both are correct for "what
+  does `foo#12` mean?" and wrong for "which repo do you want?", where the row is a full
+  `owner/repo` and nothing opens without a selection. MEASURED: 388 repos on the host, 339
+  offered — **53 unreachable by typing at the picker**. The two questions now have two
+  corpora (`known_repos.json`, `known_universe.json`). Generalises past this feature: when
+  a picker and a resolver share a source, ask which one's filters you inherited.
+- 🔴 **THE `has_issues` FILTER'S STATED JUSTIFICATION WAS FALSE, AND MY FIRST PROBE
+  CONFIRMED THE FALSE VERSION.** The comment said a bare `repo#N` "404s for EVERY N" in an
+  issues-disabled repo. It does not for PULL REQUESTS. First probe: 4 issues-disabled repos
+  via unauthenticated `curl`, 3 × 404 — which reads as confirmation and is **confounded**,
+  because an unauthenticated request 404s on a PRIVATE repo whatever the redirect does.
+  Re-run authenticated, with a positive control (2 issues-ENABLED repos first, both `PULL`):
+  **6 of 6** resolved `/issues/<pr>` to the pull request. **The confound was invisible until
+  the control was added** — the 3/4 split looked like a real mixed result. Ask what else
+  produces your 404 before believing it.
+- 🔴 **`user/repos` IS ALREADY "EVERY REPO I CONTRIBUTE TO" — MEASURED, SO NOBODY RE-ADDS A
+  SOURCE.** Its default affiliation (`owner,collaborator,organization_member`) is the widest
+  the endpoint offers. The plausible gap — a repo contributed to by PR without membership —
+  was measured: `search/issues?q=author:<login> type:pr` returned **28** repos, **all 28**
+  already in `user/repos`, **0 new**. The request was "all repos I contribute to"; the
+  answer was not a new API source, it was deleting two filters.
+- 🔴 **AN OBJECTION RECORDED IN CODE MUST BE ANSWERED, NOT STEPPED OVER.** The note beside
+  `STALE_MAPPING_DAYS` had explicitly weighed and REJECTED this timer: a scheduled `gh api`
+  run fails forever on a host without `gh auth`, so the unit is permanently red and toasts
+  daily, and a permanently-red timer is worse than no timer. That was CORRECT against a
+  generator with one failure code. Fix: exit **4** = not configured here (`SuccessExitStatus=4`,
+  quiet), exit **3** = configured and broken (still toasts). Readiness comes from
+  `gh auth status`'s **exit code**, never from matching words in its stderr — a phrasing
+  change would otherwise report every host as configured. Verified live: rc 4 on a PATH
+  with no `gh`, and the RENDERED unit inspected for `SuccessExitStatus=4` rather than
+  trusting that it built.
+- 🔴 **A NEW ARTEFACT SHAPE IS A NEW BLIND SPOT IN THE DISCLOSURE GUARD.**
+  `test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo` counts
+  `key: "owner/repo"` PAIRS. `known_universe.json` is a JSON **list** — no pairs — so it
+  scored **0** and would have sailed straight through the guard that exists to stop exactly
+  this, while naming MORE private repos than the mapping (it is unfiltered). Same structural
+  blindness as the #1283 incident, in a new shape. Added a detector for the list shape.
+- 🔴 **AND THE FIRST VERSION OF THAT DETECTOR WAS TEXTUAL AND USELESS — 9 FALSE ACCUSATIONS
+  ON ITS FIRST RUN.** Counting every quoted `a/b` flagged a `package-lock.json` (46, all npm
+  `node_modules/…` paths) and eight test files whose fixtures merely mention repos. Replaced
+  with a STRUCTURAL question — is this file a LIST of repositories? — parsed as JSON and via
+  `ast` for the Python-literal spelling. **A guard that fires on ordinary files is a guard
+  everyone learns to override**, which is worse than the gap it closes.
+- 🔴 **A DISCLOSURE GUARD WAS ONE FIXTURE KEY FROM RED.** Its own test file carried **19**
+  distinct keys against a threshold of **20**; a single new key tripped it. Worked around by
+  reusing an existing key — see rank 10 for the structural fix, deliberately left out of the
+  feature PR because narrowing a disclosure guard as a side effect is how #1283 happened.
+- 🔴 **A TEST FIXTURE THAT INVENTS CONTENT IS NOT A REDIRECT — IT SILENTLY REWROTE NINE
+  TESTS.** The autouse fixture that points the mapping away from the operator's real file
+  was extended to the new universe file, and it initially WROTE default content there.
+  Nine existing tests built to assert an EMPTY universe (unreadable mapping, mapping with no
+  usable rows) then got a picker from the file instead of the refusal they pin, and failed
+  for reasons unrelated to what they test. **A redirect must relocate a read, never supply
+  content the test did not ask for.** The universe path is now redirected to a file that
+  does not exist; tests wanting a universe write one.
+- 🔴 **A BASE-VS-HEAD MATRIX CAN BE STRUCTURALLY IMPOSSIBLE, AND SAYING SO IS THE HONEST
+  ANSWER.** The new `test_mention_open.py` cannot run at `origin/main` at all: its autouse
+  fixture does `setattr(MO, "KNOWN_UNIVERSE_PATH", …)` and the old module has no such
+  attribute, so all **163** tests ERROR at fixture setup. That is red-for-the-wrong-reason
+  and proves nothing about any guard. Evidence for that half is a MUTATION BATTERY instead —
+  8 mutants, each required to be killed by its OWN named test, plus a harness control that
+  must SURVIVE. The generator half DID produce a real matrix (14 red at `969f0581`, 46 green
+  at HEAD). **Report which half you got; an ERROR at base is not a FAIL at base.**
+- **The `| tail` trap fired again, exactly as documented.** `gate.sh … | tail -30` printed
+  `GATE_RC=0` over `GATE: RESULT=FAIL exit=1`. Read the runner's own verdict line.
+- **`gate.sh` exit 3 in a worktree is a MISSING ENVIRONMENT, not a code failure** — the
+  worktree's copied `.envrc` is `use opencode`, which puts no pytest on PATH. The gate says
+  so itself and prints the `nix develop <worktree> --command …` to re-run. Not a red gate.
+- **zsh does not word-split, and it bit a `for` loop over `find` output** (`for f in $S`
+  ran once on the whole newline-joined string). Documented in CLAUDE.md; still hit it.
+
 ## How to verify
 ```bash
 # The click path, on the deployed artifact (mention-open runs from the WORKING TREE,
 # so `git pull` alone changes it — only the telemetry half needs a switch)
-time python3 ~/workspace/devrc/scripts/mention-open.py --print 'dashboard#12'   # ~0.09s
+time python3 ~/workspace/devrc/scripts/mention-open.py --print 'dashboard#12'   # ~0.09s, REFUSES
 python3 ~/workspace/devrc/scripts/mention-open.py --print 'talos-infra#1065'    # civitai/talos-infra
 python3 ~/workspace/devrc/scripts/mention-open.py --print '#1291'               # clawgate task
 python3 ~/workspace/devrc/scripts/mention-open.py --print '#282828'             # names the colour reason
 
+# The picker universe — counts only, NEVER paste the rows anywhere
+python3 ~/workspace/devrc/scripts/regen-known-repos.py --print   # "N repo(s) in the picker universe"
+ls -l ~/.config/mention-open/known_repos.json ~/.config/mention-open/known_universe.json  # both 0600
+git -C ~/workspace/devrc ls-files | grep -cE 'known_repos|known_universe'   # must be 0
+
+# The not-configured arm — the whole reason the timer is safe. Want rc 4, NOT 3.
+PY=$(dirname $(readlink -f $(command -v python3)))
+env PATH="$PY" python3 ~/workspace/devrc/scripts/regen-known-repos.py --print; echo "rc=$?"
+
+# The timer, AFTER a home-manager switch (it does not exist before one)
+systemctl --user list-timers mention-known-repos-refresh
+systemctl --user cat mention-known-repos-refresh.service | grep SuccessExitStatus  # =4
+
 # Which half needs a switch — readlink is the arbiter, never a diff
 readlink -f ~/.config/alacritty/alacritty.toml            # /nix/store/... -> needs a switch
 readlink -f ~/.config/activity-collector/mention_scan.py  # /nix/store/... -> needs a switch
-
-# The mapping is per-host, untracked, 0600
-ls -l ~/.config/mention-open/known_repos.json
-git -C ~/workspace/devrc ls-files | grep -c 'collector/known_repos'   # must be 0
 
 # The committed mutation battery (re-runnable, unlike round 1's)
 nix develop ~/workspace/devrc -c python3 ~/workspace/devrc/scripts/tests/mutation_battery_mentions.py

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -4154,6 +4154,85 @@ in
     };
   };
 
+  # ------------------------------------------------------------------------ #
+  # mention-open's repo mapping + picker universe — the thing that makes
+  # clicking `repo#N` in Alacritty resolve, and makes the fuzzy picker offer
+  # every repo the operator contributes to.
+  #
+  # 🔴 NOT GATED ON serverMode OR graphical, AND THAT IS DELIBERATE. The
+  # consumer is a terminal click handler, which is every host with a terminal —
+  # both of them. Gating this the way `present-regen` is gated would converge
+  # the workbench and leave the laptop's mapping frozen at whenever someone last
+  # ran the generator by hand, which is the exact failure the timer exists to
+  # remove and would be invisible (a stale mapping's only symptom is the picker
+  # appearing where a resolution used to).
+  #
+  # 🔴 THIS TIMER WAS ONCE ARGUED AGAINST IN `scripts/mention-open.py`, AND THE
+  # OBJECTION WAS ANSWERED RATHER THAN OVERRULED — read it before removing the
+  # `SuccessExitStatus` below. The note beside `STALE_MAPPING_DAYS` reasoned
+  # that a scheduled `gh api user/repos` would fail on any host without
+  # `gh auth`, so the unit would be permanently red and toast on every fire, and
+  # that a permanently-red timer is worse than no timer. That was true of a
+  # generator with ONE failure code. It now exits 4 for "not configured on this
+  # host" and 3 only for a genuine failure.
+  systemd.user.services.mention-known-repos-refresh = {
+    Unit = {
+      Description = "Refresh the mention-open repo mapping and picker universe";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # 🔴 4 IS A SUCCESS TO systemd AND A FAILURE TO NOBODY. It means `gh` is
+      # absent or not logged in on this host — a legitimate state the click
+      # handler degrades cleanly to (`owner/repo#N` and local checkouts still
+      # resolve). Without this line the unit goes red on such a host and the
+      # DND-defeating failure toast fires daily, forever, which is precisely the
+      # objection that kept this timer from being written for months. A REAL
+      # failure — gh authenticated but the API errored, or returned fewer repos
+      # than the generator's floor — is still exit 3 and still toasts.
+      SuccessExitStatus = [ 4 ];
+      # A cold paginated run over ~400 repos is a few seconds; the `gh api` call
+      # carries its own 120s timeout and `gh auth status` 30s. 300 is a ceiling
+      # for a wedged network, not a budget.
+      TimeoutStartSec = 300;
+      Environment = [
+        "PATH=${lib.makeBinPath [ pkgs.python3 pkgs.git pkgs.gh pkgs.coreutils ]}"
+        # `gh` reads its token from ~/.config/gh, and the generator writes to
+        # ~/.config/mention-open — both need HOME under a user unit.
+        "HOME=%h"
+      ];
+      # 🔴 AN ABSOLUTE STORE PATH FOR THE INTERPRETER, A WORKING-TREE PATH FOR
+      # THE SCRIPT. The interpreter must not be a bare name: a `home-manager
+      # switch` writes two profile generations and the intermediate one drops
+      # every `home.packages` binary for ~1s, so anything invoked by bare name
+      # during a switch dies "command not found". The SCRIPT is read from the
+      # checkout on purpose — it is the same copy `mention-open.py` runs from,
+      # so a `git pull` updates both together and neither needs a switch.
+      ExecStart = "${pkgs.python3}/bin/python3 %h/workspace/devrc/scripts/regen-known-repos.py";
+      X-Restart-Triggers = [ "${../scripts/regen-known-repos.py}" ];
+    };
+  };
+
+  # Daily. RandomizedDelaySec keeps it off the 04:00/05:00 cluster the other
+  # units sit on; Persistent catches up a single missed run after a reboot,
+  # which matters on the laptop — a host that is closed at the boundary would
+  # otherwise skip a day silently, and the only symptom is an age.
+  systemd.user.timers.mention-known-repos-refresh = {
+    Unit = {
+      Description = "Daily timer for the mention-open repo mapping refresh";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 07:00:00";
+      Persistent = true;
+      RandomizedDelaySec = 900;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
   # The server. STATIC on purpose, and that is the whole design: no refresh
   # button, no subprocess, no credential, no sops, no gh — none of what
   # `initiatives-viewer` needs for its ↻ button. It answers two artefact routes

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -142,30 +142,59 @@ KNOWN_REPOS_PATH = Path(
     or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
     / "mention-open" / "known_repos.json")
 
-# 🔴 THE MAPPING IS HAND-REGENERATED ONLY, AND NOTHING CONVERGES IT. There is no
-# timer anywhere in `nix/` that runs `scripts/regen-known-repos.py`, so a
-# repository created after the last run is INVISIBLE to every resolution path —
-# and the symptom is the picker appearing for a name that ought to have resolved,
-# which reads as "the picker is noisy" rather than as "my mapping is old".
+# The generated PICKER UNIVERSE — a JSON list of `owner/repo`, same directory,
+# same 0600, same disclosure rules. It answers a DIFFERENT question from the
+# mapping beside it: the mapping says what a bare name MEANS, this says what the
+# operator might want OFFERED. `regen-known-repos.py`'s docstring carries the
+# full argument and the measurement.
 #
-# So the age is MEASURED and SURFACED. Its PRIMARY home is the note above the
-# picker (`universe_note`), because that is the path a stale mapping actually
-# produces — the click that did not resolve. `staleness_note` covers the two
-# refusals: `--print`, which cannot show a picker at all, and the narrow
-# shadowed-mapping arm documented in `refuse()`. Stating that split here rather
-# than "the refusal body" is deliberate: the vaguer wording read as "every
-# refusal past 7 days", which is not what the code does.
-# It is a SIGNAL, not a repair — deliberately, and the
-# alternative was weighed: a systemd-user timer would run `gh api user/repos`
-# on a schedule, and `regen-known-repos.py` REFUSES below its 25-repo floor and
-# exits 3, so a host without `gh auth` would take a failing unit and a failure
-# toast on every fire. A permanently-red timer is worse than no timer. The
-# signal fires at the exact moment the staleness bites, which is the click that
-# did not resolve.
+# 🔴 THE ENV OVERRIDE IS NOT A CONVENIENCE — IT IS WHAT LETS TESTS REDIRECT A
+# SUBPROCESS. `MENTION_OPEN_KNOWN_REPOS` exists for exactly that reason (nine
+# tests were measured reading the operator's real mapping, two of them
+# DISCLOSURE tests, and a `monkeypatch.setattr` on the module constant is
+# invisible to a child process that re-imports this file). A new host-state file
+# without the same door would re-open the same hole for the universe.
+KNOWN_UNIVERSE_PATH = Path(
+    os.environ.get("MENTION_OPEN_KNOWN_UNIVERSE")
+    or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    / "mention-open" / "known_universe.json")
+
+# 🔴 A TIMER NOW CONVERGES THE MAPPING, AND THIS PARAGRAPH USED TO SAY THE
+# OPPOSITE — do not re-derive the old reasoning from a stale copy of it. It read
+# "THE MAPPING IS HAND-REGENERATED ONLY … There is no timer anywhere in `nix/`",
+# and it argued a timer would be WORSE than the signal: `regen-known-repos.py`
+# had one failure code, so a host without `gh auth` would take a failing unit
+# and a failure toast on every fire, and a permanently-red timer is worse than
+# no timer. That objection was correct, and it was answered rather than
+# overruled — the generator now exits 4 for "not configured on this host" and 3
+# only for a real failure, and `mention-known-repos-refresh.service` sets
+# `SuccessExitStatus=4`. An unauthenticated host is quiet; a broken run toasts.
+#
+# `nix/home.nix` → `systemd.user.timers.mention-known-repos-refresh`, daily.
+#
+# 🔴 THE SIGNAL BELOW STAYS, AND IS NOW A DEADMAN RATHER THAN A REMINDER. Its
+# job changed: it used to say "you never ran the generator", which the operator
+# could act on directly. It now says "the timer has not landed a fresh file in
+# a week", whose causes are a unit that is failing, a host that was off, or a
+# token that expired — none of which the operator would otherwise see, because
+# a stale mapping's only symptom is the picker appearing where a resolution used
+# to. A converged file makes the note unreachable in the ordinary case, which is
+# the point; it is NOT dead code, and the tests reach it by ageing the file.
+#
+# Its PRIMARY home is the note above the picker (`universe_note`), because that
+# is the path a stale mapping actually produces — the click that did not
+# resolve. `staleness_note` covers the two refusals: `--print`, which cannot
+# show a picker at all, and the narrow shadowed-mapping arm documented in
+# `refuse()`. Stating that split here rather than "the refusal body" is
+# deliberate: the vaguer wording read as "every refusal past 7 days", which is
+# not what the code does.
 #
 # Seven days is a week of repo-creating, not a tuned constant; it is pinned at
 # two points (fresh and stale) rather than at a boundary, and it is not
-# env-overridable because a run must not be able to excuse itself.
+# env-overridable because a run must not be able to excuse itself. ⚠ It is
+# deliberately NOT re-tuned to the timer's daily period: a 2-day threshold would
+# fire on one missed run, and a laptop that spends a weekend closed is not a
+# fault. Seven days means "several consecutive runs did not happen".
 STALE_MAPPING_DAYS = 7
 
 # rofi theme — the same one nix/i3/config.nix already uses for the app launcher,
@@ -302,21 +331,51 @@ def picker_rows(candidates: list[dict]) -> list[str]:
     return rows
 
 
-def repo_universe(repos: dict | None) -> list[str]:
-    """Every distinct `owner/repo` this host knows about, sorted.
+def repo_universe(repos: dict | None,
+                  universe: list[str] | None = None) -> list[str]:
+    """Every distinct `owner/repo` worth offering, sorted — the picker's rows.
 
-    The input is `discover_repos()`'s mapping — the generated file laid under the
-    real local checkouts — so this is a MEASUREMENT of the host, not a list of
-    plausible names. Values that are not exactly `owner/repo` are dropped for the
-    same reason they are dropped on load: they build a URL that 404s while
-    looking authoritative.
+    TWO SOURCES, UNIONED, AND THE UNION IS THE WHOLE FIX:
+      * `universe` — the generated `known_universe.json`, which is every repo the
+        operator owns or collaborates on, unfiltered.
+      * `repos` — `discover_repos()`'s mapping: the generated resolution mapping
+        laid under the real local checkouts.
+
+    🔴 THIS USED TO READ `repos.values()` ALONE, AND THAT SILENTLY INHERITED THE
+    MAPPING'S FILTERS. The mapping exists to answer "what does the bare name
+    `foo` mean?", so it drops a repo whose issues are disabled and drops a name
+    two owners share — both correct for resolution, both wrong for a picker
+    whose rows are fully-qualified and where nothing opens without a selection.
+    MEASURED 2026-09-07: 388 repos on this host, 339 offered, **53 unreachable**
+    by typing at the picker. Reading a display list out of a lookup table is the
+    general shape; the two questions differ and so must the filters.
+
+    ⚠ THE UNION IS STRICTLY WIDENING, NEVER NARROWING, and that is deliberate.
+    A local checkout can name a repo the API never returned (a clone of somebody
+    else's repository), and the generated universe can name one that is not on
+    this disk. Neither source can REMOVE a row the other contributed — there is
+    no precedence rule here because there is no conflict to resolve: this is a
+    list of things to offer, not a mapping from a name to one answer.
+
+    Rows that are not exactly `owner/repo` are dropped from BOTH sources — they
+    build a URL that 404s while looking authoritative — and the result is deduped
+    case-insensitively, because `acme/Widget` and `acme/widget` are one
+    repository on GitHub and two identical-looking rows in rofi.
 
     🔴 THE RETURN VALUE NAMES PRIVATE REPOSITORIES. It may reach the operator's
     rofi window and nothing else — no log line, no notification body, no
     telemetry row, no test fixture. See the module docstring.
     """
-    return sorted({v for v in (repos or {}).values()
-                   if isinstance(v, str) and _OWNER_REPO_RE.match(v)})
+    by_key: dict[str, str] = {}
+    # Mapping values first, so a name this host has ON DISK keeps the spelling
+    # its remote uses; the generated universe then adds everything else.
+    for v in (repos or {}).values():
+        if isinstance(v, str) and _OWNER_REPO_RE.match(v):
+            by_key.setdefault(v.lower(), v)
+    for v in (universe or []):
+        if isinstance(v, str) and _OWNER_REPO_RE.match(v):
+            by_key.setdefault(v.lower(), v)
+    return sorted(by_key.values(), key=str.lower)
 
 
 def universe_candidates(num: str, universe: list[str]) -> list[dict]:
@@ -409,6 +468,35 @@ def load_known_repos(path: Path | None = None) -> dict[str, str]:
     # tailer loads the same mapping and a predicate open-coded at two sites is
     # wrong at one of them.
     return clean_repo_map(raw)
+
+
+def load_known_universe(path: Path | None = None) -> list[str]:
+    """`["owner/repo", …]` from the operator's generated universe file, or [].
+
+    🔴 EVERY failure is `[]` — absent, unreadable, malformed, wrong shape, wrong
+    element type. Identical posture to `load_known_repos`, for the identical
+    reason: this runs on a detached click handler with nowhere to print a
+    traceback, and the file is an OPTIONAL widener. Without it the picker still
+    offers everything `discover_repos()` found, which is exactly the behaviour
+    that shipped before this file existed — so a host that has never run the
+    generator, or is mid-write, degrades to the old universe rather than to none.
+
+    ⚠ A LIST, NOT A DICT, and the shape check is not a formality: `json.loads`
+    of the mapping file beside it returns a dict, and a `--path`/`--universe-path`
+    mix-up at generation time would otherwise silently produce a universe of
+    single characters (iterating a dict yields its keys). A non-list is [].
+    """
+    # 🔴 RESOLVED AT CALL TIME, NOT BOUND AS A DEFAULT — the same defect that
+    # made `load_known_repos`' override test inert and left the whole suite
+    # green with the call deleted. See that function's comment.
+    path = path or KNOWN_UNIVERSE_PATH
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    if not isinstance(raw, list):
+        return []
+    return [v for v in raw if isinstance(v, str) and _OWNER_REPO_RE.match(v)]
 
 
 def discover_repos(workspace: Path | None = None) -> dict:
@@ -719,18 +807,24 @@ def mapping_age_days(path: Path | None = None) -> float | None:
 def staleness_note(path: Path | None = None) -> str:
     """"the repo mapping is N days old — …" when it is, else "".
 
-    🔴 IT IS A SIGNAL FOR A FILE NOTHING CONVERGES. See `STALE_MAPPING_DAYS`.
-    A repository created since the last `regen-known-repos.py` run cannot be
-    resolved by ANY path here, and the only symptom is a picker appearing where
-    a resolution used to — so the refusal says how old the mapping is and what
-    to run. It names a COUNT and a CONSTANT PATH, never a row.
+    🔴 IT IS THE TIMER'S DEADMAN. See `STALE_MAPPING_DAYS`. A daily unit
+    regenerates this file, so past seven days SEVERAL consecutive runs did not
+    land — the unit is failing, the token expired, or the host was off — and
+    none of those is visible anywhere else, because a stale mapping's only
+    symptom is a picker appearing where a resolution used to.
+
+    ⚠ THE TEXT USED TO SAY "nothing regenerates it", WHICH IS NOW FALSE and
+    would send the operator to re-run a generator by hand instead of looking at
+    the unit that is silently failing. It names a COUNT, a CONSTANT PATH and a
+    UNIT NAME — never a row.
     """
     age = mapping_age_days(path)
     if age is None or age < STALE_MAPPING_DAYS:
         return ""
-    return (f"the repo mapping is {age:.0f} days old and nothing regenerates it "
-            f"— a repository created since then cannot resolve; run "
-            f"scripts/regen-known-repos.py")
+    return (f"the repo mapping is {age:.0f} days old — the daily refresh has "
+            f"not landed, so a repository created since then cannot resolve; "
+            f"check `systemctl --user status mention-known-repos-refresh` "
+            f"or run scripts/regen-known-repos.py")
 
 
 def universe_note(subject: str, offered: int, path: Path | None = None) -> str:
@@ -1000,7 +1094,14 @@ def main(argv: list[str] | None = None) -> int:
     may_offer_universe = (not args.print_only and not args.no_discovery
                           and not colour)
     num = span["id"] if (span is not None and span["id"].isdigit()) else offer_num
-    universe = (universe_candidates(num, repo_universe(discovered))
+    # 🔴 `load_known_universe()` IS INSIDE THE CONDITIONAL EXPRESSION ON PURPOSE
+    # — Python does not evaluate the true-branch when the condition is false, so
+    # the file read costs NOTHING on the clicks that never show a picker, which
+    # are the common ones. Hoisting it to its own statement above would put a
+    # `stat` + `read` + `json.loads` on every `owner/repo#N` click, the exact
+    # class of tax the lazy `concurrent.futures` import was moved to avoid.
+    universe = (universe_candidates(
+                    num, repo_universe(discovered, load_known_universe()))
                 if (may_offer_universe and num) else [])
     if not candidates and universe:
         # Dead end 1 — an unresolvable `repo#N`, or text the scanner refused

--- a/scripts/regen-known-repos.py
+++ b/scripts/regen-known-repos.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Regenerate the mention-resolution repo mapping — OUTSIDE the repository.
+"""Regenerate the mention repo mapping and picker universe — OUTSIDE the repo.
 
-    scripts/regen-known-repos.py [--print] [--path <file>]
+    scripts/regen-known-repos.py [--print] [--path <file>] [--universe-path <file>]
 
 🔴 THE OUTPUT IS NOT TRACKED, AND THAT IS THE POINT. `gh api user/repos` returns
 every repo the token can see, PRIVATE ONES INCLUDED. An earlier version of this
@@ -12,22 +12,74 @@ internal architecture and client relationships, and every content gate in this
 repo was structurally blind to it — they scan JSON/JSONL/HTML/TXT and hostnames,
 so a `.py` dict of repo names matched none of them.
 
-So the mapping is written to `~/.config/mention-open/known_repos.json` (mode
-0600), which is per-host, outside every checkout, and cannot be `git add`ed by
-accident. `scripts/mention-open.py` reads it if it is there and works without it.
+So both files are written to `~/.config/mention-open/` (mode 0600), which is
+per-host, outside every checkout, and cannot be `git add`ed by accident.
+`scripts/mention-open.py` reads them if they are there and works without either.
 
-WHAT IS FILTERED OUT, AND WHY EACH ONE IS A WRONG ANSWER RATHER THAN A MISSING ONE
-  * `has_issues == false` — `repo#N` builds an issues URL, and a repo with issues
-    disabled 404s for EVERY N. Measured on the first version: 44 of 383 mapped
-    repos, including `civitai/ComfyUI`, a fork whose issues are disabled and
-    whose `#100` was the example used to justify the mapping in the first place.
+TWO OUTPUTS, TWO DIFFERENT QUESTIONS — AND THAT IS THE WHOLE DESIGN HERE
+  * `known_repos.json`  — the RESOLUTION mapping: "what repo does the bare name
+    `foo` in `foo#12` mean?". A wrong answer here opens a confident wrong page,
+    so it is filtered hard (below) and an unanswerable name resolves to NOTHING.
+  * `known_universe.json` — the PICKER universe: "which repos might I want to
+    open, so I can fuzzy-type at them?". Every row is displayed as a full
+    `owner/repo` and NOTHING is opened without the operator selecting it, so the
+    filters that protect resolution buy nothing here and cost coverage.
+
+🔴 DERIVING THE UNIVERSE FROM THE MAPPING WAS THE BUG. `repo_universe()` used to
+read the mapping's `.values()`, which silently inherited both resolution filters.
+MEASURED 2026-09-07 on this host: `gh api user/repos` returned **388** repos and
+the picker offered **339** — 48 dropped for `has_issues == false` and 7 bare
+names dropped as ambiguous (14 repos), overlapping to 53 absent. All 53 are repos
+the operator owns or collaborates on, and none of them could be reached by typing
+at the picker. The universe is now built from the API rows directly.
+
+WHAT THE MAPPING FILTERS OUT, AND WHY EACH IS A WRONG ANSWER RATHER THAN A MISSING ONE
+  * `has_issues == false` — a bare `repo#N` builds an issues URL. ⚠ THE ORIGINAL
+    JUSTIFICATION HERE WAS TOO WIDE AND IS CORRECTED: it read "404s for EVERY N",
+    which is false for PULL REQUESTS. MEASURED 2026-09-07 with a positive control
+    (2 issues-ENABLED repos first, both `PULL`): **6 of 6** issues-disabled repos
+    resolved `/issues/<pr>` to the pull request. An earlier probe that saw 3 of 4
+    404 was confounded — unauthenticated `curl` 404s on a PRIVATE repo whatever
+    the redirect does. So the filter is kept for the MAPPING on the narrower true
+    reason — an issues-disabled repo has no ISSUES, so a bare `#N` naming a real
+    issue number is a wrong answer — and is NOT applied to the universe, where
+    the operator picks the repo themselves and PRs are the common case.
   * a bare name owned by TWO owners — last-write-wins silently picked one.
     Measured: 7 collisions, and `bitdex` resolved to a third party's fork rather
     than the client's repo. An ambiguous name resolves to NOTHING; the operator
     writes `owner/repo#N`, exactly as the module's no-guessing rule requires.
+    Not applied to the universe either: a picker ROW is `owner/repo`, so there is
+    no ambiguity left to arbitrate — that is precisely what the operator is being
+    asked to settle.
   * linked worktrees (`.git` is a FILE, not a directory) — they share the base
     clone's remote, so they add no owner, and their transient names churned the
-    output on every run.
+    output on every run. This one DOES apply to both.
+
+🔴 `user/repos` IS ALREADY "EVERY REPO I CONTRIBUTE TO" — MEASURED, NOT ASSUMED.
+Its default affiliation is `owner,collaborator,organization_member`, the widest
+the endpoint offers. The obvious worry is a repo contributed to by PR without
+membership, so it was measured: `search/issues?q=author:<login> type:pr` returned
+**28** repos and **all 28** were already in `user/repos` — 0 new. Do not add a
+second API source on the theory that it widens the set; it did not.
+
+EXIT CODES — AND WHY THERE ARE TWO KINDS OF FAILURE
+  0  wrote (or, with --print, reported)
+  3  🔴 A REAL FAILURE. `gh` is present and authenticated and the run still did
+     not produce a trustworthy list — the API errored, or returned fewer than
+     MIN_API_REPOS. Worth a toast; something is wrong.
+  4  ⚠ NOT CONFIGURED ON THIS HOST — `gh` is absent, or present and not logged
+     in. This is a legitimate state, not a fault, and `mention-open.py` degrades
+     to `owner/repo#N` plus local checkouts without either file.
+🔴 THE SPLIT IS WHAT MAKES THE TIMER POSSIBLE, and it exists because the timer
+was once REJECTED on exactly this ground: the note beside `STALE_MAPPING_DAYS`
+in `mention-open.py` argued a scheduled run "would take a failing unit and a
+failure toast on every fire" on a host without `gh auth`, and that a permanently
+red timer is worse than no timer. That objection was correct against a single
+failure code. `mention-known-repos-refresh.service` sets `SuccessExitStatus=4`,
+so an unauthenticated host is quiet and a genuinely broken run still toasts.
+Readiness is asked of `gh auth status`, whose exit code is a documented contract
+— never by matching words in stderr, which would make the split depend on
+`gh`'s phrasing.
 """
 from __future__ import annotations
 
@@ -39,9 +91,20 @@ import subprocess
 import sys
 from pathlib import Path
 
-DEFAULT_PATH = Path(
+_CONFIG_DIR = Path(
     os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
-) / "mention-open" / "known_repos.json"
+) / "mention-open"
+
+DEFAULT_PATH = _CONFIG_DIR / "known_repos.json"
+
+# 🔴 A SECOND FILE RATHER THAN A NEW SHAPE IN THE FIRST, DELIBERATELY. The
+# mapping is read by TWO deployed consumers — `mention-open.py` (from the working
+# tree) and the collector's `session-tailer.py` (a nix `home.file` COPY that only
+# changes on a `home-manager switch`). Changing `known_repos.json`'s shape would
+# need both to change together, and they cannot: between the switch and the next
+# regen the two would disagree about the file's format. A new file has no flag
+# day — an old reader never opens it, and a new reader treats it as absent.
+DEFAULT_UNIVERSE_PATH = _CONFIG_DIR / "known_universe.json"
 
 WORKSPACE = Path(os.environ.get("DEVRC_WORKSPACE", Path.home() / "workspace"))
 
@@ -51,8 +114,31 @@ WORKSPACE = Path(os.environ.get("DEVRC_WORKSPACE", Path.home() / "workspace"))
 # class this whole change exists to fix.
 MIN_API_REPOS = 25
 
+EXIT_FAILED = 3
+EXIT_NOT_CONFIGURED = 4
+
+
+class NotConfigured(RuntimeError):
+    """`gh` is absent or not logged in — an expected host state, not a fault.
+
+    🔴 A SEPARATE TYPE, NOT A FLAG ON THE MESSAGE, because the caller must not
+    have to read the sentence to decide whether to toast. See the module
+    docstring's exit-code section for why the two are split at all.
+    """
+
 _SSH_REMOTE = re.compile(r"^(?:ssh://)?git@[^:/]+[:/](?P<path>.+?)(?:\.git)?/?$")
 _HTTP_REMOTE = re.compile(r"^https?://[^/]+/(?P<path>.+?)(?:\.git)?/?$")
+
+# 🔴 IMPORTED, NOT RE-DECLARED — the same choice `mention-open.py` makes at its
+# own import block, for the same reason. What counts as a well-formed
+# `owner/repo` is ONE rule owned by `mention_scan`, and this generator WRITES
+# the files that module's consumers then filter on load. A second copy here
+# would be a predicate at two sites: the day the rule tightens, this script
+# keeps writing rows the reader silently drops, and the picker quietly loses
+# repos with every file looking fine.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "collector"))
+
+from mention_scan import OWNER_REPO_VALUE_RE as _OWNER_REPO_RE  # noqa: E402
 
 
 def parse_owner_repo(remote_url: str) -> str:
@@ -208,6 +294,96 @@ def build_mapping(api_repos: list[dict], local_repos: dict[str, str]) -> dict[st
     return out
 
 
+def require_gh_ready() -> None:
+    """Raise `NotConfigured` unless `gh` is present AND logged in.
+
+    🔴 THE READINESS QUESTION IS ASKED OF AN EXIT CODE, NEVER OF STDERR.
+    `gh auth status` is documented to exit non-zero when there is no usable
+    token, and that contract is stable in a way its wording is not — a guard
+    that matched "not logged in" would silently start reporting every host as
+    configured the day `gh` rephrases the message, which is the parsing-tool-
+    output trap. Nothing here reads what it printed.
+
+    ⚠ IT IS A PRECONDITION, NOT A PREDICTION. A token can be revoked between
+    this call and the API call below; that lands as a genuine failure (exit 3)
+    and SHOULD, because a host that was configured a second ago and is not now
+    is worth a toast.
+    """
+    try:
+        r = subprocess.run(["gh", "auth", "status"],
+                           capture_output=True, text=True, timeout=30)
+    except FileNotFoundError as exc:
+        raise NotConfigured("gh is not installed on this host") from exc
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise NotConfigured(f"gh auth status could not be run: {exc}") from exc
+    if r.returncode != 0:
+        raise NotConfigured("gh is installed but not logged in "
+                            "(`gh auth status` exited non-zero) — run `gh auth login`")
+
+
+def build_universe(api_repos: list[dict],
+                   local_repos: dict[str, str]) -> list[str]:
+    """Every distinct `owner/repo` worth OFFERING, sorted — the picker universe.
+
+    🔴 THIS IS DELIBERATELY WIDER THAN `build_mapping`, AND THE ASYMMETRY IS THE
+    POINT. Neither of that function's two filters is applied:
+
+      * `has_issues` is not consulted. A universe row is displayed as a full
+        `owner/repo` and turned into `/issues/<n>`, and GitHub resolves that to
+        the PULL REQUEST even where issues are disabled — measured 6/6, with a
+        positive control, on this host's own issues-disabled repos. Dropping
+        them cost 48 repos to protect against a case (a bare number that is a
+        real ISSUE id in a repo with no issues) the operator has already ruled
+        out by choosing the row.
+      * ambiguity is not arbitrated, because there is none left to arbitrate.
+        `build_mapping` drops `bitdex` when two owners have one; here BOTH
+        `alice/bitdex` and `bob/bitdex` are offered, spelled out, and the
+        operator picks. That is a better answer than the mapping's silence and a
+        far better one than last-write-wins.
+
+    Local checkouts are unioned in rather than overlaid: this is a list, not a
+    lookup, so a checkout cannot contradict an API row — it can only add one the
+    API never returned (a clone of somebody else's repository).
+
+    🔴 DEDUPED CASE-INSENSITIVELY, KEEPING THE API'S SPELLING. GitHub repo names
+    are case-insensitive, so `civitai/ComfyUI` from the API and `civitai/comfyui`
+    from a lowercase clone URL are ONE repository; offering both would put two
+    identical-looking rows in front of the operator. The API row wins because it
+    is canonical — a remote URL preserves whatever the person who cloned typed.
+
+    🔴 THE RETURN VALUE NAMES PRIVATE REPOSITORIES. It goes to a 0600 file and,
+    at click time, to the operator's own rofi window — never to a log, a
+    notification body, a telemetry row or a test fixture. See the module
+    docstring for the incident that established this.
+    """
+    by_key: dict[str, str] = {}
+    for row in api_repos:
+        full = (row.get("full_name") or "").strip()
+        if _OWNER_REPO_RE.match(full):
+            by_key.setdefault(full.lower(), full)
+    for full in local_repos.values():
+        full = (full or "").strip()
+        if _OWNER_REPO_RE.match(full):
+            by_key.setdefault(full.lower(), full)
+    # Sorted case-insensitively so the picker's order matches how it reads.
+    return sorted(by_key.values(), key=str.lower)
+
+
+def write_universe(universe: list[str], path: Path) -> None:
+    """Write 0600, parent 0700 — it names private repositories.
+
+    Same atomic tmp-then-replace as `write_mapping`: a reader that opens the
+    file while it is being rewritten must see the old content or the new, never
+    a truncated JSON document. `mention-open.py` answers a parse error with an
+    empty universe, so a torn write would silently produce an empty picker.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(universe, indent=1) + "\n")
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
 def read_api_repos() -> list[dict]:
     """Rows from `gh api user/repos`. Raises RuntimeError — never returns a
     short list quietly, because a short list is indistinguishable from a fine
@@ -276,31 +452,55 @@ def write_mapping(mapping: dict[str, str], path: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     ap.add_argument("--path", type=Path, default=DEFAULT_PATH)
+    ap.add_argument("--universe-path", type=Path, default=DEFAULT_UNIVERSE_PATH)
     ap.add_argument("--print", action="store_true", dest="print_only",
                     help="write nothing; report what WOULD be written")
     args = ap.parse_args(argv)
+
+    # 🔴 READINESS IS ASKED BEFORE THE WORK, so an unconfigured host exits 4
+    # without a 120-second paginated API call it cannot make. `NotConfigured` is
+    # caught FIRST — it subclasses RuntimeError, so the wider `except` below
+    # would swallow it and report a real failure on a host that simply has no
+    # `gh`. Ordering is the guard here; there is a test that inverts it.
+    try:
+        require_gh_ready()
+    except NotConfigured as exc:
+        print(f"regen-known-repos: not configured on this host — {exc}",
+              file=sys.stderr)
+        return EXIT_NOT_CONFIGURED
 
     try:
         api = read_api_repos()
     except RuntimeError as exc:
         print(f"regen-known-repos: {exc}", file=sys.stderr)
-        return 3
+        return EXIT_FAILED
 
     local = read_local_repos()
     mapping = build_mapping(api, local)
+    universe = build_universe(api, local)
     dropped = len([r for r in api if not r.get("has_issues")])
+    # What the mapping's filters cost the picker — printed because it is the
+    # whole reason the universe is built separately, and a number nobody can
+    # see is a number nobody checks.
+    only_universe = len(set(universe) - set(mapping.values()))
 
     if args.print_only:
         print(f"{len(mapping)} key(s) from {len(api)} repo(s) "
               f"({dropped} with issues disabled, skipped); "
               f"{len(local)} local checkout(s). Would write {args.path}")
+        print(f"{len(universe)} repo(s) in the picker universe "
+              f"({only_universe} of them reachable ONLY via the picker). "
+              f"Would write {args.universe_path}")
         return 0
 
     write_mapping(mapping, args.path)
+    write_universe(universe, args.universe_path)
     print(f"wrote {args.path} — {len(mapping)} key(s) from {len(api)} repo(s) "
           f"({dropped} with issues disabled, skipped)")
+    print(f"wrote {args.universe_path} — {len(universe)} repo(s) "
+          f"({only_universe} reachable ONLY via the picker)")
     return 0
 
 

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -18,6 +18,7 @@ The two things worth pinning:
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -2545,3 +2546,94 @@ def test_the_universe_reaches_NO_sink_but_rofi(monkeypatch, capsys):
                   UNIVERSE_ONLY.split("/")[1]):
         assert token not in blob, (
             f"a universe row reached a sink that is not rofi: {token!r}")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FILE-WIDE SPAWN PIN — required by this handler's entry in
+# `test_no_real_launchers.py::ACKNOWLEDGED_UNSTUBBED`.
+#
+# `mention-open.py` names `systemctl` in ONE operator-facing string (the
+# staleness note tells you which unit to check). `launcher_scan.hazard_hits` is
+# a TEXTUAL scan — deliberately, since erring toward reporting is right for a
+# scan whose failure mode is a missed launch — so that mention registers this
+# file as "reaching systemctl" and it had to be acknowledged.
+#
+# 🔴 AN ACKNOWLEDGEMENT BLINDS THE GUARD IT IS FILED UNDER, AND THAT WAS
+# MEASURED ON THIS EXACT TABLE: `tmux-reply-agent`'s entry claimed by grep that
+# no call site existed, and injecting a real `subprocess.run(["systemctl", …])`
+# into it left that whole suite green — the acknowledgement had absorbed the
+# thing the guard exists to catch. Its remedy was an AST pin, and this is the
+# same remedy for the same reason.
+#
+# ⚠ THE EXISTING LEDGER DOES NOT COVER THIS, WHICH IS WHY A SECOND TEST EXISTS.
+# `test_the_resolution_path_spawns_ONLY_these_local_commands` records what the
+# RESOLUTION PATH actually spawns at runtime — a stronger claim on the path it
+# drives, and blind everywhere else: a `systemctl` call added to `notify()`, or
+# to any branch that run does not reach, would not appear in its ledger. This
+# one reads the whole FILE.
+# --------------------------------------------------------------------------- #
+_SPAWN_FUNCS = {"run", "Popen", "call", "check_output", "check_call", "system",
+                "execv", "execvp", "execve", "spawnv", "spawnvp"}
+
+# Every argv[0] this handler is allowed to spawn, and why each is here:
+#   git         — reading a checkout's remote (discovery)
+#   tmux        — asking the pane for its repo
+#   notify-send — the refusal toast
+#   xdg-open    — opening the chosen URL
+#   rofi        — the picker
+EXPECTED_ARGV0 = {"git", "tmux", "notify-send", "xdg-open", "rofi"}
+
+
+def _spawn_argv0_literals(path: Path) -> set[str]:
+    """Every literal argv[0] in a spawn-shaped call, read from the SYNTAX TREE.
+
+    A non-literal argv[0] is reported as `<computed>` rather than skipped: a
+    spawn whose command comes from a variable is exactly how a ledger keyed on
+    literals gets walked past, so it must fail this test loudly instead of
+    vanishing from the set. `pick()` already carries a comment requiring its
+    rofi argv to stay a list literal for this reason.
+    """
+    tree = ast.parse(path.read_text())
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if isinstance(first, (ast.List, ast.Tuple)) and first.elts:
+            head = first.elts[0]
+            found.add(head.value if isinstance(head, ast.Constant)
+                      else "<computed>")
+        else:
+            found.add("<not-a-list>")
+    return found
+
+
+def test_mention_open_SPAWNS_these_argv0_AND_NOTHING_ELSE():
+    """🔴 GROWS-OR-SHRINKS, both directions asserted.
+
+    A NEW binary appearing here is the hazard the `ACKNOWLEDGED_UNSTUBBED`
+    entry would otherwise hide. A binary DISAPPEARING matters too: it means a
+    capability was removed and the acknowledgement's justification — which
+    names this set — has silently stopped describing the file.
+    """
+    assert _spawn_argv0_literals(HANDLER) == EXPECTED_ARGV0
+
+
+def test_systemctl_is_MENTIONED_but_never_SPAWNED():
+    """🔴 THE CLAIM THE ACKNOWLEDGEMENT ACTUALLY MAKES, asserted directly rather
+    than left to the reader of a prose justification.
+
+    Both halves are pinned. The mention must EXIST — delete the staleness note's
+    command and this test says so, because a justification describing a file
+    that no longer mentions the name is a stale entry in that table. And it must
+    remain a mention only."""
+    text = HANDLER.read_text()
+    assert re.search(r"(?<![\w-])systemctl(?![\w-])", text), (
+        "the acknowledgement in test_no_real_launchers.py exists BECAUSE this "
+        "file names systemctl; if that is gone, remove the acknowledgement too")
+    assert "systemctl" not in _spawn_argv0_literals(HANDLER), (
+        "mention-open.py now SPAWNS systemctl — the ACKNOWLEDGED_UNSTUBBED "
+        "entry covering it is an unreachability claim and is now FALSE")

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -292,11 +292,49 @@ def _mapping_is_never_the_operators(monkeypatch, tmp_path):
     when = time.time() - 1.0 * 86400  # fresh: inside STALE_MAPPING_DAYS
     os.utime(p, (when, when))
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", p)
-    # 🔴 THE SUBPROCESS HALF. `mention-open.py:135` already reads this variable,
-    # and a child inherits the environment — so this closes the class for every
-    # `_run()` test, present and future, rather than depending on each one
-    # remembering to pass `--no-discovery`.
+    # 🔴 THE SUBPROCESS HALF. `mention-open.py`'s `KNOWN_REPOS_PATH` already
+    # reads this variable, and a child inherits the environment — so this closes
+    # the class for every `_run()` test, present and future, rather than
+    # depending on each one remembering to pass `--no-discovery`.
+    #
+    # ⚠ NAMED, NOT LINE-NUMBERED. This comment used to cite `mention-open.py:135`
+    # and the line had already moved to 141 — worse, 135 is now `WORKSPACE`, a
+    # DIFFERENT variable, so the reference pointed at the wrong hazard while
+    # reading as precise. A constant's name survives an edit above it.
     monkeypatch.setenv("MENTION_OPEN_KNOWN_REPOS", str(p))
+
+    # 🔴 THE SECOND HOST-STATE FILE GETS BOTH REDIRECTS TOO. `known_universe.json`
+    # names private repositories exactly as the mapping does, and it feeds the
+    # PICKER — the one surface those names are allowed to reach. Redirecting only
+    # the mapping would leave every disclosure guard in this file asserting on
+    # `FAKE_UNIVERSE`'s synthetic names while the code under test read the
+    # operator's real 388-row universe: the guard would be structurally unable
+    # to see the leak it is named for. Same two mechanisms, same reason — the
+    # `setattr` for in-process reads, the `setenv` for `_run()`'s real child.
+    # ⚠ AND IT IS DELIBERATELY NOT WRITTEN. The mapping redirect writes
+    # `FAKE_UNIVERSE` so a leaking mutant leaks synthetic names; this one points
+    # at a path that does not exist, so `load_known_universe()` returns [] and
+    # the universe a test sees is exactly the one its own mapping state implies.
+    # Writing a default here was tried and it silently CHANGED NINE EXISTING
+    # TESTS: cases built to assert an empty universe — an unreadable mapping, a
+    # mapping holding no usable rows — started getting a picker from the file
+    # instead of the refusal they were written to pin, so they failed for a
+    # reason that had nothing to do with what they test. A redirect must relocate
+    # a read, never invent content the test did not ask for. Tests that DO want
+    # a universe write one, or patch `load_known_universe`.
+    u = tmp_path / "autouse-known-universe.json"
+    monkeypatch.setattr(MO, "KNOWN_UNIVERSE_PATH", u)
+    monkeypatch.setenv("MENTION_OPEN_KNOWN_UNIVERSE", str(u))
+
+    # 🔴 AND THE WORKSPACE, WHICH WAS THE REMAINING HOLE IN THIS FIXTURE. The
+    # two redirects above stop a child reading the operator's FILES; nothing
+    # stopped it reading their DISK. `discover_repos()` fans out `git remote
+    # get-url` over `DEVRC_WORKSPACE`, which every `_run()` test inherited from
+    # the real environment — so the next such test written with digits and
+    # without `--no-discovery` walks the operator's real `~/workspace` and reads
+    # back real repositories, exactly as the mapping hole did. It was closed
+    # per-test; a per-test guard is one forgotten flag away from being no guard.
+    monkeypatch.setenv("DEVRC_WORKSPACE", str(tmp_path / "no-checkouts-here"))
     return p
 
 
@@ -2316,3 +2354,194 @@ def test_every_TELEMETRY_only_shape_is_invisible_to_the_click_handler():
         assert MO.resolve(pat.sample) == (None, []), (
             f"{name}: a telemetry-only shape reached the CLICK surface — "
             f"resolve() is scanning at the wrong profile")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PICKER UNIVERSE IS A SEPARATE CORPUS FROM THE RESOLUTION MAPPING
+#
+# `repo_universe()` used to read `discover_repos().values()`, which silently
+# inherited both of the mapping's filters. The mapping answers "what does the
+# bare name `foo` mean?", so it MUST drop an issues-disabled repo and MUST drop
+# a bare name two owners share. A picker answers "which repo do you want?", its
+# rows are fully-qualified, and nothing opens without a selection — so neither
+# filter buys anything there and both cost coverage.
+#
+# MEASURED on the operator's host 2026-09-07: `gh api user/repos` returned 388
+# repos; the picker offered 339. 53 repos the operator owns or collaborates on
+# could not be reached by typing at the picker at all.
+# --------------------------------------------------------------------------- #
+UNIVERSE_ONLY = "rivalorg/spadeworks-archived"
+
+
+def test_repo_universe_offers_a_repo_that_is_ONLY_in_the_universe_file():
+    """🔴 THE HEADLINE REGRESSION. Red on pre-change code, where `repo_universe`
+    took one argument and read the mapping alone.
+
+    `UNIVERSE_ONLY` stands for the 53 real repos the mapping's filters removed —
+    issues disabled, or a bare name two owners share. It is deliberately NOT a
+    value of `FAKE_UNIVERSE`, so it can only arrive through the new source."""
+    out = MO.repo_universe(dict(FAKE_UNIVERSE), [UNIVERSE_ONLY])
+    assert UNIVERSE_ONLY in out, out
+    # POSITIVE CONTROL — the mapping half did not stop working in the process.
+    for full in set(FAKE_UNIVERSE.values()):
+        assert full in out, (full, out)
+
+
+def test_the_union_is_STRICTLY_WIDENING_neither_source_can_remove_a_row():
+    """Ordering and precedence are not concepts here: this is a list of things
+    to offer, not a mapping from a name to one answer. Pinned in BOTH directions
+    because a `dict.update`-shaped implementation would let the second source
+    silently drop rows the first contributed and still pass a one-way check."""
+    mapped = MO.repo_universe(dict(FAKE_UNIVERSE), [])
+    filed = MO.repo_universe({}, [UNIVERSE_ONLY])
+    both = MO.repo_universe(dict(FAKE_UNIVERSE), [UNIVERSE_ONLY])
+    assert set(both) == set(mapped) | set(filed), (both, mapped, filed)
+    assert set(both) > set(mapped), "the file must ADD to the mapping"
+    assert set(both) > set(filed), "the mapping must ADD to the file"
+
+
+def test_the_universe_dedupes_case_insensitively_and_keeps_ONE_row():
+    """`acme/Widget` and `acme/widget` are ONE repository on GitHub — GitHub repo
+    names are case-insensitive, which is why the mapping writes two spellings of
+    every key. Two identical-looking rows in rofi is a worse picker, and the
+    operator cannot tell which one is 'right' because neither is."""
+    out = MO.repo_universe({"w": "acme/Widget"}, ["acme/widget"])
+    assert out == ["acme/Widget"], (
+        "the on-disk spelling wins and the duplicate is dropped")
+
+
+def test_the_universe_file_cannot_INVENT_a_row_that_is_not_owner_slash_repo():
+    """Same rule as the mapping's `clean_repo_map`, same reason: a row that is
+    not exactly `owner/repo` builds a URL that 404s while looking authoritative.
+    A picker row is worse than a mapping row here — the operator SELECTED it, so
+    a 404 reads as the handler being broken rather than the reference being bad."""
+    junk = ["acme/widget/", "acme//widget", "noslash", "", "a/b\nc/d",
+            "  acme/widget  ", 12, None, ["acme/widget"]]
+    assert MO.repo_universe({}, junk) == []
+    # POSITIVE CONTROL: the same call with a GOOD row is non-empty, so the empty
+    # above is the filter working and not the function failing to read anything.
+    assert MO.repo_universe({}, junk + ["acme/widget"]) == ["acme/widget"]
+
+
+@pytest.mark.parametrize("body,why", [
+    (None, "absent"),
+    ("", "empty"),
+    ("{not json", "malformed"),
+    ('{"loamfield": "gardenersguild/trowelcast"}', "a DICT — the mapping's shape"),
+    ('"gardenersguild/trowelcast"', "a bare string"),
+    ("42", "a number"),
+])
+def test_load_known_universe_answers_EVERY_failure_with_an_empty_list(
+        tmp_path, body, why):
+    """🔴 IDENTICAL POSTURE TO `load_known_repos`, AND FOR THE IDENTICAL REASON:
+    this runs on a detached click handler with nowhere to print a traceback.
+
+    ⚠ THE DICT CASE IS NOT HYPOTHETICAL. `known_repos.json` sits in the same
+    directory and IS a dict; a `--path`/`--universe-path` mix-up at generation
+    time writes one where the other belongs. Without the `isinstance(raw, list)`
+    check, iterating a dict yields its KEYS — so the picker would silently offer
+    bare repo names that are not `owner/repo` and build 404 URLs from them."""
+    p = tmp_path / "universe.json"
+    if body is not None:
+        p.write_text(body)
+    assert MO.load_known_universe(p) == [], why
+
+
+def test_load_known_universe_reads_a_GOOD_file(tmp_path):
+    """The positive control for the parametrisation above. Six ways of returning
+    `[]` prove nothing about the reader unless it can also return rows — a
+    function hardcoded to `return []` passes every case above."""
+    p = tmp_path / "universe.json"
+    p.write_text(json.dumps(["acme/widget", "not a repo", "acme/gadget"]))
+    assert MO.load_known_universe(p) == ["acme/widget", "acme/gadget"], (
+        "good rows kept IN FILE ORDER, the malformed one dropped")
+
+
+def test_the_universe_path_is_resolved_at_CALL_time_not_bound_as_a_default():
+    """🔴 THE DEFECT THAT MADE `load_known_repos`' OWN OVERRIDE TEST INERT, and
+    it is a CLASS, not one site: a `path: Path = KNOWN_UNIVERSE_PATH` default is
+    evaluated at IMPORT, so every test that patches the module constant passes
+    while observing nothing. Measured on the mapping half: deleting the entire
+    `load_known_repos()` call from `discover_repos` left the suite green."""
+    import inspect
+    sig = inspect.signature(MO.load_known_universe)
+    assert sig.parameters["path"].default is None, (
+        "the default must be None and resolved inside the body")
+
+
+def test_the_picker_actually_OFFERS_a_universe_only_repo_end_to_end(monkeypatch):
+    """🔴 THE BEHAVIOURAL HALF. Every assertion above is about `repo_universe` in
+    isolation; this drives `main()` and reads what reached `pick`, so a correct
+    universe that `main()` never passes to the picker still fails.
+
+    That seam is exactly where this feature could be inert: `main()` built the
+    universe from `repo_universe(discovered)` with no second argument, and a
+    version of this change that widened the function but not the call site would
+    pass every unit test in this section."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    seen = {}
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
+    assert MO.main(["nosuchrepo#77"]) == 0
+    urls = [c["url"] for c in seen["rows"]]
+    assert any(UNIVERSE_ONLY in u for u in urls), (
+        f"the universe-only repo never reached the picker: {urls}")
+    assert all(u.endswith("/77") for u in urls), urls
+
+
+def test_the_universe_file_is_NOT_read_on_a_click_that_resolves(monkeypatch):
+    """🔴 A LATENCY GUARD, AND THE REASON THE CALL IS INSIDE A CONDITIONAL
+    EXPRESSION. The whole subsystem exists because a click took 4.3s; the fix
+    was deleting a lookup, and re-adding an unconditional `stat` + `read` +
+    `json.loads` on the fast path would be the same mistake in miniature.
+
+    `owner/repo#N` is answered by the text alone and must never touch the file."""
+    reads = []
+    monkeypatch.setattr(MO, "load_known_universe",
+                        lambda *a, **k: reads.append(1) or [])
+    monkeypatch.setattr(MO, "open_url", lambda url: reads.append(url) or 0)
+    assert MO.main(["--no-discovery", "civitai/talos-infra#1065"]) == 0
+    assert reads == ["https://github.com/civitai/talos-infra/issues/1065"], (
+        f"expected exactly one open and no universe read, got {reads}")
+
+
+def test_the_staleness_note_names_the_UNIT_not_only_the_generator(tmp_path):
+    """🔴 THE TEXT IS A CLAIM AND THE CLAIM CHANGED. It used to say "nothing
+    regenerates it", which was true and is now false: a daily user unit does.
+    Left alone, it would send the operator to re-run a generator by hand while
+    the actual fault — a failing unit, an expired token, a host that was off —
+    stayed invisible. A stale mapping past seven days now means SEVERAL runs did
+    not land, which is a different diagnosis and needs a different sentence."""
+    p = tmp_path / "known_repos.json"
+    p.write_text(json.dumps(FAKE_UNIVERSE))
+    old = time.time() - (MO.STALE_MAPPING_DAYS + 3) * 86400
+    os.utime(p, (old, old))
+    note = MO.staleness_note(p)
+    assert note, "positive control: a file this old MUST produce a note"
+    assert "mention-known-repos-refresh" in note, note
+    assert "nothing regenerates it" not in note, note
+    # And it still says nothing about a ROW — the disclosure rule is unchanged.
+    _no_universe_token_anywhere(note, "STALENESS NOTE DISCLOSURE")
+
+
+def test_the_universe_reaches_NO_sink_but_rofi(monkeypatch, capsys):
+    """🔴 THE DISCLOSURE GUARD FOR THE NEW CORPUS. `known_universe.json` names
+    private repositories — MORE of them than the mapping does, because it is
+    deliberately unfiltered — and it is read on the picker path. The existing
+    guards assert on `FAKE_UNIVERSE`'s tokens; this one adds the universe-only
+    row, which no mapping-derived guard can see."""
+    notify_argv = []
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    monkeypatch.setattr(MO, "notify",
+                        lambda *a: notify_argv.append(["notify-send", *a]))
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": "")   # dismissed
+    MO.main(["nosuchrepo#77"])
+    blob = _every_sink(capsys, notify_argv)
+    for token in (UNIVERSE_ONLY, UNIVERSE_ONLY.split("/")[0],
+                  UNIVERSE_ONLY.split("/")[1]):
+        assert token not in blob, (
+            f"a universe row reached a sink that is not rofi: {token!r}")

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -243,7 +243,7 @@ def test_the_stubbed_launcher_set_is_pinned():
 # seven scripts named it.
 ACKNOWLEDGED_UNSTUBBED = {
     "systemctl": (
-        {"airvpn-menu", "keylog-spin-capture.sh",
+        {"airvpn-menu", "keylog-spin-capture.sh", "mention-open.py",
          "monitor-blackout.sh", "run-tests.sh", "sync-claude-permissions.py",
          "syshealth", "tmux-reply-agent", "tmux-restore-observe.sh"},
         "verb-split rather than record-only — see the systemctl tests below. "
@@ -302,6 +302,36 @@ ACKNOWLEDGED_UNSTUBBED = {
         "argv[0] set is exactly {tmux_bin}, with both controls watched (clean "
         "tree passes; the injected call site fails with that test's own "
         "message). Do not restore this entry without that pin. "
+        "mention-open.py (added 2026-09-07 with the refresh timer) is the "
+        "PROSE-MENTION shape again, and it arrives WITH its pin rather than "
+        "acquiring one after an audit — which is the only lesson the "
+        "tmux-reply-agent paragraph above is asking anyone to carry. Its SINGLE "
+        "occurrence of the name is inside `staleness_note()`'s operator-facing "
+        "body: `check systemctl --user status mention-known-repos-refresh`. That "
+        "sentence is the whole point of the note — a mapping older than "
+        "STALE_MAPPING_DAYS now means the DAILY UNIT has not landed for a week, "
+        "so the actionable thing is the unit, and the previous wording ('nothing "
+        "regenerates it') sent the operator to re-run a generator by hand while a "
+        "failing unit stayed invisible. Rewording it to dodge the scanner would "
+        "delete the only pointer from the symptom to its cause. "
+        "🔴 THE PIN, because this entry would otherwise blind the guard exactly "
+        "as the one above did: "
+        "test_mention_open.py::test_mention_open_SPAWNS_these_argv0_AND_NOTHING_"
+        "ELSE walks the handler's AST and asserts its spawn argv[0] set is "
+        "exactly {git, tmux, notify-send, xdg-open, rofi}, grows-or-shrinks, "
+        "with a `<computed>` sentinel so a spawn built from a variable fails "
+        "loudly instead of leaving the set. "
+        "test_systemctl_is_MENTIONED_but_never_SPAWNED asserts both halves of "
+        "this justification directly — that the mention still EXISTS (so this "
+        "entry cannot outlive the sentence it describes) and that systemctl is "
+        "not in the spawn set. ⚠ The neighbouring runtime ledger "
+        "(test_the_resolution_path_spawns_ONLY_these_local_commands) does NOT "
+        "cover this and must not be cited for it: it records what the RESOLUTION "
+        "PATH spawns, so a systemctl call added to notify() or to any branch it "
+        "does not drive would never enter its ledger. Both controls were "
+        "WATCHED: clean tree passes, and an injected "
+        "`subprocess.run([\"systemctl\", \"restart\", …])` fails with that "
+        "test's own message. "
         "tmux-restore-observe.sh (added 2026-09-06) is the SECOND on the VERB "
         "ground and is justified separately rather than absorbed into "
         "syshealth's sentence: its single call site is `systemctl --user show "
@@ -316,7 +346,8 @@ ACKNOWLEDGED_UNSTUBBED = {
         "moment the script grows one"),
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "keylog-spin-capture.sh",
-         "notify-failure.sh", "playwright-nixos", "resume-state.sh",
+         "notify-failure.sh", "playwright-nixos", "regen-known-repos.py",
+         "resume-state.sh",
          "session-manager", "session-resolve", "ship.sh", "tmux-post-save.sh",
          "tmux-scratch-slots.sh"},
         "MEASURED unreachable: a whole-tier run under a recording interceptor "
@@ -341,6 +372,22 @@ ACKNOWLEDGED_UNSTUBBED = {
         "that raises on anything else — test_session_resolve.py pins that "
         "allowlist in both directions, so this justification cannot rot into "
         "a claim about a file that has grown a launcher. "
+        "regen-known-repos.py (added 2026-09-07 with the picker universe) is "
+        "the same PROSE-MENTION shape and is re-justified, not reworded. Its "
+        "single occurrence is one clause of a comment explaining why the picker "
+        "universe is a SECOND FILE rather than a new shape inside "
+        "known_repos.json: the collector's session-tailer.py reads that mapping "
+        "from a nix `home.file` COPY, which only changes on a `home-manager "
+        "switch`, so the two readers could not change together and a reshaped "
+        "file would have a flag day. Deleting the word would delete the reason "
+        "the design is what it is. It is not a call site: the complete set of "
+        "argv[0] literals this script can spawn is `gh` and `git`, pinned in "
+        "BOTH directions by test_regen_known_repos.py::test_regen_SPAWNS_these_"
+        "argv0_AND_NOTHING_ELSE — an AST walk with a `<computed>` sentinel, so "
+        "a spawn built from a variable fails rather than silently leaving the "
+        "set. Both controls watched: clean tree passes, an injected "
+        "`subprocess.run([\"home-manager\", \"switch\"])` fails with that "
+        "test's own message. "
         "tmux-scratch-slots.sh (added 2026-08-19) is the FOURTH of this shape "
         "and carries the STRONGEST form of the justification: the other three "
         "merely lack a call site, whereas this file has no executable "

--- a/scripts/tests/test_regen_known_repos.py
+++ b/scripts/tests/test_regen_known_repos.py
@@ -348,12 +348,52 @@ def test_a_SHORT_result_is_refused_even_though_gh_exited_zero(monkeypatch):
 
 
 def test_main_exits_nonzero_and_writes_NOTHING_when_gh_fails(monkeypatch, tmp_path, capsys):
+    """🔴 THE READINESS CHECK IS STUBBED, AND WITHOUT THAT LINE THIS TEST READ
+    THE HOST INSTEAD OF THE CODE — measured, in the tier that gates the merge.
+
+    `main()` asks `require_gh_ready()` before it reaches `read_api_repos`, so
+    stubbing only the latter makes the outcome depend on whether the MACHINE has
+    `gh`: the dev host does (readiness passes, the stub throws, exit 3 — green),
+    the nix sandbox does not (readiness fails first, exit 4 — red). It passed on
+    the dev host and failed in the sandbox for that reason alone, which is the
+    two-tier blindness `CLAUDE.md` names: each tier's environment silently
+    decides what executes, so greening one while the other is unobservable moves
+    the bug rather than removing it.
+
+    The arm under test is the AUTHENTICATED-BUT-BROKEN one — gh is present and
+    logged in, and the API call still failed. That is exit 3 and it must toast.
+    Pinning readiness explicitly is what makes the assertion about the code.
+    """
     out = tmp_path / "known_repos.json"
+    monkeypatch.setattr(RG, "require_gh_ready", lambda: None)
     monkeypatch.setattr(RG, "read_api_repos",
                         lambda: (_ for _ in ()).throw(RuntimeError("gh exited 4: no auth")))
-    assert RG.main(["--path", str(out)]) == 3
+    assert RG.main(["--path", str(out)]) == RG.EXIT_FAILED == 3
     assert not out.exists()
     assert "no auth" in capsys.readouterr().err
+
+
+def test_this_suite_never_asks_the_HOST_whether_gh_is_installed(monkeypatch,
+                                                                tmp_path):
+    """🔴 THE GUARD ON THE GUARD ABOVE, because the defect it fixes is invisible
+    on the machine anyone develops on.
+
+    Every `main()` path now runs `require_gh_ready()`, which shells out to
+    `gh auth status`. A test that neither stubs `subprocess.run` nor patches
+    `require_gh_ready` therefore reads the DEVELOPER'S MACHINE, and will keep
+    passing here while failing in the sandbox — a whole class, not one test.
+
+    This asserts the class is closed by construction: with the real readiness
+    check in force and `gh` made unreachable, `main()` returns NOT_CONFIGURED.
+    Any future test that forgets to stub gets that 4 rather than a plausible
+    wrong answer, and this test says why."""
+    def no_gh(cmd, *a, **k):
+        if cmd[:3] == ["gh", "auth", "status"]:
+            raise FileNotFoundError("gh")
+        raise AssertionError(f"nothing may run after readiness fails: {cmd}")
+    monkeypatch.setattr(RG.subprocess, "run", no_gh)
+    assert RG.main(["--path", str(tmp_path / "m.json"),
+                    "--universe-path", str(tmp_path / "u.json")]) == 4
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_regen_known_repos.py
+++ b/scripts/tests/test_regen_known_repos.py
@@ -9,6 +9,7 @@ that keep a wrong answer out of the mapping.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -43,6 +44,68 @@ def looks_like_a_repo_mapping(text: str) -> int:
     return len({k for k, _ in _PAIR_RE.findall(text)})
 
 
+# 🔴 A SECOND SHAPE, BECAUSE THE GENERATOR NOW EMITS A SECOND FILE — AND THE
+# DETECTOR ABOVE IS STRUCTURALLY BLIND TO IT. `known_universe.json` is a JSON
+# LIST of `owner/repo` strings: it carries no `key: value` pairs at all, so
+# `_PAIR_RE` finds nothing and `looks_like_a_repo_mapping` returns 0 for a file
+# that is a WIDER disclosure than the mapping (it is deliberately unfiltered, so
+# it names MORE private repositories). Committing one would have sailed past the
+# guard that exists precisely to stop that — the same structural blindness that
+# let the original incident through, in a new shape.
+_FULL_NAME_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def _owner_repo_count(items) -> int:
+    return len({s for s in items
+                if isinstance(s, str) and _FULL_NAME_RE.match(s)})
+
+
+def looks_like_a_repo_universe(text: str) -> int:
+    """How many DISTINCT `owner/repo` strings sit in a LIST LITERAL in `text`.
+
+    🔴 STRUCTURAL, NOT TEXTUAL, AND THE FIRST VERSION WAS TEXTUAL AND USELESS.
+    It counted every quoted `a/b` anywhere in the file and produced NINE false
+    accusations on the first run — `claude/skills/clickup/package-lock.json` (46,
+    every one an npm `node_modules/...` path) plus eight test files whose
+    synthetic fixtures merely mention repos in passing. A guard that fires on
+    ordinary files is a guard everyone learns to override.
+
+    So the question asked here is the one that actually matters: is this file a
+    LIST OF REPOSITORIES? That is the artefact `write_universe` emits, and it is
+    a shape no lockfile and no docstring has. Both spellings are covered — a
+    JSON document (the file itself, committed by accident) and a Python list
+    literal (the shape the ORIGINAL incident took, in which a generator wrote
+    its output into a `.py` module that was then committed).
+
+    ⚠ RESIDUAL, STATED RATHER THAN PAPERED OVER: a universe split across several
+    smaller literals, or built by a comprehension, is NOT counted. This detects
+    the dump, which is the way this has actually gone wrong twice; it is not a
+    general private-name scanner, and `claude/RULES.md` already records that no
+    gate in this repo covers repo names in prose.
+    """
+    best = 0
+    stripped = text.strip()
+    if stripped.startswith("["):
+        try:
+            doc = json.loads(stripped)
+        except ValueError:
+            doc = None
+        if isinstance(doc, list):
+            best = max(best, _owner_repo_count(doc))
+    # The Python-literal spelling. `ast.parse` rather than a regex, so a list is
+    # recognised as a list rather than as "some quoted strings near brackets".
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return best
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            best = max(best, _owner_repo_count(
+                [e.value for e in node.elts if isinstance(e, ast.Constant)]))
+    return best
+
+
 def test_the_mapping_detector_FIRES_on_a_realistic_mapping():
     """🔴 THE NEGATIVE CONTROL — without it, the sweep below is a zero that may
     be indistinguishable from a detector wired to nothing. Built from realistic
@@ -56,6 +119,31 @@ def test_the_mapping_detector_FIRES_on_a_realistic_mapping():
     # …and it does NOT fire on an ordinary small dict of the same shape.
     assert looks_like_a_repo_mapping(
         "{'a': 'o/a', 'b': 'o/b', 'c': 'o/c'}") < MAPPING_KEY_THRESHOLD
+
+
+def test_the_UNIVERSE_detector_FIRES_and_the_mapping_one_is_BLIND_to_it():
+    """🔴 THE NEGATIVE CONTROL FOR THE SECOND SHAPE — and it asserts the BLIND
+    SPOT explicitly, because that is the finding rather than a side note.
+
+    Built from a REALISTIC artefact: the exact JSON `write_universe` emits, not
+    a textbook fixture. `looks_like_a_repo_mapping` returns 0 on it — a list has
+    no `key: value` pairs — so before this detector existed, committing the
+    picker universe to this public repo would have passed the incident guard
+    that exists to prevent exactly that.
+    """
+    universe = json.dumps(sorted(
+        f"gardenersguild/{n}{i}"
+        for i, n in enumerate(["Trowelcast", "SledgeHorn", "PloughShare"] * 9)
+    ), indent=1)
+    assert looks_like_a_repo_universe(universe) >= MAPPING_KEY_THRESHOLD
+    assert looks_like_a_repo_mapping(universe) == 0, (
+        "the pair matcher must be shown BLIND to this shape — if it ever fires "
+        "here, the second detector's justification has changed and this test "
+        "is the one that should say so")
+    # …and it does NOT fire on a file that merely mentions a few repos, which is
+    # every docstring and comment in this tree.
+    assert looks_like_a_repo_universe(
+        "see 'civitai/talos-infra' and 'acme/widget'") < MAPPING_KEY_THRESHOLD
 
 
 # Directories that exist only in a working checkout and are gitignored there.
@@ -111,10 +199,20 @@ def test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo():
         keys = looks_like_a_repo_mapping(text)
         if keys >= MAPPING_KEY_THRESHOLD:
             offenders.append(f"{path.relative_to(ROOT)} ({keys} distinct repo keys)")
+            continue
+        # 🔴 THE UNIVERSE SHAPE, CHECKED ON THE SAME SWEEP RATHER THAN IN A
+        # SECOND TEST — one walk, one `len(files) > 100` floor, one place for a
+        # future third shape. A separate test would need its own floor and would
+        # be the one nobody notices has stopped walking anything.
+        fulls = looks_like_a_repo_universe(text)
+        if fulls >= MAPPING_KEY_THRESHOLD:
+            offenders.append(
+                f"{path.relative_to(ROOT)} ({fulls} distinct owner/repo names)")
     assert offenders == [], (
-        f"file(s) look like a repo mapping (via {how}): {offenders}. "
-        f"The mapping names PRIVATE repositories and this repo is PUBLIC — it "
-        f"belongs at {RG.DEFAULT_PATH}, outside every checkout.")
+        f"file(s) look like a repo mapping or picker universe (via {how}): "
+        f"{offenders}. Both name PRIVATE repositories and this repo is PUBLIC — "
+        f"they belong at {RG.DEFAULT_PATH} and {RG.DEFAULT_UNIVERSE_PATH}, "
+        f"outside every checkout.")
 
 
 def test_the_default_output_path_is_outside_every_checkout():
@@ -507,3 +605,215 @@ def test_a_checkout_with_NO_api_row_is_written_in_BOTH_spellings():
     out = RG.build_mapping([], {"PlotWidget": "acme/PlotWidget"})
     assert out.get("PlotWidget") == "acme/PlotWidget", out
     assert out.get("plotwidget") == "acme/PlotWidget", out
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PICKER UNIVERSE — WIDER THAN THE MAPPING, ON PURPOSE
+#
+# `build_mapping` answers "what does the bare name `foo` mean?" and must drop an
+# issues-disabled repo and a bare name two owners share. `build_universe`
+# answers "which repos might be worth offering?", its rows are fully-qualified,
+# and nothing opens without a selection — so it applies NEITHER filter.
+#
+# MEASURED on the operator's host 2026-09-07: 388 repos from `gh api
+# user/repos`, 339 in the mapping, so 53 were unreachable from the picker.
+# --------------------------------------------------------------------------- #
+def _api(*rows) -> list[dict]:
+    """`{full_name, has_issues}` rows in the shape `gh api user/repos` returns."""
+    return [{"full_name": f, "has_issues": h} for f, h in rows]
+
+
+def test_the_universe_KEEPS_a_repo_whose_issues_are_disabled():
+    """🔴 THE 48-REPO HALF, and the assumption that hid it was in a comment.
+
+    The mapping drops these, and the ORIGINAL justification said a bare `repo#N`
+    "404s for EVERY N". That is false for PULL REQUESTS: measured 2026-09-07
+    against the API with a positive control (2 issues-ENABLED repos first, both
+    `PULL`), **6 of 6** issues-disabled repos resolved `/issues/<pr>` to the pull
+    request. An earlier probe that saw 3 of 4 return 404 was confounded — an
+    unauthenticated request 404s on a PRIVATE repo whatever the redirect does.
+
+    The mapping still drops them, on the narrower true reason (no ISSUES exist,
+    so a bare `#N` naming an issue is a wrong answer). The universe must not."""
+    api = _api(("acme/widget", True), ("acme/noissues", False))
+    assert RG.build_universe(api, {}) == ["acme/noissues", "acme/widget"]
+    # THE CONTRAST IS THE POINT — pinned here so the two functions can never
+    # quietly converge on one filter policy.
+    assert "acme/noissues" not in RG.build_mapping(api, {}).values()
+
+
+def test_the_universe_KEEPS_BOTH_SIDES_of_an_ambiguous_bare_name():
+    """🔴 THE 7-COLLISION HALF. `build_mapping` drops `bitdex` entirely, because
+    resolving it would mean guessing between two owners — measured once picking
+    a third party's fork over the client's repo.
+
+    A picker row is `owner/repo`, so there is no ambiguity left to arbitrate:
+    offering both and letting the operator choose is exactly the question they
+    are being asked. Dropping them makes a repo unreachable to protect against
+    a guess nobody is making."""
+    api = _api(("alice/bitdex", True), ("bob/bitdex", True))
+    assert RG.build_universe(api, {}) == ["alice/bitdex", "bob/bitdex"]
+    # The mapping's silence on the shared bare name is UNCHANGED.
+    assert "bitdex" not in RG.build_mapping(api, {})
+
+
+def test_the_universe_unions_local_checkouts_the_API_never_returned():
+    """A clone of somebody else's repository is on this disk and not in
+    `user/repos`. It cannot CONTRADICT an API row — this is a list, not a
+    lookup — so it is simply added."""
+    api = _api(("acme/widget", True))
+    out = RG.build_universe(api, {"mirror": "elsewhere/stranger"})
+    assert out == ["acme/widget", "elsewhere/stranger"]
+
+
+def test_the_universe_dedupes_case_insensitively_keeping_the_API_spelling():
+    """GitHub repo names are case-insensitive, so these are ONE repository. The
+    API row wins because it is canonical; a remote URL preserves whatever the
+    person who cloned happened to type, which is why the mapping has to write
+    two spellings of every key in the first place."""
+    api = _api(("civitai/ComfyUI", True))
+    out = RG.build_universe(api, {"mirror": "civitai/comfyui"})
+    assert out == ["civitai/ComfyUI"], out
+
+
+def test_the_universe_drops_rows_that_are_not_owner_slash_repo():
+    """Same predicate as the mapping's, and IMPORTED from `mention_scan` rather
+    than re-spelled here — a row that is not exactly `owner/repo` builds a URL
+    that 404s while looking authoritative."""
+    api = _api(("acme/widget/", True), ("acme//widget", True), ("noslash", True),
+               ("", True), ("acme/widget", True))
+    assert RG.build_universe(api, {"mirror": "also/bad/three"}) == ["acme/widget"]
+
+
+def test_the_universe_is_SORTED_case_insensitively():
+    """The picker shows this list in order; sorting by raw codepoint puts every
+    capitalised name in a block ahead of the lowercase ones, which reads as
+    random to someone scanning for a name."""
+    api = _api(("acme/zebra", True), ("acme/Apple", True), ("acme/mango", True))
+    assert RG.build_universe(api, {}) == ["acme/Apple", "acme/mango", "acme/zebra"]
+
+
+def test_write_universe_is_0600_because_it_names_private_repositories(tmp_path):
+    """Identical posture to `write_mapping`. This file holds MORE private names
+    than the mapping does — it is deliberately unfiltered — so a weaker mode
+    here would be a wider disclosure than the one that started all of this."""
+    out = tmp_path / "sub" / "known_universe.json"
+    RG.write_universe(["acme/widget"], out)
+    assert json.loads(out.read_text()) == ["acme/widget"]
+    assert oct(out.stat().st_mode)[-3:] == "600", oct(out.stat().st_mode)
+    assert oct(out.parent.stat().st_mode)[-3:] == "700"
+    assert not list(out.parent.glob("*.tmp")), "the temp file must not survive"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 TWO KINDS OF FAILURE — THE SPLIT THAT MAKES THE TIMER POSSIBLE
+#
+# `mention-open.py` once argued AGAINST a scheduled run: with a single failure
+# code, a host without `gh auth` would take a failing unit and a failure toast
+# on every fire, and a permanently-red timer is worse than no timer. That was
+# correct. It is answered by exit 4 ("not configured here" — which the unit
+# declares a success) versus exit 3 ("configured and broken" — which toasts).
+# --------------------------------------------------------------------------- #
+def _stub_run(monkeypatch, *, auth_rc=0, auth_raises=None, api_rc=0, api_out=""):
+    """Replace `subprocess.run` INSIDE the generator only, keyed on argv."""
+    def fake(cmd, *a, **k):
+        if cmd[:3] == ["gh", "auth", "status"]:
+            if auth_raises is not None:
+                raise auth_raises
+            return subprocess.CompletedProcess(cmd, auth_rc, "", "")
+        if cmd[:2] == ["gh", "api"]:
+            return subprocess.CompletedProcess(cmd, api_rc, api_out, "boom")
+        return subprocess.CompletedProcess(cmd, 1, "", "")
+    monkeypatch.setattr(RG.subprocess, "run", fake)
+
+
+def _enough_repos() -> str:
+    return "".join(
+        json.dumps({"full_name": f"acme/plot{i}", "has_issues": True}) + "\n"
+        for i in range(RG.MIN_API_REPOS + 5))
+
+
+def test_a_host_with_no_gh_exits_NOT_CONFIGURED_not_FAILED(monkeypatch, tmp_path):
+    """🔴 THE WHOLE REASON THE TIMER CAN EXIST. `gh` absent is a legitimate host
+    state — the click handler degrades to `owner/repo#N` plus local checkouts —
+    so it must not be the code that toasts daily forever."""
+    _stub_run(monkeypatch, auth_raises=FileNotFoundError("no gh"))
+    rc = RG.main(["--path", str(tmp_path / "m.json"),
+                  "--universe-path", str(tmp_path / "u.json")])
+    assert rc == RG.EXIT_NOT_CONFIGURED == 4, rc
+    assert not (tmp_path / "m.json").exists(), "nothing may be written"
+    assert not (tmp_path / "u.json").exists()
+
+
+def test_gh_present_but_LOGGED_OUT_is_also_NOT_CONFIGURED(monkeypatch, tmp_path):
+    """The second spelling of the same host state, and the one a real host
+    reaches by having a token expire rather than by lacking the binary."""
+    _stub_run(monkeypatch, auth_rc=1)
+    assert RG.main(["--path", str(tmp_path / "m.json"),
+                    "--universe-path", str(tmp_path / "u.json")]) == 4
+
+
+def test_an_AUTHENTICATED_host_whose_API_call_fails_is_a_REAL_failure(
+        monkeypatch, tmp_path):
+    """🔴 THE OTHER ARM, AND WITHOUT IT THE SPLIT IS WORTHLESS. If everything
+    returned 4 the unit would be permanently green and a genuinely broken
+    refresh would be silent — which is the same failure as a permanently-red
+    gate, wearing the other colour."""
+    _stub_run(monkeypatch, auth_rc=0, api_rc=1)
+    rc = RG.main(["--path", str(tmp_path / "m.json"),
+                  "--universe-path", str(tmp_path / "u.json")])
+    assert rc == RG.EXIT_FAILED == 3, rc
+
+
+def test_an_AUTHENTICATED_host_returning_TOO_FEW_repos_is_a_REAL_failure(
+        monkeypatch, tmp_path):
+    """The floor is a truncation detector: a short list is indistinguishable
+    from a fine one once written. Authenticated + short is broken, not
+    unconfigured — so it must toast."""
+    _stub_run(monkeypatch, auth_rc=0, api_out=json.dumps(
+        {"full_name": "acme/widget", "has_issues": True}) + "\n")
+    assert RG.main(["--path", str(tmp_path / "m.json"),
+                    "--universe-path", str(tmp_path / "u.json")]) == 3
+
+
+def test_NotConfigured_is_caught_BEFORE_the_generic_RuntimeError(monkeypatch,
+                                                                 tmp_path):
+    """🔴 AN ORDERING GUARD, AND THE BUG IT PINS IS INVISIBLE BY INSPECTION.
+    `NotConfigured` SUBCLASSES `RuntimeError`. Swap the two `except` clauses in
+    `main()` and an unconfigured host reports exit 3 — a red unit and a daily
+    toast, the exact outcome the split exists to prevent — while every other
+    test in this file still passes, because they never exercise the ordering.
+
+    So this asserts the CODE, not just a message: 4, and nothing written."""
+    _stub_run(monkeypatch, auth_rc=1)
+    assert RG.main(["--path", str(tmp_path / "m.json"),
+                    "--universe-path", str(tmp_path / "u.json")]) == 4
+    assert RG.EXIT_NOT_CONFIGURED != RG.EXIT_FAILED, (
+        "the two codes must stay distinct or the unit cannot tell them apart")
+
+
+def test_a_HEALTHY_run_writes_BOTH_files(monkeypatch, tmp_path):
+    """🔴 THE POSITIVE CONTROL FOR EVERY REFUSAL ABOVE. Five tests assert that
+    nothing is written; a generator that never wrote anything would pass all
+    five. This is the one that proves the happy path still lands — and that the
+    universe is written at all, which a `write_mapping`-only regression would
+    otherwise leave to the reader's graceful `[]` fallback and hide completely."""
+    _stub_run(monkeypatch, auth_rc=0, api_out=_enough_repos())
+    m, u = tmp_path / "m.json", tmp_path / "u.json"
+    assert RG.main(["--path", str(m), "--universe-path", str(u)]) == 0
+    assert json.loads(m.read_text()), "the mapping must be written"
+    universe = json.loads(u.read_text())
+    assert isinstance(universe, list) and len(universe) == RG.MIN_API_REPOS + 5
+    assert oct(u.stat().st_mode)[-3:] == "600"
+
+
+def test_print_mode_writes_NOTHING_and_reports_the_universe(monkeypatch,
+                                                            tmp_path, capsys):
+    """`--print` must stay a read. It also reports how many repos are reachable
+    ONLY through the picker — the number this whole change is about, and one
+    nobody would check if it were never printed."""
+    _stub_run(monkeypatch, auth_rc=0, api_out=_enough_repos())
+    m, u = tmp_path / "m.json", tmp_path / "u.json"
+    assert RG.main(["--print", "--path", str(m), "--universe-path", str(u)]) == 0
+    assert not m.exists() and not u.exists()
+    assert "picker universe" in capsys.readouterr().out

--- a/scripts/tests/test_regen_known_repos.py
+++ b/scripts/tests/test_regen_known_repos.py
@@ -817,3 +817,69 @@ def test_print_mode_writes_NOTHING_and_reports_the_universe(monkeypatch,
     assert RG.main(["--print", "--path", str(m), "--universe-path", str(u)]) == 0
     assert not m.exists() and not u.exists()
     assert "picker universe" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FILE-WIDE SPAWN PIN — required by this script's entry in
+# `test_no_real_launchers.py::ACKNOWLEDGED_UNSTUBBED` under `home-manager`.
+#
+# This file names `home-manager` in ONE comment (why the picker universe is a
+# second FILE rather than a new shape inside `known_repos.json`).
+# `launcher_scan.hazard_hits` is a TEXTUAL scan, so that mention registers the
+# script as "reaching home-manager" and had to be acknowledged.
+#
+# 🔴 AN ACKNOWLEDGEMENT BLINDS THE GUARD IT IS FILED UNDER — MEASURED on this
+# very table, where `tmux-reply-agent`'s entry rested on a grep and an injected
+# real call site left the whole suite green. So the entry gets a pin, and the
+# pin is this.
+# --------------------------------------------------------------------------- #
+_SPAWN_FUNCS = {"run", "Popen", "call", "check_output", "check_call", "system",
+                "execv", "execvp", "execve", "spawnv", "spawnvp"}
+
+# gh  — `gh auth status` (readiness) and `gh api user/repos` (the rows)
+# git — `git remote get-url origin`, per local checkout
+EXPECTED_ARGV0 = {"gh", "git"}
+
+
+def _spawn_argv0_literals(path: Path) -> set[str]:
+    """Every literal argv[0] in a spawn-shaped call, from the SYNTAX TREE.
+
+    `<computed>` rather than a skip for a non-literal argv[0]: a command built
+    from a variable is how a literal-keyed ledger gets walked past, so it must
+    fail loudly instead of leaving the set."""
+    tree = ast.parse(path.read_text())
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if isinstance(first, (ast.List, ast.Tuple)) and first.elts:
+            head = first.elts[0]
+            found.add(head.value if isinstance(head, ast.Constant)
+                      else "<computed>")
+        else:
+            found.add("<not-a-list>")
+    return found
+
+
+def test_regen_SPAWNS_these_argv0_AND_NOTHING_ELSE():
+    """GROWS-OR-SHRINKS. A new binary is the hazard the acknowledgement would
+    otherwise hide; a vanished one means the justification has stopped
+    describing the file."""
+    assert _spawn_argv0_literals(GENERATOR) == EXPECTED_ARGV0
+
+
+def test_home_manager_is_MENTIONED_but_never_SPAWNED():
+    """Both halves of the acknowledgement's claim, asserted rather than left to
+    a reader of prose: the mention must still EXIST (or the table entry has
+    outlived the sentence it describes), and it must remain a mention."""
+    text = GENERATOR.read_text()
+    assert re.search(r"(?<![\w-])home-manager(?![\w-])", text), (
+        "the ACKNOWLEDGED_UNSTUBBED entry for this file exists BECAUSE it names "
+        "home-manager; if that is gone, remove the acknowledgement too")
+    assert "home-manager" not in _spawn_argv0_literals(GENERATOR), (
+        "regen-known-repos.py now SPAWNS home-manager — the acknowledgement "
+        "covering it is an unreachability claim and is now FALSE")


### PR DESCRIPTION
The picker was showing **339 of 388** repos. Asked for "all repos I contribute to,
cached + periodically refreshed, fuzzy searchable" — measured, the source was never
the problem and the filters were.

## What was actually wrong

`repo_universe()` read the resolution mapping's `.values()`, so the fuzzy picker
silently inherited both of that mapping's filters:

| filter | right for | wrong for |
|---|---|---|
| drop `has_issues == false` | resolving a bare `foo#12` | a picker: rows are full `owner/repo` |
| drop a bare name two owners share | resolving `bitdex#12` | a picker: there is no ambiguity in `alice/bitdex` |

**MEASURED on the workbench:** 53 repos the operator owns or collaborates on could
not be reached by typing at the picker. Live after the change: **392 rows, 52 of
them reachable only through the picker.**

🔴 **The `has_issues` filter's stated reason was false.** The comment said a bare
`repo#N` "404s for EVERY N" — untrue for **pull requests**. A first probe (4 repos,
unauthenticated `curl`, 3×404) appeared to confirm it and was **confounded**: an
unauthenticated request 404s on a *private* repo whatever the redirect does.
Authenticated, with a positive control (2 issues-*enabled* repos first, both `PULL`):
**6/6** issues-disabled repos resolved `/issues/<pr>` to the PR. The mapping keeps the
filter on the narrower true reason; the universe drops it.

🔴 **The source needed no widening — measured, so nobody re-adds one.** `user/repos`
already uses the widest affiliation GitHub offers. The plausible gap was checked:
`search/issues?q=author:<login> type:pr` returned **28** repos, **all 28** already in
`user/repos`, **0 new**.

## The timer, and the objection it had to answer

Nothing converged the mapping. A timer had been **explicitly rejected** in
`mention-open.py`: a scheduled `gh api` run fails forever on a host without `gh auth`,
toasting daily, and a permanently-red timer is worse than none. That was correct
against a generator with one failure code — so it was answered, not overruled:

- exit **4** = not configured on this host → `SuccessExitStatus=4`, quiet
- exit **3** = configured and broken → still toasts

Readiness comes from `gh auth status`'s **exit code**, never its wording. Verified
live: rc 4 on a PATH with no `gh`; and the **rendered unit** was inspected for
`SuccessExitStatus=4` rather than trusting that it built.

## Disclosure

`known_universe.json` names *more* private repos than the mapping (it is unfiltered),
and the incident guard **could not see it** — it counts `key: "owner/repo"` pairs, and
a JSON list has none, so the file scored **0** and would have passed the guard written
to stop exactly that. Added a structural detector (JSON + Python-literal). Its first,
textual version raised **9 false accusations** and was replaced: a guard that fires on
ordinary files is one everyone overrides.

Two prose mentions (`systemctl`, `home-manager`) tripped the textual launcher scan and
are acknowledged **with AST pins**, because an acknowledgement blinds the guard it is
filed under — this table records that being measured. Both controls watched: clean tree
passes, injected call sites fail 2/2 with each pin's own message.

## Evidence

- Generator suite: **14 new tests red at `969f0581`, green at HEAD**
- Mutation battery: **8/8 killed by their own named test**, plus a harness control
  required to survive; run under `PYTHONDONTWRITEBYTECODE=1`, each mutation required
  to match exactly once
- Dev-host tier `scripts/gate.sh --tier both`: **PASS** (22,035 pytest + 1,449 node, 0 failed)
- Sandbox tier, built **one derivation at a time** from a `git archive` extract:
  `pytests` **PASS** (22,036 passed, 0 failed, floor met), `nodetests` **PASS** (1,449)

⚠ **Honest limits.** The `mention-open` suite **cannot run at base at all** — its
fixture names a symbol the old module lacks, so all 163 error at setup. That is
red-for-the-wrong-reason, so its evidence is the battery, not a base run; an ERROR at
base is not a FAIL at base. And the Alacritty click path itself is **not verified** —
`--print` cannot distinguish auto-open from a one-row picker. That needs a human click.

## Two defects found by the gates, not by review

1. **The launcher ledger** caught the two new prose mentions (1 failed of 12,875).
   Fixing only the first would have left the second to fail the next run — swept the
   whole hazard vocabulary at once instead.
2. **The sandbox tier caught what the dev tier structurally could not.**
   `test_main_exits_nonzero_and_writes_NOTHING_when_gh_fails` stubbed `read_api_repos`
   but not readiness, so its result depended on whether the *machine* had `gh`: green on
   the dev host, red in the sandbox. Four consecutive green dev-host runs said nothing
   about it. Fixed, plus a guard on the class so the next test that forgets to stub gets
   a `4` with a sentence saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FENxxrZztNTsrKgChnGT1X
