### PR TITLE
docs(obs-read): an instant query is still a RANGE query, so `count by` unions the label

### DIFF
--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -102,6 +102,23 @@ $OBS --cluster homelab --backend loki --query '{namespace="monitoring"}' --since
   to a Loki `count_over_time`. Same trap in the time axis: `count_over_time[1h]`
   evaluated at instant T covers **T-1h → T**, so a bucket labelled `16:00` can be
   reporting a 15:31 incident.
+- 🔴 **FOURTH CASE, and it INFLATES rather than empties: `--kind instant` still issues a
+  RANGE query, so a `count by (<label>)` UNIONS that label across every evaluation
+  instant.** Each instant carries its own `[window]` lookback, so the series set you get
+  back spans `--since` **plus** the window, not the window. Measured 2026-09-07 asking for
+  distinct taskrun pods in 24h: **3,787** returned — a 48h union — against a true
+  **1,591**. Nothing errors and the number is entirely plausible, which is what makes it
+  expensive. **For a distinct-count, use the scalar form** — `count(count by (pod) (…))` —
+  **and read it at ONE instant** (`--since 10m` with the real lookback inside the range
+  selector). **The tell is the `POINTS` column**: a value beside `POINTS 251` is a matrix
+  row, not an instant reading. Same shape whenever a `by (…)` label is high-cardinality
+  and short-lived — pods, taskruns, request ids.
+- ⚠ **A high-cardinality `by (…)` over a long window can also just be REFUSED**: Loki caps
+  a single query at `maximum number of series (5000)`. Chunking the window is the obvious
+  workaround and the dangerous one — if your extractor scores a failed chunk as empty, a
+  partial scan prints as a confident total. **Narrow with a stream selector instead**
+  (`{ns="x", pod=~"<prefix>-.*"}`), which keeps each query under the cap and usually scopes
+  it to the question you were actually asking.
 
 ## Presets
 Seeded from **real** queries surveyed out of the datapacket skills


### PR DESCRIPTION
## What

Adds a **fourth case** to `obs-read`'s silent-zero guard section: `--kind instant` still issues a **range** query, so a `count by (<label>)` unions that label across every evaluation instant — and each instant carries its own `[window]` lookback. The series set therefore spans `--since` **plus** the window.

The three cases already documented (empty result, real zero, partial/sparse result) all **empty or shorten** a series. This one **inflates** it, which is why it slipped past a reader who knew the section.

## Evidence

Measured 2026-09-07 while building a denominator for the tekton CI-timeout rate (clawgate task 399):

| question | returned | true |
|---|---|---|
| distinct taskrun pods in `tekton-ci`, 24 h | **3,787** (a 48 h union) | **1,591** |

Nothing errors, and 3,787 is an entirely plausible count for that namespace — the failure is silent and self-consistent. The **`POINTS` column** is the tell: a value printed beside `POINTS 251` is a matrix row, not an instant reading.

Remedy documented: use the scalar form `count(count by (pod) (…))` and read it at **one** instant (`--since 10m`, with the real lookback inside the range selector).

## Sibling failure, also added

A high-cardinality `by (…)` over a long window is refused outright — Loki caps a single query at `maximum number of series (5000)`. Chunking the window is the obvious workaround and the dangerous one: in the same session, a 7-day denominator built from daily chunks had **4 of 7 chunks fail** on that cap while the extractor scored them as empty, and the script printed a total (8,342) that was three days of data. That number was discarded, not used.

The remedy is to narrow with a **stream selector** (`{ns="x", pod=~"<prefix>-.*"}`), which keeps each query under the cap and usually scopes it to the question being asked anyway.

## Scope

Documentation only — one file, 17 added lines, no behaviour change to `scripts/obs-read`. Routed here rather than into a client repo's handoff doc because the lesson is about **our own tooling**, per the subsystem-index protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wbxf43V3kxhPjCdKyHE9Ty
