### PR TITLE
feat(tailscale): the independent second path — and the closure preflight #1272 left open

### DIFF
--- a/nix/system/apply-tailscale.sh
+++ b/nix/system/apply-tailscale.sh
@@ -310,9 +310,13 @@ _store_path() {
 #
 # So: blank out everything that is NOT executable Nix -- comments AND string literals --
 # then require an actual SETTING: the attribute followed by `=`, `{` or a further `.`,
-# which is every way Nix can spell one and no way it can spell a mention. Prints
-# `lineno:text` per declaration, nothing at all when there is none, so the caller
-# branches on emptiness.
+# and NOT preceded by an identifier character or a dot. Prints `lineno:text` per
+# declaration, nothing at all when there is none, so the caller branches on emptiness.
+#
+# ⚠ THAT PAIR IS NOT "EVERY WAY NIX CAN SPELL A SETTING AND NO WAY IT CAN SPELL A
+# MENTION" -- this comment claimed exactly that and it was false in both directions. It
+# is a heuristic with a KNOWN, DELIBERATE direction of error, stated at the bottom of
+# this comment. What it does cover is every shape that has actually been measured here.
 #
 # 🔴 STRINGS, NOT JUST COMMENTS -- AND THE `[.={]` ANCHOR IS NOT ENOUGH ON ITS OWN. An
 # earlier version blanked comments only, on the reasoning that the anchor already rejects
@@ -324,6 +328,20 @@ _store_path() {
 # That is the most expensive lie this script can tell -- it says the backup path is DONE
 # on a host where nothing was applied, two days before the operator leaves for months.
 #
+# 🔴 A READ OF THE OPTION IS NOT A DECLARATION OF IT, AND THE ANCHOR CANNOT TELL THEM
+# APART. `config.services.tailscale.enable` is a perfectly ordinary thing to find in a
+# config that does NOT enable tailscale -- it is how one option is made to depend on
+# another -- and it carries the `.` the anchor looks for. MEASURED, both of these were
+# classified as declarations and printed "already DECLARES ... Nothing to do. Exiting 0"
+# on a host where nothing had been applied:
+#     networking.firewall.checkReversePath = lib.mkIf config.services.tailscale.enable "loose";
+#     assertions = [ { assertion = config.services.tailscale.enable; ... } ];
+# The character BEFORE the attribute path is what separates the two: a declaration begins
+# an attribute path, so it is never preceded by `.` or by the tail of another identifier,
+# while every read is reached THROUGH one (`config.`, `osConfig.`, `nodes.x.config.`).
+# Hence the `(?<![...])` guard -- one character, and it needs no list of module-argument
+# names to keep working.
+#
 # The blanking is a LEFT-TO-RIGHT SCANNER, not three independent regexes, because the
 # constructs nest: a `#` inside a string is not a comment and a `"` inside a comment is
 # not a string, and only a scanner that consumes them in order gets both right. It
@@ -333,10 +351,11 @@ _store_path() {
 #
 # Direction of error is deliberate, and unchanged: a declaration this misses means the
 # script proceeds and adds a SECOND block, which `nix-instantiate '<nixpkgs/nixos>' -A
-# system` then refuses as a duplicate definition BEFORE anything is written. A mention it
-# wrongly accepted would exit 0 and leave the host unprotected with no further check at
-# all. So when the scanner is confused -- by an identifier ending in `''`, say -- it
-# fails toward the loud, harmless side.
+# system` then refuses as a duplicate definition BEFORE anything is written. A mention or
+# a READ it wrongly accepted would exit 0 and leave the host unprotected with no further
+# check at all. So when the scanner is confused -- by an identifier ending in `''`, or by
+# an attribute path this heuristic has not seen, say -- it fails toward the loud,
+# harmless side.
 _cfg_tailscale_decls() {   # $1 = config path; prints "lineno:line" per declaration
   python3 - "$1" <<'PY'
 import re, sys
@@ -406,8 +425,18 @@ def blank_non_code(text):
 stripped = blank_non_code(src)
 
 orig = src.splitlines()
+
+# `(?<![A-Za-z0-9_.'-])` -- ONE character of context, and it is what separates a
+# DECLARATION from a READ. A declaration begins an attribute path; a read is always
+# reached through another one (`config.services.tailscale.enable`,
+# `osConfig.services.tailscale...`), so the character before it is a dot. The class also
+# covers an identifier tail, since Nix identifiers may contain `-` and `'`
+# (`my-services.tailscale...` is somebody else's attribute, not this option).
+# A negative lookbehind at position 0 succeeds, so a declaration at the very start of a
+# line is still found.
+DECL = re.compile(r"(?<![A-Za-z0-9_.'-])services\s*\.\s*tailscale\s*[.={]")
 for i, line in enumerate(stripped.splitlines()):
-    if re.search(r"services\s*\.\s*tailscale\s*[.={]", line):
+    if DECL.search(line):
         print("%d:%s" % (i + 1, orig[i].strip()))
 PY
 }
@@ -854,12 +883,36 @@ T
   printf '%s\n' '{' '  warnings = [ "not enabled" ];' '  services.tailscale.enable = true;' '}' \
     >"$dir/c-afterstring.nix"
   printf '%s\n' '{' '  # services.tailscale = { enable = true; };' '  services.tailscale.enable = true;' '}' >"$dir/c-both.nix"
+  # 🔴 THE FIXTURES THAT DISCRIMINATE A READ FROM A DECLARATION. Neither is a comment and
+  # neither is a string, so string-blanking cannot see them; both carry the `[.={]` the
+  # anchor looks for, so the anchor cannot either. MEASURED against the pre-guard regex:
+  # both printed "already DECLARES ... Nothing to do. Exiting 0" on a host with no
+  # tailscale at all. They die only on the `(?<![A-Za-z0-9_.'-])` lookbehind.
+  printf '%s\n' '{' '  networking.firewall.checkReversePath = lib.mkIf config.services.tailscale.enable "loose";' '}' \
+    >"$dir/c-cfgread.nix"
+  printf '%s\n' '{' '  assertions = [ { assertion = config.services.tailscale.enable; message = "x"; } ];' '}' \
+    >"$dir/c-assert.nix"
+  # ...and the control against a lookbehind that is too wide: a real declaration must
+  # still be found when it is NOT at the start of a line -- here after `{ ` on one line,
+  # which is how a module writes a small `mkIf` body. Without this, deleting the whole
+  # `services.tailscale` match and printing nothing would satisfy the two cases above.
+  printf '%s\n' '{' '  config = { services.tailscale.enable = true; };' '}' >"$dir/c-inline.nix"
+  # 🔴 THE SECOND-RUN CONTROL: the block this script itself writes must be recognised as
+  # a declaration on the next run, or every re-run appends another copy. Generated from
+  # the real `$BLOCK` further down would be circular; this is the shape it emits.
+  printf '%s\n' '{' '  services.tailscale = {' '    enable = true;' '    useRoutingFeatures = "server";' \
+    '    openFirewall = true;              # UDP 41641 for direct (non-DERP) connections' '  };' '}' \
+    >"$dir/c-ownblock.nix"
   for decl_case in "c-mention:0:a bare mention inside a # comment" \
                    "c-block:0:a declaration inside a /* */ block comment" \
                    "c-pkgonly:0:pkgs.tailscale in systemPackages is not a service" \
                    "c-string:0:the option NAMED in a warning string is not a setting" \
                    "c-instring:0:a whole declaration INSIDE a double-quoted string" \
                    "c-indented:0:a whole declaration inside a '' indented string" \
+                   "c-cfgread:0:a READ of the option (lib.mkIf config.services.tailscale.enable)" \
+                   "c-assert:0:a READ of the option inside an assertion" \
+                   "c-inline:1:a real declaration mid-line, after '{ '" \
+                   "c-ownblock:1:the block THIS script writes, on a second run" \
                    "c-afterstring:1:a real declaration on the line after a closed string" \
                    "c-dotted:1:services.tailscale.enable = true" \
                    "c-attrset:1:services.tailscale = { ... }" \
@@ -1109,11 +1162,20 @@ fi
 # A MENTION is not a declaration, and saying so out loud matters: the operator who wrote
 # that comment is exactly the one who might read a bare "proceeding" as "it ignored my
 # config". This branch is the reason `_cfg_tailscale_decls` strips comments at all.
+#
+# 🔴 THE WORDING NAMES THE CLASS, NOT ONE MEMBER OF IT. This line used to assert "every
+# occurrence is inside a comment", which was true of the one case that prompted it and is
+# false of the two the scanner has since grown to reject: a string literal whose contents
+# are a valid declaration, and a READ of the option (`config.services.tailscale.enable`)
+# in live code. Printing a specific, wrong reason next to the lines themselves invites the
+# operator to look at a comment that is not there and conclude the script is broken.
 if grep -q 'services\.tailscale' "$CFG"; then
   echo "  state     : $CFG MENTIONS services.tailscale but does not DECLARE it --"
   grep -n 'services\.tailscale' "$CFG" | sed 's/^/    | /'
-  echo "              every occurrence is inside a comment, so nothing is applied."
-  echo "              Proceeding to add the real block."
+  echo "              no occurrence above is a setting on this host: each is inside a"
+  echo "              comment or a string literal, or is a READ of the option"
+  echo "              (\`config.services.tailscale...\`) rather than a definition of it."
+  echo "              Nothing there applies tailscale. Proceeding to add the real block."
 fi
 
 # --- a sysctl key defined twice is a Nix evaluation error --------------------------------

--- a/nix/system/apply-tailscale.sh
+++ b/nix/system/apply-tailscale.sh
@@ -23,6 +23,9 @@
 #   TS_MAX_TOTAL_BUILDS=25
 #   TS_MAX_PENDING_MIB=64            download volume, gated separately from build count
 #   TS_MAX_TOTAL_MIB=128
+#   TS_MAX_PENDING_FETCH=50          number of paths to fetch, gated separately again --
+#   TS_MAX_TOTAL_FETCH=100           it is the axis that still has a number when the
+#                                    download SIZE cannot be parsed
 #   TS_MAX_CHANGED_PATHS=250
 #   TS_LIST_MAX=200                  how many pending derivation names a refusal prints
 #
@@ -81,10 +84,18 @@
 #      thousands of paths to fetch is a world-sized change with a build count of 0 --
 #      which is why (2) exists as a separate gate rather than a printed column.
 #
-#   2. DOWNLOAD VOLUME, baseline and total, in MiB. Same two dry-builds, the other number
-#      they report. Gated in its OWN right: a build count and a download volume are
-#      independent axes and either can be world-sized while the other is tiny. This was
-#      once a decorative column in the summary table that no gate read.
+#   2. DOWNLOAD VOLUME **AND FETCH COUNT**, baseline and total. The same two dry-builds,
+#      the other two numbers they report. Both gated in their OWN right: build count,
+#      download volume and path count are independent axes and any one of them can be
+#      world-sized while the others are tiny. Both were once decorative columns in the
+#      summary table that no gate read.
+#      🔴 AND THE SIZE IS FAIL-CLOSED. If dry-build announces paths to fetch but prints a
+#      size this script cannot parse -- an unknown unit, a comma decimal separator, or no
+#      parenthetical at all -- the volume is reported as UNKNOWN and REFUSED, never as
+#      0.0. Reporting it as zero is exactly how a 2400-path substitutable world rebuild
+#      passed all four gates in silence; measured, on four separate malformed shapes.
+#      The FETCH COUNT is the backstop for that same blind spot: it still has a number
+#      when the size does not.
 #
 #   3. THE NIXPKGS RELEASE STRING. Extracted with ONE implementation from the store-path
 #      basename of both the running system and the candidate derivation, so the two can
@@ -146,6 +157,11 @@ MAX_PENDING_BUILDS="${TS_MAX_PENDING_BUILDS:-10}"
 MAX_TOTAL_BUILDS="${TS_MAX_TOTAL_BUILDS:-25}"
 MAX_PENDING_MIB="${TS_MAX_PENDING_MIB:-64}"
 MAX_TOTAL_MIB="${TS_MAX_TOTAL_MIB:-128}"
+# Measured 2026-09-07 on this host: 24 paths pending, 25 with tailscale added. These are
+# ~2x and ~4x that, so they refuse a world-sized queue without becoming a permanent red
+# light on a normal one.
+MAX_PENDING_FETCH="${TS_MAX_PENDING_FETCH:-50}"
+MAX_TOTAL_FETCH="${TS_MAX_TOTAL_FETCH:-100}"
 MAX_CHANGED_PATHS="${TS_MAX_CHANGED_PATHS:-250}"
 LIST_MAX="${TS_LIST_MAX:-200}"
 
@@ -198,6 +214,26 @@ die() { echo "ABORT: $*" >&2; exit 1; }
 #   these 24 paths will be fetched (159.4 MiB download, 651.1 MiB unpacked):
 # Absent lines mean ZERO, which is why the self-test drives a zero case AND a non-zero
 # one: a parser wired to nothing also returns zero, and zero is the reassuring answer.
+#
+# 🔴 THE SIZE FIELD IS `UNKNOWN`, NOT 0.0, WHENEVER IT CANNOT BE READ -- AND THAT IS THE
+# WHOLE POINT OF THIS FUNCTION'S SECOND HALF. The previous implementation searched for
+#   will be fetched \(([0-9.]+) ([KMG]i?B) download
+# and left `mib = 0.0` on no match, which is indistinguishable from a genuine zero.
+# MEASURED, all four against the real gate: `these 2400 paths will be fetched:` (no
+# parenthetical at all), `2.5 TiB`, `900000000 B`, and `4096,0 MiB` (a comma decimal
+# separator, which a non-C locale produces) EACH returned `0|2400|0.0` -- so a
+# 2400-path, entirely substitutable world rebuild passed all four gates in silence.
+# That is precisely the change the download gate was added to stop.
+#
+# So the distinction that has to survive is "there was nothing to fetch" vs "there was
+# something to fetch and I could not size it":
+#   * NO fetch line at all  -> genuinely nothing to fetch -> 0.0.
+#   * a fetch line WITH a size this function understands -> that size, scaled to MiB.
+#   * a fetch line whose size it cannot read -> the literal string `UNKNOWN`, which
+#     `_gate_reasons` REFUSES on. Fail closed: an unmeasured download is not a small one.
+# The unit table is exhaustive over what nix emits and `.get()` returns None -- there is
+# deliberately no defaulting-to-MiB fallback, because a unit this script has never heard
+# of is exactly the case where guessing 1.0 turns a TiB into a rounding error.
 _drybuild_counts() {   # $1 = file holding dry-build's stderr; prints "built|fetched|mib"
   python3 - "$1" <<'PY'
 import re, sys
@@ -213,13 +249,24 @@ def count(kind):
         return 0
     return int(m.group(1)) if m.group(1) else 1
 
-mib = 0.0
-m = re.search(r"will be fetched \(([0-9.]+) ([KMG]i?B) download", text)
-if m:
-    v, unit = float(m.group(1)), m.group(2)
-    mib = v * {"KiB": 1 / 1024.0, "MiB": 1.0, "GiB": 1024.0,
-               "KB": 1 / 1024.0, "MB": 1.0, "GB": 1024.0}.get(unit, 1.0)
-print("%d|%d|%.1f" % (count("built"), count("fetched"), mib))
+UNITS = {"B": 1 / 1048576.0,
+         "KB": 1 / 1024.0, "KiB": 1 / 1024.0,
+         "MB": 1.0,        "MiB": 1.0,
+         "GB": 1024.0,     "GiB": 1024.0,
+         "TB": 1048576.0,  "TiB": 1048576.0}
+
+fetch_line = re.search(r"^(?:these [0-9]+|this) paths? will be fetched\b(.*)$", text, re.M)
+if fetch_line is None:
+    mib = "0.0"                       # no fetch line -> nothing to fetch -> a real zero
+else:
+    m = re.match(r"\s*\(\s*([0-9]+(?:\.[0-9]+)?)\s+([A-Za-z]+)\s+download\b",
+                 fetch_line.group(1))
+    if m is None:
+        mib = "UNKNOWN"               # a fetch line we cannot size -- NOT a zero
+    else:
+        factor = UNITS.get(m.group(2))
+        mib = "UNKNOWN" if factor is None else "%.1f" % (float(m.group(1)) * factor)
+print("%d|%d|%s" % (count("built"), count("fetched"), mib))
 PY
 }
 
@@ -261,16 +308,35 @@ _store_path() {
 # expensive possible lie, because it tells the operator the backup path is DONE.
 # Measured; that exact one-line fixture reproduced it.
 #
-# So: strip Nix comments FIRST (`#` to end of line, and `/* ... */` blocks, both replaced
-# with spaces so line numbers survive), then require an actual SETTING -- the attribute
-# followed by `=`, `{` or a further `.`, which is every way Nix can spell one and no way
-# it can spell a mention. Prints `lineno:text` per declaration, nothing at all when
-# there is none, so the caller branches on emptiness.
+# So: blank out everything that is NOT executable Nix -- comments AND string literals --
+# then require an actual SETTING: the attribute followed by `=`, `{` or a further `.`,
+# which is every way Nix can spell one and no way it can spell a mention. Prints
+# `lineno:text` per declaration, nothing at all when there is none, so the caller
+# branches on emptiness.
 #
-# Direction of error is deliberate: a declaration this misses means the script proceeds
-# and adds a SECOND block, which `nix-instantiate '<nixpkgs/nixos>' -A system` then
-# refuses as a duplicate definition BEFORE anything is written. A mention it wrongly
-# accepted would exit 0 and leave the host unprotected with no further check at all.
+# 🔴 STRINGS, NOT JUST COMMENTS -- AND THE `[.={]` ANCHOR IS NOT ENOUGH ON ITS OWN. An
+# earlier version blanked comments only, on the reasoning that the anchor already rejects
+# a bare mention. It does reject `"services.tailscale is not enabled here"`. It does NOT
+# reject a string that happens to contain the punctuation, and MEASURED, both of these
+# reported the host as ALREADY CONFIGURED and printed "Nothing to do. Exiting 0":
+#     warnings = [ "you should run services.tailscale.enable = true; here" ];
+#     text = ''<newline>  services.tailscale.enable = true;<newline>'';
+# That is the most expensive lie this script can tell -- it says the backup path is DONE
+# on a host where nothing was applied, two days before the operator leaves for months.
+#
+# The blanking is a LEFT-TO-RIGHT SCANNER, not three independent regexes, because the
+# constructs nest: a `#` inside a string is not a comment and a `"` inside a comment is
+# not a string, and only a scanner that consumes them in order gets both right. It
+# handles `#` line comments, `/* */` blocks, `"..."` with backslash escapes, and Nix's
+# `''...''` indented strings with their `''$`, `'''` and `''\` escapes. Newlines are
+# preserved so the line numbers reported below still index the ORIGINAL file.
+#
+# Direction of error is deliberate, and unchanged: a declaration this misses means the
+# script proceeds and adds a SECOND block, which `nix-instantiate '<nixpkgs/nixos>' -A
+# system` then refuses as a duplicate definition BEFORE anything is written. A mention it
+# wrongly accepted would exit 0 and leave the host unprotected with no further check at
+# all. So when the scanner is confused -- by an identifier ending in `''`, say -- it
+# fails toward the loud, harmless side.
 _cfg_tailscale_decls() {   # $1 = config path; prints "lineno:line" per declaration
   python3 - "$1" <<'PY'
 import re, sys
@@ -279,11 +345,65 @@ try:
 except Exception as e:
     sys.stderr.write("read: %s\n" % e); sys.exit(2)
 
-# Blank out comments, preserving every newline so line numbers still line up.
-def blank(m):
-    return re.sub(r"[^\n]", " ", m.group(0))
-stripped = re.sub(r"/\*.*?\*/", blank, src, flags=re.S)
-stripped = re.sub(r"#[^\n]*", blank, stripped)
+
+def blank_non_code(text):
+    """Replace comments and string literals with spaces, keeping every newline."""
+    out = list(text)
+    n = len(text)
+
+    def wipe(a, b):
+        for k in range(a, b):
+            if out[k] != "\n":
+                out[k] = " "
+
+    i = 0
+    while i < n:
+        if text.startswith("#", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            wipe(i, j)
+            i = j
+        elif text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            wipe(i, j)
+            i = j
+        elif text.startswith("''", i):
+            # Nix indented string. It ends at the next `''` that is not itself the start
+            # of an escape: `''$`, `'''` and `''\` all continue the string.
+            j = i + 2
+            while j < n:
+                if text.startswith("''", j):
+                    if text[j + 2:j + 3] in ("$", "'", "\\"):
+                        j += 3
+                        continue
+                    j += 2
+                    break
+                j += 1
+            else:
+                j = n
+            wipe(i, j)
+            i = j
+        elif text.startswith('"', i):
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            else:
+                j = n
+            wipe(i, j)
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+stripped = blank_non_code(src)
 
 orig = src.splitlines()
 for i, line in enumerate(stripped.splitlines()):
@@ -458,7 +578,7 @@ T
   # 🔴 The refusing fixture is not invented: 40 pending / 47 total / +7 delta is what
   # `nixos-rebuild dry-build` reported on this host on 2026-09-07, against an UNCHANGED
   # config and with the tailscale block added. The gate must refuse THAT.
-  got=$(_gate_reasons 26.11 26.11 40 47)
+  got=$(_gate_reasons 26.11 26.11 40 47 0.0 17.6 3 4)
   if printf '%s' "$got" | grep -q 'PENDING WORK UNRELATED'; then
     echo "  [self-test] gate REFUSES the real measured state (40 pending / 47 total) -> ok"
   else
@@ -467,7 +587,7 @@ T
   # The allowing branch: nothing pending, tailscale's own 7 derivations. If this
   # refused, the script could never succeed and the gate would be a permanent red
   # light that everyone learns to override.
-  got=$(_gate_reasons 26.11 26.11 0 7)
+  got=$(_gate_reasons 26.11 26.11 0 7 0.0 17.6 2 5)
   if [ -z "$got" ]; then
     echo "  [self-test] gate ALLOWS a clean tree with tailscale's own 7 builds -> ok"
   else
@@ -475,14 +595,14 @@ T
   fi
   # 🔴 THE RELEASE JUMP, which must refuse on its own even when the counts are tiny --
   # a release change is an OS upgrade however small the queue looks at eval time.
-  got=$(_gate_reasons 26.05 26.11 0 3)
+  got=$(_gate_reasons 26.05 26.11 0 3 0.0 9.5 1 3)
   if printf '%s' "$got" | grep -q 'NIXPKGS RELEASE CHANGE'; then
     echo "  [self-test] gate REFUSES a 26.05 -> 26.11 jump even with 3 builds pending -> ok"
   else
     echo "  [self-test] gate FAILED: a release jump passed on low counts. got: '$got'"; rc=1
   fi
   # And the total-size gate on its own, with a clean baseline.
-  got=$(_gate_reasons 26.11 26.11 0 900)
+  got=$(_gate_reasons 26.11 26.11 0 900 0.0 17.6 3 6)
   if printf '%s' "$got" | grep -q 'TOTAL BUILD SIZE'; then
     echo "  [self-test] gate REFUSES 900 total builds from a clean baseline -> ok"
   else
@@ -490,9 +610,13 @@ T
   fi
 
   # --- _over_mib, the FRACTIONAL comparison ------------------------------------------
-  # `-gt` cannot compare "159.4" at all: it aborts the shell. Driven in both directions,
-  # and across the boundary with a fraction on BOTH sides so a mutant that truncates to
-  # an integer (159.4 -> 159, 64.5 -> 64) is visible.
+  # `-gt` cannot compare "159.4" at all. MEASURED in the shape the gate actually uses
+  # (`if _over ...; then`): bash prints `[: 159.4: integer expected` to stderr, `[`
+  # returns 2, errexit does not apply to an `if` condition, and EXECUTION CONTINUES with
+  # the gate SILENT -- it fails OPEN, it does not abort. See `_over_mib` below; this
+  # comment used to say the opposite. Driven in both directions, and across the boundary
+  # with a fraction on BOTH sides so a mutant that truncates to an integer (159.4 -> 159,
+  # 64.5 -> 64) is visible.
   if _over_mib "159.4" "64";   then echo "  [self-test] _over_mib 159.4 > 64 -> ok"; else echo "  [self-test] _over_mib FAILED: 159.4 not > 64"; rc=1; fi
   if _over_mib "17.6" "64";    then echo "  [self-test] _over_mib FAILED: 17.6 > 64"; rc=1; else echo "  [self-test] _over_mib 17.6 < 64 -> not over -> ok"; fi
   if _over_mib "64.5" "64.4";  then echo "  [self-test] _over_mib 64.5 > 64.4 (fraction decides) -> ok"; else echo "  [self-test] _over_mib FAILED: 64.5 not > 64.4 -- truncating to int?"; rc=1; fi
@@ -503,7 +627,7 @@ T
   # one that walked straight through a gate that read only build counts. 0 to build,
   # 4 GiB to fetch. Both build gates are silent here BY CONSTRUCTION, so if this passes
   # the download gate is genuinely the only thing that saw it.
-  got=$(_gate_reasons 26.11 26.11 0 0 4096.0 4096.0)
+  got=$(_gate_reasons 26.11 26.11 0 0 4096.0 4096.0 3 3)
   if printf '%s' "$got" | grep -q 'PENDING DOWNLOAD VOLUME'; then
     echo "  [self-test] gate REFUSES 4096 MiB of pending downloads at ZERO builds -> ok"
   else
@@ -516,14 +640,14 @@ T
   fi
   # The download gates must ALLOW tailscale's own measured cost, or the script can never
   # succeed and the gate becomes a permanent red light everyone learns to override.
-  got=$(_gate_reasons 26.11 26.11 0 7 0.0 17.6)
+  got=$(_gate_reasons 26.11 26.11 0 7 0.0 17.6 0 1)
   if [ -z "$got" ]; then
     echo "  [self-test] gate ALLOWS tailscale's own measured 7 builds / 17.6 MiB -> ok"
   else
     echo "  [self-test] gate FAILED: refused the measured tailscale-only delta: '$got'"; rc=1
   fi
   # And the TOTAL download gate on its own, from a clean baseline.
-  got=$(_gate_reasons 26.11 26.11 0 0 0.0 900.0)
+  got=$(_gate_reasons 26.11 26.11 0 0 0.0 900.0 0 4)
   if printf '%s' "$got" | grep -q 'TOTAL DOWNLOAD VOLUME'; then
     echo "  [self-test] gate REFUSES 900 MiB total from a clean baseline -> ok"
   else
@@ -532,7 +656,7 @@ T
   # 🔴 THE NEGATIVE DELTA. The two dry-builds are separate evaluations and CAN disagree;
   # the old phrasing rendered "Only -3 of the 37 are tailscale's" -- nonsense stated as
   # a measurement, inside the one message the operator reads to make a judgement call.
-  got=$(_gate_reasons 26.11 26.11 40 37)
+  got=$(_gate_reasons 26.11 26.11 40 37 0.0 17.6 3 2)
   if printf '%s' "$got" | grep -q 'Only -'; then
     echo "  [self-test] negative-delta phrasing FAILED: still says 'Only -N of the M'"; rc=1
   elif printf '%s' "$got" | grep -q 'FEWER builds'; then
@@ -540,11 +664,161 @@ T
   else
     echo "  [self-test] negative-delta phrasing FAILED: got '$got'"; rc=1
   fi
-  got=$(_gate_reasons 26.11 26.11 40 47)
+  got=$(_gate_reasons 26.11 26.11 40 47 0.0 17.6 3 4)
   if printf '%s' "$got" | grep -q "Only 7 of the 47 are tailscale's"; then
     echo "  [self-test] a POSITIVE delta still reads 'Only 7 of the 47' -> ok"
   else
     echo "  [self-test] positive-delta phrasing FAILED: got '$got'"; rc=1
+  fi
+
+  # --- _is_num, the thing that keeps a non-number away from the comparison ------------
+  local numcase
+  for numcase in "0:yes" "0.0:yes" "17.6:yes" "4096.0:yes" "159.4:yes" \
+                 "UNKNOWN:no" ":no" ".:no" "1.2.3:no" "4096,0:no" "-1:no" "1e3:no"; do
+    if _is_num "${numcase%%:*}"; then got=yes; else got=no; fi
+    if [ "$got" = "${numcase##*:}" ]; then
+      echo "  [self-test] _is_num '${numcase%%:*}' -> $got -> ok"
+    else
+      echo "  [self-test] _is_num '${numcase%%:*}' FAILED: got $got, want ${numcase##*:}"; rc=1
+    fi
+  done
+  # The control that makes the case above matter: awk WOULD have said "not over".
+  if _over_mib "UNKNOWN" "64"; then
+    echo "  [self-test] the _over_mib fixture is not what this file claims"; rc=1
+  else
+    echo "  [self-test] _over_mib('UNKNOWN', 64) is silently FALSE -- so _is_num is load-bearing -> ok"
+  fi
+
+  # --- 🔴 AN UNMEASURABLE DOWNLOAD MUST REFUSE, NOT READ AS ZERO -----------------------
+  # The build counts and the fetch counts are held DELIBERATELY BELOW every other limit
+  # here, so nothing but the unparseable-size branch can produce a refusal. If this
+  # passes, that branch is genuinely the only thing that saw it.
+  got=$(_gate_reasons 26.11 26.11 0 3 UNKNOWN 17.6 3 4)
+  if printf '%s' "$got" | grep -q 'PENDING DOWNLOAD VOLUME COULD NOT BE MEASURED'; then
+    echo "  [self-test] gate REFUSES an UNPARSEABLE pending download size -> ok"
+  else
+    echo "  [self-test] gate FAILED OPEN on an unparseable pending size. got: '$got'"; rc=1
+  fi
+  got=$(_gate_reasons 26.11 26.11 0 3 0.0 UNKNOWN 3 4)
+  if printf '%s' "$got" | grep -q 'TOTAL DOWNLOAD VOLUME COULD NOT BE MEASURED'; then
+    echo "  [self-test] gate REFUSES an UNPARSEABLE total download size -> ok"
+  else
+    echo "  [self-test] gate FAILED OPEN on an unparseable total size. got: '$got'"; rc=1
+  fi
+
+  # --- the FETCH COUNT gates, both directions -----------------------------------------
+  # The download SIZES here are 0.0 and the build counts are 3, both far under their
+  # limits, so only the fetch gates can speak.
+  got=$(_gate_reasons 26.11 26.11 0 3 0.0 17.6 2400 2401)
+  if printf '%s' "$got" | grep -q 'PENDING FETCH COUNT'; then
+    echo "  [self-test] gate REFUSES 2400 pending paths to fetch -> ok"
+  else
+    echo "  [self-test] gate FAILED: 2400 pending fetches allowed. got: '$got'"; rc=1
+  fi
+  got=$(_gate_reasons 26.11 26.11 0 3 0.0 17.6 7 913)
+  if printf '%s' "$got" | grep -q 'TOTAL FETCH COUNT'; then
+    echo "  [self-test] gate REFUSES 913 total paths to fetch from a small baseline -> ok"
+  else
+    echo "  [self-test] gate FAILED: 913 total fetches allowed. got: '$got'"; rc=1
+  fi
+  # 🔴 AND IT MUST ALLOW THE MEASURED REALITY, or the fetch gate is a permanent red light
+  # that everyone learns to override. 24 pending / 25 total is what this host reported on
+  # 2026-09-07 -- neither number is a round multiple of its limit.
+  got=$(_gate_reasons 26.11 26.11 0 7 0.0 17.6 24 25)
+  if [ -z "$got" ]; then
+    echo "  [self-test] gate ALLOWS the measured 24 pending / 25 total fetched paths -> ok"
+  else
+    echo "  [self-test] gate FAILED: refused the measured fetch counts: '$got'"; rc=1
+  fi
+
+  # --- the ARITY guard ------------------------------------------------------------------
+  # A call site that omits an axis must be LOUD. The old signature defaulted the missing
+  # ones to 0, which is a gate that cannot fire dressed as a gate that passed.
+  if got=$(_gate_reasons 26.11 26.11 0 3 0.0 17.6 2>&1); then
+    echo "  [self-test] _gate_reasons FAILED: returned 0 for a 6-argument call"; rc=1
+  elif printf '%s' "$got" | grep -q 'needs 8 arguments'; then
+    echo "  [self-test] _gate_reasons refuses a 6-argument call by name -> ok"
+  else
+    echo "  [self-test] _gate_reasons FAILED: wrong error for a short call: '$got'"; rc=1
+  fi
+
+  # --- 🔴 THE SEAM: _drybuild_counts -> _gate_reasons, JOINED ---------------------------
+  # Everything above drives the parser on well-formed text and the gate on numbers typed
+  # in by hand. The defect this replaces lived in NEITHER -- it lived in the join, where
+  # the parser's "I could not read this" was spelled `0.0` and the gate read it as "there
+  # is nothing to download". So these cases go through BOTH, exactly as the real run
+  # does, and the fixtures are the four malformed shapes measured against the old gate.
+  local seam_case seam_label seam_text seam_counts seam_gate
+  # 🔴 THE POSITIVE CONTROL FIRST. A well-formed world-sized fetch line must REFUSE --
+  # otherwise a seam harness that refused everything (or that was wired to nothing and
+  # happened to print a refusal) would look identical to a working one.
+  printf 'these 2400 paths will be fetched (4096.0 MiB download, 9000.0 MiB unpacked):\n' \
+    >"$dir/seam-ok.txt"
+  seam_counts=$(_drybuild_counts "$dir/seam-ok.txt")
+  IFS='|' read -r _sb _sf _sm <<<"$seam_counts"
+  seam_gate=$(_gate_reasons 26.11 26.11 "$_sb" "$_sb" "$_sm" "$_sm" "$_sf" "$_sf")
+  if [ -n "$seam_gate" ] && [ "$_sm" = "4096.0" ]; then
+    echo "  [self-test] seam control: a well-formed 4096.0 MiB / 2400-path line parses AND refuses -> ok"
+  else
+    echo "  [self-test] seam control FAILED: counts '$seam_counts', gate '$seam_gate'"; rc=1
+  fi
+  # And a genuinely EMPTY dry-build must still pass the seam, or the gate is a red light.
+  printf 'building the system configuration...\n' >"$dir/seam-zero.txt"
+  seam_counts=$(_drybuild_counts "$dir/seam-zero.txt")
+  IFS='|' read -r _sb _sf _sm <<<"$seam_counts"
+  seam_gate=$(_gate_reasons 26.11 26.11 "$_sb" "$_sb" "$_sm" "$_sm" "$_sf" "$_sf")
+  if [ -z "$seam_gate" ] && [ "$seam_counts" = "0|0|0.0" ]; then
+    echo "  [self-test] seam control: an EMPTY dry-build is a real 0.0 and is ALLOWED -> ok"
+  else
+    echo "  [self-test] seam control FAILED on the empty case: counts '$seam_counts', gate '$seam_gate'"; rc=1
+  fi
+  # Now the four measured malformed shapes. Every one of them returned `0|2400|0.0` and
+  # passed all four gates in silence.
+  #
+  # 🔴 THE EXPECTED SIZE IS PINNED EXACTLY, not merely asserted "not 0.0". A weaker
+  # version of this loop was MUTATION-TESTED and a mutant that defaulted an unrecognised
+  # unit to MiB -- reading 4 EiB as 4.0 -- SURVIVED it: the value was not 0.0, and the
+  # fetch-count gate refused the change for an unrelated reason. The fetch gate catching
+  # it is defence in depth, not a reason to leave this guard unable to see the bug it
+  # exists for.
+  local seam_want
+  for seam_case in \
+      "no size parenthetical at all|UNKNOWN|these 2400 paths will be fetched:" \
+      "a TiB download (understood -- must SCALE, not refuse)|2621440.0|these 2400 paths will be fetched (2.5 TiB download, 9.0 TiB unpacked):" \
+      "a comma decimal separator|UNKNOWN|these 2400 paths will be fetched (4096,0 MiB download, 9000,0 MiB unpacked):" \
+      "a unit this script has never seen|UNKNOWN|these 2400 paths will be fetched (4.0 EiB download, 9.0 EiB unpacked):"; do
+    seam_label="${seam_case%%|*}"
+    seam_case="${seam_case#*|}"
+    seam_want="${seam_case%%|*}"
+    seam_text="${seam_case#*|}"
+    printf '%s\n' "$seam_text" >"$dir/seam.txt"
+    seam_counts=$(_drybuild_counts "$dir/seam.txt")
+    IFS='|' read -r _sb _sf _sm <<<"$seam_counts"
+    seam_gate=$(_gate_reasons 26.11 26.11 "$_sb" "$_sb" "$_sm" "$_sm" "$_sf" "$_sf")
+    if [ "$_sm" != "$seam_want" ]; then
+      echo "  [self-test] seam FAILED: $seam_label sized as '$_sm', want '$seam_want'"; rc=1
+    elif [ -z "$seam_gate" ]; then
+      echo "  [self-test] seam FAILED: $seam_label passed the gate ($seam_counts)"; rc=1
+    else
+      echo "  [self-test] seam: $seam_label -> $seam_counts -> REFUSED -> ok"
+    fi
+  done
+  # 🔴 `2.5 TiB` IS PARSEABLE NOW, and it must be scaled, not merely refused: a TiB read
+  # as 2.5 MiB is six orders of magnitude of "this is fine".
+  printf 'these 3 paths will be fetched (2.5 TiB download, 9.0 TiB unpacked):\n' >"$dir/tib.txt"
+  got=$(_drybuild_counts "$dir/tib.txt")
+  if [ "$got" = "0|3|2621440.0" ]; then
+    echo "  [self-test] 2.5 TiB is scaled to MiB (2621440.0), not read as 2.5 -> ok"
+  else
+    echo "  [self-test] TiB scaling FAILED: got '$got', want '0|3|2621440.0'"; rc=1
+  fi
+  # A bare-byte size is likewise a real number, not an UNKNOWN.
+  printf 'these 2 paths will be fetched (900000000 B download, 1000000000 B unpacked):\n' >"$dir/bytes.txt"
+  got=$(_drybuild_counts "$dir/bytes.txt")
+  if [ "$got" = "0|2|858.3" ]; then
+    echo "  [self-test] a bare-byte size is scaled to MiB (900000000 B -> 858.3) -> ok"
+  else
+    echo "  [self-test] byte scaling FAILED: got '$got', want '0|2|858.3'"; rc=1
   fi
 
   # --- _cfg_tailscale_decls: a MENTION is not a DECLARATION ---------------------------
@@ -564,11 +838,29 @@ T
   # passes every other fixture here, so the anchor is untested and a config that merely
   # NAMES the option in a warning string reports the host as already done.
   printf '%s\n' '{' '  warnings = [ "services.tailscale is not enabled here" ];' '}' >"$dir/c-string.nix"
+  # 🔴 THE FIXTURE THAT DISCRIMINATES STRING-BLANKING FROM THE `[.={]` ANCHOR ALONE. The
+  # case above carries no `[.={]` after the attribute path, so it is rejected by the
+  # anchor and stays 0 even with every line of string handling deleted -- it cannot see
+  # that mutation. These two CAN: each is a string whose CONTENTS are a syntactically
+  # perfect declaration, and each reported "Nothing to do. Exiting 0" before the scanner
+  # existed.
+  printf '%s\n' '{' '  warnings = [ "you should run services.tailscale.enable = true; here" ];' '}' \
+    >"$dir/c-instring.nix"
+  printf '%s\n' '{' "  text = ''" '    services.tailscale.enable = true;' "  '';" '}' \
+    >"$dir/c-indented.nix"
+  # ...and the control that keeps the two above from being satisfied by a scanner that
+  # blanks the whole file: a real declaration SITTING AFTER a closed string on the line
+  # before must still be found.
+  printf '%s\n' '{' '  warnings = [ "not enabled" ];' '  services.tailscale.enable = true;' '}' \
+    >"$dir/c-afterstring.nix"
   printf '%s\n' '{' '  # services.tailscale = { enable = true; };' '  services.tailscale.enable = true;' '}' >"$dir/c-both.nix"
   for decl_case in "c-mention:0:a bare mention inside a # comment" \
                    "c-block:0:a declaration inside a /* */ block comment" \
                    "c-pkgonly:0:pkgs.tailscale in systemPackages is not a service" \
                    "c-string:0:the option NAMED in a warning string is not a setting" \
+                   "c-instring:0:a whole declaration INSIDE a double-quoted string" \
+                   "c-indented:0:a whole declaration inside a '' indented string" \
+                   "c-afterstring:1:a real declaration on the line after a closed string" \
                    "c-dotted:1:services.tailscale.enable = true" \
                    "c-attrset:1:services.tailscale = { ... }" \
                    "c-both:1:a commented-out copy PLUS a real one"; do
@@ -593,10 +885,34 @@ T
 
 _over() { [ "$1" -gt "$2" ]; }
 
-# The MiB figures are FRACTIONAL ("159.4"), so `-gt` cannot compare them: bash would
-# abort with "integer expression expected" inside a gate, under `set -e`, which is the
-# gate failing OPEN dressed as a crash. awk does the comparison in floating point.
+# 🔴 THE MiB FIGURES ARE FRACTIONAL ("159.4") AND `-gt` CANNOT COMPARE THEM -- BUT NOT IN
+# THE WAY THIS COMMENT USED TO CLAIM. It said `-gt` "aborts the shell ... under `set -e`".
+# MEASURED in the shape actually used here, `if _over "159.4" "64"; then`:
+#     $ set -euo pipefail; _over() { [ "$1" -gt "$2" ]; }
+#     $ if _over "159.4" "64"; then echo FIRED; else echo SILENT; fi; echo "continued"
+#     bash: line 2: [: 159.4: integer expected
+#     SILENT
+#     continued                          <- and the script exits 0
+# `[` prints to stderr and returns 2; because the call is the CONDITION of an `if`,
+# errexit does not apply to it, so nothing aborts -- the gate simply does not fire and
+# execution carries on. The conclusion (use awk) was right; the stated mechanism was
+# backwards, and it matters: a comment describing a LOUD abort where the truth is a
+# SILENT fail-open is how the next maintainer decides the guard is redundant and deletes
+# it. awk does the comparison in floating point, and `_is_num` below keeps a
+# non-numeric string from reaching it at all.
 _over_mib() { awk -v a="$1" -v b="$2" 'BEGIN { exit !(a + 0 > b + 0) }'; }
+
+# 🔴 A BARE NON-NEGATIVE DECIMAL, AND NOTHING ELSE. `_over_mib UNKNOWN 64` would evaluate
+# `"UNKNOWN" + 0` as 0 in awk and report "not over" -- the fail-open this whole round
+# exists to close. Every MiB figure is put through here BEFORE any comparison, and a
+# value that fails is REFUSED rather than compared.
+_is_num() {
+  case "$1" in
+    ''|.|*[!0-9.]*) return 1 ;;   # empty, a bare dot, or any character that is not a digit/dot
+    *.*.*)          return 1 ;;   # more than one decimal point
+  esac
+  return 0
+}
 
 # THE GATE, as a pure function of the six numbers, so every branch can be driven from
 # fixtures. A refusal that has only ever been reasoned about is not a guard; the
@@ -610,11 +926,32 @@ _over_mib() { awk -v a="$1" -v b="$2" 'BEGIN { exit !(a + 0 > b + 0) }'; }
 # untouched. Build count and download volume are independent axes and either can be
 # world-sized alone.
 #
+# 🔴 THE FETCH COUNTS ARE NOT DECORATION EITHER -- THE SAME DEFECT, ONE COLUMN OVER.
+# `_drybuild_counts` has always parsed the fetch count correctly and the summary table
+# has always printed it, and until now NO GATE READ IT. That is the identical
+# "decorative column" shape the download-volume gate was added to fix: a change of 2400
+# fetched paths whose size could not be read passed every gate, and the count -- correct,
+# parsed, printed -- was sitting right there. Defaults are set from the SAME measurement
+# as the rest: 24 pending / 25 total on this host on 2026-09-07, tailscale's own cost
+# being +1 fetched path.
+#
+# 🔴 ALL EIGHT ARGUMENTS ARE REQUIRED. They used to have `${5:-0}`-style defaults, which
+# is the shape that lets a call site quietly omit an axis and get a gate that cannot
+# fire. A missing argument is now loud.
+#
 # Prints one reason per paragraph; empty output means "allow".
-_gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_builds
-                    # $5 pending_mib  $6 total_mib   (both optional; default 0)
+_gate_reasons() {   # $1 run_rel      $2 cand_rel
+                    # $3 pending_builds  $4 total_builds
+                    # $5 pending_mib     $6 total_mib      (may be the string UNKNOWN)
+                    # $7 pending_fetch   $8 total_fetch
+  if [ "$#" -ne 8 ]; then
+    printf '%s\n' "INTERNAL ERROR: _gate_reasons needs 8 arguments, got $#. Refusing to
+    return a verdict from a gate that was not given every axis it measures." >&2
+    return 2
+  fi
   local run_rel="$1" cand_rel="$2" b_built="$3" c_built="$4"
-  local b_mib="${5:-0}" c_mib="${6:-0}" d_built=$(( $4 - $3 )) delta_note
+  local b_mib="$5" c_mib="$6" b_fetch="$7" c_fetch="$8"
+  local d_built=$(( $4 - $3 )) delta_note
   # 🔴 A NEGATIVE DELTA IS A REAL OBSERVED STATE, not an impossible one: the two
   # dry-builds are separate evaluations and the store can gain paths between them, so the
   # candidate can legitimately report FEWER builds than the baseline. Phrased as
@@ -643,16 +980,47 @@ _gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_build
     printf '%s\n' "TOTAL BUILD SIZE: $c_built derivations would be built (limit
     $MAX_TOTAL_BUILDS). Adding tailscale should be a handful of substituted paths."
   fi
-  if _over_mib "$b_mib" "$MAX_PENDING_MIB"; then
+  # 🔴 UNPARSEABLE FIRST, AND IT REFUSES. An unmeasured download is not a small one, and
+  # the numeric gates below would silently read it as zero.
+  if ! _is_num "$b_mib"; then
+    printf '%s\n' "PENDING DOWNLOAD VOLUME COULD NOT BE MEASURED ('$b_mib'). \`nixos-rebuild
+    dry-build\` announced paths to fetch for the CURRENT config but printed a size this
+    script cannot read -- an unknown unit, a locale that uses a comma decimal separator,
+    or no size at all. REFUSED, deliberately: an unmeasured download is not a small one,
+    and reporting it as 0 MiB is how a 2400-path substitutable world rebuild walked
+    through all four gates in silence. Read the numbers yourself:
+      nixos-rebuild dry-build   (its summary goes to STDERR)
+    then re-run with --allow-world-rebuild if you are satisfied."
+  elif _over_mib "$b_mib" "$MAX_PENDING_MIB"; then
     printf '%s\n' "PENDING DOWNLOAD VOLUME: the CURRENT config already wants to fetch
     $b_mib MiB (limit $MAX_PENDING_MIB MiB), and \`switch\` fetches it too. A change with
     NOTHING to build can still be world-sized -- a fully substitutable channel bump is
     thousands of paths and gigabytes of download at a build count of zero. Same clean
     fix: land the pending change on its own first, or --allow-world-rebuild."
   fi
-  if _over_mib "$c_mib" "$MAX_TOTAL_MIB"; then
+  if ! _is_num "$c_mib"; then
+    printf '%s\n' "TOTAL DOWNLOAD VOLUME COULD NOT BE MEASURED ('$c_mib') for the
+    CANDIDATE config. Same reason and same refusal as above: this gate does not treat an
+    unreadable size as zero."
+  elif _over_mib "$c_mib" "$MAX_TOTAL_MIB"; then
     printf '%s\n' "TOTAL DOWNLOAD VOLUME: $c_mib MiB would be fetched (limit
     $MAX_TOTAL_MIB MiB). Tailscale's own measured cost on this host is ~17.6 MiB."
+  fi
+  # 🔴 THE FETCH COUNT, WHICH IS THE AXIS THAT STILL HAS A NUMBER WHEN THE SIZE DOES NOT.
+  # It is the only gate that sees a fetch line whose size is unreadable AND whose volume
+  # therefore cannot be compared -- so it is not redundant with the two above, it is the
+  # backstop for exactly their blind spot.
+  if _over "$b_fetch" "$MAX_PENDING_FETCH"; then
+    printf '%s\n' "PENDING FETCH COUNT: the CURRENT config already wants to fetch
+    $b_fetch paths (limit $MAX_PENDING_FETCH), and \`switch\` fetches them too. Measured
+    on this host, a normal pending queue is ~24 paths and tailscale's own cost is +1.
+    Thousands of paths is a channel bump wearing a feature's clothes, whatever the
+    download size says -- or fails to say. Land the pending change on its own first, or
+    --allow-world-rebuild."
+  fi
+  if _over "$c_fetch" "$MAX_TOTAL_FETCH"; then
+    printf '%s\n' "TOTAL FETCH COUNT: $c_fetch paths would be fetched (limit
+    $MAX_TOTAL_FETCH). Adding tailscale measured 25 fetched paths in total on this host."
   fi
 }
 
@@ -1020,7 +1388,8 @@ echo
 
 # --- the gate ---------------------------------------------------------------------------
 # One implementation, exercised in both directions by --self-test above.
-refuse=$(_gate_reasons "$run_rel" "$cand_rel" "$b_built" "$c_built" "$b_mib" "$c_mib")
+refuse=$(_gate_reasons "$run_rel" "$cand_rel" "$b_built" "$c_built" \
+                       "$b_mib" "$c_mib" "$b_fetch" "$c_fetch")
 
 if [ -n "$refuse" ] && [ "$ALLOW_WORLD" != "1" ]; then
   echo "REFUSING to switch:" >&2
@@ -1215,9 +1584,23 @@ case "$chk_rc" in
     echo "              Nothing outstanding; the steps below are already done."
     ;;
   4)
-    echo "  verifier  : rc 4 -- EXPECTED. The switch succeeded and the node is NOT YET"
-    echo "              AUTHENTICATED, because this script does not run \`tailscale up\`"
-    echo "              (it needs a browser). No defect was found. KEEPING the config."
+    # 🔴 NAME WHAT WAS OBSERVED, NOT ONE CAUSE OUT OF SEVERAL. This used to read "the
+    # switch succeeded and the node is NOT YET AUTHENTICATED" -- an assertion about the
+    # node's identity, made by a script that never looked at it, for an exit code with
+    # more than one cause. It is reachable two lines below the verifier printing
+    # `PASS authed`, on an authenticated node whose prefs could not be read. On a first
+    # run the not-yet-authenticated reading is almost always right, which is exactly why
+    # it is worth not asserting: the run where it is wrong is the run that matters.
+    echo "  verifier  : rc 4 -- INCOMPLETE, and NO DEFECT WAS FOUND. One or more of the"
+    echo "              verifier's claims could not be evaluated; the reasons are listed"
+    echo "              under 'NOT YET DETERMINABLE' in its own output immediately above,"
+    echo "              and that output is the authority on which ones. On a first run"
+    echo "              that is normally 'this node has never authenticated', because"
+    echo "              this script does not run \`tailscale up\` (it needs a browser) --"
+    echo "              but rc 4 also covers unreadable prefs on a node that IS"
+    echo "              authenticated. KEEPING the config either way: an unevaluated"
+    echo "              claim is not a defect. Note that a node which HAD an identity and"
+    echo "              LOST it -- an expired or revoked key -- is rc 1, not this."
     ;;
   3)
     echo "  verifier  : rc 3 -- the node side is correct; an ADMIN-CONSOLE action is"
@@ -1235,9 +1618,10 @@ case "$chk_rc" in
   1)
     die "the verifier reports a definitive node-side FAILURE (rc 1) after the switch.
   That is NOT the not-yet-authenticated state -- rc 4 is, and this is not it. Something
-  the node itself controls is wrong: forwarding off, no LAN route, or a node that HAS a
-  tailnet identity and is nevertheless not Running/Online/advertising. Its output is
-  immediately above. Rolling back."
+  the node itself controls is wrong: forwarding off, no LAN route, a node that HAS a
+  tailnet identity and is nevertheless not Running/Online/advertising, or a node that HAD
+  one and has LOST it (an expired or revoked node key). Its output is immediately above
+  and names which. Rolling back."
     ;;
   *)
     die "the verifier exited $chk_rc, which is not one of its documented codes
@@ -1287,5 +1671,7 @@ echo
 echo "Then confirm all of it, from live runtime state:"
 echo "       bash ${CHECK} --role ${ROLE}"
 echo "         0 = done   3 = a step above is outstanding"
-echo "         4 = step 1 has not been done yet (what it says RIGHT NOW)"
-echo "         1 = a node-side defect   2 = it could not read the daemon"
+echo "         4 = a claim could not be evaluated and no defect was found"
+echo "             (normally: step 1 has not been done yet)"
+echo "         1 = a node-side defect -- INCLUDING an EXPIRED or REVOKED node key,"
+echo "             which is what step 3 exists to prevent   2 = it could not read the daemon"

--- a/nix/system/apply-tailscale.sh
+++ b/nix/system/apply-tailscale.sh
@@ -21,7 +21,10 @@
 #   TS_EXPECT_MESH_IP_CLIENT=10.42.0.100
 #   TS_MAX_PENDING_BUILDS=10         see THE CLOSURE PREFLIGHT
 #   TS_MAX_TOTAL_BUILDS=25
+#   TS_MAX_PENDING_MIB=64            download volume, gated separately from build count
+#   TS_MAX_TOTAL_MIB=128
 #   TS_MAX_CHANGED_PATHS=250
+#   TS_LIST_MAX=200                  how many pending derivation names a refusal prints
 #
 # Flags:
 #   --dry-run                stop after the closure preflight; never writes the config
@@ -57,32 +60,49 @@
 # THE DEFAULT THRESHOLDS ARE CALIBRATED FROM MEASUREMENT, not guessed. On the same host,
 # the same day, the SAME dry-build run against a config carrying the server block was
 # **47 derivations to build, 25 to fetch (177.0 MiB)**. So tailscale's own true cost is
-# **+7 derivations and +1 fetched path** -- `tailscale-1.102.3` plus six regenerated
-# unit/etc/activation derivations. That is the scale a "add tailscale" change should be,
-# and it is why TS_MAX_PENDING_BUILDS defaults to 10 and TS_MAX_TOTAL_BUILDS to 25.
-# On this host today the pending gate therefore REFUSES, which is the correct answer:
-# 40 queued derivations are not what you asked for.
+# **+7 derivations, +1 fetched path and +17.6 MiB** -- `tailscale-1.102.3` plus six
+# regenerated unit/etc/activation derivations. That is the scale a "add tailscale" change
+# should be, and it is why TS_MAX_PENDING_BUILDS defaults to 10, TS_MAX_TOTAL_BUILDS to
+# 25, TS_MAX_PENDING_MIB to 64 and TS_MAX_TOTAL_MIB to 128. On this host today the
+# pending gates therefore REFUSE, which is the correct answer: 40 queued derivations and
+# 159.4 MiB of queued downloads are not what you asked for.
 #
-# So, BEFORE switching, this script measures the change in three independent ways and
-# REFUSES by default when the answer is "you are about to rebuild the world":
+# So, BEFORE switching, this script measures the change in FOUR ways and REFUSES by
+# default when the answer is "you are about to rebuild the world". Each is listed with
+# what it CANNOT see, because a gate's blind spot is the part worth knowing:
 #
-#   1. BASELINE vs CANDIDATE, not just the total. `nixos-rebuild dry-build` is run TWICE
-#      -- once against the CURRENT config and once against the patched one. The
-#      difference is what tailscale actually costs; the baseline is what `switch` would
-#      drag in whether or not you ran this script. Reporting only the total would blame
-#      tailscale for a channel bump, and reporting only the delta would hide it.
+#   1. BUILD COUNTS, BASELINE vs CANDIDATE -- not just the total. `nixos-rebuild
+#      dry-build` is run TWICE, once against the CURRENT config and once against the
+#      patched one. The difference is what tailscale actually costs; the baseline is what
+#      `switch` would drag in whether or not you ran this script. Reporting only the
+#      total would blame tailscale for a channel bump, and reporting only the delta would
+#      hide it.
+#      BLIND TO: a change that is entirely SUBSTITUTABLE. Zero derivations to build and
+#      thousands of paths to fetch is a world-sized change with a build count of 0 --
+#      which is why (2) exists as a separate gate rather than a printed column.
 #
-#   2. THE NIXPKGS RELEASE STRING. Extracted with ONE implementation from the store-path
+#   2. DOWNLOAD VOLUME, baseline and total, in MiB. Same two dry-builds, the other number
+#      they report. Gated in its OWN right: a build count and a download volume are
+#      independent axes and either can be world-sized while the other is tiny. This was
+#      once a decorative column in the summary table that no gate read.
+#
+#   3. THE NIXPKGS RELEASE STRING. Extracted with ONE implementation from the store-path
 #      basename of both the running system and the candidate derivation, so the two can
 #      never drift apart, and cross-checked against /run/current-system/nixos-version so
 #      a broken extractor cannot silently agree with itself. A release change is refused
 #      unconditionally -- it is an OS upgrade wearing a feature's clothes.
+#      🔴 BLIND TO A REVISION BUMP WITHIN ONE RELEASE, BY CONSTRUCTION. The release is
+#      the leading major.minor, so `26.11pre1066106` -> `26.11pre1066425` -- which is
+#      exactly the pending state of this host today -- reads as NO release change and
+#      this gate does not fire. That is deliberate (every channel tick would otherwise
+#      refuse), and it is why gates 1 and 2 are the ones that actually stop a same-release
+#      world rebuild. When the releases match but the revisions differ, the preflight
+#      says so out loud instead of printing a bare, reassuring "26.11 -> 26.11".
 #
-#   3. THE CLOSURE SET. After a build that the two gates above have already approved,
-#      the running and candidate closures are compared as SETS
-#      (`nix-store -qR | comm -3`), which cannot silently return a reassuring zero the
-#      way a parsed diff can, plus `nix store diff-closures` for a human-readable
-#      package-level report.
+#   4. THE CLOSURE SET. After a build that the gates above have already approved, the
+#      running and candidate closures are compared as SETS (`nix-store -qR | comm -3`),
+#      which cannot silently return a reassuring zero the way a parsed diff can, plus
+#      `nix store diff-closures` for a human-readable package-level report.
 #
 # 🔴 `readlink -f` IS USED ON BOTH SIDES, ALWAYS. `/nix/var/nix/profiles/system` is a
 # symlink TO ANOTHER SYMLINK (measured: it reads `system-389-link`, a bare NAME), while
@@ -96,7 +116,26 @@
 # preflight pass -- the candidate is built from a temp file via `--include
 # nixos-config=`, so a refusal leaves /etc/nixos untouched and there is nothing to roll
 # back. Once the file IS moved into place a trap restores the backup on ANY failure.
-# Re-running once tailscale is configured is a no-op that exits 0.
+# Re-running once tailscale is DECLARED (an actual setting, not a mention in a comment)
+# is a no-op that exits 0.
+#
+# 🔴 WHAT SUCCESS LOOKS LIKE, AND WHY IT IS NOT rc 0 FROM THE VERIFIER. This script does
+# not run `tailscale up` -- that needs a browser. So the state it lands in is: service
+# installed, daemon running, node NOT authenticated. `check-tailscale.sh` calls that
+# rc 4 (INCOMPLETE, no defect), and rc 4 is a SUCCESSFUL apply. An earlier version
+# treated anything other than rc 0/2/3 as a node-side failure and rolled back the config
+# it had just installed -- on the very first run, every time, guaranteed.
+#
+# 🔴 KILLSWITCH INTERACTION -- READ THIS BEFORE TRUSTING THE REDUNDANCY STORY.
+# `scripts/airvpn-updown`'s degraded/fallback rulesets allow egress on a LITERAL
+# interface list -- `lo`, the airvpn tun, `nebula.mesh`, `cni0`, `flannel.1`, `docker0`
+# -- and then `drop`. `tailscale0` is NOT on that list and there is no DERP/control-plane
+# carve-out, while nebula has three. So IF the AirVPN killswitch ever arms fail-closed,
+# NEBULA SURVIVES AND TAILSCALE DIES -- the exact inverse of the independence this whole
+# change is for. AirVPN is default-OFF on these hosts, so this is a latent interaction
+# and not a live defect, and `airvpn-updown` is deliberately NOT touched here (changing
+# a killswitch to widen egress is its own change, with its own review). Recorded so the
+# next person does not discover it from the far side of an outage.
 set -euo pipefail
 
 SUBNET="${TS_SUBNET:-192.168.50.0/24}"
@@ -105,7 +144,10 @@ MESH_SERVER="${TS_EXPECT_MESH_IP_SERVER:-10.42.0.30}"
 MESH_CLIENT="${TS_EXPECT_MESH_IP_CLIENT:-10.42.0.100}"
 MAX_PENDING_BUILDS="${TS_MAX_PENDING_BUILDS:-10}"
 MAX_TOTAL_BUILDS="${TS_MAX_TOTAL_BUILDS:-25}"
+MAX_PENDING_MIB="${TS_MAX_PENDING_MIB:-64}"
+MAX_TOTAL_MIB="${TS_MAX_TOTAL_MIB:-128}"
 MAX_CHANGED_PATHS="${TS_MAX_CHANGED_PATHS:-250}"
+LIST_MAX="${TS_LIST_MAX:-200}"
 
 DRYRUN=0
 ALLOW_WORLD=0
@@ -115,14 +157,27 @@ SELFTEST=0
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK="${HERE}/check-tailscale.sh"
 
+# 🔴 The help text is the comment header, printed to WHEREVER IT ENDS -- deliberately not
+# a hardcoded line range. `sed -n '2,95p'` cut this file's SAFETY paragraph off in the
+# middle of its second sentence, silently dropping the rollback and idempotency
+# guarantees from `--help`; check-tailscale.sh's equivalent OVERSHOT and printed the
+# literal `set -euo pipefail` as documentation. A line range is a second copy of a fact
+# the file already states, and it goes stale on the first edit. This reads the fact.
+_print_help() { awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)             DRYRUN=1; shift ;;
     --allow-world-rebuild) ALLOW_WORLD=1; shift ;;
-    --role)                ROLE="${2:-}"; shift 2 ;;
+    # 🔴 `--role` AS THE FINAL ARGUMENT. `shift 2` with one argument left fails, and
+    # under `set -e` that killed the script with exit 1 and NOTHING printed at all --
+    # a bare failure with no hint of what was wrong, on a script that is run under sudo
+    # by an operator with three days left. Checked explicitly.
+    --role)                [ $# -ge 2 ] || { echo "ABORT: --role needs a value ('server' or 'client'); it was given as the last argument with nothing after it." >&2; exit 1; }
+                           ROLE="$2"; shift 2 ;;
     --role=*)              ROLE="${1#--role=}"; shift ;;
     --self-test)           SELFTEST=1; shift ;;
-    -h|--help)             sed -n '2,95p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)             _print_help; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -196,6 +251,45 @@ _store_path() {
     /nix/store/*) printf '%s' "$p"; return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# Is tailscale actually DECLARED in this config, or merely mentioned?
+#
+# 🔴 `grep -q 'services\.tailscale'` WAS THE WHOLE IDEMPOTENCY TEST, and a file whose
+# only occurrence was `# TODO: consider services.tailscale one day` made this script
+# print "Nothing to do. Exiting 0" on a host where nothing had been applied -- the most
+# expensive possible lie, because it tells the operator the backup path is DONE.
+# Measured; that exact one-line fixture reproduced it.
+#
+# So: strip Nix comments FIRST (`#` to end of line, and `/* ... */` blocks, both replaced
+# with spaces so line numbers survive), then require an actual SETTING -- the attribute
+# followed by `=`, `{` or a further `.`, which is every way Nix can spell one and no way
+# it can spell a mention. Prints `lineno:text` per declaration, nothing at all when
+# there is none, so the caller branches on emptiness.
+#
+# Direction of error is deliberate: a declaration this misses means the script proceeds
+# and adds a SECOND block, which `nix-instantiate '<nixpkgs/nixos>' -A system` then
+# refuses as a duplicate definition BEFORE anything is written. A mention it wrongly
+# accepted would exit 0 and leave the host unprotected with no further check at all.
+_cfg_tailscale_decls() {   # $1 = config path; prints "lineno:line" per declaration
+  python3 - "$1" <<'PY'
+import re, sys
+try:
+    src = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+except Exception as e:
+    sys.stderr.write("read: %s\n" % e); sys.exit(2)
+
+# Blank out comments, preserving every newline so line numbers still line up.
+def blank(m):
+    return re.sub(r"[^\n]", " ", m.group(0))
+stripped = re.sub(r"/\*.*?\*/", blank, src, flags=re.S)
+stripped = re.sub(r"#[^\n]*", blank, stripped)
+
+orig = src.splitlines()
+for i, line in enumerate(stripped.splitlines()):
+    if re.search(r"services\s*\.\s*tailscale\s*[.={]", line):
+        print("%d:%s" % (i + 1, orig[i].strip()))
+PY
 }
 
 _self_test() {
@@ -394,18 +488,144 @@ T
   else
     echo "  [self-test] gate FAILED: 900 builds allowed. got: '$got'"; rc=1
   fi
+
+  # --- _over_mib, the FRACTIONAL comparison ------------------------------------------
+  # `-gt` cannot compare "159.4" at all: it aborts the shell. Driven in both directions,
+  # and across the boundary with a fraction on BOTH sides so a mutant that truncates to
+  # an integer (159.4 -> 159, 64.5 -> 64) is visible.
+  if _over_mib "159.4" "64";   then echo "  [self-test] _over_mib 159.4 > 64 -> ok"; else echo "  [self-test] _over_mib FAILED: 159.4 not > 64"; rc=1; fi
+  if _over_mib "17.6" "64";    then echo "  [self-test] _over_mib FAILED: 17.6 > 64"; rc=1; else echo "  [self-test] _over_mib 17.6 < 64 -> not over -> ok"; fi
+  if _over_mib "64.5" "64.4";  then echo "  [self-test] _over_mib 64.5 > 64.4 (fraction decides) -> ok"; else echo "  [self-test] _over_mib FAILED: 64.5 not > 64.4 -- truncating to int?"; rc=1; fi
+  if _over_mib "64.0" "64.0";  then echo "  [self-test] _over_mib FAILED: equal read as over"; rc=1; else echo "  [self-test] _over_mib 64.0 == 64.0 -> not over -> ok"; fi
+  if _over_mib "0.0" "0";      then echo "  [self-test] _over_mib FAILED: 0 > 0"; rc=1; else echo "  [self-test] _over_mib 0.0 == 0 -> not over -> ok"; fi
+
+  # 🔴 THE SUBSTITUTABLE WORLD REBUILD -- the case the download gate exists for, and the
+  # one that walked straight through a gate that read only build counts. 0 to build,
+  # 4 GiB to fetch. Both build gates are silent here BY CONSTRUCTION, so if this passes
+  # the download gate is genuinely the only thing that saw it.
+  got=$(_gate_reasons 26.11 26.11 0 0 4096.0 4096.0)
+  if printf '%s' "$got" | grep -q 'PENDING DOWNLOAD VOLUME'; then
+    echo "  [self-test] gate REFUSES 4096 MiB of pending downloads at ZERO builds -> ok"
+  else
+    echo "  [self-test] gate FAILED: a 4 GiB substitutable change passed. got: '$got'"; rc=1
+  fi
+  if printf '%s' "$got" | grep -qE 'BUILD SIZE|PENDING WORK'; then
+    echo "  [self-test] the build gates FAILED: they claim to have seen a 0-build change"; rc=1
+  else
+    echo "  [self-test] ...and neither BUILD gate fired on it -- so it was the download gate -> ok"
+  fi
+  # The download gates must ALLOW tailscale's own measured cost, or the script can never
+  # succeed and the gate becomes a permanent red light everyone learns to override.
+  got=$(_gate_reasons 26.11 26.11 0 7 0.0 17.6)
+  if [ -z "$got" ]; then
+    echo "  [self-test] gate ALLOWS tailscale's own measured 7 builds / 17.6 MiB -> ok"
+  else
+    echo "  [self-test] gate FAILED: refused the measured tailscale-only delta: '$got'"; rc=1
+  fi
+  # And the TOTAL download gate on its own, from a clean baseline.
+  got=$(_gate_reasons 26.11 26.11 0 0 0.0 900.0)
+  if printf '%s' "$got" | grep -q 'TOTAL DOWNLOAD VOLUME'; then
+    echo "  [self-test] gate REFUSES 900 MiB total from a clean baseline -> ok"
+  else
+    echo "  [self-test] gate FAILED: 900 MiB total allowed. got: '$got'"; rc=1
+  fi
+  # 🔴 THE NEGATIVE DELTA. The two dry-builds are separate evaluations and CAN disagree;
+  # the old phrasing rendered "Only -3 of the 37 are tailscale's" -- nonsense stated as
+  # a measurement, inside the one message the operator reads to make a judgement call.
+  got=$(_gate_reasons 26.11 26.11 40 37)
+  if printf '%s' "$got" | grep -q 'Only -'; then
+    echo "  [self-test] negative-delta phrasing FAILED: still says 'Only -N of the M'"; rc=1
+  elif printf '%s' "$got" | grep -q 'FEWER builds'; then
+    echo "  [self-test] a negative delta is reported as a DISAGREEMENT, not 'Only -3' -> ok"
+  else
+    echo "  [self-test] negative-delta phrasing FAILED: got '$got'"; rc=1
+  fi
+  got=$(_gate_reasons 26.11 26.11 40 47)
+  if printf '%s' "$got" | grep -q "Only 7 of the 47 are tailscale's"; then
+    echo "  [self-test] a POSITIVE delta still reads 'Only 7 of the 47' -> ok"
+  else
+    echo "  [self-test] positive-delta phrasing FAILED: got '$got'"; rc=1
+  fi
+
+  # --- _cfg_tailscale_decls: a MENTION is not a DECLARATION ---------------------------
+  # 🔴 The idempotency test used to be `grep -q 'services\.tailscale'`, so the first
+  # fixture below made this script print "Nothing to do. Exiting 0" on a host where
+  # nothing had been applied. Both directions are driven, and the comment cases are the
+  # point -- a checker that only ever sees real declarations cannot fail this way.
+  local decl_case name body want n_got
+  # Fixture bodies carry a leading marker so the loop can hold them on one line.
+  printf '%s\n' '{' '  # TODO: consider services.tailscale one day' '}' >"$dir/c-mention.nix"
+  printf '%s\n' '{' '  /* services.tailscale = { enable = true; }; */' '}' >"$dir/c-block.nix"
+  printf '%s\n' '{' '  services.tailscale.enable = true;' '}' >"$dir/c-dotted.nix"
+  printf '%s\n' '{' '  services.tailscale = {' '    enable = true;' '  };' '}' >"$dir/c-attrset.nix"
+  printf '%s\n' '{' '  environment.systemPackages = [ pkgs.tailscale ];' '}' >"$dir/c-pkgonly.nix"
+  # 🔴 THE FIXTURE THAT DISCRIMINATES THE `[.={]` ANCHOR. `services.tailscale` in live
+  # code that is NOT a setting. Without this case a match on the bare attribute path
+  # passes every other fixture here, so the anchor is untested and a config that merely
+  # NAMES the option in a warning string reports the host as already done.
+  printf '%s\n' '{' '  warnings = [ "services.tailscale is not enabled here" ];' '}' >"$dir/c-string.nix"
+  printf '%s\n' '{' '  # services.tailscale = { enable = true; };' '  services.tailscale.enable = true;' '}' >"$dir/c-both.nix"
+  for decl_case in "c-mention:0:a bare mention inside a # comment" \
+                   "c-block:0:a declaration inside a /* */ block comment" \
+                   "c-pkgonly:0:pkgs.tailscale in systemPackages is not a service" \
+                   "c-string:0:the option NAMED in a warning string is not a setting" \
+                   "c-dotted:1:services.tailscale.enable = true" \
+                   "c-attrset:1:services.tailscale = { ... }" \
+                   "c-both:1:a commented-out copy PLUS a real one"; do
+    name="${decl_case%%:*}"; body="${decl_case#*:}"; want="${body%%:*}"; body="${body#*:}"
+    n_got=$(_cfg_tailscale_decls "$dir/${name}.nix" | wc -l)
+    if [ "$n_got" = "$want" ]; then
+      echo "  [self-test] declared? $body -> $n_got -> ok"
+    else
+      echo "  [self-test] declared? $body FAILED: got $n_got, want $want"; rc=1
+    fi
+  done
+  # The line number must survive the comment blanking, or the "already configured"
+  # report points the operator at the wrong line of their own config.
+  got=$(_cfg_tailscale_decls "$dir/c-both.nix")
+  if [ "$got" = "3:services.tailscale.enable = true;" ]; then
+    echo "  [self-test] a declaration keeps its ORIGINAL line number (3) -> ok"
+  else
+    echo "  [self-test] declaration line number FAILED: got '$got'"; rc=1
+  fi
   return $rc
 }
 
 _over() { [ "$1" -gt "$2" ]; }
 
-# THE GATE, as a pure function of the four numbers, so both of its branches can be
-# driven from fixtures. A refusal that has only ever been reasoned about is not a
-# guard; the self-test below watches this one both refuse and allow, using the numbers
-# MEASURED on this host rather than invented ones.
+# The MiB figures are FRACTIONAL ("159.4"), so `-gt` cannot compare them: bash would
+# abort with "integer expression expected" inside a gate, under `set -e`, which is the
+# gate failing OPEN dressed as a crash. awk does the comparison in floating point.
+_over_mib() { awk -v a="$1" -v b="$2" 'BEGIN { exit !(a + 0 > b + 0) }'; }
+
+# THE GATE, as a pure function of the six numbers, so every branch can be driven from
+# fixtures. A refusal that has only ever been reasoned about is not a guard; the
+# self-test below watches this one both refuse and allow, using the numbers MEASURED on
+# this host rather than invented ones.
+#
+# 🔴 THE DOWNLOAD ARGUMENTS ARE NOT DECORATION. An earlier version took only the two
+# release strings and the two BUILD counts, while the summary table printed fetch counts
+# and MiB that no gate ever read -- so a pending change that was entirely SUBSTITUTABLE
+# (0 derivations to build, thousands of paths, several GiB to download) passed the gate
+# untouched. Build count and download volume are independent axes and either can be
+# world-sized alone.
+#
 # Prints one reason per paragraph; empty output means "allow".
 _gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_builds
-  local run_rel="$1" cand_rel="$2" b_built="$3" c_built="$4" d_built=$(( $4 - $3 ))
+                    # $5 pending_mib  $6 total_mib   (both optional; default 0)
+  local run_rel="$1" cand_rel="$2" b_built="$3" c_built="$4"
+  local b_mib="${5:-0}" c_mib="${6:-0}" d_built=$(( $4 - $3 )) delta_note
+  # 🔴 A NEGATIVE DELTA IS A REAL OBSERVED STATE, not an impossible one: the two
+  # dry-builds are separate evaluations and the store can gain paths between them, so the
+  # candidate can legitimately report FEWER builds than the baseline. Phrased as
+  # "Only -3 of the 37 are tailscale's", which is nonsense presented as a measurement.
+  if [ "$d_built" -ge 0 ]; then
+    delta_note="Only $d_built of the $c_built are tailscale's."
+  else
+    delta_note="The candidate reports FEWER builds ($c_built) than the current config
+    ($b_built), so the two dry-builds disagree and NO delta can be attributed to
+    tailscale -- most likely the store gained paths between the two evaluations."
+  fi
   if [ "$run_rel" != "$cand_rel" ]; then
     printf '%s\n' "NIXPKGS RELEASE CHANGE: $run_rel -> $cand_rel.
     This is an OS UPGRADE, not a feature. The last time this happened here a 4-line
@@ -414,7 +634,7 @@ _gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_build
   if _over "$b_built" "$MAX_PENDING_BUILDS"; then
     printf '%s\n' "PENDING WORK UNRELATED TO TAILSCALE: $b_built derivations are already
     queued by the CURRENT config (limit $MAX_PENDING_BUILDS), and \`switch\` applies
-    them too. Only $d_built of the $c_built are tailscale's.
+    them too. $delta_note
     THE CLEAN FIX IS TO SEPARATE THE TWO OPERATIONS: run \`sudo nixos-rebuild switch\`
     on its own, at a time you choose, watch it land, then re-run this script -- the
     delta will then be just tailscale. Or accept it with --allow-world-rebuild."
@@ -422,6 +642,17 @@ _gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_build
   if _over "$c_built" "$MAX_TOTAL_BUILDS"; then
     printf '%s\n' "TOTAL BUILD SIZE: $c_built derivations would be built (limit
     $MAX_TOTAL_BUILDS). Adding tailscale should be a handful of substituted paths."
+  fi
+  if _over_mib "$b_mib" "$MAX_PENDING_MIB"; then
+    printf '%s\n' "PENDING DOWNLOAD VOLUME: the CURRENT config already wants to fetch
+    $b_mib MiB (limit $MAX_PENDING_MIB MiB), and \`switch\` fetches it too. A change with
+    NOTHING to build can still be world-sized -- a fully substitutable channel bump is
+    thousands of paths and gigabytes of download at a build count of zero. Same clean
+    fix: land the pending change on its own first, or --allow-world-rebuild."
+  fi
+  if _over_mib "$c_mib" "$MAX_TOTAL_MIB"; then
+    printf '%s\n' "TOTAL DOWNLOAD VOLUME: $c_mib MiB would be fetched (limit
+    $MAX_TOTAL_MIB MiB). Tailscale's own measured cost on this host is ~17.6 MiB."
   fi
 }
 
@@ -496,14 +727,25 @@ fi
 # Asked of the FILE here because this is a question about what the file will contain.
 # Whether it is RUNNING is a different question, and check-tailscale.sh is the only
 # thing that answers it -- it reads the live daemon, never the config.
-if grep -q 'services\.tailscale' "$CFG"; then
-  echo "  state     : $CFG already mentions services.tailscale:"
-  grep -n 'services\.tailscale' "$CFG" | sed 's/^/    | /'
+ts_decls=$(_cfg_tailscale_decls "$CFG") \
+  || die "could not read $CFG to decide whether tailscale is already declared"
+if [ -n "$ts_decls" ]; then
+  echo "  state     : $CFG already DECLARES services.tailscale:"
+  printf '%s\n' "$ts_decls" | sed 's/^/    | /'
   echo
   echo "Nothing to do. Exiting 0 without touching $CFG."
   echo "Whether it is actually WORKING is a different question -- ask the verifier:"
   echo "    bash ${CHECK} --role ${ROLE}"
   exit 0
+fi
+# A MENTION is not a declaration, and saying so out loud matters: the operator who wrote
+# that comment is exactly the one who might read a bare "proceeding" as "it ignored my
+# config". This branch is the reason `_cfg_tailscale_decls` strips comments at all.
+if grep -q 'services\.tailscale' "$CFG"; then
+  echo "  state     : $CFG MENTIONS services.tailscale but does not DECLARE it --"
+  grep -n 'services\.tailscale' "$CFG" | sed 's/^/    | /'
+  echo "              every occurrence is inside a comment, so nothing is applied."
+  echo "              Proceeding to add the real block."
 fi
 
 # --- a sysctl key defined twice is a Nix evaluation error --------------------------------
@@ -554,6 +796,7 @@ TMP="${CFG%.nix}.tailscale-candidate.$$.nix"
 BAK="${CFG}.bak-tailscale-$(date +%Y%m%d-%H%M%S)-$$"
 WORK=$(mktemp -d)
 PATCHED=0
+SWITCH_ATTEMPTED=0
 SWITCHED=0
 OK=0
 
@@ -566,11 +809,27 @@ finish() {
     cp -p "$BAK" "$CFG"
     echo >&2
     echo "ROLLED BACK: $CFG restored from $BAK" >&2
+    # 🔴 THREE STATES, NOT TWO, AND ONLY ONE OF THEM IS ESTABLISHED. This used to branch
+    # on SWITCHED and assert, when it was 0, "The system was never switched, so nothing
+    # is running the change." That is a claim about the RUNNING system derived from a
+    # flag that only records whether `nixos-rebuild switch` RETURNED ZERO. A switch can
+    # exit non-zero AFTER activating -- a unit that fails to start is the ordinary case
+    # -- and it writes the bootloader entry before that, so the assertion is false in
+    # exactly the situation it gets printed in. State what is known.
     if [ "$SWITCHED" = "1" ]; then
       echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
       echo "   system is not -- run \`sudo nixos-rebuild switch\` to return it." >&2
+    elif [ "$SWITCH_ATTEMPTED" = "1" ]; then
+      echo "🔴 \`nixos-rebuild switch\` WAS STARTED and did not complete. Whether the" >&2
+      echo "   RUNNING system changed is NOT established by this script: a switch can" >&2
+      echo "   activate and still exit non-zero (e.g. a unit fails to start), and it" >&2
+      echo "   writes the bootloader entry before that. The FILE is restored; the" >&2
+      echo "   running system may or may not carry the change. Check, then decide:" >&2
+      echo "       readlink -f /run/current-system" >&2
+      echo "       sudo nixos-rebuild list-generations | tail -3" >&2
+      echo "   \`sudo nixos-rebuild switch\` returns the running system to $CFG." >&2
     else
-      echo "   The system was never switched, so nothing is running the change." >&2
+      echo "   \`nixos-rebuild switch\` was never started, so nothing activated." >&2
     fi
   fi
   exit $rc
@@ -584,6 +843,16 @@ if [ "$ROLE" = "server" ]; then
   # Added by nix/system/apply-tailscale.sh. Nebula is the primary remote path; this
   # exists so that a nebula outage while off-LAN is not a total loss of access. It
   # shares no component with nebula: different control plane, different relays.
+  #
+  # 🔴 ONE SHARED COMPONENT DOES EXIST, AND IT IS NOT SYMMETRIC: the AirVPN killswitch.
+  # \`scripts/airvpn-updown\`'s degraded and fallback rulesets allow egress on a LITERAL
+  # interface list -- lo, the airvpn tun, nebula.mesh, cni0, flannel.1, docker0 -- and
+  # then \`drop\`. \`tailscale0\` is not on it, and unlike nebula (three carve-outs)
+  # tailscale has no DERP/control-plane bypass. So if that killswitch ever arms
+  # fail-closed, NEBULA SURVIVES AND TAILSCALE DIES -- the inverse of the redundancy this
+  # block is for. AirVPN is default-OFF on these hosts, so it is a latent interaction,
+  # not a live defect; it is NOT fixed here because widening a killswitch is its own
+  # change with its own review.
   #
   # THIS HOST IS THE SUBNET ROUTER. Advertising ${SUBNET} makes the whole LAN
   # reachable over the tailnet, not just this machine.
@@ -626,6 +895,16 @@ else
   #
   # 🔴 It does NOT log the node in, and it does not set --accept-routes. Both are
   # runtime state owned by \`tailscale up\`. See check-tailscale.sh.
+  #
+  # 🔴 ONE SHARED COMPONENT DOES EXIST, AND IT IS NOT SYMMETRIC: the AirVPN killswitch.
+  # \`scripts/airvpn-updown\`'s degraded and fallback rulesets allow egress on a LITERAL
+  # interface list -- lo, the airvpn tun, nebula.mesh, cni0, flannel.1, docker0 -- and
+  # then \`drop\`. \`tailscale0\` is not on it, and unlike nebula (three carve-outs)
+  # tailscale has no DERP/control-plane bypass. So if that killswitch ever arms
+  # fail-closed, NEBULA SURVIVES AND TAILSCALE DIES -- the inverse of the redundancy this
+  # block is for. AirVPN is default-OFF on these hosts, so it is a latent interaction,
+  # not a live defect; it is NOT fixed here because widening a killswitch is its own
+  # change with its own review.
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "client";
@@ -640,7 +919,13 @@ awk -v blk="$BLOCK" -v anchor="$anchor_line" '
   { print }
 ' "$CFG" > "$TMP"
 
-added=$(( $(wc -l < "$TMP") - $(wc -l < "$CFG") ))
+# 🔴 `awk END{print NR}`, NOT `wc -l`. `wc -l` counts NEWLINES, so a config whose last
+# line has no trailing newline is undercounted by one -- while awk's output always ends
+# with one. The difference then came out as "expected the patch to add exactly 32 lines,
+# it added 33", a message naming the wrong problem entirely and sending the operator to
+# look for a bug in the block. awk counts RECORDS, and a final line without a newline is
+# still a record, so both sides are measured the same way.
+added=$(( $(awk 'END{print NR}' "$TMP") - $(awk 'END{print NR}' "$CFG") ))
 expected=$(printf '%s\n' "$BLOCK" | wc -l)
 [ "$added" = "$expected" ] || die "expected the patch to add exactly $expected lines, it added $added"
 echo "  temp file : $TMP  (+$added lines)"
@@ -719,25 +1004,61 @@ printf '  %-28s %8s %8s %9s M\n' "TOTAL if you switch"    "$c_built" "$c_fetch" 
 printf '  %-28s %8s %8s\n'       "DELTA (tailscale only)" "$d_built" "$d_fetch"
 echo
 echo "  release   : running $run_rel  ->  candidate $cand_rel"
+# 🔴 SAY WHAT THE RELEASE GATE CANNOT SEE, RIGHT WHERE IT REPORTS. `_release_of` reduces
+# to major.minor, so this host's pending `26.11pre1066106` -> `26.11pre1066425` prints
+# `26.11 -> 26.11` and the release gate does NOT fire on it. A bare matching pair reads
+# as "nothing is moving"; it means "nothing is moving THAT THIS GATE MEASURES". The
+# build-count and download-volume gates are what cover a same-release channel tick.
+if [ "$run_rel" = "$cand_rel" ] && [ "$running_version" != "$cand_version" ]; then
+  echo "              same RELEASE, but the revisions DIFFER:"
+  echo "                $running_version"
+  echo "                $cand_version"
+  echo "              The release gate compares major.minor only, so it does NOT fire on"
+  echo "              this. The build-count and download gates are what cover it."
+fi
 echo
 
 # --- the gate ---------------------------------------------------------------------------
 # One implementation, exercised in both directions by --self-test above.
-refuse=$(_gate_reasons "$run_rel" "$cand_rel" "$b_built" "$c_built")
+refuse=$(_gate_reasons "$run_rel" "$cand_rel" "$b_built" "$c_built" "$b_mib" "$c_mib")
 
 if [ -n "$refuse" ] && [ "$ALLOW_WORLD" != "1" ]; then
   echo "REFUSING to switch:" >&2
   printf '  - %s\n' "$refuse" >&2
   echo >&2
   echo "  $CFG was NOT modified. Nothing to roll back." >&2
-  echo "  Largest pending items, so you can judge the cost yourself:" >&2
   # 🔴 `|| true` is load-bearing, twice over: `grep` exits 1 when it matches nothing,
   # and `head` closing the pipe early SIGPIPEs everything upstream. With `set -e` plus
   # `pipefail` either would abort HERE -- inside the refusal path, one line before
   # `exit 4` -- so the script would exit 1 and never print the override the operator
   # needs. A cosmetic listing must not be able to change the exit code.
-  { grep -oE '/nix/store/[a-z0-9]+-[^ ]+\.drv' "$WORK/base.err" | sed 's#.*/[a-z0-9]*-##' \
-      | sort -u | head -15 | sed 's/^/      /'; } >&2 || true
+  #
+  # 🔴 THIS LISTING IS THE ONLY DIAGNOSTIC FOR THE --allow-world-rebuild DECISION, AND IT
+  # USED TO HIDE THE ANSWER. It was headed "Largest pending items" and cut at `head -15`
+  # of an ALPHABETICAL list -- so on the real 38-derivation queue on this host everything
+  # from `s` onward was invisible, including every `steam-*` derivation, the only heavy
+  # builds present; `wine-wow-11.0`, the culprit in the 2h16m incident this whole script
+  # exists because of, sorts last of all. "Largest" was also a false claim: nothing here
+  # is sorted by size, and a .drv name carries no size. So: it is named for what it is,
+  # it shows EVERY item up to a generous cap, and when it does cap it says how many were
+  # omitted rather than trailing off.
+  drvnames=$( { grep -oE '/nix/store/[a-z0-9]+-[^ ]+\.drv' "$WORK/base.err" \
+      | sed -e 's#.*/[a-z0-9]*-##' -e 's/\.drv$//' | sort -u; } || true )
+  n_drv=0
+  [ -z "$drvnames" ] || n_drv=$(printf '%s\n' "$drvnames" | wc -l)
+  echo "  All $n_drv pending derivations, so you can judge the cost yourself" >&2
+  echo "  (alphabetical -- this is a NAME list, not a size ranking):" >&2
+  if [ "$n_drv" -gt "$LIST_MAX" ]; then
+    printf '%s\n' "$drvnames" | head -n "$LIST_MAX" | sed 's/^/      /' >&2 || true
+    echo "      ... and $(( n_drv - LIST_MAX )) more NOT shown (alphabetically after the" >&2
+    echo "      last line above -- the heavy ones may well be among them). Raise the cap" >&2
+    echo "      with TS_LIST_MAX=$n_drv to see every one." >&2
+  elif [ "$n_drv" -gt 0 ]; then
+    printf '%s\n' "$drvnames" | sed 's/^/      /' >&2
+  else
+    echo "      (none -- the refusal above is about downloads or the release string," >&2
+    echo "       not about derivations to build)" >&2
+  fi
   echo >&2
   echo "  To proceed anyway, exactly as written:" >&2
   echo "      sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]} --allow-world-rebuild" >&2
@@ -798,13 +1119,58 @@ echo "== apply =="
 [ -e "$BAK" ] && die "backup path $BAK already exists; refusing to overwrite it"
 cp -p "$CFG" "$BAK"
 echo "  backup    : $BAK"
-cp -p "$TMP" "$CFG"
+# 🔴 PATCHED IS SET **BEFORE** THE COPY, AND THE ORDER IS THE WHOLE POINT. `cp` is not
+# atomic -- it truncates the destination and then writes -- so a failure PART WAY
+# THROUGH (ENOSPC, an I/O error; `/` on this host sits at 77%) leaves $CFG half
+# overwritten. With the flag set after the copy, `set -e` would abort with PATCHED=0,
+# the trap's rollback branch would be skipped, and the operator would be left with a
+# corrupt configuration.nix, an unused good backup sitting beside it, and NOTHING
+# PRINTED. Setting it first costs nothing in the other direction: a `cp` that fails
+# before writing a single byte simply restores a byte-identical file.
+# The flag therefore means "$CFG MAY have been modified", not "it was".
 PATCHED=1
+cp -p "$TMP" "$CFG"
 echo "  applied   : $CFG"
 echo
 
 echo "== nixos-rebuild switch =="
-nixos-rebuild switch
+# 🔴 THE STATUS IS CAPTURED, NOT ASSUMED. This rebuild can run for hours, which is
+# exactly when it gets interrupted or killed, and the line after it used to be a bare
+# `SWITCHED=1` -- a variable that says "the switch succeeded" set without anyone having
+# asked whether it did.
+#
+# MEASURED on bash 5.3.15 here, with the signal confirmed to have landed (the killed
+# child's own wall time is the control -- a `kill` that returns 0 against a process with
+# SIGINT ignored looks identical to "the shell continued"):
+#   * SIGINT, to the child alone AND to the whole process group (the tty Ctrl-C shape):
+#     bash propagates the child's SIGINT death and TERMINATES the script at this line,
+#     exit 130. The EXIT trap fires and rolls back. So the Ctrl-C case never reaches the
+#     check below -- it is already handled, and the claim that a SIGINT-killed child
+#     silently continues did NOT reproduce.
+#   * SIGTERM and SIGHUP: no such propagation. The child exits 143 / 129 and execution
+#     CONTINUES here. Under the old `nixos-rebuild switch` + `SWITCHED=1` those exits
+#     did trip errexit, but they aborted the script with no statement of what happened;
+#     with the capture the operator is told which signal killed the rebuild.
+# So the check below is reachable and it is the SIGTERM/SIGHUP/SIGKILL path -- driven
+# with `kill -TERM` and `kill -HUP` against the real script, both watched to print the
+# message and roll back.
+#
+# `rc=0` FIRST, then `cmd || rc=$?`: `cmd; rc=$?` is dead code under `set -e`, and
+# `cmd || rc=$?` without the seed dies under `set -u` on the SUCCESS path.
+switch_rc=0
+SWITCH_ATTEMPTED=1
+nixos-rebuild switch || switch_rc=$?
+if [ "$switch_rc" -ge 128 ]; then
+  die "\`nixos-rebuild switch\` was KILLED BY SIGNAL $(( switch_rc - 128 )) (exit
+  $switch_rc). It did NOT complete. Signal 15 is a \`kill\`/timeout, 9 an out-of-memory
+  or hard kill, 1 a lost terminal; a Ctrl-C (signal 2) normally kills this script
+  outright instead of arriving here. Whether the switch ACTIVATED before it died is not
+  established -- see the rollback note below."
+elif [ "$switch_rc" != "0" ]; then
+  die "\`nixos-rebuild switch\` exited $switch_rc. It did not complete successfully.
+  Note that a non-zero exit does NOT mean nothing was activated -- see the rollback note
+  below. Its own output is above."
+fi
 SWITCHED=1
 echo
 
@@ -819,16 +1185,65 @@ command -v tailscale >/dev/null 2>&1 || die "the \`tailscale\` CLI is still not 
   after the switch. Open a new shell and re-check before assuming this failed."
 echo "  cli       : $(tailscale version 2>&1 | head -1)"
 
-# The verifier is the authority on whether this is a working path. rc 3 means the node
-# is correct and an ADMIN-CONSOLE action is outstanding -- that is the EXPECTED state
-# straight after a switch, and rolling back a correct config because a human has not
-# opened a browser yet would be absurd.
+# =====================================================================================
+# 🔴 WHAT COUNTS AS SUCCESS -- and the assumption that used to make the FIRST RUN ROLL
+# BACK, EVERY TIME, GUARANTEED.
+#
+# This block used to accept rc 0/2/3 and treat everything else as a node-side failure,
+# on the stated premise that "rc 3 is the EXPECTED state straight after a switch". That
+# premise was false, and this script is the reason: it deliberately does NOT run
+# `tailscale up` (see the next steps below), so straight after a switch the node has
+# never authenticated -- BackendState `NeedsLogin`, `Online` false, no TailscaleIPs,
+# nothing advertised. Under the old verifier that was four separate FAIL entries and rc
+# **1**, not 3, so `die` fired, the EXIT trap restored the backup, and the run ended
+# "ABORT ... ROLLED BACK" having deleted the very thing it had just installed.
+#
+# So the states are now enumerated with what each one MEANS, and the verifier reports
+# "configured but not yet authenticated" as its own code rather than as a defect.
+# Rollback is for a GENUINE failure only.
+#
+# `bash "$CHECK"`, not `"$CHECK"`: the file is guaranteed READABLE by the preflight
+# (`[ -r "$CHECK" ]`), not executable -- a checkout copied without its mode bits, or
+# read off a noexec mount, would fail with "permission denied" here, one line after a
+# successful switch, and be rolled back for it. Running it under an explicit interpreter
+# makes `-r` the right precondition and makes it sufficient.
 chk_rc=0
-"$CHECK" --role "$ROLE" || chk_rc=$?
+bash "$CHECK" --role "$ROLE" || chk_rc=$?
 case "$chk_rc" in
-  0) echo "  verifier  : PASS -- nothing outstanding" ;;
-  2|3) echo "  verifier  : rc $chk_rc -- the node still needs the manual steps below" ;;
-  *) die "the verifier reports a node-side FAILURE (rc=$chk_rc) after the switch" ;;
+  0)
+    echo "  verifier  : rc 0 -- PASS. Authenticated, approved, key expiry disabled."
+    echo "              Nothing outstanding; the steps below are already done."
+    ;;
+  4)
+    echo "  verifier  : rc 4 -- EXPECTED. The switch succeeded and the node is NOT YET"
+    echo "              AUTHENTICATED, because this script does not run \`tailscale up\`"
+    echo "              (it needs a browser). No defect was found. KEEPING the config."
+    ;;
+  3)
+    echo "  verifier  : rc 3 -- the node side is correct; an ADMIN-CONSOLE action is"
+    echo "              outstanding (route approval and/or key expiry). KEEPING the"
+    echo "              config -- a browser tab nobody has clicked is not a defect."
+    ;;
+  2)
+    echo "  verifier  : 🔴 rc 2 -- CANNOT DETERMINE. The switch succeeded and tailscaled" >&2
+    echo "              is active, but the verifier could not read the daemon's state," >&2
+    echo "              so this run has NOT established that the path works. The config" >&2
+    echo "              is KEPT (nothing was shown to be wrong with it). Re-run the" >&2
+    echo "              verifier by hand and read its reason:" >&2
+    echo "                  bash ${CHECK} --role ${ROLE}" >&2
+    ;;
+  1)
+    die "the verifier reports a definitive node-side FAILURE (rc 1) after the switch.
+  That is NOT the not-yet-authenticated state -- rc 4 is, and this is not it. Something
+  the node itself controls is wrong: forwarding off, no LAN route, or a node that HAS a
+  tailnet identity and is nevertheless not Running/Online/advertising. Its output is
+  immediately above. Rolling back."
+    ;;
+  *)
+    die "the verifier exited $chk_rc, which is not one of its documented codes
+  (0 pass, 1 node-side fail, 2 cannot determine, 3 admin action, 4 not yet
+  authenticated). An unrecognised code is not evidence of success. Rolling back."
+    ;;
 esac
 
 OK=1
@@ -842,11 +1257,19 @@ echo
 echo "1. AUTHENTICATE THIS NODE (needs a browser; prints a login URL):"
 if [ "$ROLE" = "server" ]; then
   echo "       sudo tailscale up --advertise-routes=${SUBNET} --accept-dns=false"
-  echo "   (--accept-dns=false keeps tailscale out of this host's resolver, which"
-  echo "    dnsmasq and the .lan names already own.)"
 else
-  echo "       sudo tailscale up --accept-routes"
+  echo "       sudo tailscale up --accept-routes --accept-dns=false"
 fi
+# 🔴 `--accept-dns=false` ON BOTH ROLES. The reasoning is identical on the two machines
+# -- MagicDNS makes tailscale take over the host resolver, and on this fleet dnsmasq and
+# the `.lan` names already own it -- so giving the server the flag and not the client
+# would hand the resolver of the ONE machine the operator travels with to tailscale,
+# months from anyone who could fix it. The cost is real and is stated rather than hidden.
+echo "   (--accept-dns=false keeps tailscale out of this host's resolver, which dnsmasq"
+echo "    and the .lan names already own. It applies to BOTH hosts for the same reason."
+echo "    THE COST: MagicDNS names will not resolve here, so address the other machine by"
+echo "    its tailnet address -- \`tailscale status\` prints it. Drop the flag on a host"
+echo "    where you would rather have MagicDNS than keep its current resolver.)"
 echo
 if [ "$ROLE" = "server" ]; then
   echo "2. APPROVE THE SUBNET ROUTE -- admin console only. Until this is done the route"
@@ -862,4 +1285,7 @@ echo "       https://login.tailscale.com/admin/machines"
 echo "       -> this machine -> ... -> Disable key expiry"
 echo
 echo "Then confirm all of it, from live runtime state:"
-echo "       bash ${CHECK} --role ${ROLE}      # 0 = done, 3 = a step above is outstanding"
+echo "       bash ${CHECK} --role ${ROLE}"
+echo "         0 = done   3 = a step above is outstanding"
+echo "         4 = step 1 has not been done yet (what it says RIGHT NOW)"
+echo "         1 = a node-side defect   2 = it could not read the daemon"

--- a/nix/system/apply-tailscale.sh
+++ b/nix/system/apply-tailscale.sh
@@ -1,0 +1,865 @@
+#!/usr/bin/env bash
+# Add Tailscale to this host as an INDEPENDENT SECOND PATH, and switch to it.
+#
+#   sudo env "PATH=$PATH" bash nix/system/apply-tailscale.sh --dry-run   # see the cost
+#   sudo env "PATH=$PATH" bash nix/system/apply-tailscale.sh             # do it
+#
+# Nebula is currently the ONLY remote path to the workbench. If its lighthouse, its
+# relay, or the host firewall in front of it breaks while the operator is off-LAN, there
+# is no second door. Tailscale is that second door, and it shares no component with
+# nebula: different control plane, different relays, different code.
+#
+# This inserts a `services.tailscale` block into /etc/nixos/configuration.nix and runs
+# `nixos-rebuild switch`. It does NOT log the node in -- that needs a browser and is
+# printed as the next step. It cannot approve the subnet route or disable node-key
+# expiry either; both live only in the admin console. Those are REPORTED, never faked.
+#
+# Overrides (all optional):
+#   TS_SUBNET=192.168.50.0/24        the LAN the server role advertises
+#   TS_CFG=/etc/nixos/configuration.nix
+#   TS_EXPECT_MESH_IP_SERVER=10.42.0.30
+#   TS_EXPECT_MESH_IP_CLIENT=10.42.0.100
+#   TS_MAX_PENDING_BUILDS=10         see THE CLOSURE PREFLIGHT
+#   TS_MAX_TOTAL_BUILDS=25
+#   TS_MAX_CHANGED_PATHS=250
+#
+# Flags:
+#   --dry-run                stop after the closure preflight; never writes the config
+#   --allow-world-rebuild    proceed even when the preflight says the pending change is
+#                            far larger than this delta, or the release string moves
+#   --role server|client     override the host role (normally auto-detected)
+#   --self-test              validate this script's own parsers, then exit
+#
+# WHICH HOST: `hostname` is NOT a discriminator on this fleet -- BOTH machines answer
+# `nixos`. The guard is this host's nebula mesh address, which is unique by
+# construction:
+#   10.42.0.30  -> workbench -> SUBNET ROUTER (useRoutingFeatures = "server",
+#                  IP forwarding on, advertises the LAN)
+#   10.42.0.100 -> laptop    -> plain CLIENT  (useRoutingFeatures = "client")
+# Anything else aborts before any write rather than guessing.
+#
+# ============================================================================
+# 🔴 THE CLOSURE PREFLIGHT -- WHY THIS SCRIPT IS NOT FOUR LINES OF `sed`
+# ============================================================================
+# `nixos-rebuild switch` applies EVERYTHING PENDING in the configuration, not just the
+# delta you added. MEASURED on this exact machine: a 4-line nebula relay edit triggered a
+# 26.05 -> 26.11 release jump that took 2h16m and rebuilt the world, largely
+# `wine-wow-11.0`. A script advertised as "add a few lines" attempted a full OS upgrade.
+# That was recorded as an OPEN defect on devrc PR #1272 and never fixed; this is the fix.
+#
+# MEASURED AGAIN 2026-09-07, on an UNCHANGED config, before this script existed:
+# `nixos-rebuild dry-build` reported **40 derivations to build and 24 paths to fetch
+# (159.4 MiB download, 651.1 MiB unpacked)**, and the system it would produce was
+# `26.11pre1066425.9387b3fcc0c2` against a running `26.11pre1066106.3ed67ec0a4d3`. So
+# the hazard is not hypothetical or historical -- it is the state of this host TODAY,
+# and none of those 40 derivations has anything to do with tailscale.
+#
+# THE DEFAULT THRESHOLDS ARE CALIBRATED FROM MEASUREMENT, not guessed. On the same host,
+# the same day, the SAME dry-build run against a config carrying the server block was
+# **47 derivations to build, 25 to fetch (177.0 MiB)**. So tailscale's own true cost is
+# **+7 derivations and +1 fetched path** -- `tailscale-1.102.3` plus six regenerated
+# unit/etc/activation derivations. That is the scale a "add tailscale" change should be,
+# and it is why TS_MAX_PENDING_BUILDS defaults to 10 and TS_MAX_TOTAL_BUILDS to 25.
+# On this host today the pending gate therefore REFUSES, which is the correct answer:
+# 40 queued derivations are not what you asked for.
+#
+# So, BEFORE switching, this script measures the change in three independent ways and
+# REFUSES by default when the answer is "you are about to rebuild the world":
+#
+#   1. BASELINE vs CANDIDATE, not just the total. `nixos-rebuild dry-build` is run TWICE
+#      -- once against the CURRENT config and once against the patched one. The
+#      difference is what tailscale actually costs; the baseline is what `switch` would
+#      drag in whether or not you ran this script. Reporting only the total would blame
+#      tailscale for a channel bump, and reporting only the delta would hide it.
+#
+#   2. THE NIXPKGS RELEASE STRING. Extracted with ONE implementation from the store-path
+#      basename of both the running system and the candidate derivation, so the two can
+#      never drift apart, and cross-checked against /run/current-system/nixos-version so
+#      a broken extractor cannot silently agree with itself. A release change is refused
+#      unconditionally -- it is an OS upgrade wearing a feature's clothes.
+#
+#   3. THE CLOSURE SET. After a build that the two gates above have already approved,
+#      the running and candidate closures are compared as SETS
+#      (`nix-store -qR | comm -3`), which cannot silently return a reassuring zero the
+#      way a parsed diff can, plus `nix store diff-closures` for a human-readable
+#      package-level report.
+#
+# 🔴 `readlink -f` IS USED ON BOTH SIDES, ALWAYS. `/nix/var/nix/profiles/system` is a
+# symlink TO ANOTHER SYMLINK (measured: it reads `system-389-link`, a bare NAME), while
+# `/run/current-system` points straight at the store. A single-level `readlink` returns
+# a link name on one side and a store path on the other, so they can NEVER compare equal
+# and the mismatch is reported forever. A previous session shipped exactly that bug.
+# `_store_path` below resolves fully and REFUSES anything that is not under /nix/store,
+# so a silent empty string cannot masquerade as agreement.
+#
+# SAFETY. Nothing is written to the config until every precondition AND the closure
+# preflight pass -- the candidate is built from a temp file via `--include
+# nixos-config=`, so a refusal leaves /etc/nixos untouched and there is nothing to roll
+# back. Once the file IS moved into place a trap restores the backup on ANY failure.
+# Re-running once tailscale is configured is a no-op that exits 0.
+set -euo pipefail
+
+SUBNET="${TS_SUBNET:-192.168.50.0/24}"
+CFG="${TS_CFG:-/etc/nixos/configuration.nix}"
+MESH_SERVER="${TS_EXPECT_MESH_IP_SERVER:-10.42.0.30}"
+MESH_CLIENT="${TS_EXPECT_MESH_IP_CLIENT:-10.42.0.100}"
+MAX_PENDING_BUILDS="${TS_MAX_PENDING_BUILDS:-10}"
+MAX_TOTAL_BUILDS="${TS_MAX_TOTAL_BUILDS:-25}"
+MAX_CHANGED_PATHS="${TS_MAX_CHANGED_PATHS:-250}"
+
+DRYRUN=0
+ALLOW_WORLD=0
+ROLE="${TS_ROLE:-}"
+SELFTEST=0
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${HERE}/check-tailscale.sh"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)             DRYRUN=1; shift ;;
+    --allow-world-rebuild) ALLOW_WORLD=1; shift ;;
+    --role)                ROLE="${2:-}"; shift 2 ;;
+    --role=*)              ROLE="${1#--role=}"; shift ;;
+    --self-test)           SELFTEST=1; shift ;;
+    -h|--help)             sed -n '2,95p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "${ROLE:-}" in
+  ""|server|client) ;;
+  *) echo "ABORT: role must be 'server' or 'client', got '$ROLE'" >&2; exit 1 ;;
+esac
+
+die() { echo "ABORT: $*" >&2; exit 1; }
+
+# =====================================================================================
+# parsers -- each one validated by --self-test before any verdict is read off it
+# =====================================================================================
+
+# `nixos-rebuild dry-build` writes its summary to STDERR, and the shape is
+#   these 40 derivations will be built:      /  this derivation will be built:
+#   these 24 paths will be fetched (159.4 MiB download, 651.1 MiB unpacked):
+# Absent lines mean ZERO, which is why the self-test drives a zero case AND a non-zero
+# one: a parser wired to nothing also returns zero, and zero is the reassuring answer.
+_drybuild_counts() {   # $1 = file holding dry-build's stderr; prints "built|fetched|mib"
+  python3 - "$1" <<'PY'
+import re, sys
+try:
+    text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+except Exception as e:
+    sys.stderr.write("parse: %s\n" % e); sys.exit(2)
+
+def count(kind):
+    m = re.search(r"^(?:these ([0-9]+)|this) (?:derivations?|paths?) will be %s" % kind,
+                  text, re.M)
+    if not m:
+        return 0
+    return int(m.group(1)) if m.group(1) else 1
+
+mib = 0.0
+m = re.search(r"will be fetched \(([0-9.]+) ([KMG]i?B) download", text)
+if m:
+    v, unit = float(m.group(1)), m.group(2)
+    mib = v * {"KiB": 1 / 1024.0, "MiB": 1.0, "GiB": 1024.0,
+               "KB": 1 / 1024.0, "MB": 1.0, "GB": 1024.0}.get(unit, 1.0)
+print("%d|%d|%.1f" % (count("built"), count("fetched"), mib))
+PY
+}
+
+# ONE extractor, fed from BOTH the running system's store path and the candidate
+# derivation's, so the two sides can never drift apart -- the same discipline that
+# check-nebula-relays.sh applies to its `-config` argument. Input is a store-path
+# basename; output is the nixos version string.
+# 🔴 `.drv` is stripped in its OWN pass. A trailing `\(\.drv\)\?` in the extraction
+# regex does NOT work: BRE `[^-]*` is greedy and swallows `.drv` itself, so the optional
+# group matches empty and the version comes back as `26.11pre…c0c2.drv`. Measured -- the
+# self-test caught it on the first run.
+_version_from_store_basename() {   # stdin -> version, or nothing
+  sed 's/\.drv$//' | sed -n 's/^[a-z0-9]\{32\}-nixos-system-.*-\([0-9][^-]*\)$/\1/p'
+}
+
+# The RELEASE is the leading major.minor. `26.11pre1066425.9387b3fcc0c2` -> `26.11`.
+# A change here is an OS upgrade, not a feature, however small the diff looks.
+_release_of() { printf '%s' "${1%%pre*}" | cut -d. -f1,2; }
+
+# Resolve a symlink CHAIN to a store path, and refuse anything else.
+# 🔴 `readlink -f`, never plain `readlink`: /nix/var/nix/profiles/system is a symlink to
+# a symlink and single-level readlink returns the bare name `system-NNN-link`, which can
+# never equal a store path. Returning "" on failure rather than a partial answer means a
+# comparison can never silently succeed against nothing.
+_store_path() {
+  local p
+  p=$(readlink -f "$1" 2>/dev/null || true)
+  case "$p" in
+    /nix/store/*) printf '%s' "$p"; return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_self_test() {
+  local dir rc=0 got
+  dir=$(mktemp -d)
+  trap 'rm -rf "$dir"' RETURN
+
+  # --- _drybuild_counts, both directions ------------------------------------------
+  # 🔴 THE POSITIVE CONTROL. Every gate below reads a COUNT, and a zero is
+  # indistinguishable from a parser wired to nothing. The plural fixture is the REAL
+  # output measured on this host on 2026-09-07, verbatim.
+  cat >"$dir/plural.txt" <<'T'
+building the system configuration...
+evaluation warning: something harmless
+these 40 derivations will be built:
+  /nix/store/aaaa-nixos-manual-html.drv
+these 24 paths will be fetched (159.4 MiB download, 651.1 MiB unpacked):
+  /nix/store/bbbb-mesa-26.2.2
+T
+  got=$(_drybuild_counts "$dir/plural.txt")
+  if [ "$got" = "40|24|159.4" ]; then
+    echo "  [self-test] dry-build counts, plural (the measured shape) -> ok"
+  else
+    echo "  [self-test] dry-build counts plural FAILED: got '$got', want '40|24|159.4'"; rc=1
+  fi
+
+  # SINGULAR. Nix drops the count word entirely for 1, so a regex that requires digits
+  # reads "this derivation will be built" as ZERO -- the reassuring direction.
+  cat >"$dir/singular.txt" <<'T'
+this derivation will be built:
+  /nix/store/cccc-thing.drv
+this path will be fetched (0.1 MiB download, 0.3 MiB unpacked):
+  /nix/store/dddd-other
+T
+  got=$(_drybuild_counts "$dir/singular.txt")
+  if [ "$got" = "1|1|0.1" ]; then
+    echo "  [self-test] dry-build counts, singular ('this ... will be built') -> ok"
+  else
+    echo "  [self-test] dry-build counts singular FAILED: got '$got', want '1|1|0.1'"; rc=1
+  fi
+
+  # THE ZERO CASE -- a config with nothing pending prints neither line.
+  printf 'building the system configuration...\n' >"$dir/zero.txt"
+  got=$(_drybuild_counts "$dir/zero.txt")
+  if [ "$got" = "0|0|0.0" ]; then
+    echo "  [self-test] dry-build counts, nothing pending -> 0|0|0.0 -> ok"
+  else
+    echo "  [self-test] dry-build counts zero FAILED: got '$got'"; rc=1
+  fi
+
+  # A GiB download must not be read as 2.5 MiB -- that is three orders of magnitude of
+  # "this is fine" on the gate that exists to stop a world rebuild.
+  cat >"$dir/gib.txt" <<'T'
+these 3 paths will be fetched (2.5 GiB download, 9.0 GiB unpacked):
+T
+  got=$(_drybuild_counts "$dir/gib.txt")
+  if [ "$got" = "0|3|2560.0" ]; then
+    echo "  [self-test] a GiB download is scaled to MiB (2.5 GiB -> 2560.0) -> ok"
+  else
+    echo "  [self-test] GiB scaling FAILED: got '$got', want '0|3|2560.0'"; rc=1
+  fi
+
+  # --- _version_from_store_basename, one implementation, several real inputs --------
+  got=$(printf '%s\n' "ihli9cw6p4b86rjhz75rymiwrgckzdfv-nixos-system-nixos-26.11pre1066106.3ed67ec0a4d3" | _version_from_store_basename)
+  if [ "$got" = "26.11pre1066106.3ed67ec0a4d3" ]; then
+    echo "  [self-test] version from a running-system basename -> ok"
+  else
+    echo "  [self-test] version from running-system basename FAILED: '$got'"; rc=1
+  fi
+  got=$(printf '%s\n' "6klnvgksn7b5qrm0ynz8q1nikamdkil2-nixos-system-nixos-26.11pre1066425.9387b3fcc0c2.drv" | _version_from_store_basename)
+  if [ "$got" = "26.11pre1066425.9387b3fcc0c2" ]; then
+    echo "  [self-test] version from a candidate .drv basename -> ok"
+  else
+    echo "  [self-test] version from .drv basename FAILED: '$got'"; rc=1
+  fi
+  # A HOSTNAME CONTAINING DASHES must not eat the version. `nixos` has none, so the
+  # obvious greedy implementation passes every real input on this fleet and breaks the
+  # day the host is renamed.
+  got=$(printf '%s\n' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-nixos-system-my-work-box-25.05.20250101.abcdef1" | _version_from_store_basename)
+  if [ "$got" = "25.05.20250101.abcdef1" ]; then
+    echo "  [self-test] version survives a dashed hostname (my-work-box) -> ok"
+  else
+    echo "  [self-test] dashed hostname FAILED: got '$got'"; rc=1
+  fi
+  # And a path that is NOT a system closure must yield NOTHING, not a guess. Returning
+  # a wrong version on both sides would make them compare EQUAL and wave a release
+  # jump straight through.
+  got=$(printf '%s\n' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.1" | _version_from_store_basename)
+  if [ -z "$got" ]; then
+    echo "  [self-test] a non-system store path yields no version -> ok"
+  else
+    echo "  [self-test] non-system path FAILED: invented '$got'"; rc=1
+  fi
+
+  # --- _release_of ------------------------------------------------------------------
+  for pair in "26.11pre1066106.3ed67ec0a4d3:26.11" "26.05.20260101.abc:26.05" "25.05:25.05"; do
+    got=$(_release_of "${pair%%:*}")
+    if [ "$got" = "${pair##*:}" ]; then
+      echo "  [self-test] release of ${pair%%:*} -> ${pair##*:} -> ok"
+    else
+      echo "  [self-test] release of ${pair%%:*} FAILED: got '$got'"; rc=1
+    fi
+  done
+  # 🔴 THE CASE THE GATE EXISTS FOR: two versions in the SAME release must compare
+  # equal, and two in DIFFERENT releases must not. Asserted as a relationship, because
+  # a _release_of that returned a constant would satisfy every case above.
+  if [ "$(_release_of 26.11pre1)" = "$(_release_of 26.11pre2)" ]; then
+    echo "  [self-test] same release, different revision -> equal -> ok"
+  else
+    echo "  [self-test] same-release comparison FAILED"; rc=1
+  fi
+  if [ "$(_release_of 26.05.1)" != "$(_release_of 26.11pre2)" ]; then
+    echo "  [self-test] 26.05 vs 26.11 -> different -> ok  (this is the 2h16m jump)"
+  else
+    echo "  [self-test] release-jump comparison FAILED: 26.05 read as 26.11"; rc=1
+  fi
+
+  # --- _store_path ------------------------------------------------------------------
+  # 🔴 THE TWO-LEVEL SYMLINK. Built as a real chain, because that is the shape that
+  # made a previous session's comparison fail forever: plain `readlink` on the outer
+  # link returns the NAME of the inner one.
+  mkdir -p "$dir/store"
+  ln -s "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-thing" "$dir/inner-link"
+  ln -s "inner-link" "$dir/outer-link"
+  got=$(_store_path "$dir/outer-link" || true)
+  if [ "$got" = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-thing" ]; then
+    echo "  [self-test] _store_path resolves a symlink-to-a-symlink -> ok"
+  else
+    echo "  [self-test] _store_path two-level FAILED: got '$got'"; rc=1
+  fi
+  # The control that proves the case above is not vacuous: single-level readlink on the
+  # SAME input returns a bare name, which is the bug.
+  if [ "$(readlink "$dir/outer-link")" = "inner-link" ]; then
+    echo "  [self-test] single-level readlink returns 'inner-link' -> the trap is real -> ok"
+  else
+    echo "  [self-test] the two-level fixture is not what this file claims"; rc=1
+  fi
+  # Non-store paths must REFUSE, so an empty result can never read as agreement.
+  # 🔴 The target is a plain file in the temp dir, NOT something under /etc: on NixOS
+  # most of /etc is itself a symlink INTO /nix/store, so `ln -s /etc/hostname` builds a
+  # fixture that legitimately resolves to a store path and the case passes vacuously.
+  # Measured -- this was the fixture's first version and it reported a false FAILURE.
+  : > "$dir/plain-file"
+  ln -s "$dir/plain-file" "$dir/not-store"
+  if _store_path "$dir/not-store" >/dev/null 2>&1; then
+    echo "  [self-test] _store_path FAILED: accepted a non-store path"; rc=1
+  else
+    echo "  [self-test] _store_path refuses a non-store path -> ok"
+  fi
+  if _store_path "$dir/does-not-exist" >/dev/null 2>&1; then
+    echo "  [self-test] _store_path FAILED: accepted a dangling path"; rc=1
+  else
+    echo "  [self-test] _store_path refuses a dangling path -> ok"
+  fi
+
+  # --- the gate predicate, driven ----------------------------------------------------
+  # The parsers being right is not the same as the GATE being right.
+  if _over "11" "10"; then echo "  [self-test] _over 11 > 10 -> ok"; else echo "  [self-test] _over FAILED"; rc=1; fi
+  if _over "10" "10"; then echo "  [self-test] _over FAILED: 10 > 10"; rc=1; else echo "  [self-test] _over 10 == 10 -> not over -> ok"; fi
+  if _over "0" "10";  then echo "  [self-test] _over FAILED: 0 > 10"; rc=1;  else echo "  [self-test] _over 0 < 10 -> not over -> ok"; fi
+
+  # --- THE GATE ITSELF, both directions, on MEASURED numbers ------------------------
+  # A guard whose refusing branch has never been watched execute is not a guard, and a
+  # guard that refuses everything is not one either. Both are driven here.
+  #
+  # 🔴 The refusing fixture is not invented: 40 pending / 47 total / +7 delta is what
+  # `nixos-rebuild dry-build` reported on this host on 2026-09-07, against an UNCHANGED
+  # config and with the tailscale block added. The gate must refuse THAT.
+  got=$(_gate_reasons 26.11 26.11 40 47)
+  if printf '%s' "$got" | grep -q 'PENDING WORK UNRELATED'; then
+    echo "  [self-test] gate REFUSES the real measured state (40 pending / 47 total) -> ok"
+  else
+    echo "  [self-test] gate FAILED: allowed 40 pending derivations. got: '$got'"; rc=1
+  fi
+  # The allowing branch: nothing pending, tailscale's own 7 derivations. If this
+  # refused, the script could never succeed and the gate would be a permanent red
+  # light that everyone learns to override.
+  got=$(_gate_reasons 26.11 26.11 0 7)
+  if [ -z "$got" ]; then
+    echo "  [self-test] gate ALLOWS a clean tree with tailscale's own 7 builds -> ok"
+  else
+    echo "  [self-test] gate FAILED: refused a clean tailscale-only delta: '$got'"; rc=1
+  fi
+  # 🔴 THE RELEASE JUMP, which must refuse on its own even when the counts are tiny --
+  # a release change is an OS upgrade however small the queue looks at eval time.
+  got=$(_gate_reasons 26.05 26.11 0 3)
+  if printf '%s' "$got" | grep -q 'NIXPKGS RELEASE CHANGE'; then
+    echo "  [self-test] gate REFUSES a 26.05 -> 26.11 jump even with 3 builds pending -> ok"
+  else
+    echo "  [self-test] gate FAILED: a release jump passed on low counts. got: '$got'"; rc=1
+  fi
+  # And the total-size gate on its own, with a clean baseline.
+  got=$(_gate_reasons 26.11 26.11 0 900)
+  if printf '%s' "$got" | grep -q 'TOTAL BUILD SIZE'; then
+    echo "  [self-test] gate REFUSES 900 total builds from a clean baseline -> ok"
+  else
+    echo "  [self-test] gate FAILED: 900 builds allowed. got: '$got'"; rc=1
+  fi
+  return $rc
+}
+
+_over() { [ "$1" -gt "$2" ]; }
+
+# THE GATE, as a pure function of the four numbers, so both of its branches can be
+# driven from fixtures. A refusal that has only ever been reasoned about is not a
+# guard; the self-test below watches this one both refuse and allow, using the numbers
+# MEASURED on this host rather than invented ones.
+# Prints one reason per paragraph; empty output means "allow".
+_gate_reasons() {   # $1 run_rel  $2 cand_rel  $3 pending_builds  $4 total_builds
+  local run_rel="$1" cand_rel="$2" b_built="$3" c_built="$4" d_built=$(( $4 - $3 ))
+  if [ "$run_rel" != "$cand_rel" ]; then
+    printf '%s\n' "NIXPKGS RELEASE CHANGE: $run_rel -> $cand_rel.
+    This is an OS UPGRADE, not a feature. The last time this happened here a 4-line
+    nebula edit turned into a 2h16m world rebuild. Refused regardless of size."
+  fi
+  if _over "$b_built" "$MAX_PENDING_BUILDS"; then
+    printf '%s\n' "PENDING WORK UNRELATED TO TAILSCALE: $b_built derivations are already
+    queued by the CURRENT config (limit $MAX_PENDING_BUILDS), and \`switch\` applies
+    them too. Only $d_built of the $c_built are tailscale's.
+    THE CLEAN FIX IS TO SEPARATE THE TWO OPERATIONS: run \`sudo nixos-rebuild switch\`
+    on its own, at a time you choose, watch it land, then re-run this script -- the
+    delta will then be just tailscale. Or accept it with --allow-world-rebuild."
+  fi
+  if _over "$c_built" "$MAX_TOTAL_BUILDS"; then
+    printf '%s\n' "TOTAL BUILD SIZE: $c_built derivations would be built (limit
+    $MAX_TOTAL_BUILDS). Adding tailscale should be a handful of substituted paths."
+  fi
+}
+
+if [ "$SELFTEST" = "1" ]; then
+  command -v python3 >/dev/null 2>&1 || die "python3 is not on PATH"
+  echo "self-test:"
+  st_rc=0
+  _self_test || st_rc=$?     # 🔴 seed FIRST. `f; rc=$?` is dead code under `set -e`,
+                             # and `f || rc=$?` without the seed dies under `set -u`
+                             # on the SUCCESS path. Both shapes have shipped here.
+  if [ "$st_rc" != "0" ]; then echo "self-test: FAILED" >&2; exit 1; fi
+  echo "self-test: all controls passed"
+  exit 0
+fi
+
+# =====================================================================================
+# preflight -- no writes
+# =====================================================================================
+echo "== preflight =="
+
+[ "$(id -u)" = "0" ] || die "must run as root:
+  sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]}"
+
+# 🔴 python3 is NOT in /run/current-system/sw/bin on these hosts, and sudo here has no
+# secure_path -- root gets a python3 only by inheriting the caller's PATH. Preflighted
+# rather than discovered halfway through a patch.
+for t in awk sed diff systemctl ip date nixos-rebuild nix-instantiate nix-store nix python3; do
+  command -v "$t" >/dev/null 2>&1 || die "\`$t\` is not on PATH.
+  sudo inherits the CALLER's PATH here (there is no secure_path), and python3 in
+  particular is NOT in /run/current-system/sw/bin. Re-run from a shell that has it:
+    sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]}"
+done
+
+[ -r "$CHECK" ] || die "cannot read the verifier at $CHECK (run this from the repo checkout)"
+
+echo "  self-test : validating this script's own parsers before trusting their numbers"
+# 🔴 CAPTURED, THEN INDENTED -- deliberately NOT `_self_test | sed 's/^/  /' || rc=$?`.
+# In a pipeline `$?` is the pipeline's status, which is `sed`'s (always 0) UNLESS
+# `pipefail` happens to be set. MEASURED both ways: with pipefail rc=1, without it rc=0
+# and the gate is INERT while looking correct. That would make this whole
+# parsers-earn-their-verdict check a no-op keyed on an exit code reporting something
+# else. Not left depending on a `set` line 400 lines away.
+st_rc=0
+st_out=$(_self_test) || st_rc=$?
+printf '%s\n' "$st_out" | sed 's/^/  /'
+[ "$st_rc" = "0" ] || die "this script's parsers failed their own controls -- every
+  number the closure preflight prints would be meaningless"
+
+# --- which host is this? --------------------------------------------------------------
+if [ -z "$ROLE" ]; then
+  have_ip=$(ip -4 -o addr show nebula.mesh 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1)
+  [ -n "$have_ip" ] || die "no address on nebula.mesh, so the host role cannot be
+  auto-detected, and \`hostname\` does not discriminate these machines (both answer
+  \`nixos\`). Say which host this is:
+    --role server   # the workbench, $MESH_SERVER, becomes the subnet router
+    --role client   # the laptop,    $MESH_CLIENT, becomes a plain client"
+  case "$have_ip" in
+    "$MESH_SERVER") ROLE=server ;;
+    "$MESH_CLIENT") ROLE=client ;;
+    *) die "WRONG HOST: nebula.mesh is $have_ip, which is neither the workbench
+  ($MESH_SERVER) nor the laptop ($MESH_CLIENT). Refusing to guess. If you really mean
+  this host, pass --role server or --role client." ;;
+  esac
+  echo "  host      : nebula.mesh = $have_ip -> role '$ROLE'"
+else
+  echo "  host      : role '$ROLE' (forced)"
+fi
+
+[ -f "$CFG" ] && [ -w "$CFG" ] || die "$CFG is not a writable regular file"
+
+# --- already done? ---------------------------------------------------------------------
+# Asked of the FILE here because this is a question about what the file will contain.
+# Whether it is RUNNING is a different question, and check-tailscale.sh is the only
+# thing that answers it -- it reads the live daemon, never the config.
+if grep -q 'services\.tailscale' "$CFG"; then
+  echo "  state     : $CFG already mentions services.tailscale:"
+  grep -n 'services\.tailscale' "$CFG" | sed 's/^/    | /'
+  echo
+  echo "Nothing to do. Exiting 0 without touching $CFG."
+  echo "Whether it is actually WORKING is a different question -- ask the verifier:"
+  echo "    bash ${CHECK} --role ${ROLE}"
+  exit 0
+fi
+
+# --- a sysctl key defined twice is a Nix evaluation error --------------------------------
+# `boot.kernel.sysctl."x"` and `boot.kernel.sysctl = { ... }` merge happily (measured),
+# but two definitions of the SAME key at the same priority do not. Checked before
+# writing rather than discovered by the parse afterwards, so the message names the
+# actual conflict.
+# Scoped to the SERVER role, because the client block adds no sysctls at all -- an
+# unscoped loop would abort on a laptop whose config already tunes forwarding for some
+# unrelated reason, refusing a change that could not have collided with it.
+sysctl_keys=()
+if [ "$ROLE" = "server" ]; then
+  sysctl_keys=("net.ipv4.ip_forward" "net.ipv6.conf.all.forwarding")
+fi
+for k in ${sysctl_keys[@]+"${sysctl_keys[@]}"}; do
+  if grep -q "\"${k}\"" "$CFG"; then
+    die "$CFG already defines the sysctl \"$k\":
+$(grep -n "\"${k}\"" "$CFG" | sed 's/^/    /')
+  Two definitions of one key at the same priority is a Nix evaluation error. Merge it
+  by hand instead of letting this script add a second one."
+  fi
+done
+
+# --- the anchor -------------------------------------------------------------------------
+# The block is appended just before the module's final closing brace. Two independent
+# conditions must BOTH hold, so a file shaped differently aborts rather than being
+# guessed at: exactly one line in the file is a bare `}` at column 0, AND it is the last
+# non-blank line.
+closers=$(grep -c '^}[[:space:]]*$' "$CFG" || true)
+last_sig=$(awk 'NF{l=$0} END{print l}' "$CFG")
+if [ "$closers" != "1" ] || [ "$last_sig" != "}" ]; then
+  die "cannot locate the module's final closing brace in $CFG
+  (bare-\`}\` lines: $closers, expected 1; last non-blank line: '$last_sig', expected '}')
+  Add the tailscale block by hand instead -- see --help for exactly what it should say."
+fi
+anchor_line=$(grep -n '^}[[:space:]]*$' "$CFG" | cut -d: -f1)
+echo "  anchor    : the module's final \`}\` is line $anchor_line, and it is unique"
+echo
+
+# =====================================================================================
+# build the patched config in a TEMP FILE -- $CFG is not touched until the preflight
+# passes. The temp lives NEXT TO $CFG on purpose: the config's own `imports` are
+# RELATIVE (./airvpn-host.nix, ./hardware-configuration.nix), so a temp file anywhere
+# else evaluates to a different -- and broken -- system.
+# =====================================================================================
+echo "== patch (temp file only) =="
+TMP="${CFG%.nix}.tailscale-candidate.$$.nix"
+BAK="${CFG}.bak-tailscale-$(date +%Y%m%d-%H%M%S)-$$"
+WORK=$(mktemp -d)
+PATCHED=0
+SWITCHED=0
+OK=0
+
+finish() {
+  local rc=$?
+  rm -f "$TMP"
+  rm -rf "$WORK"
+  if [ "$OK" = "1" ]; then exit $rc; fi
+  if [ "$PATCHED" = "1" ] && [ -f "$BAK" ]; then
+    cp -p "$BAK" "$CFG"
+    echo >&2
+    echo "ROLLED BACK: $CFG restored from $BAK" >&2
+    if [ "$SWITCHED" = "1" ]; then
+      echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
+      echo "   system is not -- run \`sudo nixos-rebuild switch\` to return it." >&2
+    else
+      echo "   The system was never switched, so nothing is running the change." >&2
+    fi
+  fi
+  exit $rc
+}
+trap finish EXIT
+
+if [ "$ROLE" = "server" ]; then
+  BLOCK=$(cat <<EOF
+
+  # --- Tailscale: the INDEPENDENT SECOND PATH to this host ---------------------------
+  # Added by nix/system/apply-tailscale.sh. Nebula is the primary remote path; this
+  # exists so that a nebula outage while off-LAN is not a total loss of access. It
+  # shares no component with nebula: different control plane, different relays.
+  #
+  # THIS HOST IS THE SUBNET ROUTER. Advertising ${SUBNET} makes the whole LAN
+  # reachable over the tailnet, not just this machine.
+  #
+  # 🔴 WHAT THIS BLOCK DOES **NOT** DO. It starts tailscaled and permits routing. It
+  # does NOT log the node in and it does NOT advertise anything -- both are runtime
+  # state owned by \`tailscale up\`, which needs a browser. And the route still has to
+  # be APPROVED in the admin console before it carries a single packet; until then the
+  # node reports it is advertising and nothing flows. \`check-tailscale.sh\` reports
+  # those as separate claims because they are separate claims.
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "server";
+    openFirewall = true;              # UDP 41641 for direct (non-DERP) connections
+  };
+
+  # A subnet router that cannot forward advertises a route into a black hole.
+  #
+  # 🔴 REDUNDANT TODAY, ON PURPOSE. \`useRoutingFeatures = "server"\` already sets
+  # net.ipv4.conf.all.forwarding and net.ipv6.conf.all.forwarding at \`mkOverride 97\`,
+  # which OUTRANKS a plain definition here (97 < 100), so the ipv6 line below loses and
+  # the module's value is what lands. Both are kept anyway: flipping useRoutingFeatures
+  # would otherwise take forwarding with it silently. net.ipv4.ip_forward is the same
+  # kernel knob as net.ipv4.conf.all.forwarding, spelled the way check-tailscale.sh
+  # reads it back out of /proc.
+  boot.kernel.sysctl."net.ipv4.ip_forward" = 1;
+  boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = 1;
+EOF
+)
+else
+  BLOCK=$(cat <<EOF
+
+  # --- Tailscale: the INDEPENDENT SECOND PATH off this host --------------------------
+  # Added by nix/system/apply-tailscale.sh. This host is a PLAIN CLIENT: it advertises
+  # nothing and consumes the workbench's ${SUBNET} advertisement.
+  #
+  # \`useRoutingFeatures = "client"\` is what makes an accepted subnet route usable: it
+  # sets networking.firewall.checkReversePath = "loose", without which return traffic
+  # over a subnet route is dropped by strict reverse-path filtering.
+  #
+  # 🔴 It does NOT log the node in, and it does not set --accept-routes. Both are
+  # runtime state owned by \`tailscale up\`. See check-tailscale.sh.
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "client";
+    openFirewall = true;              # UDP 41641 for direct (non-DERP) connections
+  };
+EOF
+)
+fi
+
+awk -v blk="$BLOCK" -v anchor="$anchor_line" '
+  NR == anchor { print blk }
+  { print }
+' "$CFG" > "$TMP"
+
+added=$(( $(wc -l < "$TMP") - $(wc -l < "$CFG") ))
+expected=$(printf '%s\n' "$BLOCK" | wc -l)
+[ "$added" = "$expected" ] || die "expected the patch to add exactly $expected lines, it added $added"
+echo "  temp file : $TMP  (+$added lines)"
+
+nix-instantiate --parse "$TMP" >/dev/null 2>&1 || die "the patched file is not valid Nix -- $CFG untouched"
+echo "  nix parse : OK"
+echo "  diff:"
+diff -u "$CFG" "$TMP" | sed 's/^/    /' || true
+echo
+
+# =====================================================================================
+# 🔴 THE CLOSURE PREFLIGHT
+# =====================================================================================
+echo "== closure preflight =="
+echo "  \`nixos-rebuild switch\` applies EVERYTHING PENDING, not just this delta."
+echo "  Measuring what it would actually do, from the TEMP file. $CFG is still untouched."
+echo
+
+running=$(_store_path /run/current-system) \
+  || die "/run/current-system does not resolve into /nix/store -- refusing to compare"
+profile=$(_store_path /nix/var/nix/profiles/system || true)
+echo "  running   : $running"
+if [ -n "$profile" ] && [ "$profile" != "$running" ]; then
+  echo "  NOTE: /nix/var/nix/profiles/system resolves to a DIFFERENT closure:"
+  echo "        $profile"
+  echo "        (both were resolved with \`readlink -f\`; the profile is a symlink TO A"
+  echo "         SYMLINK, so this is a real difference and not the classic comparison bug)"
+fi
+
+running_version=$(basename "$running" | _version_from_store_basename)
+[ -n "$running_version" ] || die "could not extract a version from $running"
+# CONTROL: the extractor's answer must agree with the file the system ships. Without
+# this, an extractor that is wrong on BOTH sides agrees with itself and waves a release
+# jump straight through.
+if [ -r /run/current-system/nixos-version ]; then
+  file_version=$(tr -d '[:space:]' < /run/current-system/nixos-version)
+  [ "$running_version" = "$file_version" ] || die "the version extractor disagrees with
+  /run/current-system/nixos-version (extracted '$running_version', file says
+  '$file_version'). Refusing to gate on a number this script cannot read correctly."
+  echo "  version   : $running_version  (extractor agrees with /run/current-system/nixos-version)"
+else
+  echo "  version   : $running_version  (no nixos-version file to cross-check against)"
+fi
+
+echo "  evaluating the candidate system derivation..."
+cand_drv=$(nix-instantiate '<nixpkgs/nixos>' -A system --include "nixos-config=$TMP" 2>"$WORK/inst.err") \
+  || { sed 's/^/    | /' "$WORK/inst.err" >&2; die "could not evaluate the patched configuration"; }
+cand_version=$(basename "$cand_drv" | _version_from_store_basename)
+[ -n "$cand_version" ] || die "could not extract a version from the candidate derivation
+  $cand_drv"
+echo "  candidate : $cand_version"
+
+run_rel=$(_release_of "$running_version")
+cand_rel=$(_release_of "$cand_version")
+
+echo
+echo "  measuring what is PENDING (the current config, unchanged)..."
+nixos-rebuild dry-build --include "nixos-config=$CFG" >"$WORK/base.out" 2>"$WORK/base.err" \
+  || die "dry-build of the CURRENT config failed -- fix that before adding anything"
+base=$(_drybuild_counts "$WORK/base.err")
+IFS='|' read -r b_built b_fetch b_mib <<<"$base"
+
+echo "  measuring the CANDIDATE (with tailscale)..."
+nixos-rebuild dry-build --include "nixos-config=$TMP" >"$WORK/cand.out" 2>"$WORK/cand.err" \
+  || die "dry-build of the PATCHED config failed"
+cand=$(_drybuild_counts "$WORK/cand.err")
+IFS='|' read -r c_built c_fetch c_mib <<<"$cand"
+
+d_built=$(( c_built - b_built ))
+d_fetch=$(( c_fetch - b_fetch ))
+
+echo
+printf '  %-28s %8s %8s %10s\n' "" "build" "fetch" "download"
+printf '  %-28s %8s %8s %9s M\n' "PENDING (not yours)"    "$b_built" "$b_fetch" "$b_mib"
+printf '  %-28s %8s %8s %9s M\n' "TOTAL if you switch"    "$c_built" "$c_fetch" "$c_mib"
+printf '  %-28s %8s %8s\n'       "DELTA (tailscale only)" "$d_built" "$d_fetch"
+echo
+echo "  release   : running $run_rel  ->  candidate $cand_rel"
+echo
+
+# --- the gate ---------------------------------------------------------------------------
+# One implementation, exercised in both directions by --self-test above.
+refuse=$(_gate_reasons "$run_rel" "$cand_rel" "$b_built" "$c_built")
+
+if [ -n "$refuse" ] && [ "$ALLOW_WORLD" != "1" ]; then
+  echo "REFUSING to switch:" >&2
+  printf '  - %s\n' "$refuse" >&2
+  echo >&2
+  echo "  $CFG was NOT modified. Nothing to roll back." >&2
+  echo "  Largest pending items, so you can judge the cost yourself:" >&2
+  # 🔴 `|| true` is load-bearing, twice over: `grep` exits 1 when it matches nothing,
+  # and `head` closing the pipe early SIGPIPEs everything upstream. With `set -e` plus
+  # `pipefail` either would abort HERE -- inside the refusal path, one line before
+  # `exit 4` -- so the script would exit 1 and never print the override the operator
+  # needs. A cosmetic listing must not be able to change the exit code.
+  { grep -oE '/nix/store/[a-z0-9]+-[^ ]+\.drv' "$WORK/base.err" | sed 's#.*/[a-z0-9]*-##' \
+      | sort -u | head -15 | sed 's/^/      /'; } >&2 || true
+  echo >&2
+  echo "  To proceed anyway, exactly as written:" >&2
+  echo "      sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]} --allow-world-rebuild" >&2
+  exit 4
+fi
+if [ -n "$refuse" ]; then
+  echo "  🔴 --allow-world-rebuild given; proceeding DESPITE:"
+  printf '     - %s\n' "$refuse"
+  echo
+fi
+
+if [ "$DRYRUN" = "1" ]; then
+  echo "== --dry-run =="
+  echo "Stopping here. $CFG was NOT modified and nothing was switched."
+  echo "The block that WOULD be added is in the diff above."
+  OK=1
+  exit 0
+fi
+
+# --- build (still not activating) ---------------------------------------------------------
+echo "  building the candidate system (no activation)..."
+( cd "$WORK" && nixos-rebuild build --include "nixos-config=$TMP" ) \
+  || die "the candidate system failed to BUILD -- $CFG untouched"
+built=$(_store_path "$WORK/result") \
+  || die "nixos-rebuild build left no usable ./result symlink"
+echo "  built     : $built"
+
+# --- the closure, compared as SETS ---------------------------------------------------------
+# 🔴 Deliberately not a parse of `nix store diff-closures`. That command prints NOTHING
+# when two closures match, so an empty result is indistinguishable from a command that
+# did not run -- the reassuring-zero shape. A set difference of the two closures cannot
+# do that: it is derived from two enumerations that are separately non-empty, and the
+# closure sizes are printed beside the answer so a zero can be checked against them.
+nix-store -qR "$running" | sort > "$WORK/run.txt"
+nix-store -qR "$built"   | sort > "$WORK/new.txt"
+n_run=$(wc -l < "$WORK/run.txt"); n_new=$(wc -l < "$WORK/new.txt")
+[ "$n_run" -gt 100 ] && [ "$n_new" -gt 100 ] \
+  || die "a system closure of $n_run / $n_new paths is not credible -- \`nix-store -qR\`
+  did not do what this script assumes, so the comparison below would be meaningless"
+changed=$(comm -3 "$WORK/run.txt" "$WORK/new.txt" | wc -l)
+echo "  closure   : running $n_run paths, candidate $n_new paths, $changed differ"
+echo
+echo "  package-level diff (nix store diff-closures):"
+nix store diff-closures "$running" "$built" 2>/dev/null | head -40 | sed 's/^/    /' || true
+echo
+
+if _over "$changed" "$MAX_CHANGED_PATHS" && [ "$ALLOW_WORLD" != "1" ]; then
+  die "$changed store paths differ between the running and candidate closures (limit
+  $MAX_CHANGED_PATHS). That is a world-sized change, not a tailscale-sized one.
+  $CFG was NOT modified. To proceed anyway:
+      sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]} --allow-world-rebuild"
+fi
+
+# =====================================================================================
+# only now is the real config touched
+# =====================================================================================
+echo "== apply =="
+[ -e "$BAK" ] && die "backup path $BAK already exists; refusing to overwrite it"
+cp -p "$CFG" "$BAK"
+echo "  backup    : $BAK"
+cp -p "$TMP" "$CFG"
+PATCHED=1
+echo "  applied   : $CFG"
+echo
+
+echo "== nixos-rebuild switch =="
+nixos-rebuild switch
+SWITCHED=1
+echo
+
+# =====================================================================================
+# verify -- the RUNTIME symptom, not the rollout
+# =====================================================================================
+echo "== verify =="
+active=$(systemctl is-active tailscaled.service 2>/dev/null || true)
+[ "$active" = "active" ] || die "tailscaled is '$active' after the switch, not 'active'"
+echo "  unit      : tailscaled active"
+command -v tailscale >/dev/null 2>&1 || die "the \`tailscale\` CLI is still not on PATH
+  after the switch. Open a new shell and re-check before assuming this failed."
+echo "  cli       : $(tailscale version 2>&1 | head -1)"
+
+# The verifier is the authority on whether this is a working path. rc 3 means the node
+# is correct and an ADMIN-CONSOLE action is outstanding -- that is the EXPECTED state
+# straight after a switch, and rolling back a correct config because a human has not
+# opened a browser yet would be absurd.
+chk_rc=0
+"$CHECK" --role "$ROLE" || chk_rc=$?
+case "$chk_rc" in
+  0) echo "  verifier  : PASS -- nothing outstanding" ;;
+  2|3) echo "  verifier  : rc $chk_rc -- the node still needs the manual steps below" ;;
+  *) die "the verifier reports a node-side FAILURE (rc=$chk_rc) after the switch" ;;
+esac
+
+OK=1
+echo
+echo "=== SWITCHED ==="
+echo "Backup of the previous config: $BAK"
+echo "To revert:  sudo cp $BAK $CFG && sudo nixos-rebuild switch"
+echo
+echo "🔴 NOT DONE YET. Three steps remain and NONE of them can be scripted."
+echo
+echo "1. AUTHENTICATE THIS NODE (needs a browser; prints a login URL):"
+if [ "$ROLE" = "server" ]; then
+  echo "       sudo tailscale up --advertise-routes=${SUBNET} --accept-dns=false"
+  echo "   (--accept-dns=false keeps tailscale out of this host's resolver, which"
+  echo "    dnsmasq and the .lan names already own.)"
+else
+  echo "       sudo tailscale up --accept-routes"
+fi
+echo
+if [ "$ROLE" = "server" ]; then
+  echo "2. APPROVE THE SUBNET ROUTE -- admin console only. Until this is done the route"
+  echo "   carries NO traffic and the node cannot tell the difference:"
+  echo "       https://login.tailscale.com/admin/machines"
+  echo "       -> this machine -> ... -> Edit route settings -> tick ${SUBNET} -> Save"
+  echo
+fi
+echo "3. DISABLE NODE KEY EXPIRY -- admin console only. The default is 180 days, which"
+echo "   is SHORTER than the trip; when it lapses this backup path goes dark with no"
+echo "   local error:"
+echo "       https://login.tailscale.com/admin/machines"
+echo "       -> this machine -> ... -> Disable key expiry"
+echo
+echo "Then confirm all of it, from live runtime state:"
+echo "       bash ${CHECK} --role ${ROLE}      # 0 = done, 3 = a step above is outstanding"

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+# Read-only check: is Tailscale actually carrying a usable second path INTO the LAN?
+#
+# Tailscale is the INDEPENDENT BACKUP for nebula. Nebula is currently the only remote
+# path to the workbench; if its lighthouse, its relay or the host firewall in front of
+# it breaks while the operator is off-LAN for months, there is no second door. This
+# script answers whether the second door is actually open -- not whether it was
+# configured.
+#
+#   bash nix/system/check-tailscale.sh                 # auto-detect the host role
+#   bash nix/system/check-tailscale.sh --role server   # force the subnet-router role
+#   bash nix/system/check-tailscale.sh --role client   # force the plain-client role
+#   bash nix/system/check-tailscale.sh --self-test     # validate the parser only
+#
+# Overrides (all optional):
+#   TS_ROLE=server|client            same as --role
+#   TS_SUBNET=192.168.50.0/24        the subnet the server role must advertise
+#   TS_EXPECT_MESH_IP_SERVER=10.42.0.30
+#   TS_EXPECT_MESH_IP_CLIENT=10.42.0.100
+#
+# 🔴 IT READS LIVE RUNTIME STATE, NOT THE NIX CONFIG AND NOT THE UNIT FILE. Everything
+# below comes from `tailscale status --json` and `tailscale debug prefs` (the running
+# daemon's own answer), from /proc/sys (the kernel's own answer), and from `ip route`.
+# `systemctl cat tailscaled` exits 0 for a unit that is dead or was never started, so a
+# config that BUILT but never ACTIVATED reads as applied -- that exact bug is why
+# check-nebula-relays.sh was rewritten, and this script does not repeat it. The unit's
+# state is printed as CONTEXT only; no verdict is keyed on it.
+#
+# 🔴 ADVERTISED AND APPROVED ARE TWO DIFFERENT CLAIMS AND BOTH ARE PRINTED.
+#   * ADVERTISED lives on this node -- `AdvertiseRoutes` in the daemon's prefs. It is
+#     entirely under this script's control and says nothing about whether traffic flows.
+#   * APPROVED lives in the Tailscale admin console. Until a human ticks the route there
+#     it carries NO traffic, and from the node's side that is INDISTINGUISHABLE from
+#     success: the node happily reports it is advertising. The approval signal is
+#     `Self.PrimaryRoutes` in `tailscale status --json`, which the control plane only
+#     populates once the route is approved.
+#   Reporting only the first would certify a subnet router that routes nothing.
+#
+# 🔴 NODE KEY EXPIRY. Tailscale node keys expire after 180 days BY DEFAULT. A trip of
+# several months crosses that, and the failure mode is the backup path going dark while
+# it is being relied on -- silently, with no local error. The expiry date and the days
+# remaining are reported, and expiry being ENABLED AT ALL is treated as an outstanding
+# action, not as a pass.
+#
+# Exit: 0 = every claim holds, including admin-console approval and disabled key expiry
+#       3 = everything THIS HOST controls is correct, but an ADMIN-CONSOLE action is
+#           still outstanding (route not approved, and/or key expiry still enabled).
+#           Split out from 1 on purpose: it is not a defect on the node, it is a human
+#           step that cannot be scripted, and apply-tailscale.sh must not roll back a
+#           correct switch because a browser tab has not been clicked yet.
+#       1 = a definitive node-side FAIL (not running, not authenticated, not
+#           advertising, forwarding off, no LAN route)
+#       2 = cannot determine -- tailscale absent, daemon unreachable, role ambiguous,
+#           parser failure, or the parser failed its own controls
+set -euo pipefail
+
+SUBNET="${TS_SUBNET:-192.168.50.0/24}"
+MESH_SERVER="${TS_EXPECT_MESH_IP_SERVER:-10.42.0.30}"
+MESH_CLIENT="${TS_EXPECT_MESH_IP_CLIENT:-10.42.0.100}"
+ROLE="${TS_ROLE:-}"
+SELFTEST=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test) SELFTEST=1; shift ;;
+    --role)      ROLE="${2:-}"; shift 2 ;;
+    --role=*)    ROLE="${1#--role=}"; shift ;;
+    -h|--help)   sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)           echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# 🔴 Validated HERE, not next to the host probe further down. Measured: with the check
+# sitting after the `tailscale` binary precondition, `--role bogus` was rejected with
+# "no tailscale binary on PATH" -- the right exit code for the wrong reason, and an
+# error message that sends the operator to fix something that is not broken.
+case "${ROLE:-}" in
+  ""|server|client) ;;
+  *) echo "CANNOT DETERMINE: role must be 'server' or 'client', got '$ROLE'" >&2; exit 2 ;;
+esac
+
+# --- exact membership of a comma-separated list -------------------------------------
+# NOT a substring test. `192.168.50.0/24` is a substring of `192.168.50.0/241`, and a
+# prefix match also accepts `192.168.50.0/2` -- both are pinned by controls in
+# _self_test, in the failing direction.
+_in_csv() {  # $1 = needle, $2 = csv
+  case ",${2}," in *,"${1}",*) return 0 ;; esac
+  return 1
+}
+
+# --- the parser -------------------------------------------------------------------
+# Stdlib json only, on purpose: `jq` is not guaranteed on either host, and PyYAML is
+# already known not to be importable from the python3 on the default PATH here.
+#
+# Emits ONE `|`-separated record so a caller cannot half-read it:
+#   backend|online|ips|advertised|primary|expiry_iso|expiry_days|route_all|prefs_src
+#
+# Exits 2 rather than printing a record when the document is not what it claims to be,
+# so "the parser found nothing" can never be reported as "this node advertises nothing"
+# -- which is a definitive FAIL derived from a file that was never understood.
+_parse_ts() {   # $1 = status json path, $2 = prefs json path or "-" when unavailable
+  python3 - "$1" "$2" <<'PY'
+import datetime, json, sys
+
+def load(p):
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+try:
+    st = load(sys.argv[1])
+except Exception as e:
+    sys.stderr.write("parse: status: %s\n" % e)
+    sys.exit(2)
+if not isinstance(st, dict) or "BackendState" not in st:
+    sys.stderr.write("parse: no BackendState key -- not a `tailscale status --json` document\n")
+    sys.exit(2)
+
+me = st.get("Self") or {}
+backend = st.get("BackendState") or "?"
+online = "true" if me.get("Online") is True else "false"
+
+ips = [i for i in (st.get("TailscaleIPs") or me.get("TailscaleIPs") or []) if isinstance(i, str)]
+primary = [r for r in (me.get("PrimaryRoutes") or []) if isinstance(r, str)]
+
+# Key expiry. `KeyExpiry` is omitempty AND some builds emit the Go zero time instead,
+# so BOTH spellings of "expiry is disabled" have to be handled; treating only one of
+# them as disabled reports a node with expiry OFF as expiring on 0001-01-01.
+raw = me.get("KeyExpiry") or ""
+expiry, days = "", ""
+if raw and not raw.startswith("0001-01-01"):
+    try:
+        t = datetime.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        now = datetime.datetime.now(datetime.timezone.utc)
+        expiry = t.isoformat()
+        days = str((t - now).days)
+    except Exception as e:                # a value we cannot read is NOT "disabled"
+        sys.stderr.write("parse: KeyExpiry %r: %s\n" % (raw, e))
+        sys.exit(2)
+
+advertised, route_all, src = [], "?", "none"
+if sys.argv[2] != "-":
+    try:
+        pf = load(sys.argv[2])
+    except Exception as e:
+        sys.stderr.write("parse: prefs: %s\n" % e)
+        sys.exit(2)
+    if not isinstance(pf, dict) or "AdvertiseRoutes" not in pf:
+        sys.stderr.write("parse: no AdvertiseRoutes key -- not a `tailscale debug prefs` document\n")
+        sys.exit(2)
+    advertised = [r for r in (pf.get("AdvertiseRoutes") or []) if isinstance(r, str)]
+    route_all = "true" if pf.get("RouteAll") is True else "false"
+    src = "prefs"
+
+print("|".join((backend, online, ",".join(ips), ",".join(advertised),
+                ",".join(primary), expiry, days, route_all, src)))
+PY
+}
+
+# --- self-test: prove the parser can say BOTH answers before trusting either -------
+# A checker that cannot go red is not evidence, and one that has never gone green may
+# be wired to nothing. Every fixture below is a shape the real daemon emits.
+#
+# 🔴 PUBLIC-REPO SAFE BY CONSTRUCTION. 100.64.0.0/10 is the CGNAT range Tailscale
+# itself hands out (not routable to anything of ours), 192.168.50.0/24 is RFC1918, and
+# every hostname is under the reserved `.example.test` TLD. No real public IP and no
+# client hostname is spelled anywhere in this file.
+#
+# The DAYS field is asserted separately, from fixtures generated at run time at
+# `+N days +12 hours`, so the twelve-hour cushion makes the floor deterministic instead
+# of racing the second boundary. Two different N kill a mutant that hardcodes or
+# mis-scales the value.
+_self_test() {
+  local dir rc=0
+  dir=$(mktemp -d)
+  trap 'rm -rf "$dir"' RETURN
+
+  # Compares everything EXCEPT the days field (7th), which has its own cases below.
+  _t() {  # $1 = name, $2 = expected record with `D` in the days slot, $3 = status, $4 = prefs
+    local g norm
+    if ! g=$(_parse_ts "$3" "$4" 2>/dev/null); then
+      echo "  [self-test] $1: parser exited non-zero"; rc=1; return 0
+    fi
+    norm=$(printf '%s' "$g" | awk -F'|' -v OFS='|' '{ if ($7 != "") $7 = "D"; print }')
+    if [ "$norm" = "$2" ]; then
+      echo "  [self-test] $1 -> ok"
+    else
+      echo "  [self-test] $1 FAILED: got '$norm', want '$2'"; rc=1
+    fi
+    return 0
+  }
+
+  cat >"$dir/adv-prefs.json" <<'J'
+{"AdvertiseRoutes":["192.168.50.0/24"],"RouteAll":false,"WantRunning":true}
+J
+
+  # A subnet router that IS advertising and HAS been approved. PrimaryRoutes and
+  # AdvertiseRoutes carry the SAME string -- that is the trap: reading either one alone
+  # answers both questions identically and certifies an unapproved router.
+  cat >"$dir/approved.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"workbench","DNSName":"workbench.tailnet.example.test.","Online":true,
+         "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":["192.168.50.0/24"]}}
+J
+  _t "advertised + approved                       " \
+     "Running|true|100.100.10.5|192.168.50.0/24|192.168.50.0/24|2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "$dir/approved.json" "$dir/adv-prefs.json"
+
+  # 🔴 THE CASE THIS SCRIPT EXISTS FOR: advertised, NOT approved. Identical on the node
+  # side; PrimaryRoutes is the only thing that differs, and it is EMPTY.
+  cat >"$dir/unapproved.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"workbench","Online":true,
+         "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":[]}}
+J
+  _t "advertised but NOT approved (empty Primary) " \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "$dir/unapproved.json" "$dir/adv-prefs.json"
+
+  # PrimaryRoutes absent entirely (the field is omitempty) must read the SAME as empty,
+  # not as a parser failure and not as approval.
+  cat >"$dir/noprimary.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"workbench","Online":true,"KeyExpiry":"2099-01-02T03:04:05Z"}}
+J
+  _t "PrimaryRoutes absent == not approved        " \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "$dir/noprimary.json" "$dir/adv-prefs.json"
+
+  # Key expiry DISABLED, both spellings. Omitted...
+  cat >"$dir/noexpiry.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"laptop","Online":true,"PrimaryRoutes":[]}}
+J
+  _t "key expiry disabled (field omitted)         " \
+     "Running|true|100.100.10.5|||||?|none" "$dir/noexpiry.json" "-"
+  # ...and spelled as the Go zero time, which is NOT an expiry in the year 1.
+  cat >"$dir/zeroexpiry.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"laptop","Online":true,"KeyExpiry":"0001-01-01T00:00:00Z","PrimaryRoutes":[]}}
+J
+  _t "key expiry disabled (Go zero time)          " \
+     "Running|true|100.100.10.5|||||?|none" "$dir/zeroexpiry.json" "-"
+
+  # A logged-out node: BackendState carries it, Online is false, no addresses.
+  cat >"$dir/needslogin.json" <<'J'
+{"BackendState":"NeedsLogin","AuthURL":"https://login.example.test/a/abc","TailscaleIPs":[],
+ "Self":{"HostName":"laptop","Online":false}}
+J
+  _t "NeedsLogin (not authenticated)              " \
+     "NeedsLogin|false||||||?|none" "$dir/needslogin.json" "-"
+
+  # A plain client that ACCEPTS routes. RouteAll is the `--accept-routes` pref, and
+  # `AdvertiseRoutes: null` is how the daemon spells "none" -- distinct from `[]`.
+  cat >"$dir/client-prefs.json" <<'J'
+{"AdvertiseRoutes":null,"RouteAll":true,"WantRunning":true}
+J
+  _t "client prefs: null routes, RouteAll on      " \
+     "Running|true|100.100.10.5|||||true|prefs" "$dir/noexpiry.json" "$dir/client-prefs.json"
+
+  # --- the DAYS arithmetic, at two points -------------------------------------------
+  local n exp got_days
+  for n in 10 400; do
+    exp=$(date -u -d "+${n} days +12 hours" +%Y-%m-%dT%H:%M:%SZ)
+    printf '{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],"Self":{"Online":true,"KeyExpiry":"%s"}}\n' \
+      "$exp" >"$dir/exp-$n.json"
+    got_days=$(_parse_ts "$dir/exp-$n.json" "-" | cut -d'|' -f7)
+    if [ "$got_days" = "$n" ]; then
+      echo "  [self-test] expiry in $n days -> reports $n -> ok"
+    else
+      echo "  [self-test] expiry in $n days FAILED: reports '$got_days'"; rc=1
+    fi
+  done
+  # An ALREADY-EXPIRED key must report a negative number, not be mistaken for disabled.
+  exp=$(date -u -d "-5 days -12 hours" +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],"Self":{"Online":true,"KeyExpiry":"%s"}}\n' \
+    "$exp" >"$dir/exp-past.json"
+  got_days=$(_parse_ts "$dir/exp-past.json" "-" | cut -d'|' -f7)
+  case "$got_days" in
+    -*) echo "  [self-test] an already-expired key reports $got_days (negative) -> ok" ;;
+    *)  echo "  [self-test] an already-expired key FAILED: reports '$got_days'"; rc=1 ;;
+  esac
+
+  # --- the parser must REFUSE rather than answer -------------------------------------
+  local f
+  for f in notstatus broken notprefs; do
+    case "$f" in
+      notstatus) printf '{"hello":"world"}\n' >"$dir/$f.json"
+                 set -- "$dir/$f.json" "-"
+                 ;;
+      broken)    printf 'not json at all\n' >"$dir/$f.json"
+                 set -- "$dir/$f.json" "-"
+                 ;;
+      notprefs)  printf '{"RouteAll":true}\n' >"$dir/$f.json"
+                 set -- "$dir/approved.json" "$dir/$f.json"
+                 ;;
+    esac
+    if _parse_ts "$1" "$2" >/dev/null 2>&1; then
+      echo "  [self-test] $f: FAILED -- parser answered instead of exiting 2"; rc=1
+    else
+      echo "  [self-test] $f -> rc 2, not a false 'nothing advertised' -> ok"
+    fi
+  done
+  # An UNREADABLE KeyExpiry must also refuse. Reporting it as "" would print
+  # "DISABLED -- this node key does not expire" for a key that does expire.
+  printf '{"BackendState":"Running","Self":{"Online":true,"KeyExpiry":"whenever"}}\n' >"$dir/badexp.json"
+  if _parse_ts "$dir/badexp.json" "-" >/dev/null 2>&1; then
+    echo "  [self-test] unreadable KeyExpiry FAILED -- answered instead of exiting 2"; rc=1
+  else
+    echo "  [self-test] unreadable KeyExpiry -> rc 2, not a false 'DISABLED' -> ok"
+  fi
+
+  # --- the verdict predicate, driven -------------------------------------------------
+  # The parser being right is not the same as the VERDICT being right. Drive _in_csv
+  # directly, in BOTH directions, so it cannot be wired to nothing.
+  if _in_csv "192.168.50.0/24" "192.168.50.0/24"; then
+    echo "  [self-test] _in_csv exact match -> ok"
+  else
+    echo "  [self-test] _in_csv exact match FAILED"; rc=1
+  fi
+  if _in_csv "192.168.50.0/24" "10.0.0.0/8,192.168.50.0/24,::/0"; then
+    echo "  [self-test] _in_csv middle of a list -> ok"
+  else
+    echo "  [self-test] _in_csv middle of a list FAILED"; rc=1
+  fi
+  if _in_csv "192.168.50.0/24" ""; then
+    echo "  [self-test] _in_csv on an EMPTY list FAILED: said yes"; rc=1
+  else
+    echo "  [self-test] _in_csv on an EMPTY list -> no -> ok"
+  fi
+  # 🔴 A SUBSTRING must not count: /24 is a substring of /241, and a prefix match would
+  # also accept the wrong mask /2. Both would certify a router advertising the wrong
+  # thing.
+  if _in_csv "192.168.50.0/24" "192.168.50.0/241"; then
+    echo "  [self-test] _in_csv substring FAILED: /241 matched /24"; rc=1
+  else
+    echo "  [self-test] _in_csv rejects a substring (/241 != /24) -> ok"
+  fi
+  if _in_csv "192.168.50.0/24" "192.168.50.0/16"; then
+    echo "  [self-test] _in_csv FAILED: a different mask matched"; rc=1
+  else
+    echo "  [self-test] _in_csv rejects a different mask (/16 != /24) -> ok"
+  fi
+  return $rc
+}
+
+if [ "$SELFTEST" = "1" ]; then
+  command -v python3 >/dev/null 2>&1 || {
+    echo "CANNOT DETERMINE: python3 is not on PATH" >&2; exit 2; }
+  echo "parser self-test:"
+  st_rc=0
+  _self_test || st_rc=$?     # 🔴 `rc=0` FIRST, then `f || rc=$?`. A bare `f; rc=$?`
+                             # is dead code under `set -e`, and `f || rc=$?` without
+                             # the seed dies under `set -u` on the SUCCESS path.
+  if [ "$st_rc" != "0" ]; then
+    echo "self-test: FAILED -- the parser's verdict would mean nothing" >&2
+    exit 2                   # 2, not 1: 1 means "tailscale is wrong", another claim
+  fi
+  echo "self-test: all controls passed"
+  exit 0
+fi
+
+# --- preconditions -----------------------------------------------------------------
+command -v python3 >/dev/null 2>&1 || {
+  echo "CANNOT DETERMINE: python3 is not on PATH." >&2
+  echo "  It is NOT in /run/current-system/sw/bin on these hosts. Run this from a" >&2
+  echo "  shell that has one (the devrc nix develop shell does)." >&2
+  exit 2; }
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "CANNOT DETERMINE: no \`tailscale\` binary on PATH." >&2
+  echo "  Tailscale has not been applied to this host yet:" >&2
+  echo "    sudo env \"PATH=\$PATH\" bash nix/system/apply-tailscale.sh" >&2
+  exit 2
+fi
+
+# --- which host is this? ------------------------------------------------------------
+# 🔴 `hostname` CANNOT discriminate these machines -- BOTH answer `nixos`. The nebula
+# mesh address is unique by construction, so that is the discriminator.
+#
+# 🔴 BUT NEBULA MAY BE THE THING THAT IS BROKEN. Tailscale exists precisely as the
+# backup for a dead nebula, so the interface being absent is the EXPECTED case when
+# this script matters most. It is not guessed at: the role is reported as ambiguous
+# and the exact `--role` remedy is printed. Pass `--role` and the probe never runs.
+if [ -z "$ROLE" ]; then
+  mesh=$(ip -4 -o addr show nebula.mesh 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1)
+  case "$mesh" in
+    "$MESH_SERVER") ROLE=server ;;
+    "$MESH_CLIENT") ROLE=client ;;
+    "")  echo "CANNOT DETERMINE: no address on nebula.mesh, so the host role cannot be" >&2
+         echo "  auto-detected. This is EXPECTED when nebula is down -- which is exactly" >&2
+         echo "  when tailscale matters. Say which host this is:" >&2
+         echo "    bash ${BASH_SOURCE[0]} --role server   # the workbench (subnet router)" >&2
+         echo "    bash ${BASH_SOURCE[0]} --role client   # the laptop" >&2
+         exit 2 ;;
+    *)   echo "CANNOT DETERMINE: nebula.mesh is $mesh, which is neither the workbench" >&2
+         echo "  ($MESH_SERVER) nor the laptop ($MESH_CLIENT). Refusing to guess a role." >&2
+         echo "  Re-run with --role server or --role client if you mean it." >&2
+         exit 2 ;;
+  esac
+  echo "role    : $ROLE  (from nebula.mesh = $mesh)"
+else
+  echo "role    : $ROLE  (forced -- validated at argument-parse time, above)"
+fi
+
+# --- the parser earns its verdict before the verdict is read ------------------------
+echo "parser self-test:"
+st_rc=0
+_self_test || st_rc=$?
+if [ "$st_rc" != "0" ]; then
+  echo "CANNOT DETERMINE: the parser failed its own controls -- its verdict would mean nothing" >&2
+  exit 2
+fi
+
+# --- live runtime state --------------------------------------------------------------
+TMPD=$(mktemp -d)
+trap 'rm -rf "$TMPD"' EXIT
+
+# 🔴 Key the verdict on the CONTENT, never on an exit code that reports something else.
+# `tailscale status` exits NON-ZERO for perfectly readable states (a stopped or
+# logged-out backend), so treating rc as the signal reports "cannot read tailscale" for
+# a daemon that answered fully and truthfully -- the exact inverse of the truth. Take
+# the JSON if it parses; the rc is only worth looking at when it does not.
+ts_rc=0
+tailscale status --json >"$TMPD/status.json" 2>"$TMPD/status.err" || ts_rc=$?
+if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/status.json" 2>/dev/null; then
+  echo "CANNOT DETERMINE: \`tailscale status --json\` produced no readable JSON (rc=$ts_rc)." >&2
+  sed 's/^/    | /' "$TMPD/status.err" >&2 || true
+  echo "  The daemon is not reachable. Check it is actually RUNNING, not merely" >&2
+  echo "  configured:  systemctl status tailscaled" >&2
+  exit 2
+fi
+
+# Prefs are how the node's OWN advertisement is read. Optional: without them the
+# ADVERTISED claim is reported as UNKNOWN rather than silently as "nothing".
+prefs_arg="-"
+if tailscale debug prefs >"$TMPD/prefs.json" 2>"$TMPD/prefs.err"; then
+  if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/prefs.json" 2>/dev/null; then
+    prefs_arg="$TMPD/prefs.json"
+  fi
+fi
+
+if ! rec=$(_parse_ts "$TMPD/status.json" "$prefs_arg"); then
+  echo "CANNOT DETERMINE: could not parse the daemon's own state" >&2
+  exit 2
+fi
+IFS='|' read -r backend online ips advertised primary expiry days route_all prefs_src <<<"$rec"
+
+# CONTEXT ONLY -- deliberately not a verdict. `systemctl cat` exits 0 for a dead unit
+# and `is-active` says nothing about whether the node is authenticated or routing.
+unit_state=$(systemctl is-active tailscaled.service 2>/dev/null || true)
+
+if [ "$ROLE" = "server" ]; then
+  UP_CMD="sudo tailscale up --advertise-routes=${SUBNET} --accept-dns=false"
+else
+  UP_CMD="sudo tailscale up --accept-routes"
+fi
+
+echo
+echo "daemon  : tailscaled unit is '${unit_state:-unknown}'  (context only -- no verdict is keyed on it)"
+echo "backend : $backend"
+echo "online  : $online"
+echo "addrs   : ${ips:-<none>}"
+echo "adverts : ${advertised:-<none>}   (source: $prefs_src -- what THIS NODE claims)"
+echo "primary : ${primary:-<none>}   (source: control plane -- what is APPROVED)"
+if [ -n "$expiry" ]; then
+  echo "keyexp  : $expiry  (${days} days from now)"
+else
+  echo "keyexp  : DISABLED -- this node key does not expire"
+fi
+echo
+
+# --- verdicts ------------------------------------------------------------------------
+rc=0
+fails=()
+actions=()
+
+if [ "$backend" != "Running" ]; then
+  fails+=("tailscaled backend is '$backend', not 'Running' -- this node carries no traffic.
+    If it is NeedsLogin or Stopped, bring it up:  $UP_CMD")
+fi
+if [ "$online" != "true" ]; then
+  fails+=("the control plane does not consider this node Online; it cannot be reached.")
+fi
+if [ -z "$ips" ]; then
+  fails+=("this node has no Tailscale address -- it has never authenticated to a tailnet.
+    Authenticate it:  $UP_CMD")
+fi
+
+if [ "$prefs_src" = "none" ]; then
+  fails+=("could not read \`tailscale debug prefs\`, so what this node ADVERTISES is
+    UNKNOWN. Deliberately not reported as 'advertises nothing' -- that would be a
+    definitive claim derived from a file that was never read.")
+elif [ "$ROLE" = "server" ]; then
+  if _in_csv "$SUBNET" "$advertised"; then
+    echo "PASS  advertise : this node advertises $SUBNET"
+  else
+    fails+=("this node does NOT advertise $SUBNET (advertised: ${advertised:-<none>}).
+    Fix:  $UP_CMD")
+  fi
+elif [ -n "$advertised" ]; then
+  echo "NOTE  advertise : a CLIENT is advertising routes ($advertised) -- not wrong, but"
+  echo "                  the laptop is meant to be a plain client."
+else
+  echo "PASS  advertise : plain client, advertises nothing (as intended)"
+fi
+
+if [ "$ROLE" = "server" ]; then
+  # 🔴 THE SECOND, DIFFERENT CLAIM. An advertised-but-unapproved route looks IDENTICAL
+  # to success from this node and carries no traffic at all.
+  if _in_csv "$SUBNET" "$primary"; then
+    echo "PASS  approved  : $SUBNET is APPROVED in the admin console; this node is its primary router"
+  else
+    actions+=("$SUBNET is advertised but NOT APPROVED. It carries NO traffic until a
+    human approves it, and the node cannot tell the difference. This CANNOT be
+    scripted -- the admin console is the only place it exists:
+      https://login.tailscale.com/admin/machines -> this machine -> ... ->
+      Edit route settings -> tick $SUBNET -> Save")
+  fi
+
+  # Forwarding, read from the KERNEL. A sysctl that is in the config but was never
+  # activated reads as ON if you read the config instead of /proc.
+  #
+  # TS_PROC_ROOT exists so BOTH directions of this check can be driven from fixtures.
+  # A guard whose failing branch has never been watched execute is not evidence, and
+  # neither host currently has ipv6 forwarding on, so the passing branch alone would
+  # be all anyone ever saw.
+  v4=$(cat "${TS_PROC_ROOT:-/proc}/sys/net/ipv4/ip_forward" 2>/dev/null || echo "?")
+  v6=$(cat "${TS_PROC_ROOT:-/proc}/sys/net/ipv6/conf/all/forwarding" 2>/dev/null || echo "?")
+  if [ "$v4" = "1" ]; then
+    echo "PASS  forward4  : net.ipv4.ip_forward = 1 (live, from /proc)"
+  else
+    fails+=("net.ipv4.ip_forward is '$v4', not 1. A subnet router that cannot forward
+    advertises a route into a black hole. Read from /proc, so this is the KERNEL's
+    answer and not the config's.")
+  fi
+  if [ "$v6" = "1" ]; then
+    echo "PASS  forward6  : net.ipv6.conf.all.forwarding = 1 (live, from /proc)"
+  else
+    actions+=("net.ipv6.conf.all.forwarding is '$v6', not 1. IPv4 forwarding is what
+    $SUBNET needs, so this is reported rather than failed.")
+  fi
+
+  # The subnet has to actually be reachable FROM here, over something that is not
+  # tailscale itself. Advertising a subnet you are not on routes nothing.
+  lanroute=$(ip -4 -o route show 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -v 'dev tailscale' || true)
+  if [ -n "$lanroute" ]; then
+    echo "PASS  lanroute  : $SUBNET is directly reachable from this host --"
+    printf '                  %s\n' "$lanroute"
+  else
+    fails+=("no non-tailscale route to $SUBNET in \`ip route\`. This host is advertising
+    a subnet it is not on; traffic arriving over tailscale would have nowhere to go.")
+  fi
+else
+  if [ "$route_all" = "true" ]; then
+    echo "PASS  acceptrt  : this client accepts subnet routes (RouteAll / --accept-routes)"
+  elif [ "$prefs_src" = "prefs" ]; then
+    actions+=("this client does not accept subnet routes (RouteAll=$route_all), so the
+    workbench's $SUBNET advertisement will not be installed here. Fix:  $UP_CMD")
+  fi
+  if ip -4 -o route show 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -q 'dev tailscale'; then
+    echo "PASS  lanroute  : $SUBNET is installed here via a tailscale interface"
+  else
+    actions+=("$SUBNET is not in this host's routing table via tailscale. Either the
+    route is not approved in the admin console, or --accept-routes is off here, or the
+    workbench is not advertising. Check the workbench with --role server.")
+  fi
+fi
+
+# 🔴 KEY EXPIRY. Enabled at all is an outstanding action, because the 180-day default is
+# SHORTER than the trip and the lapse is silent.
+if [ -z "$expiry" ]; then
+  echo "PASS  keyexpiry : disabled -- this node key will not expire mid-trip"
+else
+  actions+=("node key expiry is ENABLED: it expires $expiry, in $days days.
+    Tailscale's default is 180 days, shorter than a months-long trip, and when it lapses
+    this backup path goes dark with no local error. Disabling it is an ADMIN-CONSOLE
+    action that cannot be scripted:
+      https://login.tailscale.com/admin/machines -> this machine -> ... ->
+      Disable key expiry")
+fi
+
+echo
+if [ ${#fails[@]} -gt 0 ]; then
+  echo "FAIL: this host is NOT carrying a usable tailscale path."
+  for f in "${fails[@]}"; do printf '  - %s\n' "$f"; done
+  rc=1
+fi
+if [ ${#actions[@]} -gt 0 ]; then
+  echo "ACTION REQUIRED (admin console / human -- cannot be scripted):"
+  for a in "${actions[@]}"; do printf '  - %s\n' "$a"; done
+  # 🔴 NOT `[ "$rc" = 0 ] && rc=3`: under `set -e` an `a && b` whose test is FALSE
+  # fails as a whole and kills the script right before it prints its verdict.
+  if [ "$rc" = "0" ]; then rc=3; fi
+fi
+if [ "$rc" = "0" ]; then
+  echo "PASS: tailscale is a working second path on this host, and nothing is outstanding."
+fi
+exit "$rc"

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -17,6 +17,11 @@
 #   TS_SUBNET=192.168.50.0/24        the subnet the server role must advertise
 #   TS_EXPECT_MESH_IP_SERVER=10.42.0.30
 #   TS_EXPECT_MESH_IP_CLIENT=10.42.0.100
+#   TS_SETTLE_SECS=3                 how long to wait before RE-READING a daemon whose
+#                                    first answer is self-contradictory; 0 disables it
+#   TS_STATE_FILE=/var/lib/tailscale/tailscaled.state
+#                                    the on-disk fallback for "did this node ever hold an
+#                                    identity", consulted only when prefs are unreadable
 #
 # 🔴 IT READS LIVE RUNTIME STATE, NOT THE NIX CONFIG AND NOT THE UNIT FILE. Everything
 # below comes from `tailscale status --json` and `tailscale debug prefs` (the running
@@ -58,17 +63,22 @@
 # made the apply script roll back the config it had just installed. But the reverse error
 # is worse:
 #
-#   NONE       -- never authenticated. No addresses AND backend NeedsLogin/NoState/empty.
-#                 rc 4. Genuinely expected straight after apply.
-#   OK         -- an address in 100.64.0.0/10, a backend that is not a logged-out one, and
+#   NONE       -- never authenticated. No addresses, backend NeedsLogin/NoState/empty,
+#                 AND no persisted profile on disk. rc 4. Expected straight after apply.
+#   OK         -- a tailnet address, a backend that is not a logged-out one, and
 #                 `Self.Expired` not set. Every other claim is judged against this.
 #   LOST       -- 🔴 THIS NODE HAD AN IDENTITY AND NO LONGER HAS ONE. rc 1, a FAIL.
 #                 Node keys expire after 180 days by default -- SHORTER THAN THE TRIP --
-#                 and `tailscale logout` / an admin revoke do the same thing. Two shapes,
-#                 and BOTH are handled because only one of them has been observed here:
+#                 and `tailscale logout` / an admin revoke do the same thing. THREE
+#                 shapes, all handled, because which one a given daemon emits has not
+#                 been observed here:
 #                   * the daemon drops the node to `NeedsLogin`/`NoState` while KEEPING
-#                     the netmap address it was issued; and
-#                   * `Self.Expired: true` with the backend still `Running`.
+#                     the netmap address it was issued;
+#                   * `Self.Expired: true` with the backend still `Running`; and
+#                   * 🔴 the RESTART shape -- no address, no `Self`, no `Expired` and no
+#                     `KeyExpiry` at all, but the daemon's PERSISTED prefs still name a
+#                     tailnet identity. See the next paragraph: this is the only shape
+#                     that survives a reboot, and the other two do not.
 #                 An earlier version required backend AND address to AGREE and called
 #                 disagreement "not authenticated", so an EXPIRED node printed
 #                 "THIS NODE HAS NEVER AUTHENTICATED ... that is the EXPECTED state
@@ -76,8 +86,24 @@
 #                 retained -- and exited 4, "no defect found". A checker that answers
 #                 "no defect" when the backup path is dead is worse than no checker.
 #   INCOHERENT -- a backend that is neither logged-out nor holding an address (e.g.
-#                 `Running` with an empty netmap). Not the post-apply state and not a
-#                 usable one. rc 1, with its own message: it does NOT claim expiry.
+#                 `Running` with an empty netmap). rc 4, with its own message: it does NOT
+#                 claim expiry and it is NOT a defect. See the rc-4 note below.
+#
+# 🔴 THE NETMAP DOES NOT SURVIVE A RESTART, SO NEITHER DO TWO OF THE THREE EXPIRY
+# DETECTORS. `TailscaleIPs`, `Self.Expired` and `Self.KeyExpiry` are all netmap fields,
+# and the netmap is in-memory only -- it is fed by control-plane map responses and there
+# is no restore-from-disk path. So on a node whose key lapsed, ONE reboot, power cut or
+# `nixos-rebuild switch` wipes all three at once: the daemon mints a new node key,
+# control answers with an AuthURL, no map poll happens, and `tailscale status` reports
+# `NeedsLogin` with nothing in it. Judged on the netmap alone that is a FRESH INSTALL --
+# rc 4, "no defect found", "It is NOT a node-side defect" -- about a backup path that is
+# dead. `lost` would only have survived while the daemon had run CONTINUOUSLY since
+# before the lapse, which over a months-long trip is not a safe assumption.
+# So the fourth signal is read from something durable: the daemon's persisted prefs
+# (`Config`/`ipn.Prefs.Persist`, reloaded from `tailscaled.state` on every start). A
+# non-empty NodeID or LoginName there means a login was COMPLETED on this host at some
+# point, and a logged-out backend on top of that is a LOST identity. Absence still reads
+# as `none`, because a genuinely fresh install has no persisted profile.
 #
 # Exit: 0 = every claim holds, including admin-console approval and disabled key expiry
 #       3 = everything THIS HOST controls is correct, but an ADMIN-CONSOLE action is
@@ -89,9 +115,12 @@
 #           evaluated. The common cause is that the node has NEVER authenticated -- the
 #           EXPECTED state straight after apply-tailscale.sh -- in which case
 #           advertisement, route approval and key expiry are all unknowable rather than
-#           wrong. Also covers unreadable prefs on a node that IS authenticated. Like 3,
-#           this is NOT a reason to roll back a switch. It is NOT used for a node that
-#           has LOST an identity it once had; that is 1.
+#           wrong. Also covers unreadable prefs on a node that IS authenticated, and a
+#           daemon whose own state is self-contradictory (INCOHERENT above) -- which is
+#           what a daemon looks like before its first netmap arrives, and which this
+#           script re-reads once after a settle before reporting. Like 3, this is NOT a
+#           reason to roll back a switch. It is NOT used for a node that has LOST an
+#           identity it once had; that is 1.
 #       1 = a definitive node-side FAIL: the node HAS or HAD a tailnet identity and
 #           something about it is wrong -- an EXPIRED or REVOKED node key, a backend that
 #           is not Running, not Online, not advertising, forwarding off, or no LAN route.
@@ -159,35 +188,58 @@ _in_csv() {  # $1 = needle, $2 = csv
 # line as the claim that the node had never logged in.
 #
 # The signals, and which way each one cuts:
-#   * an address in 100.64.0.0/10 is DURABLE, and durability is the whole point: a node
-#     keeps it when the backend is `Stopped` (WantRunning=false) AND when its key has
-#     expired. So an address is evidence an identity was ISSUED -- never, on its own,
-#     evidence that it is still valid.
+#   * a TAILNET ADDRESS outlives the login: a node keeps the address it was issued when
+#     the backend is `Stopped` (WantRunning=false) and when its key has expired. So an
+#     address is evidence an identity was ISSUED -- never, on its own, evidence that it
+#     is still valid. ⚠ IT IS TESTED AS PRESENT-OR-ABSENT, NOT RANGE-CHECKED. This used
+#     to be written as "an address in 100.64.0.0/10", which reads as a range test the
+#     code has never performed. It is deliberately not added: `TailscaleIPs` is by
+#     construction the list the tailnet issued (100.64.0.0/10 and fd7a:115c:a1e0::/48),
+#     so a range test could only ever turn an unexpected-but-real address -- an IPv6-only
+#     netmap, a future range -- into "this node has no identity", which is the REASSURING
+#     answer and the one that hides a dead key.
 #   * `BackendState` is the daemon's own word for what it can do RIGHT NOW. `NeedsLogin`
 #     / `NoState` mean it cannot act as a tailnet member at this moment.
 #   * `Self.Expired` is the control plane saying the node key is dead while the backend
 #     may still read `Running`. It was parsed-adjacent and thrown away before.
+#   * the PERSISTED PROFILE in the daemon's prefs is the only one of the four that
+#     survives a restart -- the other three are netmap fields and the netmap is
+#     in-memory only. See the header.
 #
-# So: address + logged-out backend is not "no identity", it is a LOST one. Only the
-# absence of BOTH is "never authenticated".
+# So: address + logged-out backend is not "no identity", it is a LOST one -- and so is a
+# persisted profile + logged-out backend, even with the netmap gone. Only the absence of
+# ALL of them is "never authenticated".
 #
 # ⚠ WHICH SHAPE A REAL EXPIRY PRODUCES HAS NOT BEEN CAPTURED FROM A LIVE DAEMON HERE --
-# the two above are from documented behaviour. Both are therefore treated as LOST, so it
-# does not matter which one the daemon actually emits; the cost of handling the one that
-# never occurs is a dead branch, and the cost of handling neither is a silent dead path.
-_identity_state() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs, $3 = Expired
+# they are from documented behaviour. All are therefore treated as LOST, so it does not
+# matter which one the daemon actually emits; the cost of handling the one that never
+# occurs is a dead branch, and the cost of handling neither is a silent dead path.
+_identity_state() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs,
+                      # $3 = Self.Expired, $4 = persisted identity on disk
   # The control plane's explicit "this key is dead" outranks everything else, including a
   # backend that still says `Running`.
   if [ "$3" = "true" ]; then printf 'lost'; return 0; fi
   case "$1" in
     NeedsLogin|NoState|"")
-      # Logged out. WITH an address it had an identity and lost it; without one it never
-      # had any.
-      if [ -n "$2" ]; then printf 'lost'; else printf 'none'; fi ;;
+      # Logged out. WITH an address it had an identity and lost it.
+      if [ -n "$2" ]; then printf 'lost'; return 0; fi
+      # 🔴 NO ADDRESS IS NOT "NEVER AUTHENTICATED" -- THE NETMAP DOES NOT SURVIVE A
+      # RESTART. This is the whole restart hole: after a reboot or a `nixos-rebuild
+      # switch` on a node whose key lapsed, there is no address, no `Self`, no
+      # `KeyExpiry` and no `Expired` to see, so all three in-netmap detectors go blind
+      # together and the dead backup path reads as a fresh install. The DISK still
+      # remembers: a persisted profile ($4) means a login was completed here at some
+      # point, so a logged-out backend on top of it is a LOST identity, not the absence
+      # of one. Without that evidence the answer stays `none` -- a genuinely fresh
+      # install has no persisted profile, and that is the state every first apply is in.
+      if [ "$4" = "true" ]; then printf 'lost'; else printf 'none'; fi ;;
     *)
       # A backend that is not logged-out. With an address that is a live identity.
       # Without one the daemon is contradicting itself -- and that is neither the
-      # post-apply state (which is NeedsLogin) nor a usable one.
+      # post-apply state (which is NeedsLogin) nor a usable one. Deliberately NOT
+      # promoted to `lost` when a persisted profile exists: `Starting` with no netmap on
+      # an authenticated node is the ordinary few seconds after a daemon restart, and
+      # calling that a dead key would fail a node that is merely still coming up.
       if [ -n "$2" ]; then printf 'ok'; else printf 'incoherent'; fi ;;
   esac
 }
@@ -197,13 +249,30 @@ _identity_state() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs, $3
 # already known not to be importable from the python3 on the default PATH here.
 #
 # Emits ONE `|`-separated record so a caller cannot half-read it:
-#   backend|online|ips|advertised|primary|expiry_iso|expiry_days|route_all|prefs_src|expired
+#   backend|online|ips|advertised|primary|expiry_iso|expiry_days|route_all|prefs_src|expired|persisted
 #
 # 🔴 `expired` IS THE LAST FIELD AND IT IS READ. `Self.Expired` used to be sitting one
 # line away from `Self.KeyExpiry` in this parser and was never extracted, so the single
 # most likely way this backup path dies mid-trip -- the node key lapsing at ~180 days --
 # was invisible to every verdict below. It is appended rather than inserted so the field
 # positions the self-test asserts by index do not silently shift.
+#
+# 🔴 `persisted` IS THE ONLY SIGNAL HERE THAT SURVIVES A RESTART, and it is the whole
+# point of it existing. Everything the three expiry detectors read -- `TailscaleIPs`,
+# `Self.Expired`, `Self.KeyExpiry` -- lives in the NETMAP, which is in-memory only: it is
+# populated from control-plane map responses and there is no restore-from-disk path. So
+# on a reboot, a power cut or a `nixos-rebuild switch` AFTER the key lapsed, the daemon
+# mints a new node key, control answers with an AuthURL, no map poll happens, and status
+# comes back `NeedsLogin` with no `Self`, no address, no `KeyExpiry` and no `Expired`.
+# All three detectors go blind at once and the node reads as a FRESH INSTALL.
+# `Config` (`ipn.Prefs.Persist`) is different: prefs are written to and reloaded from
+# `tailscaled.state`, so a node that has ever completed a login still names its NodeID
+# and its UserProfile.LoginName there after any number of restarts. That is durable
+# evidence an identity was ISSUED -- exactly what `TailscaleIPs` used to be relied on for
+# and no longer can be. It is appended, for the same field-position reason as above.
+#
+# Absence still reads as "never authenticated" on purpose: a genuinely fresh install has
+# no persisted profile, and that is the state EVERY first apply lands in.
 #
 # Exits 2 rather than printing a record when the document is not what it claims to be,
 # so "the parser found nothing" can never be reported as "this node advertises nothing"
@@ -253,6 +322,7 @@ if raw and not raw.startswith("0001-01-01"):
         sys.exit(2)
 
 advertised, route_all, src = [], "?", "none"
+persisted = "false"
 if sys.argv[2] != "-":
     try:
         pf = load(sys.argv[2])
@@ -266,8 +336,30 @@ if sys.argv[2] != "-":
     route_all = "true" if pf.get("RouteAll") is True else "false"
     src = "prefs"
 
+    # The persisted identity. `ipn.Prefs.Persist` is marshalled under the key `Config`;
+    # `Persist` is accepted too so a build that spells it the Go field name is not read
+    # as a fresh install. Only a NON-EMPTY NodeID or LoginName counts -- a present but
+    # empty profile is what a daemon that has never logged in carries, and treating that
+    # as an identity would report every first-run host as a dead backup path and make
+    # apply-tailscale.sh roll back the config it had just installed.
+    #
+    # `LoggedOut` is deliberately NOT read as evidence. It would cover the
+    # `tailscale logout` shape (logout deletes the profile, so `Config` goes away with
+    # it), but what a never-logged-in daemon writes there has not been established here,
+    # and a false `true` on a fresh node is precisely the rollback above. An unverified
+    # signal is not added on the reassuring-to-check but expensive-to-be-wrong side.
+    pcfg = pf.get("Config")
+    if pcfg is None:
+        pcfg = pf.get("Persist")
+    if isinstance(pcfg, dict):
+        node_id = pcfg.get("NodeID")
+        up = pcfg.get("UserProfile")
+        login = up.get("LoginName") if isinstance(up, dict) else None
+        if (isinstance(node_id, str) and node_id) or (isinstance(login, str) and login):
+            persisted = "true"
+
 print("|".join((backend, online, ",".join(ips), ",".join(advertised),
-                ",".join(primary), expiry, days, route_all, src, expired)))
+                ",".join(primary), expiry, days, route_all, src, expired, persisted)))
 PY
 }
 
@@ -317,7 +409,7 @@ J
          "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":["192.168.50.0/24"]}}
 J
   _t "advertised + approved                       " \
-     "Running|true|100.100.10.5|192.168.50.0/24|192.168.50.0/24|2099-01-02T03:04:05+00:00|D|false|prefs|false" \
+     "Running|true|100.100.10.5|192.168.50.0/24|192.168.50.0/24|2099-01-02T03:04:05+00:00|D|false|prefs|false|false" \
      "$dir/approved.json" "$dir/adv-prefs.json"
 
   # 🔴 THE CASE THIS SCRIPT EXISTS FOR: advertised, NOT approved. Identical on the node
@@ -328,7 +420,7 @@ J
          "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":[]}}
 J
   _t "advertised but NOT approved (empty Primary) " \
-     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false" \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false|false" \
      "$dir/unapproved.json" "$dir/adv-prefs.json"
 
   # PrimaryRoutes absent entirely (the field is omitempty) must read the SAME as empty,
@@ -338,7 +430,7 @@ J
  "Self":{"HostName":"workbench","Online":true,"KeyExpiry":"2099-01-02T03:04:05Z"}}
 J
   _t "PrimaryRoutes absent == not approved        " \
-     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false" \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false|false" \
      "$dir/noprimary.json" "$dir/adv-prefs.json"
 
   # Key expiry DISABLED, both spellings. Omitted...
@@ -347,14 +439,14 @@ J
  "Self":{"HostName":"laptop","Online":true,"PrimaryRoutes":[]}}
 J
   _t "key expiry disabled (field omitted)         " \
-     "Running|true|100.100.10.5|||||?|none|false" "$dir/noexpiry.json" "-"
+     "Running|true|100.100.10.5|||||?|none|false|false" "$dir/noexpiry.json" "-"
   # ...and spelled as the Go zero time, which is NOT an expiry in the year 1.
   cat >"$dir/zeroexpiry.json" <<'J'
 {"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
  "Self":{"HostName":"laptop","Online":true,"KeyExpiry":"0001-01-01T00:00:00Z","PrimaryRoutes":[]}}
 J
   _t "key expiry disabled (Go zero time)          " \
-     "Running|true|100.100.10.5|||||?|none|false" "$dir/zeroexpiry.json" "-"
+     "Running|true|100.100.10.5|||||?|none|false|false" "$dir/zeroexpiry.json" "-"
 
   # 🔴 `Self.Expired` MUST REACH THE RECORD. Every other fixture in this file has the
   # field absent, so they all assert the LAST slot as `false` -- which a parser that
@@ -365,7 +457,7 @@ J
  "Self":{"HostName":"workbench","Online":true,"Expired":true,"PrimaryRoutes":[]}}
 J
   _t "Self.Expired reaches the record as 'true'  " \
-     "Running|true|100.100.10.5|192.168.50.0/24||||false|prefs|true" \
+     "Running|true|100.100.10.5|192.168.50.0/24||||false|prefs|true|false" \
      "$dir/expired.json" "$dir/adv-prefs.json"
 
   # A logged-out node: BackendState carries it, Online is false, no addresses.
@@ -374,7 +466,7 @@ J
  "Self":{"HostName":"laptop","Online":false}}
 J
   _t "NeedsLogin (not authenticated)              " \
-     "NeedsLogin|false||||||?|none|false" "$dir/needslogin.json" "-"
+     "NeedsLogin|false||||||?|none|false|false" "$dir/needslogin.json" "-"
 
   # A plain client that ACCEPTS routes. RouteAll is the `--accept-routes` pref, and
   # `AdvertiseRoutes: null` is how the daemon spells "none" -- distinct from `[]`.
@@ -382,7 +474,36 @@ J
 {"AdvertiseRoutes":null,"RouteAll":true,"WantRunning":true}
 J
   _t "client prefs: null routes, RouteAll on      " \
-     "Running|true|100.100.10.5|||||true|prefs|false" "$dir/noexpiry.json" "$dir/client-prefs.json"
+     "Running|true|100.100.10.5|||||true|prefs|false|false" "$dir/noexpiry.json" "$dir/client-prefs.json"
+
+  # 🔴 THE PERSISTED IDENTITY MUST REACH THE RECORD, AND THE EMPTY PROFILE MUST NOT.
+  # Every other prefs fixture here has no `Config` at all, so they all assert the last
+  # slot as `false` -- which a parser that hardcoded `false`, or never read the key,
+  # would satisfy. These two are the pair that can tell those apart, and they are the
+  # ONLY signal in this file that survives a daemon restart.
+  #
+  # The status side is `needslogin.json` on purpose: no address, no `Self.Expired`, no
+  # `KeyExpiry`. That is EXACTLY what a node whose key lapsed looks like after a reboot,
+  # and it is indistinguishable from a fresh install on every field except this one.
+  cat >"$dir/persisted-prefs.json" <<'J'
+{"AdvertiseRoutes":["192.168.50.0/24"],"RouteAll":false,"WantRunning":true,
+ "Config":{"NodeID":"nEXAMPLECafeBeef","UserProfile":{"LoginName":"operator@example.test"}}}
+J
+  _t "a persisted profile reaches the record       " \
+     "NeedsLogin|false||192.168.50.0/24||||false|prefs|false|true" \
+     "$dir/needslogin.json" "$dir/persisted-prefs.json"
+
+  # ...and the control against a parser that reports any `Config` key as an identity: a
+  # daemon that has never logged in carries an EMPTY profile, and reading that as
+  # "this node had an identity" would make every first run a FAIL and roll back the
+  # config apply-tailscale.sh had just installed.
+  cat >"$dir/emptyprofile-prefs.json" <<'J'
+{"AdvertiseRoutes":["192.168.50.0/24"],"RouteAll":false,"WantRunning":true,
+ "Config":{"NodeID":"","UserProfile":{"LoginName":"","DisplayName":""}}}
+J
+  _t "an EMPTY persisted profile is not an identity" \
+     "NeedsLogin|false||192.168.50.0/24||||false|prefs|false|false" \
+     "$dir/needslogin.json" "$dir/emptyprofile-prefs.json"
 
   # --- the DAYS arithmetic, at two points -------------------------------------------
   local n exp got_days
@@ -477,45 +598,63 @@ J
   # an EXPIRED node key exit 4 as "no defect found", which is the failure this whole
   # script exists to prevent.
   #
-  # The three `lost` rows are the ones that matter, and each carries DIFFERENT evidence:
-  # a retained address under two different logged-out backends, and the explicit
-  # `Expired` flag under a backend that still reads `Running`. A mutant that reads only
-  # the address, or only the flag, survives one row and dies on the others.
+  # The `lost` rows are the ones that matter, and each carries DIFFERENT evidence: a
+  # retained address under two different logged-out backends, the explicit `Expired` flag
+  # under a backend that still reads `Running`, and -- the only one that survives a
+  # RESTART -- a persisted profile on disk with no address at all. A mutant that reads
+  # only one of the three survives its row and dies on the others.
+  #
+  # 🔴 THE PERSISTED ROWS ARE THE RESTART HOLE. Every other `lost` row needs something
+  # the netmap holds, and the netmap is in-memory only: reboot a node whose key lapsed and
+  # the address, `Self`, `KeyExpiry` and `Expired` all vanish together, leaving exactly
+  # the `NeedsLogin`-with-nothing shape that the three rows above them call `none`.
   local a_case
   for a_case in \
-      "Running:100.100.10.5:false:ok:a logged-in node" \
-      "Stopped:100.100.10.5:false:ok:logged in but WantRunning=false -- the key still exists" \
-      "NeedsLogin::false:none:the state straight after apply-tailscale.sh" \
-      "NoState::false:none:the daemon has no state at all" \
-      "::false:none:an empty BackendState with no address is not evidence of anything" \
-      "NeedsLogin:100.100.10.5:false:lost:EXPIRED/REVOKED -- logged out but the netmap address was RETAINED" \
-      "NoState:100.100.10.5:false:lost:the same, via NoState" \
-      "Running:100.100.10.5:true:lost:Self.Expired outranks a backend that still says Running" \
-      ":100.100.10.5:false:lost:an address with no backend word is still an issued identity" \
-      "Running::false:incoherent:Running with an empty netmap is neither fresh nor usable" \
-      "Stopped::false:incoherent:Stopped with no address at all"; do
-    local a_backend a_ips a_exp a_want a_why a_got
-    IFS=':' read -r a_backend a_ips a_exp a_want a_why <<<"$a_case"
-    a_got=$(_identity_state "$a_backend" "$a_ips" "$a_exp")
+      "Running:100.100.10.5:false:false:ok:a logged-in node" \
+      "Stopped:100.100.10.5:false:false:ok:logged in but WantRunning=false -- the key still exists" \
+      "Running:100.100.10.5:false:true:ok:a live identity is still ok when a profile is also on disk" \
+      "NeedsLogin::false:false:none:the state straight after apply-tailscale.sh" \
+      "NoState::false:false:none:the daemon has no state at all" \
+      "::false:false:none:an empty BackendState, no address and no profile is not evidence of anything" \
+      "NeedsLogin:100.100.10.5:false:false:lost:EXPIRED/REVOKED -- logged out but the netmap address was RETAINED" \
+      "NoState:100.100.10.5:false:false:lost:the same, via NoState" \
+      "Running:100.100.10.5:true:false:lost:Self.Expired outranks a backend that still says Running" \
+      ":100.100.10.5:false:false:lost:an address with no backend word is still an issued identity" \
+      "NeedsLogin::false:true:lost:🔴 THE RESTART CASE -- netmap gone, but the DISK still holds a profile" \
+      "NoState::false:true:lost:the same, via NoState" \
+      "::false:true:lost:a persisted profile is evidence even with no backend word at all" \
+      "Running::false:false:incoherent:Running with an empty netmap is neither fresh nor usable" \
+      "Running::false:true:incoherent:still-coming-up is NOT a dead key, even with a profile on disk" \
+      "Stopped::false:false:incoherent:Stopped with no address at all"; do
+    local a_backend a_ips a_exp a_per a_want a_why a_got
+    IFS=':' read -r a_backend a_ips a_exp a_per a_want a_why <<<"$a_case"
+    a_got=$(_identity_state "$a_backend" "$a_ips" "$a_exp" "$a_per")
     if [ "$a_got" = "$a_want" ]; then
-      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp -> $a_got  ($a_why) -> ok"
+      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp / persisted=$a_per -> $a_got  ($a_why) -> ok"
     else
-      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp FAILED: got '$a_got', want '$a_want'"; rc=1
+      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp / persisted=$a_per FAILED: got '$a_got', want '$a_want'"; rc=1
     fi
   done
   # 🔴 THE RELATIONSHIP, not just the rows: a retained address must move the answer AWAY
-  # from `none`, and the Expired flag must move it away from `ok`. Asserted as a pair of
-  # inequalities so a table that happened to be right row-by-row for the wrong reason
-  # still has to satisfy the property the rows exist to express.
-  if [ "$(_identity_state NeedsLogin '' false)" = "$(_identity_state NeedsLogin 100.100.10.5 false)" ]; then
+  # from `none`, the Expired flag must move it away from `ok`, and a persisted profile
+  # must move a netmap-less logged-out node away from `none`. Asserted as inequalities so
+  # a table that happened to be right row-by-row for the wrong reason still has to satisfy
+  # the property the rows exist to express.
+  if [ "$(_identity_state NeedsLogin '' false false)" = "$(_identity_state NeedsLogin 100.100.10.5 false false)" ]; then
     echo "  [self-test] FAILED: a RETAINED address does not change the answer -- expiry is invisible"; rc=1
   else
     echo "  [self-test] a retained address changes NeedsLogin's answer (none -> lost) -> ok"
   fi
-  if [ "$(_identity_state Running 100.100.10.5 false)" = "$(_identity_state Running 100.100.10.5 true)" ]; then
+  if [ "$(_identity_state Running 100.100.10.5 false false)" = "$(_identity_state Running 100.100.10.5 true false)" ]; then
     echo "  [self-test] FAILED: Self.Expired does not change the answer -- the flag is discarded"; rc=1
   else
     echo "  [self-test] Self.Expired changes Running's answer (ok -> lost) -> ok"
+  fi
+  if [ "$(_identity_state NeedsLogin '' false false)" = "$(_identity_state NeedsLogin '' false true)" ]; then
+    echo "  [self-test] FAILED: a PERSISTED profile does not change the answer -- an expired key
+    that survived a restart still reads as a fresh install, which is the whole hole"; rc=1
+  else
+    echo "  [self-test] a persisted profile changes NeedsLogin-with-no-address (none -> lost) -> ok"
   fi
   return $rc
 }
@@ -592,35 +731,86 @@ fi
 TMPD=$(mktemp -d)
 trap 'rm -rf "$TMPD"' EXIT
 
-# 🔴 Key the verdict on the CONTENT, never on an exit code that reports something else.
-# `tailscale status` exits NON-ZERO for perfectly readable states (a stopped or
-# logged-out backend), so treating rc as the signal reports "cannot read tailscale" for
-# a daemon that answered fully and truthfully -- the exact inverse of the truth. Take
-# the JSON if it parses; the rc is only worth looking at when it does not.
-ts_rc=0
-tailscale status --json >"$TMPD/status.json" 2>"$TMPD/status.err" || ts_rc=$?
-if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/status.json" 2>/dev/null; then
-  echo "CANNOT DETERMINE: \`tailscale status --json\` produced no readable JSON (rc=$ts_rc)." >&2
-  sed 's/^/    | /' "$TMPD/status.err" >&2 || true
-  echo "  The daemon is not reachable. Check it is actually RUNNING, not merely" >&2
-  echo "  configured:  systemctl status tailscaled" >&2
-  exit 2
-fi
-
-# Prefs are how the node's OWN advertisement is read. Optional: without them the
-# ADVERTISED claim is reported as UNKNOWN rather than silently as "nothing".
-prefs_arg="-"
-if tailscale debug prefs >"$TMPD/prefs.json" 2>"$TMPD/prefs.err"; then
-  if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/prefs.json" 2>/dev/null; then
-    prefs_arg="$TMPD/prefs.json"
+# Reads the daemon's whole answer into the record variables. A FUNCTION because it is
+# called TWICE: once, and again after a short settle when the first answer is
+# self-contradictory (see the settle block below).
+_read_live_state() {
+  # 🔴 Key the verdict on the CONTENT, never on an exit code that reports something else.
+  # `tailscale status` exits NON-ZERO for perfectly readable states (a stopped or
+  # logged-out backend), so treating rc as the signal reports "cannot read tailscale" for
+  # a daemon that answered fully and truthfully -- the exact inverse of the truth. Take
+  # the JSON if it parses; the rc is only worth looking at when it does not.
+  ts_rc=0
+  tailscale status --json >"$TMPD/status.json" 2>"$TMPD/status.err" || ts_rc=$?
+  if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/status.json" 2>/dev/null; then
+    echo "CANNOT DETERMINE: \`tailscale status --json\` produced no readable JSON (rc=$ts_rc)." >&2
+    sed 's/^/    | /' "$TMPD/status.err" >&2 || true
+    echo "  The daemon is not reachable. Check it is actually RUNNING, not merely" >&2
+    echo "  configured:  systemctl status tailscaled" >&2
+    exit 2
   fi
-fi
 
-if ! rec=$(_parse_ts "$TMPD/status.json" "$prefs_arg"); then
-  echo "CANNOT DETERMINE: could not parse the daemon's own state" >&2
-  exit 2
+  # Prefs are how the node's OWN advertisement is read, and how the PERSISTED identity is
+  # read. Optional: without them the ADVERTISED claim is reported as UNKNOWN rather than
+  # silently as "nothing".
+  prefs_arg="-"
+  if tailscale debug prefs >"$TMPD/prefs.json" 2>"$TMPD/prefs.err"; then
+    if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMPD/prefs.json" 2>/dev/null; then
+      prefs_arg="$TMPD/prefs.json"
+    fi
+  fi
+
+  if ! rec=$(_parse_ts "$TMPD/status.json" "$prefs_arg"); then
+    echo "CANNOT DETERMINE: could not parse the daemon's own state" >&2
+    exit 2
+  fi
+  IFS='|' read -r backend online ips advertised primary expiry days route_all prefs_src expired persisted <<<"$rec"
+
+  # 🔴 THE SECOND, ON-DISK READING OF THE SAME QUESTION -- and it is deliberately narrow.
+  # It runs ONLY when prefs could not be read at all, because prefs are the authority
+  # when they are available and a second opinion that can only disagree with the
+  # authority is not worth the risk. `tailscaled.state` is mode 0600 root, so this is
+  # reachable only for a root caller whose local API is nevertheless unreadable -- a
+  # narrow case, but the alternative there is the restart hole with no detector at all.
+  #
+  # The marker is `"profile-`, a per-profile entry key, and NOT `_current-profile`: the
+  # latter is written for the empty profile a never-logged-in daemon carries, so keying
+  # on it would report a FRESH host as a dead backup path and make apply-tailscale.sh
+  # roll back the config it had just installed. The file is a JSON map whose VALUES are
+  # base64 (no `"` and no `-`), so the marker cannot be matched inside one. Nothing from
+  # the file is printed -- it holds this node's private keys.
+  if [ "$persisted" != "true" ] && [ "$prefs_src" = "none" ]; then
+    if [ -r "${TS_STATE_FILE:-/var/lib/tailscale/tailscaled.state}" ] \
+       && grep -q '"profile-' "${TS_STATE_FILE:-/var/lib/tailscale/tailscaled.state}" 2>/dev/null; then
+      persisted=true
+    fi
+  fi
+}
+_read_live_state
+
+# 🔴 THE SETTLE RE-READ. `incoherent` is "a backend that is not logged-out, holding no
+# address" -- and the most ordinary way to be in it is to have read the daemon in the few
+# seconds between `tailscaled` starting (or `tailscale up` being run) and its first
+# netmap arriving. The verdict text for it has always SAID so: "if tailscaled was only
+# just started it may still be fetching its netmap -- re-run this check before doing
+# anything else." Nothing ever re-ran it; the whole run was rendered off one instantaneous
+# sample, and apply-tailscale.sh -- which calls this checker with no settle window at all,
+# straight after `systemctl is-active` -- acted on it.
+#
+# So this run takes the second sample itself, ONCE, rather than telling a human to.
+# Only on `incoherent`: every other answer is already stable evidence, and re-reading a
+# `lost` or an `ok` would just cost a delay. `TS_SETTLE_SECS=0` disables it.
+_settle="${TS_SETTLE_SECS:-3}"
+case "$_settle" in ''|*[!0-9]*) _settle=3 ;; esac
+if [ "$(_identity_state "$backend" "$ips" "$expired" "$persisted")" = "incoherent" ] \
+   && [ "$_settle" != "0" ]; then
+  echo "settle  : the daemon's first answer was self-contradictory (backend '$backend',"
+  echo "          no tailnet address). That is what a daemon looks like BEFORE its first"
+  echo "          netmap arrives, so this run waits ${_settle}s and reads it once more"
+  echo "          rather than rendering a verdict off one instantaneous sample."
+  sleep "$_settle"
+  _read_live_state
 fi
-IFS='|' read -r backend online ips advertised primary expiry days route_all prefs_src expired <<<"$rec"
 
 # CONTEXT ONLY -- deliberately not a verdict. `systemctl cat` exits 0 for a dead unit
 # and `is-active` says nothing about whether the node is authenticated or routing.
@@ -674,7 +864,7 @@ unknowns=()
 # but it is now derived from a classifier that can say WHY it is not 1 -- because "never
 # had an identity" (rc 4, expected) and "had one and lost it" (rc 1, the backup path is
 # DEAD) used to be the same answer, and the reassuring one won.
-idstate=$(_identity_state "$backend" "$ips" "$expired")
+idstate=$(_identity_state "$backend" "$ips" "$expired" "$persisted")
 # An explicit `if`, not `[ ... ] && authed=1`. MEASURED on bash 5.3.15: that shape does
 # NOT abort mid-script under `set -e` -- but when it is the LAST statement executed it
 # becomes the script's exit status, so the same line is harmless here and would silently
@@ -700,23 +890,48 @@ case "$idstate" in
     fi
     ;;
   none)
-    noid_reason="\`tailscale up\` has never run on this host"
-    unknowns+=("THIS NODE HAS NEVER AUTHENTICATED to a tailnet (backend '$backend', no
-    addresses, Self.Expired '$expired'). That is the EXPECTED state immediately after
-    \`apply-tailscale.sh\`, which installs and starts the service but deliberately does
-    NOT log in -- \`tailscale up\` needs a browser. It is NOT a node-side defect, and
-    every claim below that depends on a tailnet identity is reported UNKNOWN rather than
-    guessed at. Authenticate it, then re-run this check:
+    # 🔴 NAME WHAT WAS OBSERVED, NOT ONE CAUSE OUT OF SEVERAL. This used to assert
+    # "\`tailscale up\` has never run on this host" -- one cause, stated as fact, by a run
+    # that cannot see a command's history. `none` is what a fresh install looks like, and
+    # it is ALSO what a node looks like after `tailscale logout` deleted its profile.
+    # What the run actually measured is the absence of all four pieces of evidence, so
+    # that is what it says.
+    noid_reason="this run found no tailnet address and no persisted profile on this node"
+    unknowns+=("THIS NODE HAS NEVER AUTHENTICATED to a tailnet, as far as this run can
+    see: backend '$backend', no addresses, Self.Expired '$expired', and no persisted
+    identity in the daemon's own prefs (\`Config\`/\`Persist\`, source: $prefs_src). That
+    combination is the EXPECTED state immediately after \`apply-tailscale.sh\`, which
+    installs and starts the service but deliberately does NOT log in -- \`tailscale up\`
+    needs a browser. A completed \`tailscale logout\` looks the same, because it deletes
+    the profile this run looks for; either way there is no identity here NOW. It is NOT a
+    node-side defect, and every claim below that depends on a tailnet identity is reported
+    UNKNOWN rather than guessed at. Authenticate it, then re-run this check:
       $UP_CMD")
     ;;
   lost)
     # 🔴 A FAIL, AND THE MOST IMPORTANT ONE IN THIS SCRIPT. This is what a lapsed node key
     # looks like from the node, and the trip is longer than the 180-day default.
+    #
+    # The evidence sentence is BUILT from what was actually observed. It used to be one
+    # fixed string claiming "the netmap addresses it was issued are still present:
+    # ${ips}" -- which prints "<none>" and then "a node that had never logged in would
+    # have NEITHER" whenever this state is reached via `Self.Expired` or via the persisted
+    # profile, neither of which needs an address.
+    lost_ev=""
+    if [ -n "$ips" ]; then
+      lost_ev="the netmap addresses it was issued are still present: $ips, which a node
+    that had never logged in would not have."
+    elif [ "$persisted" = "true" ]; then
+      lost_ev="there is no netmap address left -- the netmap is in-memory only and does
+    not survive a restart -- but the daemon's PERSISTED prefs still name a tailnet
+    identity for this node, which a host that had never logged in would not have."
+    else
+      lost_ev="Self.Expired is the control plane's own word that this node's key is dead."
+    fi
     noid_reason="this node's tailnet identity is EXPIRED or REVOKED (see the FAIL above)"
     fails+=("🔴 THIS NODE HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE. Backend is
-    '$backend', Self.Expired is '$expired', and the netmap addresses it was issued are
-    still present: ${ips:-<none>}. A node that had never logged in would have NEITHER --
-    so this is not the fresh-install state, it is an EXPIRED NODE KEY, a \`tailscale
+    '$backend', Self.Expired is '$expired', and $lost_ev
+    So this is not the fresh-install state, it is an EXPIRED NODE KEY, a \`tailscale
     logout\`, or a node removed/disabled in the admin console. THE BACKUP PATH IS DEAD
     RIGHT NOW: nothing reaches this host over tailscale until it is re-authenticated.
     Tailscale's default key lifetime is 180 days, which is shorter than a months-long
@@ -728,16 +943,31 @@ case "$idstate" in
       Disable key expiry")
     ;;
   *)
-    # `incoherent`: a backend that is neither logged-out nor holding an address.
-    noid_reason="the daemon's own state is self-contradictory (see the FAIL above)"
-    fails+=("the daemon reports backend '$backend' -- which is NOT one of the logged-out
-    states -- yet lists NO tailnet address at all. Those two cannot both be true of a
-    working node, so this run will not resolve them into either 'authenticated' or 'never
-    authenticated'. It is reported as a defect rather than as 'not yet determinable'
-    because a node in this state carries no traffic, and because the post-apply state is
-    \`NeedsLogin\` with no address, which is NOT this. If tailscaled was only just
-    started it may still be fetching its netmap -- re-run this check before doing
-    anything else. If it persists:
+    # 🔴 `incoherent` IS AN UNEVALUATED CLAIM, NOT A DEFECT -- AND IT IS ON THE OTHER SIDE
+    # OF THIS SCRIPT'S OWN LINE FROM WHERE IT USED TO SIT. It was a FAIL, so rc 1, so
+    # apply-tailscale.sh's `die` fired, the EXIT trap restored $CFG, and the operator was
+    # told the running system had NOT been restored -- all for a state whose own message
+    # says "re-run this check before doing anything else". The message was right and the
+    # exit code contradicted it. The cost of that spurious rollback is not a wasted run:
+    # `configuration.nix` loses the tailscale block while the RUNNING system keeps it, so
+    # the next `nixos-rebuild switch` by anyone silently deletes the backup path.
+    #
+    # This run has already taken a second sample after a settle (above), so reaching here
+    # means the state PERSISTED -- but "the daemon contradicts itself" is still a claim
+    # this run could not resolve into authenticated or not, not a measured defect. rc 4:
+    # loud, listed under NOT YET DETERMINABLE, and not a reason to roll back a switch.
+    # A node that is genuinely broken in a way this script can MEASURE -- forwarding off,
+    # no LAN route, an expired key -- still fails below, on its own evidence.
+    noid_reason="the daemon's own state is self-contradictory (see the note below)"
+    unknowns+=("THE DAEMON'S OWN STATE IS SELF-CONTRADICTORY: backend '$backend' -- which
+    is NOT one of the logged-out states -- yet it lists NO tailnet address at all. Those
+    two cannot both be true of a working node, so this run will not resolve them into
+    either 'authenticated' or 'never authenticated', and it does not call it a defect
+    either: an unevaluated claim is not evidence of one. A daemon that has only just
+    started, or one that has just been given \`tailscale up\`, looks exactly like this
+    until its first netmap arrives -- this run already waited and re-read once, so if you
+    are seeing this immediately after a restart, wait and run it again. If it persists,
+    the node is carrying no traffic and it is worth looking at directly:
       systemctl status tailscaled ; tailscale status
       $UP_CMD")
     ;;
@@ -803,7 +1033,9 @@ if [ "$ROLE" = "server" ]; then
     either (see the FAIL above), so approval cannot even be asked for yet -- there is
     nothing for the admin console to approve. Fix the advertisement FIRST, then re-run
     this check and expect an approval action to appear. NOTE EITHER WAY: $SUBNET carries
-    NO traffic over tailscale right now.")
+    NO traffic over tailscale VIA THIS NODE right now -- \`Self.PrimaryRoutes\` is a fact
+    about THIS node only, so it cannot and does not say whether some OTHER node in the
+    tailnet is an approved primary router for the same subnet.")
     else
       unknowns+=("$SUBNET is NOT in \`PrimaryRoutes\`, so it is not approved -- but this
     run could not read this node's own prefs, so it CANNOT tell whether the cause is an
@@ -811,7 +1043,10 @@ if [ "$ROLE" = "server" ]; then
     Those have different fixes (a browser vs \`tailscale up\` on this host) and this run
     has no evidence to choose between them. Get prefs readable and re-run:
       tailscale debug prefs
-    NOTE EITHER WAY: $SUBNET carries NO traffic over tailscale right now.")
+    NOTE EITHER WAY: $SUBNET carries NO traffic over tailscale VIA THIS NODE right now.
+    \`Self.PrimaryRoutes\` is a fact about THIS node only -- another node in the tailnet
+    could be an approved primary router for the same subnet and this run would not see
+    it.")
     fi
   fi
 

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -104,6 +104,10 @@
 # non-empty NodeID or LoginName there means a login was COMPLETED on this host at some
 # point, and a logged-out backend on top of that is a LOST identity. Absence still reads
 # as `none`, because a genuinely fresh install has no persisted profile.
+# MEASURED 2026-09-08, a real unprivileged tailscaled 1.102.3 that had never
+# authenticated: `Config` is `null`, `tailscaled.state` is the two bytes `{}` -- and
+# `LoggedOut` is **true**, which is why `LoggedOut` is NOT one of the signals. Reading it
+# as evidence of a lost identity would fail every first run.
 #
 # Exit: 0 = every claim holds, including admin-console approval and disabled key expiry
 #       3 = everything THIS HOST controls is correct, but an ADMIN-CONSOLE action is
@@ -343,11 +347,14 @@ if sys.argv[2] != "-":
     # as an identity would report every first-run host as a dead backup path and make
     # apply-tailscale.sh roll back the config it had just installed.
     #
-    # `LoggedOut` is deliberately NOT read as evidence. It would cover the
-    # `tailscale logout` shape (logout deletes the profile, so `Config` goes away with
-    # it), but what a never-logged-in daemon writes there has not been established here,
-    # and a false `true` on a fresh node is precisely the rollback above. An unverified
-    # signal is not added on the reassuring-to-check but expensive-to-be-wrong side.
+    # 🔴 `LoggedOut` IS NOT EVIDENCE OF A LOST IDENTITY, AND THAT IS MEASURED, NOT
+    # ASSUMED. It looks like it would cover the `tailscale logout` shape -- logout
+    # deletes the profile, so `Config` goes away with it -- but a real tailscaled
+    # 1.102.3, started fresh and never authenticated, reported `"LoggedOut": true` and
+    # `"Config": null` (measured 2026-09-08, unprivileged daemon, its own statedir).
+    # Reading it as an identity would therefore make EVERY first run a rc-1 FAIL and roll
+    # back the config apply-tailscale.sh had just installed. `Config` is the field that
+    # discriminates, and it is the only one used.
     pcfg = pf.get("Config")
     if pcfg is None:
         pcfg = pf.get("Persist")
@@ -773,12 +780,16 @@ _read_live_state() {
   # reachable only for a root caller whose local API is nevertheless unreadable -- a
   # narrow case, but the alternative there is the restart hole with no detector at all.
   #
-  # The marker is `"profile-`, a per-profile entry key, and NOT `_current-profile`: the
-  # latter is written for the empty profile a never-logged-in daemon carries, so keying
-  # on it would report a FRESH host as a dead backup path and make apply-tailscale.sh
-  # roll back the config it had just installed. The file is a JSON map whose VALUES are
-  # base64 (no `"` and no `-`), so the marker cannot be matched inside one. Nothing from
-  # the file is printed -- it holds this node's private keys.
+  # The marker is `"profile-`, a per-profile entry key, and NOT `_current-profile`: both
+  # key names exist in the 1.102.3 binary, but the latter is the pointer, written for the
+  # empty profile a never-logged-in daemon carries too, so keying on it could report a
+  # FRESH host as a dead backup path and make apply-tailscale.sh roll back the config it
+  # had just installed. Measured 2026-09-08 on a real unprivileged tailscaled 1.102.3
+  # that had never authenticated: its `tailscaled.state` was the two bytes `{}` --
+  # neither key present -- so this branch correctly finds nothing on a fresh host.
+  # The file is a JSON map whose VALUES are base64 (no `"` and no `-`), so the marker
+  # cannot be matched inside one. Nothing from the file is printed -- it holds this
+  # node's private keys.
   if [ "$persisted" != "true" ] && [ "$prefs_src" = "none" ]; then
     if [ -r "${TS_STATE_FILE:-/var/lib/tailscale/tailscaled.state}" ] \
        && grep -q '"profile-' "${TS_STATE_FILE:-/var/lib/tailscale/tailscaled.state}" 2>/dev/null; then

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -28,8 +28,18 @@
 # daemon's own answer), from /proc/sys (the kernel's own answer), and from `ip route`.
 # `systemctl cat tailscaled` exits 0 for a unit that is dead or was never started, so a
 # config that BUILT but never ACTIVATED reads as applied -- that exact bug is why
-# check-nebula-relays.sh was rewritten, and this script does not repeat it. The unit's
-# state is printed as CONTEXT only; no verdict is keyed on it.
+# check-nebula-relays.sh was rewritten, and this script does not repeat it.
+#
+# 🔴 THE UNIT'S STATE CARRIES EXACTLY ONE VERDICT, AND NO OTHERS. `is-active` says
+# nothing about whether the node is authenticated or routing -- so nothing about
+# identity, advertisement, approval or forwarding is keyed on it -- but it says
+# something decisive about LIVENESS. A `tailscaled` that is `inactive` or `failed` is a
+# dead backup path right now, and it used to be reported as rc 4, "no defect found":
+# with the daemon down there is no status and no prefs to read, so every claim comes out
+# merely unevaluated. That is now a FAIL. It is gated on the unit EXISTING
+# (`LoadState=loaded`), because on a host where tailscale was never installed
+# `is-active` prints `inactive` too, and failing there would make every first run roll
+# back its own switch. See the exit-code notes below.
 #
 # 🔴 ADVERTISED AND APPROVED ARE TWO DIFFERENT CLAIMS AND BOTH ARE PRINTED.
 #   * ADVERTISED lives on this node -- `AdvertiseRoutes` in the daemon's prefs. It is
@@ -128,6 +138,9 @@
 #       1 = a definitive node-side FAIL: the node HAS or HAD a tailnet identity and
 #           something about it is wrong -- an EXPIRED or REVOKED node key, a backend that
 #           is not Running, not Online, not advertising, forwarding off, or no LAN route.
+#           ALSO, independently of any identity: an installed `tailscaled` unit that is
+#           not running (see the unit paragraph above). A unit that does not exist on
+#           this host at all is NOT this -- that is the never-applied state and stays 4.
 #       2 = cannot determine -- tailscale absent, daemon unreachable, role ambiguous,
 #           parser failure, or the parser failed its own controls
 set -euo pipefail
@@ -823,9 +836,24 @@ if [ "$(_identity_state "$backend" "$ips" "$expired" "$persisted")" = "incoheren
   _read_live_state
 fi
 
-# CONTEXT ONLY -- deliberately not a verdict. `systemctl cat` exits 0 for a dead unit
-# and `is-active` says nothing about whether the node is authenticated or routing.
+# 🔴 TWO READS, AND THE SECOND ONE IS WHAT MAKES THE FIRST SAFE TO ACT ON.
+# `is-active` says nothing about whether the node is authenticated or routing -- no
+# verdict below about identity, advertisement, approval or forwarding is keyed on it --
+# but it does say whether the daemon is ALIVE, and a dead `tailscaled` is a dead backup
+# path. That single verdict is drawn below.
+#
+# 🔴 WHICH SIGNAL DECIDES THAT THE UNIT EXISTS: `LoadState`, NEVER `is-active`.
+# MEASURED on systemd 261, this host: for a service that does not exist at all,
+# `systemctl is-active` prints `inactive` (rc 4) -- BYTE-IDENTICAL to what it prints for
+# a unit that exists and is stopped -- while `systemctl show -p LoadState --value` prints
+# `not-found` for the absent one and `loaded` for real stopped units (checked against
+# `fstrim.service` and `emergency.service`). So `is-active` alone cannot tell "tailscale
+# was never applied here" from "tailscaled is down", and keying a FAIL on it would make
+# every never-applied host a node-side FAILURE -- which is rc 1, which is `die` and a
+# rollback in apply-tailscale.sh: the first-run blocker this script has been fixed for
+# twice already.
 unit_state=$(systemctl is-active tailscaled.service 2>/dev/null || true)
+unit_load=$(systemctl show -p LoadState --value tailscaled.service 2>/dev/null || true)
 
 # 🔴 `--accept-dns=false` ON BOTH ROLES, and the symmetry is the point. The reasoning is
 # the same on either machine: MagicDNS makes tailscale take over the host resolver, and
@@ -846,7 +874,9 @@ else
 fi
 
 echo
-echo "daemon  : tailscaled unit is '${unit_state:-unknown}'  (context only -- no verdict is keyed on it)"
+echo "daemon  : tailscaled unit is '${unit_state:-unknown}', LoadState '${unit_load:-unknown}'"
+echo "          (a unit that EXISTS and is not 'active' FAILS below; no other verdict is"
+echo "           keyed on the unit, and a unit that is not on this host at all is not one)"
 echo "backend : $backend"
 echo "online  : $online"
 echo "addrs   : ${ips:-<none>}"
@@ -870,6 +900,35 @@ rc=0
 fails=()
 actions=()
 unknowns=()
+
+# 🔴 A DEAD `tailscaled` IS A DEFECT, AND IT USED TO BE rc 4 -- "NOT YET DETERMINABLE (no
+# defect found)". With the daemon stopped or crashed there is no `tailscale status` and no
+# `tailscale debug prefs` to read, and the on-disk fallback needs root, so `_identity_state`
+# lands on `none` and every claim in this script comes out UNEVALUATED rather than wrong.
+# MEASURED two ways: a real tailscaled 1.102.3 killed mid-run did not move the exit code
+# off 4, and the fixture control below (`test_a_dead_tailscaled_unit_is_a_failure_not_
+# incomplete`) is RED against the code at dca21bfd for the same reason. "No defect found"
+# about a stopped daemon is the reassuring answer on the one fact the operator most needs
+# told from the far side of a trip.
+#
+# 🔴 GATED ON THE UNIT EXISTING, and that gate is the whole risk of this check. Only
+# `LoadState=loaded` counts as "the unit is really here" -- see the measurement beside the
+# reads above. Every other answer, INCLUDING `not-found` (never installed), `masked`, an
+# error, or an empty string from a host with no systemd or a systemctl too old for
+# `--value`, leaves this run exactly as it was before this block existed. Deliberately
+# fail-OPEN: this guard may only ever add a finding about a unit it has positively
+# identified, because the false positive costs a rollback of a correct switch.
+if [ "$unit_load" = "loaded" ] && [ "$unit_state" != "active" ]; then
+  fails+=("🔴 THE tailscaled UNIT IS INSTALLED ON THIS HOST BUT IS NOT RUNNING:
+    \`systemctl is-active tailscaled.service\` says '${unit_state:-unknown}', and its
+    LoadState is 'loaded', so the unit genuinely exists here -- this is NOT the
+    never-installed state. THE BACKUP PATH IS DEAD RIGHT NOW: a daemon that is not
+    running carries no traffic and answers no login, whatever else this run could or
+    could not evaluate about the node's identity. Read why it stopped, then start it:
+      systemctl status tailscaled
+      journalctl -u tailscaled -b --no-pager | tail -50
+      sudo systemctl start tailscaled")
+fi
 
 # 🔴 FOUR ANSWERS, THREE OUTCOMES. `authed` stays as the one flag the claims below read,
 # but it is now derived from a classifier that can say WHY it is not 1 -- because "never

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -42,14 +42,36 @@
 # remaining are reported, and expiry being ENABLED AT ALL is treated as an outstanding
 # action, not as a pass.
 #
+# 🔴 AN ABSENT `KeyExpiry` IS AMBIGUOUS AND IS NOT RESOLVED TO "DISABLED". The field is
+# missing in three different situations -- expiry genuinely disabled, the node never
+# authenticated so no node key exists at all, and a build that does not emit it -- and
+# only the first is reassuring. Resolving absence to the reassuring branch printed
+# `PASS keyexpiry : disabled` on a node that had never logged in, for the single item
+# most likely to kill this path silently mid-trip. "Disabled" is now claimed ONLY when
+# the node IS authenticated; otherwise the claim is UNKNOWN (see rc 4).
+#
+# 🔴 AUTHENTICATED IS A FIRST-CLASS STATE, NOT A FAILURE. `apply-tailscale.sh` installs
+# the service and switches; it deliberately does NOT run `tailscale up`, which needs a
+# browser. So immediately after a successful apply the node is configured, running, and
+# has no tailnet identity at all -- backend `NeedsLogin`, no address, nothing
+# advertised, no key. Reporting that as a node-side FAIL made the apply script roll back
+# the config it had just installed. It is rc 4.
+#
 # Exit: 0 = every claim holds, including admin-console approval and disabled key expiry
 #       3 = everything THIS HOST controls is correct, but an ADMIN-CONSOLE action is
 #           still outstanding (route not approved, and/or key expiry still enabled).
 #           Split out from 1 on purpose: it is not a defect on the node, it is a human
 #           step that cannot be scripted, and apply-tailscale.sh must not roll back a
 #           correct switch because a browser tab has not been clicked yet.
-#       1 = a definitive node-side FAIL (not running, not authenticated, not
-#           advertising, forwarding off, no LAN route)
+#       4 = INCOMPLETE. No defect was found, but one or more claims could not be
+#           evaluated. Overwhelmingly the common cause is that the node has not
+#           authenticated yet -- the EXPECTED state straight after apply-tailscale.sh --
+#           in which case advertisement, route approval and key expiry are all
+#           unknowable rather than wrong. Also covers unreadable prefs. Like 3, this is
+#           NOT a reason to roll back a switch.
+#       1 = a definitive node-side FAIL: the node HAS a tailnet identity and something
+#           about it is wrong (backend not Running, not Online, not advertising,
+#           forwarding off, no LAN route).
 #       2 = cannot determine -- tailscale absent, daemon unreachable, role ambiguous,
 #           parser failure, or the parser failed its own controls
 set -euo pipefail
@@ -60,12 +82,23 @@ MESH_CLIENT="${TS_EXPECT_MESH_IP_CLIENT:-10.42.0.100}"
 ROLE="${TS_ROLE:-}"
 SELFTEST=0
 
+# 🔴 The help text is the comment header, printed to WHEREVER IT ENDS -- deliberately not
+# a hardcoded line range. `sed -n '2,56p'` overshot by two lines and printed the literal
+# `set -euo pipefail` as if it were documentation, and apply-tailscale.sh's equivalent
+# UNDERSHOT and silently dropped its whole rollback/idempotency paragraph. A range is a
+# second copy of a fact the file already states; this reads the fact.
+_print_help() { awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --self-test) SELFTEST=1; shift ;;
-    --role)      ROLE="${2:-}"; shift 2 ;;
+    # 🔴 `--role` AS THE FINAL ARGUMENT. `shift 2` with one argument left fails, and
+    # under `set -e` that killed the script with exit 1 and NOTHING printed -- the
+    # operator sees a bare failure and no hint of what is wrong. Checked explicitly.
+    --role)      [ $# -ge 2 ] || { echo "CANNOT DETERMINE: --role needs a value ('server' or 'client'); it was given as the last argument with nothing after it." >&2; exit 2; }
+                 ROLE="$2"; shift 2 ;;
     --role=*)    ROLE="${1#--role=}"; shift ;;
-    -h|--help)   sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)   _print_help; exit 0 ;;
     *)           echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -86,6 +119,26 @@ esac
 _in_csv() {  # $1 = needle, $2 = csv
   case ",${2}," in *,"${1}",*) return 0 ;; esac
   return 1
+}
+
+# --- has this node ever authenticated to a tailnet? -----------------------------------
+# 🔴 THE STATE apply-tailscale.sh LANDS IN, and the reason this predicate exists rather
+# than being inlined: the apply script installs the service and switches, then asks this
+# checker whether to keep the change. Straight after that switch the node has NEVER run
+# `tailscale up` (it needs a browser), so backend is `NeedsLogin`, there is no address,
+# nothing is advertised and there is no node key. Reporting that as a node-side FAIL is
+# what made the apply script roll back a config it had just installed correctly.
+#
+# TWO signals, and they must AGREE -- disagreement means NOT authenticated, because the
+# reassuring answer is the one that has to carry more evidence:
+#   * an address in 100.64.0.0/10 is the DURABLE signal. A node that has completed
+#     `tailscale up` keeps it even when the backend is `Stopped` (WantRunning=false).
+#   * `BackendState` is the daemon saying it in words. `NeedsLogin` / `NoState` mean
+#     there is no tailnet identity, whatever else is in the document.
+_authenticated() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs
+  [ -n "$2" ] || return 1
+  case "$1" in NeedsLogin|NoState|"") return 1 ;; esac
+  return 0
 }
 
 # --- the parser -------------------------------------------------------------------
@@ -340,6 +393,31 @@ J
   else
     echo "  [self-test] _in_csv rejects a different mask (/16 != /24) -> ok"
   fi
+
+  # --- _authenticated, driven in BOTH directions -------------------------------------
+  # 🔴 The whole rc-4 split, and the key-expiry claim, hang off this one predicate. A
+  # version that answered "yes" to everything would make rc 4 unreachable and put the
+  # post-switch FAIL back; one that answered "no" to everything would make rc 0
+  # unreachable and permanently report a working node as not-yet-set-up. Both directions
+  # are driven, on the exact states the daemon emits.
+  local a_case
+  for a_case in \
+      "Running:100.100.10.5:yes:a logged-in node" \
+      "Stopped:100.100.10.5:yes:logged in but WantRunning=false -- the key still exists" \
+      "NeedsLogin::no:the state straight after apply-tailscale.sh" \
+      "NoState::no:the daemon has no state at all" \
+      "NeedsLogin:100.100.10.5:no:signals DISAGREE -- must not resolve to authenticated" \
+      "Running::no:Running with no address is not an identity" \
+      ":100.100.10.5:no:an empty BackendState is not evidence of anything"; do
+    local a_backend a_ips a_want a_why a_got
+    IFS=':' read -r a_backend a_ips a_want a_why <<<"$a_case"
+    if _authenticated "$a_backend" "$a_ips"; then a_got=yes; else a_got=no; fi
+    if [ "$a_got" = "$a_want" ]; then
+      echo "  [self-test] _authenticated '${a_backend:-<empty>}' / '${a_ips:-<none>}' -> $a_got  ($a_why) -> ok"
+    else
+      echo "  [self-test] _authenticated '${a_backend:-<empty>}' / '${a_ips:-<none>}' FAILED: got $a_got, want $a_want"; rc=1
+    fi
+  done
   return $rc
 }
 
@@ -449,10 +527,22 @@ IFS='|' read -r backend online ips advertised primary expiry days route_all pref
 # and `is-active` says nothing about whether the node is authenticated or routing.
 unit_state=$(systemctl is-active tailscaled.service 2>/dev/null || true)
 
+# 🔴 `--accept-dns=false` ON BOTH ROLES, and the symmetry is the point. The reasoning is
+# the same on either machine: MagicDNS makes tailscale take over the host resolver, and
+# on this fleet the resolver is already owned by dnsmasq and the `.lan` names. Giving the
+# server the flag and not the client would hand the laptop's resolver to tailscale --
+# the ONE machine the operator travels with, and the one whose name resolution nobody
+# can fix from the far side. The cost is stated out loud in apply-tailscale.sh's next
+# steps: MagicDNS names do not resolve, so address the workbench by its tailnet address.
+#
+# 🔴 These two strings are duplicated in apply-tailscale.sh's next-step text, and
+# `scripts/tests/test_tailscale_scripts.py` pins them EQUAL across the two files -- an
+# operator who follows the apply script's instructions and then runs this checker must
+# not be told to run a different command from the one they were told to run.
 if [ "$ROLE" = "server" ]; then
   UP_CMD="sudo tailscale up --advertise-routes=${SUBNET} --accept-dns=false"
 else
-  UP_CMD="sudo tailscale up --accept-routes"
+  UP_CMD="sudo tailscale up --accept-routes --accept-dns=false"
 fi
 
 echo
@@ -465,31 +555,54 @@ echo "primary : ${primary:-<none>}   (source: control plane -- what is APPROVED)
 if [ -n "$expiry" ]; then
   echo "keyexp  : $expiry  (${days} days from now)"
 else
-  echo "keyexp  : DISABLED -- this node key does not expire"
+  echo "keyexp  : <no KeyExpiry field>  (that means 'disabled' ONLY on an authenticated"
+  echo "                                 node -- see the verdict below)"
 fi
 echo
 
 # --- verdicts ------------------------------------------------------------------------
+# THREE buckets, deliberately not two. `fails` is a defect on this node; `actions` is a
+# human step in the admin console; `unknowns` is a claim this run COULD NOT EVALUATE.
+# Folding the third into the first is what made a freshly-switched, perfectly correct
+# host report a node-side FAILURE.
 rc=0
 fails=()
 actions=()
+unknowns=()
 
-if [ "$backend" != "Running" ]; then
-  fails+=("tailscaled backend is '$backend', not 'Running' -- this node carries no traffic.
-    If it is NeedsLogin or Stopped, bring it up:  $UP_CMD")
-fi
-if [ "$online" != "true" ]; then
-  fails+=("the control plane does not consider this node Online; it cannot be reached.")
-fi
-if [ -z "$ips" ]; then
-  fails+=("this node has no Tailscale address -- it has never authenticated to a tailnet.
-    Authenticate it:  $UP_CMD")
+authed=0
+if _authenticated "$backend" "$ips"; then authed=1; fi
+
+if [ "$authed" = "1" ]; then
+  echo "PASS  authed    : this node holds a tailnet identity ($ips)"
+  # These two are verdicts ONLY once there is an identity to have a verdict about.
+  if [ "$backend" != "Running" ]; then
+    fails+=("tailscaled backend is '$backend', not 'Running' -- this node carries no
+    traffic even though it IS logged in (it holds $ips). Bring it up:  $UP_CMD")
+  fi
+  if [ "$online" != "true" ]; then
+    fails+=("the control plane does not consider this node Online; it cannot be reached.")
+  fi
+else
+  unknowns+=("THIS NODE HAS NEVER AUTHENTICATED to a tailnet (backend '$backend',
+    addresses: ${ips:-<none>}). That is the EXPECTED state immediately after
+    \`apply-tailscale.sh\`, which installs and starts the service but deliberately does
+    NOT log in -- \`tailscale up\` needs a browser. It is NOT a node-side defect, and
+    every claim below that depends on a tailnet identity is reported UNKNOWN rather than
+    guessed at. Authenticate it, then re-run this check:
+      $UP_CMD")
 fi
 
+# --- what this node ADVERTISES (its own prefs) ---------------------------------------
 if [ "$prefs_src" = "none" ]; then
-  fails+=("could not read \`tailscale debug prefs\`, so what this node ADVERTISES is
+  unknowns+=("could not read \`tailscale debug prefs\`, so what this node ADVERTISES is
     UNKNOWN. Deliberately not reported as 'advertises nothing' -- that would be a
-    definitive claim derived from a file that was never read.")
+    definitive claim derived from a file that was never read. It is equally not reported
+    as a node-side FAIL: a file this script could not read is not evidence of a defect.")
+elif [ "$authed" != "1" ]; then
+  unknowns+=("what this node advertises cannot be judged before it authenticates:
+    \`AdvertiseRoutes\` is set BY \`tailscale up\`, which has never run here.
+    (prefs currently say: ${advertised:-<none>})")
 elif [ "$ROLE" = "server" ]; then
   if _in_csv "$SUBNET" "$advertised"; then
     echo "PASS  advertise : this node advertises $SUBNET"
@@ -507,7 +620,12 @@ fi
 if [ "$ROLE" = "server" ]; then
   # 🔴 THE SECOND, DIFFERENT CLAIM. An advertised-but-unapproved route looks IDENTICAL
   # to success from this node and carries no traffic at all.
-  if _in_csv "$SUBNET" "$primary"; then
+  if [ "$authed" != "1" ]; then
+    unknowns+=("whether $SUBNET is APPROVED in the admin console cannot be known before
+    this node authenticates -- the control plane has no machine here yet, so there is
+    nothing to approve and \`PrimaryRoutes\` is empty for a reason that is not refusal.
+    Re-run after \`tailscale up\`.")
+  elif _in_csv "$SUBNET" "$primary"; then
     echo "PASS  approved  : $SUBNET is APPROVED in the admin console; this node is its primary router"
   else
     actions+=("$SUBNET is advertised but NOT APPROVED. It carries NO traffic until a
@@ -551,7 +669,11 @@ if [ "$ROLE" = "server" ]; then
     a subnet it is not on; traffic arriving over tailscale would have nowhere to go.")
   fi
 else
-  if [ "$route_all" = "true" ]; then
+  if [ "$authed" != "1" ]; then
+    unknowns+=("whether this client accepts subnet routes cannot be judged before it
+    authenticates: \`RouteAll\` is the \`--accept-routes\` pref and is set BY
+    \`tailscale up\`. (prefs currently say RouteAll=$route_all)")
+  elif [ "$route_all" = "true" ]; then
     echo "PASS  acceptrt  : this client accepts subnet routes (RouteAll / --accept-routes)"
   elif [ "$prefs_src" = "prefs" ]; then
     actions+=("this client does not accept subnet routes (RouteAll=$route_all), so the
@@ -559,6 +681,9 @@ else
   fi
   if ip -4 -o route show 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -q 'dev tailscale'; then
     echo "PASS  lanroute  : $SUBNET is installed here via a tailscale interface"
+  elif [ "$authed" != "1" ]; then
+    unknowns+=("$SUBNET is not installed here via tailscale, but this node has not
+    authenticated, so no route COULD have been installed. Not a finding yet.")
   else
     actions+=("$SUBNET is not in this host's routing table via tailscale. Either the
     route is not approved in the admin console, or --accept-routes is off here, or the
@@ -566,17 +691,31 @@ else
   fi
 fi
 
-# 🔴 KEY EXPIRY. Enabled at all is an outstanding action, because the 180-day default is
-# SHORTER than the trip and the lapse is silent.
-if [ -z "$expiry" ]; then
-  echo "PASS  keyexpiry : disabled -- this node key will not expire mid-trip"
-else
+# 🔴 KEY EXPIRY -- and the ABSENT case is the one that matters. `Self.KeyExpiry` missing
+# is ambiguous between (a) expiry genuinely disabled, (b) the node has no node key at
+# all because it never authenticated, and (c) a build that does not emit the field.
+# Resolving that absence to (a) is how this printed `PASS keyexpiry : disabled` for a
+# node that had never logged in -- the reassuring branch, on the single item most likely
+# to kill this path silently mid-trip. "Disabled" is claimed ONLY when there IS a node
+# key for expiry to have been disabled on.
+if [ -n "$expiry" ]; then
   actions+=("node key expiry is ENABLED: it expires $expiry, in $days days.
     Tailscale's default is 180 days, shorter than a months-long trip, and when it lapses
     this backup path goes dark with no local error. Disabling it is an ADMIN-CONSOLE
     action that cannot be scripted:
       https://login.tailscale.com/admin/machines -> this machine -> ... ->
       Disable key expiry")
+elif [ "$authed" != "1" ]; then
+  unknowns+=("NODE KEY EXPIRY IS UNKNOWN, not disabled. \`Self.KeyExpiry\` is absent, and
+    on a node that has never authenticated that means the control plane has never issued
+    a node key -- there is nothing yet for expiry to be on or off for. Absence is
+    ambiguous, and this is the one claim where guessing the reassuring answer is most
+    expensive: the default is 180 days, shorter than the trip, and the lapse is silent.
+    Re-run after \`tailscale up\` -- and expect it to say ENABLED, because that is the
+    default a new node gets.")
+else
+  echo "PASS  keyexpiry : disabled -- this node IS authenticated and the daemon reports no"
+  echo "                  KeyExpiry, so this node key will not expire mid-trip"
 fi
 
 echo
@@ -584,6 +723,15 @@ if [ ${#fails[@]} -gt 0 ]; then
   echo "FAIL: this host is NOT carrying a usable tailscale path."
   for f in "${fails[@]}"; do printf '  - %s\n' "$f"; done
   rc=1
+fi
+# 🔴 UNKNOWN OUTRANKS ACTION-REQUIRED and is outranked by FAIL. A run that could not
+# evaluate half its claims must not be reported as "everything on this host is correct,
+# just go click a button" -- rc 3 says the node side is DONE, and rc 4 says it is not
+# yet knowable. Both are equally not a reason to roll back a switch.
+if [ ${#unknowns[@]} -gt 0 ]; then
+  echo "NOT YET DETERMINABLE (no defect found -- these claims cannot be evaluated yet):"
+  for u in "${unknowns[@]}"; do printf '  - %s\n' "$u"; done
+  if [ "$rc" = "0" ]; then rc=4; fi
 fi
 if [ ${#actions[@]} -gt 0 ]; then
   echo "ACTION REQUIRED (admin console / human -- cannot be scripted):"

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -50,12 +50,34 @@
 # most likely to kill this path silently mid-trip. "Disabled" is now claimed ONLY when
 # the node IS authenticated; otherwise the claim is UNKNOWN (see rc 4).
 #
-# 🔴 AUTHENTICATED IS A FIRST-CLASS STATE, NOT A FAILURE. `apply-tailscale.sh` installs
-# the service and switches; it deliberately does NOT run `tailscale up`, which needs a
-# browser. So immediately after a successful apply the node is configured, running, and
-# has no tailnet identity at all -- backend `NeedsLogin`, no address, nothing
-# advertised, no key. Reporting that as a node-side FAIL made the apply script roll back
-# the config it had just installed. It is rc 4.
+# 🔴 IDENTITY IS THREE STATES, NOT TWO, AND CONFLATING TWO OF THEM IS THE WORST BUG THIS
+# SCRIPT CAN HAVE. `apply-tailscale.sh` installs the service and switches; it deliberately
+# does NOT run `tailscale up`, which needs a browser. So immediately after a successful
+# apply the node is configured, running, and has no tailnet identity at all -- backend
+# `NeedsLogin`, no address, nothing advertised, no key. Reporting THAT as a node-side FAIL
+# made the apply script roll back the config it had just installed. But the reverse error
+# is worse:
+#
+#   NONE       -- never authenticated. No addresses AND backend NeedsLogin/NoState/empty.
+#                 rc 4. Genuinely expected straight after apply.
+#   OK         -- an address in 100.64.0.0/10, a backend that is not a logged-out one, and
+#                 `Self.Expired` not set. Every other claim is judged against this.
+#   LOST       -- 🔴 THIS NODE HAD AN IDENTITY AND NO LONGER HAS ONE. rc 1, a FAIL.
+#                 Node keys expire after 180 days by default -- SHORTER THAN THE TRIP --
+#                 and `tailscale logout` / an admin revoke do the same thing. Two shapes,
+#                 and BOTH are handled because only one of them has been observed here:
+#                   * the daemon drops the node to `NeedsLogin`/`NoState` while KEEPING
+#                     the netmap address it was issued; and
+#                   * `Self.Expired: true` with the backend still `Running`.
+#                 An earlier version required backend AND address to AGREE and called
+#                 disagreement "not authenticated", so an EXPIRED node printed
+#                 "THIS NODE HAS NEVER AUTHENTICATED ... that is the EXPECTED state
+#                 immediately after apply-tailscale.sh" -- next to the very address it had
+#                 retained -- and exited 4, "no defect found". A checker that answers
+#                 "no defect" when the backup path is dead is worse than no checker.
+#   INCOHERENT -- a backend that is neither logged-out nor holding an address (e.g.
+#                 `Running` with an empty netmap). Not the post-apply state and not a
+#                 usable one. rc 1, with its own message: it does NOT claim expiry.
 #
 # Exit: 0 = every claim holds, including admin-console approval and disabled key expiry
 #       3 = everything THIS HOST controls is correct, but an ADMIN-CONSOLE action is
@@ -64,14 +86,15 @@
 #           step that cannot be scripted, and apply-tailscale.sh must not roll back a
 #           correct switch because a browser tab has not been clicked yet.
 #       4 = INCOMPLETE. No defect was found, but one or more claims could not be
-#           evaluated. Overwhelmingly the common cause is that the node has not
-#           authenticated yet -- the EXPECTED state straight after apply-tailscale.sh --
-#           in which case advertisement, route approval and key expiry are all
-#           unknowable rather than wrong. Also covers unreadable prefs. Like 3, this is
-#           NOT a reason to roll back a switch.
-#       1 = a definitive node-side FAIL: the node HAS a tailnet identity and something
-#           about it is wrong (backend not Running, not Online, not advertising,
-#           forwarding off, no LAN route).
+#           evaluated. The common cause is that the node has NEVER authenticated -- the
+#           EXPECTED state straight after apply-tailscale.sh -- in which case
+#           advertisement, route approval and key expiry are all unknowable rather than
+#           wrong. Also covers unreadable prefs on a node that IS authenticated. Like 3,
+#           this is NOT a reason to roll back a switch. It is NOT used for a node that
+#           has LOST an identity it once had; that is 1.
+#       1 = a definitive node-side FAIL: the node HAS or HAD a tailnet identity and
+#           something about it is wrong -- an EXPIRED or REVOKED node key, a backend that
+#           is not Running, not Online, not advertising, forwarding off, or no LAN route.
 #       2 = cannot determine -- tailscale absent, daemon unreachable, role ambiguous,
 #           parser failure, or the parser failed its own controls
 set -euo pipefail
@@ -121,24 +144,52 @@ _in_csv() {  # $1 = needle, $2 = csv
   return 1
 }
 
-# --- has this node ever authenticated to a tailnet? -----------------------------------
-# 🔴 THE STATE apply-tailscale.sh LANDS IN, and the reason this predicate exists rather
-# than being inlined: the apply script installs the service and switches, then asks this
-# checker whether to keep the change. Straight after that switch the node has NEVER run
-# `tailscale up` (it needs a browser), so backend is `NeedsLogin`, there is no address,
-# nothing is advertised and there is no node key. Reporting that as a node-side FAIL is
-# what made the apply script roll back a config it had just installed correctly.
+# --- what is this node's tailnet IDENTITY? -------------------------------------------
+# Prints exactly one of: none | ok | lost | incoherent.  See the header for what each
+# means and why there are four names for three verdicts.
 #
-# TWO signals, and they must AGREE -- disagreement means NOT authenticated, because the
-# reassuring answer is the one that has to carry more evidence:
-#   * an address in 100.64.0.0/10 is the DURABLE signal. A node that has completed
-#     `tailscale up` keeps it even when the backend is `Stopped` (WantRunning=false).
-#   * `BackendState` is the daemon saying it in words. `NeedsLogin` / `NoState` mean
-#     there is no tailnet identity, whatever else is in the document.
-_authenticated() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs
-  [ -n "$2" ] || return 1
-  case "$1" in NeedsLogin|NoState|"") return 1 ;; esac
-  return 0
+# 🔴 THE ERROR THIS REPLACES. The predecessor was a two-valued `_authenticated` that
+# required BOTH signals to agree and resolved every disagreement to "not authenticated"
+# -- on the stated principle that "the reassuring answer has to carry more evidence".
+# The principle is right; the application was inverted. "Never authenticated" is not the
+# cautious answer here, it is the REASSURING one: it routes to rc 4, "no defect found",
+# and prints that this is the expected state right after an apply. So the ONE state that
+# kills this backup path on a months-long trip -- a node key that expired at ~180 days --
+# was reported as a fresh install, with the retained 100.x address printed on the same
+# line as the claim that the node had never logged in.
+#
+# The signals, and which way each one cuts:
+#   * an address in 100.64.0.0/10 is DURABLE, and durability is the whole point: a node
+#     keeps it when the backend is `Stopped` (WantRunning=false) AND when its key has
+#     expired. So an address is evidence an identity was ISSUED -- never, on its own,
+#     evidence that it is still valid.
+#   * `BackendState` is the daemon's own word for what it can do RIGHT NOW. `NeedsLogin`
+#     / `NoState` mean it cannot act as a tailnet member at this moment.
+#   * `Self.Expired` is the control plane saying the node key is dead while the backend
+#     may still read `Running`. It was parsed-adjacent and thrown away before.
+#
+# So: address + logged-out backend is not "no identity", it is a LOST one. Only the
+# absence of BOTH is "never authenticated".
+#
+# ⚠ WHICH SHAPE A REAL EXPIRY PRODUCES HAS NOT BEEN CAPTURED FROM A LIVE DAEMON HERE --
+# the two above are from documented behaviour. Both are therefore treated as LOST, so it
+# does not matter which one the daemon actually emits; the cost of handling the one that
+# never occurs is a dead branch, and the cost of handling neither is a silent dead path.
+_identity_state() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs, $3 = Expired
+  # The control plane's explicit "this key is dead" outranks everything else, including a
+  # backend that still says `Running`.
+  if [ "$3" = "true" ]; then printf 'lost'; return 0; fi
+  case "$1" in
+    NeedsLogin|NoState|"")
+      # Logged out. WITH an address it had an identity and lost it; without one it never
+      # had any.
+      if [ -n "$2" ]; then printf 'lost'; else printf 'none'; fi ;;
+    *)
+      # A backend that is not logged-out. With an address that is a live identity.
+      # Without one the daemon is contradicting itself -- and that is neither the
+      # post-apply state (which is NeedsLogin) nor a usable one.
+      if [ -n "$2" ]; then printf 'ok'; else printf 'incoherent'; fi ;;
+  esac
 }
 
 # --- the parser -------------------------------------------------------------------
@@ -146,7 +197,13 @@ _authenticated() {   # $1 = BackendState, $2 = comma-separated TailscaleIPs
 # already known not to be importable from the python3 on the default PATH here.
 #
 # Emits ONE `|`-separated record so a caller cannot half-read it:
-#   backend|online|ips|advertised|primary|expiry_iso|expiry_days|route_all|prefs_src
+#   backend|online|ips|advertised|primary|expiry_iso|expiry_days|route_all|prefs_src|expired
+#
+# 🔴 `expired` IS THE LAST FIELD AND IT IS READ. `Self.Expired` used to be sitting one
+# line away from `Self.KeyExpiry` in this parser and was never extracted, so the single
+# most likely way this backup path dies mid-trip -- the node key lapsing at ~180 days --
+# was invisible to every verdict below. It is appended rather than inserted so the field
+# positions the self-test asserts by index do not silently shift.
 #
 # Exits 2 rather than printing a record when the document is not what it claims to be,
 # so "the parser found nothing" can never be reported as "this node advertises nothing"
@@ -174,6 +231,11 @@ online = "true" if me.get("Online") is True else "false"
 
 ips = [i for i in (st.get("TailscaleIPs") or me.get("TailscaleIPs") or []) if isinstance(i, str)]
 primary = [r for r in (me.get("PrimaryRoutes") or []) if isinstance(r, str)]
+
+# `Self.Expired` -- the control plane's own "this node key is dead". Compared to the
+# literal `True` and nothing else: `omitempty` means the field is ABSENT on a healthy
+# node, and a truthiness test would read a stray non-empty string as expired.
+expired = "true" if me.get("Expired") is True else "false"
 
 # Key expiry. `KeyExpiry` is omitempty AND some builds emit the Go zero time instead,
 # so BOTH spellings of "expiry is disabled" have to be handled; treating only one of
@@ -205,7 +267,7 @@ if sys.argv[2] != "-":
     src = "prefs"
 
 print("|".join((backend, online, ",".join(ips), ",".join(advertised),
-                ",".join(primary), expiry, days, route_all, src)))
+                ",".join(primary), expiry, days, route_all, src, expired)))
 PY
 }
 
@@ -255,7 +317,7 @@ J
          "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":["192.168.50.0/24"]}}
 J
   _t "advertised + approved                       " \
-     "Running|true|100.100.10.5|192.168.50.0/24|192.168.50.0/24|2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "Running|true|100.100.10.5|192.168.50.0/24|192.168.50.0/24|2099-01-02T03:04:05+00:00|D|false|prefs|false" \
      "$dir/approved.json" "$dir/adv-prefs.json"
 
   # 🔴 THE CASE THIS SCRIPT EXISTS FOR: advertised, NOT approved. Identical on the node
@@ -266,7 +328,7 @@ J
          "KeyExpiry":"2099-01-02T03:04:05Z","PrimaryRoutes":[]}}
 J
   _t "advertised but NOT approved (empty Primary) " \
-     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false" \
      "$dir/unapproved.json" "$dir/adv-prefs.json"
 
   # PrimaryRoutes absent entirely (the field is omitempty) must read the SAME as empty,
@@ -276,7 +338,7 @@ J
  "Self":{"HostName":"workbench","Online":true,"KeyExpiry":"2099-01-02T03:04:05Z"}}
 J
   _t "PrimaryRoutes absent == not approved        " \
-     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs" \
+     "Running|true|100.100.10.5|192.168.50.0/24||2099-01-02T03:04:05+00:00|D|false|prefs|false" \
      "$dir/noprimary.json" "$dir/adv-prefs.json"
 
   # Key expiry DISABLED, both spellings. Omitted...
@@ -285,14 +347,26 @@ J
  "Self":{"HostName":"laptop","Online":true,"PrimaryRoutes":[]}}
 J
   _t "key expiry disabled (field omitted)         " \
-     "Running|true|100.100.10.5|||||?|none" "$dir/noexpiry.json" "-"
+     "Running|true|100.100.10.5|||||?|none|false" "$dir/noexpiry.json" "-"
   # ...and spelled as the Go zero time, which is NOT an expiry in the year 1.
   cat >"$dir/zeroexpiry.json" <<'J'
 {"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
  "Self":{"HostName":"laptop","Online":true,"KeyExpiry":"0001-01-01T00:00:00Z","PrimaryRoutes":[]}}
 J
   _t "key expiry disabled (Go zero time)          " \
-     "Running|true|100.100.10.5|||||?|none" "$dir/zeroexpiry.json" "-"
+     "Running|true|100.100.10.5|||||?|none|false" "$dir/zeroexpiry.json" "-"
+
+  # 🔴 `Self.Expired` MUST REACH THE RECORD. Every other fixture in this file has the
+  # field absent, so they all assert the LAST slot as `false` -- which a parser that
+  # hardcoded `false`, or dropped the field entirely, would satisfy. This is the fixture
+  # that can tell those apart: it is the only one whose expected value is `true`.
+  cat >"$dir/expired.json" <<'J'
+{"BackendState":"Running","TailscaleIPs":["100.100.10.5"],
+ "Self":{"HostName":"workbench","Online":true,"Expired":true,"PrimaryRoutes":[]}}
+J
+  _t "Self.Expired reaches the record as 'true'  " \
+     "Running|true|100.100.10.5|192.168.50.0/24||||false|prefs|true" \
+     "$dir/expired.json" "$dir/adv-prefs.json"
 
   # A logged-out node: BackendState carries it, Online is false, no addresses.
   cat >"$dir/needslogin.json" <<'J'
@@ -300,7 +374,7 @@ J
  "Self":{"HostName":"laptop","Online":false}}
 J
   _t "NeedsLogin (not authenticated)              " \
-     "NeedsLogin|false||||||?|none" "$dir/needslogin.json" "-"
+     "NeedsLogin|false||||||?|none|false" "$dir/needslogin.json" "-"
 
   # A plain client that ACCEPTS routes. RouteAll is the `--accept-routes` pref, and
   # `AdvertiseRoutes: null` is how the daemon spells "none" -- distinct from `[]`.
@@ -308,7 +382,7 @@ J
 {"AdvertiseRoutes":null,"RouteAll":true,"WantRunning":true}
 J
   _t "client prefs: null routes, RouteAll on      " \
-     "Running|true|100.100.10.5|||||true|prefs" "$dir/noexpiry.json" "$dir/client-prefs.json"
+     "Running|true|100.100.10.5|||||true|prefs|false" "$dir/noexpiry.json" "$dir/client-prefs.json"
 
   # --- the DAYS arithmetic, at two points -------------------------------------------
   local n exp got_days
@@ -394,30 +468,55 @@ J
     echo "  [self-test] _in_csv rejects a different mask (/16 != /24) -> ok"
   fi
 
-  # --- _authenticated, driven in BOTH directions -------------------------------------
-  # 🔴 The whole rc-4 split, and the key-expiry claim, hang off this one predicate. A
-  # version that answered "yes" to everything would make rc 4 unreachable and put the
-  # post-switch FAIL back; one that answered "no" to everything would make rc 0
-  # unreachable and permanently report a working node as not-yet-set-up. Both directions
-  # are driven, on the exact states the daemon emits.
+  # --- _identity_state, every state driven -------------------------------------------
+  # 🔴 EVERY VERDICT IN THIS SCRIPT HANGS OFF THIS ONE FUNCTION, so all four answers are
+  # driven and each is reachable from at least two different inputs. A version that
+  # answered `none` to everything would make rc 0 unreachable and permanently report a
+  # working node as not-yet-set-up; one that answered `ok` to everything would put the
+  # post-switch rollback back; and one that never says `lost` -- the shipped bug -- lets
+  # an EXPIRED node key exit 4 as "no defect found", which is the failure this whole
+  # script exists to prevent.
+  #
+  # The three `lost` rows are the ones that matter, and each carries DIFFERENT evidence:
+  # a retained address under two different logged-out backends, and the explicit
+  # `Expired` flag under a backend that still reads `Running`. A mutant that reads only
+  # the address, or only the flag, survives one row and dies on the others.
   local a_case
   for a_case in \
-      "Running:100.100.10.5:yes:a logged-in node" \
-      "Stopped:100.100.10.5:yes:logged in but WantRunning=false -- the key still exists" \
-      "NeedsLogin::no:the state straight after apply-tailscale.sh" \
-      "NoState::no:the daemon has no state at all" \
-      "NeedsLogin:100.100.10.5:no:signals DISAGREE -- must not resolve to authenticated" \
-      "Running::no:Running with no address is not an identity" \
-      ":100.100.10.5:no:an empty BackendState is not evidence of anything"; do
-    local a_backend a_ips a_want a_why a_got
-    IFS=':' read -r a_backend a_ips a_want a_why <<<"$a_case"
-    if _authenticated "$a_backend" "$a_ips"; then a_got=yes; else a_got=no; fi
+      "Running:100.100.10.5:false:ok:a logged-in node" \
+      "Stopped:100.100.10.5:false:ok:logged in but WantRunning=false -- the key still exists" \
+      "NeedsLogin::false:none:the state straight after apply-tailscale.sh" \
+      "NoState::false:none:the daemon has no state at all" \
+      "::false:none:an empty BackendState with no address is not evidence of anything" \
+      "NeedsLogin:100.100.10.5:false:lost:EXPIRED/REVOKED -- logged out but the netmap address was RETAINED" \
+      "NoState:100.100.10.5:false:lost:the same, via NoState" \
+      "Running:100.100.10.5:true:lost:Self.Expired outranks a backend that still says Running" \
+      ":100.100.10.5:false:lost:an address with no backend word is still an issued identity" \
+      "Running::false:incoherent:Running with an empty netmap is neither fresh nor usable" \
+      "Stopped::false:incoherent:Stopped with no address at all"; do
+    local a_backend a_ips a_exp a_want a_why a_got
+    IFS=':' read -r a_backend a_ips a_exp a_want a_why <<<"$a_case"
+    a_got=$(_identity_state "$a_backend" "$a_ips" "$a_exp")
     if [ "$a_got" = "$a_want" ]; then
-      echo "  [self-test] _authenticated '${a_backend:-<empty>}' / '${a_ips:-<none>}' -> $a_got  ($a_why) -> ok"
+      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp -> $a_got  ($a_why) -> ok"
     else
-      echo "  [self-test] _authenticated '${a_backend:-<empty>}' / '${a_ips:-<none>}' FAILED: got $a_got, want $a_want"; rc=1
+      echo "  [self-test] _identity_state '${a_backend:-<empty>}' / '${a_ips:-<none>}' / Expired=$a_exp FAILED: got '$a_got', want '$a_want'"; rc=1
     fi
   done
+  # 🔴 THE RELATIONSHIP, not just the rows: a retained address must move the answer AWAY
+  # from `none`, and the Expired flag must move it away from `ok`. Asserted as a pair of
+  # inequalities so a table that happened to be right row-by-row for the wrong reason
+  # still has to satisfy the property the rows exist to express.
+  if [ "$(_identity_state NeedsLogin '' false)" = "$(_identity_state NeedsLogin 100.100.10.5 false)" ]; then
+    echo "  [self-test] FAILED: a RETAINED address does not change the answer -- expiry is invisible"; rc=1
+  else
+    echo "  [self-test] a retained address changes NeedsLogin's answer (none -> lost) -> ok"
+  fi
+  if [ "$(_identity_state Running 100.100.10.5 false)" = "$(_identity_state Running 100.100.10.5 true)" ]; then
+    echo "  [self-test] FAILED: Self.Expired does not change the answer -- the flag is discarded"; rc=1
+  else
+    echo "  [self-test] Self.Expired changes Running's answer (ok -> lost) -> ok"
+  fi
   return $rc
 }
 
@@ -521,7 +620,7 @@ if ! rec=$(_parse_ts "$TMPD/status.json" "$prefs_arg"); then
   echo "CANNOT DETERMINE: could not parse the daemon's own state" >&2
   exit 2
 fi
-IFS='|' read -r backend online ips advertised primary expiry days route_all prefs_src <<<"$rec"
+IFS='|' read -r backend online ips advertised primary expiry days route_all prefs_src expired <<<"$rec"
 
 # CONTEXT ONLY -- deliberately not a verdict. `systemctl cat` exits 0 for a dead unit
 # and `is-active` says nothing about whether the node is authenticated or routing.
@@ -550,6 +649,7 @@ echo "daemon  : tailscaled unit is '${unit_state:-unknown}'  (context only -- no
 echo "backend : $backend"
 echo "online  : $online"
 echo "addrs   : ${ips:-<none>}"
+echo "expired : $expired   (Self.Expired -- the control plane's own word on the node key)"
 echo "adverts : ${advertised:-<none>}   (source: $prefs_src -- what THIS NODE claims)"
 echo "primary : ${primary:-<none>}   (source: control plane -- what is APPROVED)"
 if [ -n "$expiry" ]; then
@@ -570,43 +670,101 @@ fails=()
 actions=()
 unknowns=()
 
+# 🔴 FOUR ANSWERS, THREE OUTCOMES. `authed` stays as the one flag the claims below read,
+# but it is now derived from a classifier that can say WHY it is not 1 -- because "never
+# had an identity" (rc 4, expected) and "had one and lost it" (rc 1, the backup path is
+# DEAD) used to be the same answer, and the reassuring one won.
+idstate=$(_identity_state "$backend" "$ips" "$expired")
+# An explicit `if`, not `[ ... ] && authed=1`. MEASURED on bash 5.3.15: that shape does
+# NOT abort mid-script under `set -e` -- but when it is the LAST statement executed it
+# becomes the script's exit status, so the same line is harmless here and would silently
+# turn a PASS into an exit 1 if anything were ever moved after it. See the note beside
+# the `actions` bucket at the bottom of this file.
 authed=0
-if _authenticated "$backend" "$ips"; then authed=1; fi
+if [ "$idstate" = "ok" ]; then authed=1; fi
+# Why the identity-dependent claims below cannot be judged. Set for every non-`ok` state
+# so no claim ever has to invent a reason -- the old text said "`tailscale up` has never
+# run here" unconditionally, which is a false statement about an EXPIRED node.
+noid_reason=""
 
-if [ "$authed" = "1" ]; then
-  echo "PASS  authed    : this node holds a tailnet identity ($ips)"
-  # These two are verdicts ONLY once there is an identity to have a verdict about.
-  if [ "$backend" != "Running" ]; then
-    fails+=("tailscaled backend is '$backend', not 'Running' -- this node carries no
+case "$idstate" in
+  ok)
+    echo "PASS  authed    : this node holds a tailnet identity ($ips)"
+    # These two are verdicts ONLY once there is an identity to have a verdict about.
+    if [ "$backend" != "Running" ]; then
+      fails+=("tailscaled backend is '$backend', not 'Running' -- this node carries no
     traffic even though it IS logged in (it holds $ips). Bring it up:  $UP_CMD")
-  fi
-  if [ "$online" != "true" ]; then
-    fails+=("the control plane does not consider this node Online; it cannot be reached.")
-  fi
-else
-  unknowns+=("THIS NODE HAS NEVER AUTHENTICATED to a tailnet (backend '$backend',
-    addresses: ${ips:-<none>}). That is the EXPECTED state immediately after
+    fi
+    if [ "$online" != "true" ]; then
+      fails+=("the control plane does not consider this node Online; it cannot be reached.")
+    fi
+    ;;
+  none)
+    noid_reason="\`tailscale up\` has never run on this host"
+    unknowns+=("THIS NODE HAS NEVER AUTHENTICATED to a tailnet (backend '$backend', no
+    addresses, Self.Expired '$expired'). That is the EXPECTED state immediately after
     \`apply-tailscale.sh\`, which installs and starts the service but deliberately does
     NOT log in -- \`tailscale up\` needs a browser. It is NOT a node-side defect, and
     every claim below that depends on a tailnet identity is reported UNKNOWN rather than
     guessed at. Authenticate it, then re-run this check:
       $UP_CMD")
-fi
+    ;;
+  lost)
+    # 🔴 A FAIL, AND THE MOST IMPORTANT ONE IN THIS SCRIPT. This is what a lapsed node key
+    # looks like from the node, and the trip is longer than the 180-day default.
+    noid_reason="this node's tailnet identity is EXPIRED or REVOKED (see the FAIL above)"
+    fails+=("🔴 THIS NODE HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE. Backend is
+    '$backend', Self.Expired is '$expired', and the netmap addresses it was issued are
+    still present: ${ips:-<none>}. A node that had never logged in would have NEITHER --
+    so this is not the fresh-install state, it is an EXPIRED NODE KEY, a \`tailscale
+    logout\`, or a node removed/disabled in the admin console. THE BACKUP PATH IS DEAD
+    RIGHT NOW: nothing reaches this host over tailscale until it is re-authenticated.
+    Tailscale's default key lifetime is 180 days, which is shorter than a months-long
+    trip, and the lapse produces no local error -- which is why this is a FAIL and not an
+    'incomplete'. Re-authenticate, from a machine with a browser:
+      $UP_CMD
+    Then DISABLE KEY EXPIRY so it cannot happen again:
+      https://login.tailscale.com/admin/machines -> this machine -> ... ->
+      Disable key expiry")
+    ;;
+  *)
+    # `incoherent`: a backend that is neither logged-out nor holding an address.
+    noid_reason="the daemon's own state is self-contradictory (see the FAIL above)"
+    fails+=("the daemon reports backend '$backend' -- which is NOT one of the logged-out
+    states -- yet lists NO tailnet address at all. Those two cannot both be true of a
+    working node, so this run will not resolve them into either 'authenticated' or 'never
+    authenticated'. It is reported as a defect rather than as 'not yet determinable'
+    because a node in this state carries no traffic, and because the post-apply state is
+    \`NeedsLogin\` with no address, which is NOT this. If tailscaled was only just
+    started it may still be fetching its netmap -- re-run this check before doing
+    anything else. If it persists:
+      systemctl status tailscaled ; tailscale status
+      $UP_CMD")
+    ;;
+esac
 
 # --- what this node ADVERTISES (its own prefs) ---------------------------------------
+# 🔴 `adv_verdict` RECORDS WHETHER THIS CLAIM WAS ACTUALLY EVALUATED, and the approval
+# check below reads it. Without it, a run with unreadable prefs printed BOTH "what this
+# node ADVERTISES is UNKNOWN" and "$SUBNET is advertised but NOT APPROVED" -- the second
+# asserting, and pointing the operator at the admin console over, the exact fact the
+# first had just declared unknowable. Three values: `unknown`, `yes`, `no`.
+adv_verdict=unknown
 if [ "$prefs_src" = "none" ]; then
   unknowns+=("could not read \`tailscale debug prefs\`, so what this node ADVERTISES is
     UNKNOWN. Deliberately not reported as 'advertises nothing' -- that would be a
     definitive claim derived from a file that was never read. It is equally not reported
     as a node-side FAIL: a file this script could not read is not evidence of a defect.")
 elif [ "$authed" != "1" ]; then
-  unknowns+=("what this node advertises cannot be judged before it authenticates:
-    \`AdvertiseRoutes\` is set BY \`tailscale up\`, which has never run here.
+  unknowns+=("what this node advertises cannot be judged: $noid_reason, and
+    \`AdvertiseRoutes\` is runtime state owned by \`tailscale up\`.
     (prefs currently say: ${advertised:-<none>})")
 elif [ "$ROLE" = "server" ]; then
   if _in_csv "$SUBNET" "$advertised"; then
+    adv_verdict=yes
     echo "PASS  advertise : this node advertises $SUBNET"
   else
+    adv_verdict=no
     fails+=("this node does NOT advertise $SUBNET (advertised: ${advertised:-<none>}).
     Fix:  $UP_CMD")
   fi
@@ -621,18 +779,40 @@ if [ "$ROLE" = "server" ]; then
   # 🔴 THE SECOND, DIFFERENT CLAIM. An advertised-but-unapproved route looks IDENTICAL
   # to success from this node and carries no traffic at all.
   if [ "$authed" != "1" ]; then
-    unknowns+=("whether $SUBNET is APPROVED in the admin console cannot be known before
-    this node authenticates -- the control plane has no machine here yet, so there is
-    nothing to approve and \`PrimaryRoutes\` is empty for a reason that is not refusal.
-    Re-run after \`tailscale up\`.")
+    unknowns+=("whether $SUBNET is APPROVED in the admin console cannot be known while
+    this node has no valid identity -- $noid_reason -- so \`PrimaryRoutes\` is empty for
+    a reason that is not refusal. Re-run once the node holds a live identity.")
   elif _in_csv "$SUBNET" "$primary"; then
     echo "PASS  approved  : $SUBNET is APPROVED in the admin console; this node is its primary router"
-  else
+  elif [ "$adv_verdict" = "yes" ]; then
     actions+=("$SUBNET is advertised but NOT APPROVED. It carries NO traffic until a
     human approves it, and the node cannot tell the difference. This CANNOT be
     scripted -- the admin console is the only place it exists:
       https://login.tailscale.com/admin/machines -> this machine -> ... ->
       Edit route settings -> tick $SUBNET -> Save")
+  else
+    # 🔴 NOT APPROVED, BUT THIS RUN CANNOT SAY THE CONSOLE IS WHY. `PrimaryRoutes` is
+    # empty for BOTH "the admin never ticked it" and "the node never advertised it", and
+    # those need different fixes -- one is a browser, the other is `tailscale up` on this
+    # host. Naming the console when the advertisement is unknown, or is known to be
+    # ABSENT, sends the operator to the wrong machine. Reported as an unevaluated claim
+    # rather than an admin action; when the advertisement is known-absent the FAIL above
+    # is already the finding, and rc 1 outranks this either way.
+    if [ "$adv_verdict" = "no" ]; then
+      unknowns+=("$SUBNET is NOT in \`PrimaryRoutes\`, but this node is not advertising it
+    either (see the FAIL above), so approval cannot even be asked for yet -- there is
+    nothing for the admin console to approve. Fix the advertisement FIRST, then re-run
+    this check and expect an approval action to appear. NOTE EITHER WAY: $SUBNET carries
+    NO traffic over tailscale right now.")
+    else
+      unknowns+=("$SUBNET is NOT in \`PrimaryRoutes\`, so it is not approved -- but this
+    run could not read this node's own prefs, so it CANNOT tell whether the cause is an
+    unticked box in the admin console or a node that never advertised the route at all.
+    Those have different fixes (a browser vs \`tailscale up\` on this host) and this run
+    has no evidence to choose between them. Get prefs readable and re-run:
+      tailscale debug prefs
+    NOTE EITHER WAY: $SUBNET carries NO traffic over tailscale right now.")
+    fi
   fi
 
   # Forwarding, read from the KERNEL. A sysctl that is in the config but was never
@@ -670,8 +850,8 @@ if [ "$ROLE" = "server" ]; then
   fi
 else
   if [ "$authed" != "1" ]; then
-    unknowns+=("whether this client accepts subnet routes cannot be judged before it
-    authenticates: \`RouteAll\` is the \`--accept-routes\` pref and is set BY
+    unknowns+=("whether this client accepts subnet routes cannot be judged: $noid_reason.
+    \`RouteAll\` is the \`--accept-routes\` pref and is runtime state owned by
     \`tailscale up\`. (prefs currently say RouteAll=$route_all)")
   elif [ "$route_all" = "true" ]; then
     echo "PASS  acceptrt  : this client accepts subnet routes (RouteAll / --accept-routes)"
@@ -682,8 +862,8 @@ else
   if ip -4 -o route show 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -q 'dev tailscale'; then
     echo "PASS  lanroute  : $SUBNET is installed here via a tailscale interface"
   elif [ "$authed" != "1" ]; then
-    unknowns+=("$SUBNET is not installed here via tailscale, but this node has not
-    authenticated, so no route COULD have been installed. Not a finding yet.")
+    unknowns+=("$SUBNET is not installed here via tailscale, and $noid_reason, so no
+    route COULD be installed. Not a separate finding.")
   else
     actions+=("$SUBNET is not in this host's routing table via tailscale. Either the
     route is not approved in the admin console, or --accept-routes is off here, or the
@@ -698,7 +878,20 @@ fi
 # node that had never logged in -- the reassuring branch, on the single item most likely
 # to kill this path silently mid-trip. "Disabled" is claimed ONLY when there IS a node
 # key for expiry to have been disabled on.
-if [ -n "$expiry" ]; then
+if [ -n "$expiry" ] && [ "${days#-}" != "$days" ]; then
+  # 🔴 A DATE IN THE PAST IS A THIRD, INDEPENDENT DETECTOR of the dead-key state, and it
+  # reads a different field from either shape `_identity_state` handles. A daemon that
+  # kept reporting `Running` with `Self.Expired` absent while its KeyExpiry had already
+  # lapsed would slip past both of those; it does not slip past this. Cheap, and the
+  # failure it covers is the one that ends the trip's remote access.
+  fails+=("🔴 THIS NODE'S KEY EXPIRY DATE IS IN THE PAST: $expiry ($days days, i.e.
+    ${days#-} days ago). The node key has LAPSED and this backup path is dead until the
+    node is re-authenticated:
+      $UP_CMD
+    Then disable key expiry so it cannot recur:
+      https://login.tailscale.com/admin/machines -> this machine -> ... ->
+      Disable key expiry")
+elif [ -n "$expiry" ]; then
   actions+=("node key expiry is ENABLED: it expires $expiry, in $days days.
     Tailscale's default is 180 days, shorter than a months-long trip, and when it lapses
     this backup path goes dark with no local error. Disabling it is an ADMIN-CONSOLE
@@ -706,13 +899,12 @@ if [ -n "$expiry" ]; then
       https://login.tailscale.com/admin/machines -> this machine -> ... ->
       Disable key expiry")
 elif [ "$authed" != "1" ]; then
-  unknowns+=("NODE KEY EXPIRY IS UNKNOWN, not disabled. \`Self.KeyExpiry\` is absent, and
-    on a node that has never authenticated that means the control plane has never issued
-    a node key -- there is nothing yet for expiry to be on or off for. Absence is
+  unknowns+=("NODE KEY EXPIRY IS UNKNOWN, not disabled. \`Self.KeyExpiry\` is absent and
+    $noid_reason, so there is no live node key for expiry to be on or off for. Absence is
     ambiguous, and this is the one claim where guessing the reassuring answer is most
     expensive: the default is 180 days, shorter than the trip, and the lapse is silent.
-    Re-run after \`tailscale up\` -- and expect it to say ENABLED, because that is the
-    default a new node gets.")
+    Re-run once the node holds a live identity -- and expect it to say ENABLED, because
+    that is the default a new node gets.")
 else
   echo "PASS  keyexpiry : disabled -- this node IS authenticated and the daemon reports no"
   echo "                  KeyExpiry, so this node key will not expire mid-trip"
@@ -736,8 +928,12 @@ fi
 if [ ${#actions[@]} -gt 0 ]; then
   echo "ACTION REQUIRED (admin console / human -- cannot be scripted):"
   for a in "${actions[@]}"; do printf '  - %s\n' "$a"; done
-  # 🔴 NOT `[ "$rc" = 0 ] && rc=3`: under `set -e` an `a && b` whose test is FALSE
-  # fails as a whole and kills the script right before it prints its verdict.
+  # 🔴 NOT `[ "$rc" = 0 ] && rc=3`. MEASURED on bash 5.3.15, and the mechanism is NOT the
+  # "aborts the script" one this comment used to assert: an `a && b` whose test is FALSE
+  # does NOT trigger errexit mid-script -- errexit does not apply to the non-final command
+  # of an AND-list. What it DOES do is leave the list's status non-zero, so when such a
+  # line is the last statement executed it becomes the script's exit status: a PASS run
+  # would exit 1 having printed a PASS. An explicit `if` cannot do either.
   if [ "$rc" = "0" ]; then rc=3; fi
 fi
 if [ "$rc" = "0" ]; then

--- a/nix/system/check-tailscale.sh
+++ b/nix/system/check-tailscale.sh
@@ -1164,7 +1164,7 @@ else
     actions+=("this client does not accept subnet routes (RouteAll=$route_all), so the
     workbench's $SUBNET advertisement will not be installed here. Fix:  $UP_CMD")
   fi
-  if ip -4 -o route show 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -q 'dev tailscale'; then
+  if ip -4 -o route show table all 2>/dev/null | awk -v s="$SUBNET" '$1==s' | grep -q 'dev tailscale'; then
     echo "PASS  lanroute  : $SUBNET is installed here via a tailscale interface"
   elif [ "$authed" != "1" ]; then
     unknowns+=("$SUBNET is not installed here via tailscale, and $noid_reason, so no

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -363,21 +362,20 @@ def test_only_a_real_declaration_counts_as_already_configured(tmp_path, body, de
     assert got is declared, f"{body!r} -> declared={got}, want {declared}\n{r.stdout}"
 
 
-def test_shellcheck_is_clean_at_warning_level():
-    sc = shutil.which("shellcheck")
-    if not sc:
-        pytest.skip("shellcheck not on PATH")
-    # NEGATIVE CONTROL first: a clean report from a scanner that is not scanning is not
-    # a clean report.
-    bad = Path(os.environ.get("TMPDIR", "/tmp")) / f"ts-shellcheck-control-{os.getpid()}.sh"
-    write_exec(bad, "foo=1\ncat $1 | grep x\n")
-    try:
-        control = _run(sc, "-S", "warning", bad)
-        assert control.returncode != 0, "shellcheck reported a known-bad script as clean"
-    finally:
-        bad.unlink(missing_ok=True)
-    r = _run(sc, "-S", "warning", APPLY, CHECK)
-    assert r.returncode == 0, r.stdout + r.stderr
+# 🔴 THERE IS DELIBERATELY NO SHELLCHECK TEST HERE, and the omission is the finding.
+# A first version ran `shellcheck -S warning` on both scripts and `pytest.skip`ped when
+# the binary was absent. `shellcheck` is not in this repo's `gateTools`, so it is absent
+# in EVERY gate run: the test could only ever skip, and `run-tests.sh` rejected it as an
+# UNPINNED SKIP -- "a test that did not run" -- turning the whole pytest tier red with
+# `failed=0`. Both remedies were worse than removing it:
+#   * pinning it in EXPECTED_SKIPS ships a test that never executes anywhere, which is
+#     the vacuous-guard shape this suite exists to prevent;
+#   * adding shellcheck to `gateTools` changes the toolchain for every target and every
+#     developer, to gate two files, in a PR about something else.
+# So shellcheck stays a manual step. It was run for this change against
+# `nix-shell -p shellcheck` (0.11.0) -- clean at `-S warning` on both scripts, with the
+# scanner negative-controlled against a known-bad script first, since a clean report
+# from a scanner that is not scanning is not a clean report.
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -16,8 +16,23 @@ CAN be exercised without one, chosen for the defects that were actually found:
   * the freshly-switched state (`NeedsLogin`, no address) must be rc 4, not a FAIL, and
     must NOT print "keyexpiry : disabled" -- an absent `KeyExpiry` on an unauthenticated
     node means "no node key exists", not "expiry is off".
+  * 🔴 and the MIRROR of that, which is the more expensive error: a node that HAD an
+    identity and LOST it -- an expired or revoked node key -- must be rc 1, never rc 4.
+    Keys expire at 180 days by default, shorter than the trip. The checker used to
+    require BackendState and the address list to AGREE and to resolve disagreement to
+    "never authenticated", so an expired node printed "THIS NODE HAS NEVER AUTHENTICATED
+    ... the EXPECTED state immediately after apply-tailscale.sh" beside the very address
+    it had retained, and exited 4: "no defect found", about a dead backup path.
+  * the closure preflight's DOWNLOAD gate must fail CLOSED. `_drybuild_counts` used to
+    return 0.0 MiB for any size string it could not parse -- indistinguishable from
+    nothing to download -- so a 2400-path substitutable world rebuild passed all four
+    gates in silence. The parser and the gate were each tested; the defect lived in the
+    SEAM between them, which is now driven directly.
   * `--help` must print the comment header and stop -- not truncate it, not run past it
-    into `set -euo pipefail`.
+    into `set -euo pipefail`. The guard for that must NOT be built from the same
+    "stop at the first non-# line" rule the implementation uses, or it cannot see the
+    implementation truncate: one inserted blank line cost 56 of 75 help lines with both
+    tests green.
   * `--role` as the final argument must SAY something rather than exit 1 in silence.
 
 Both scripts' own `--self-test` suites are run here too, so their internal controls are
@@ -54,16 +69,46 @@ def _run(*argv, **kw):
     )
 
 
+# 🔴 THE HEADER IS BOUNDED BY `set -euo pipefail`, NOT BY "the first non-# line" -- AND
+# THAT DIFFERENCE IS THE WHOLE GUARD. The previous helper walked from the shebang and
+# STOPPED AT THE FIRST NON-`#` LINE: the exact rule the scripts' own `--help` awk uses.
+# A guard built from the implementation's rule cannot see the implementation truncate.
+# MUTATION-PROVEN, against the then-75-line header at dd207064: inserting ONE blank line
+# into check-tailscale.sh's header dropped `--help` from 75 lines to 19 -- losing the
+# entire exit-code vocabulary, the thing an operator reads this text for -- and BOTH
+# `--help` tests still passed, because `want` had been computed with the same truncating
+# rule and shrank to match.
+#
+# So the boundary is read from a DIFFERENT fact: both files end their header at the
+# literal `set -euo pipefail`. Everything between the shebang and that line must be a
+# comment; a blank or code line in there is the truncation itself, and is reported as
+# such rather than being silently absorbed into the expectation.
+HEADER_END = "set -euo pipefail"
+
+# State pins, not rule restatements. The floors sit under the current lengths (98 and
+# 148) with room for ordinary editing. Their job is the case the structural check above
+# would still call well-formed: a wholesale deletion of most of the header, every
+# remaining line still a comment.
+HELP_MIN_LINES = {"check-tailscale.sh": 70, "apply-tailscale.sh": 110}
+
+
 def _header_comment_lines(path: Path) -> list[str]:
-    """The `#` block after the shebang -- the text `--help` is supposed to print."""
-    out = []
-    for i, line in enumerate(path.read_text().splitlines()):
-        if i == 0:
-            continue
-        if not line.startswith("#"):
-            break
-        out.append(re.sub(r"^# ?", "", line))
-    return out
+    """The header block, delimited by `set -euo pipefail` -- what `--help` must print."""
+    lines = path.read_text().splitlines()
+    assert HEADER_END in lines, (
+        f"{path.name} has no bare `{HEADER_END}` line, so this test cannot locate the "
+        "end of the header independently of the awk that prints it"
+    )
+    block = lines[1:lines.index(HEADER_END)]
+    intruders = [(i + 2, ln) for i, ln in enumerate(block) if not ln.startswith("#")]
+    assert not intruders, (
+        f"{path.name}: line(s) {[n for n, _ in intruders]} between the shebang and "
+        f"`{HEADER_END}` do not start with '#'. The `--help` awk stops at the first such "
+        "line, so everything after it is silently dropped from the help text -- one "
+        "blank line here cost check-tailscale.sh 56 of its then-75 lines, including its "
+        f"whole exit-code vocabulary. Offending line(s): {[ln for _, ln in intruders]!r}"
+    )
+    return [re.sub(r"^# ?", "", ln) for ln in block]
 
 
 # --------------------------------------------------------------------------------------
@@ -164,7 +209,37 @@ def test_help_prints_exactly_the_comment_header(script):
         f"({len(got)} lines printed vs {len(want)} in the header). A hardcoded line "
         "range truncated one of these mid-paragraph and ran the other past the end."
     )
-    assert "set -euo pipefail" not in "\n".join(got)
+    assert HEADER_END not in "\n".join(got)
+    # A minimum length, pinned as STATE. `got == want` above compares the printed text to
+    # the file's own header; if BOTH shrink together it stays green, which is how the
+    # truncation this test now guards went unseen. This assertion is not derived from the
+    # file at all.
+    floor = HELP_MIN_LINES[script.name]
+    assert len(got) >= floor, (
+        f"{script.name} --help printed only {len(got)} lines; it has never been shorter "
+        f"than {floor}. Something truncated the header."
+    )
+
+
+def test_check_help_carries_the_whole_exit_code_vocabulary():
+    """The exit codes are what an operator reads `--help` FOR, and they live at the very
+    END of check-tailscale.sh's header -- so they are the first thing a truncation loses.
+    Asserted against the PRINTED output, on the code's meaning and not just its digit."""
+    got = _run("bash", CHECK, "--help").stdout
+    for code, meaning in (
+        ("0", "every claim holds"),
+        ("1", "definitive node-side FAIL"),
+        ("2", "cannot determine"),
+        ("3", "ADMIN-CONSOLE action"),
+        ("4", "INCOMPLETE"),
+    ):
+        # `Exit: 0 = ...` sits on the same line as the label, the rest are indented.
+        assert re.search(rf"(?:^|\s){code} = ", got, flags=re.M), (
+            f"`--help` does not document exit code {code}:\n{got}"
+        )
+        assert meaning in got, (
+            f"`--help` documents exit {code} without saying '{meaning}':\n{got}"
+        )
 
 
 @pytest.mark.parametrize("script", [APPLY, CHECK], ids=lambda p: p.name)
@@ -312,6 +387,133 @@ def test_an_authenticated_but_broken_node_is_still_a_failure(tmp_path):
     assert "FAIL:" in r.stdout
 
 
+# --------------------------------------------------------------------------------------
+# 🔴 AN EXPIRED OR REVOKED NODE KEY IS A FAILURE, NOT "not yet authenticated"
+#
+# Node keys expire after 180 days by default -- shorter than the trip -- so this is the
+# single most likely way the backup path dies while it is being relied on. The checker
+# used to require BackendState and the address list to AGREE and to resolve every
+# disagreement to "never authenticated", which is rc 4: "NOT YET DETERMINABLE (no defect
+# found)". It printed "THIS NODE HAS NEVER AUTHENTICATED ... That is the EXPECTED state
+# immediately after apply-tailscale.sh" beside the very 100.x address the node had
+# retained. A checker that answers "no defect" when the path is dead is worse than none.
+#
+# ⚠ WHICH JSON SHAPE A REAL EXPIRY PRODUCES HAS NOT BEEN CAPTURED FROM A LIVE DAEMON, so
+# both documented shapes are pinned: the address survives while the backend drops to
+# NeedsLogin, and `Self.Expired: true` under a backend that still reads Running.
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "label,status",
+    [
+        (
+            "logged out but the netmap address was RETAINED",
+            {
+                "BackendState": "NeedsLogin",
+                "TailscaleIPs": ["100.100.10.5"],
+                "Self": {"Online": False, "PrimaryRoutes": [SUBNET]},
+            },
+        ),
+        (
+            "NoState with the address retained",
+            {
+                "BackendState": "NoState",
+                "TailscaleIPs": ["100.100.10.5"],
+                "Self": {"Online": False, "PrimaryRoutes": [SUBNET]},
+            },
+        ),
+        (
+            "Self.Expired under a backend that still says Running",
+            {
+                "BackendState": "Running",
+                "TailscaleIPs": ["100.100.10.5"],
+                "Self": {"Online": True, "PrimaryRoutes": [SUBNET], "Expired": True},
+            },
+        ),
+    ],
+    ids=["needslogin-retained-addr", "nostate-retained-addr", "running-expired-flag"],
+)
+def test_an_expired_or_revoked_node_key_is_a_failure_not_incomplete(tmp_path, label, status):
+    env = _fake_tailscale(tmp_path, status, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    out = r.stdout + r.stderr
+    assert r.returncode == 1, (
+        f"{label}: a node that HAD an identity and lost it exited {r.returncode}, not 1. "
+        "rc 4 says 'no defect found' about a dead backup path.\n" + out
+    )
+    assert "HAS NEVER AUTHENTICATED" not in out, (
+        f"{label}: still claims the node never authenticated, next to the address it "
+        "retained:\n" + out
+    )
+    assert "HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE" in r.stdout, out
+
+
+def test_the_expired_shapes_are_not_reachable_by_the_fresh_install_path(tmp_path):
+    """The control for the three cases above, in the other direction: strip BOTH pieces
+    of evidence -- no retained address, no Expired flag -- and the SAME code must go back
+    to rc 4. Without this, a checker that simply failed everything would satisfy them."""
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, NO_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, r.stdout + r.stderr
+    assert "HAS NEVER AUTHENTICATED" in r.stdout
+
+
+def test_a_key_expiry_date_in_the_past_is_a_failure(tmp_path):
+    """The third, independent detector: a daemon still reporting Running with no Expired
+    flag, whose KeyExpiry has nonetheless lapsed. It reads a different field from either
+    shape above, so a build that emits neither of those still cannot hide a dead key."""
+    status = {
+        "BackendState": "Running",
+        "TailscaleIPs": ["100.100.10.5"],
+        "Self": {
+            "Online": True,
+            "PrimaryRoutes": [SUBNET],
+            "KeyExpiry": "2020-01-02T03:04:05Z",
+        },
+    }
+    env = _fake_tailscale(tmp_path, status, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "KEY EXPIRY DATE IS IN THE PAST" in r.stdout, r.stdout
+    # ...and the control: the SAME shape with a future date is an ACTION (rc 3), not a
+    # FAIL. A guard that failed on any KeyExpiry at all would pass the assertion above.
+    status["Self"]["KeyExpiry"] = "2099-01-02T03:04:05Z"
+    (tmp_path / "future").mkdir()
+    env = _fake_tailscale(tmp_path / "future", status, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 3, r.stdout + r.stderr
+    assert "KEY EXPIRY DATE IS IN THE PAST" not in r.stdout
+
+
+def test_an_unreadable_prefs_run_does_not_assert_what_the_node_advertises(tmp_path):
+    """One run printed BOTH `what this node ADVERTISES is UNKNOWN` and `<subnet> is
+    advertised but NOT APPROVED` -- the second asserting, and sending the operator to the
+    admin console over, the exact fact the first had declared unknowable. `PrimaryRoutes`
+    being empty has two causes with different fixes (a browser vs `tailscale up` here),
+    and a run that cannot read prefs has no evidence to choose between them."""
+    unapproved = {
+        "BackendState": "Running",
+        "TailscaleIPs": ["100.100.10.5"],
+        "Self": {"Online": True, "PrimaryRoutes": []},
+    }
+    env = _fake_tailscale(tmp_path, unapproved, None)  # prefs unreadable
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    # The verdict paragraphs are hard-wrapped, so compare on whitespace-normalised text.
+    flat = " ".join(r.stdout.split())
+    assert "what this node ADVERTISES is UNKNOWN" in flat, r.stdout
+    assert "is advertised but NOT APPROVED" not in flat, (
+        "the run asserts the node advertises the route in the same breath as declaring "
+        "that unknowable:\n" + r.stdout
+    )
+    assert "carries NO traffic over tailscale right now" in flat, r.stdout
+    # THE CONTROL: with prefs READABLE and the route genuinely advertised, the admin
+    # console action must still fire. Otherwise this test is satisfied by deleting it.
+    (tmp_path / "readable").mkdir()
+    env = _fake_tailscale(tmp_path / "readable", unapproved, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 3, r.stdout + r.stderr
+    assert "is advertised but NOT APPROVED" in r.stdout, r.stdout
+
+
 def test_a_subnet_router_with_no_lan_route_still_fails(tmp_path):
     """The control for the stubbed routing table above: with the route REMOVED, a
     subnet router is a definitive FAIL even though everything else is perfect. Without
@@ -321,6 +523,119 @@ def test_a_subnet_router_with_no_lan_route_still_fails(tmp_path):
     r = _run("bash", CHECK, "--role", "server", env=env)
     assert r.returncode == 1, r.stdout + r.stderr
     assert "no non-tailscale route" in r.stdout, r.stdout
+
+
+# --------------------------------------------------------------------------------------
+# 🔴 THE SEAM: what the dry-build PARSER returns, fed to the GATE that reads it
+#
+# The parser was tested on well-formed fixtures and the gate was tested on numbers typed
+# in by hand, and the defect lived in NEITHER -- it lived in the join. `_drybuild_counts`
+# spelled "I could not read the download size" as `0.0`, and `_gate_reasons` read that as
+# "there is nothing to download". MEASURED against the old code, all four shapes below
+# returned `0|2400|0.0` and passed every gate in silence: a 2400-path, entirely
+# substitutable world rebuild, which is exactly what the gate exists to stop.
+#
+# So this drives BOTH functions, out of the real script, exactly as a real run does.
+# --------------------------------------------------------------------------------------
+def _gate_probe(tmp_path: Path, dry_build_stderr: str) -> tuple[str, str]:
+    """Run `_drybuild_counts` on `dry_build_stderr`, feed the result to `_gate_reasons`.
+
+    Returns (counts_record, gate_output). Empty gate output means "allowed".
+    """
+    src = APPLY.read_text()
+    # Everything up to the `--self-test` dispatcher: the limit variables and every
+    # function, and nothing that touches the host.
+    prefix = src.split('\nif [ "$SELFTEST" = "1" ]; then', 1)[0]
+    assert "_gate_reasons()" in prefix and "_drybuild_counts()" in prefix, (
+        "the seam probe no longer captures both functions -- the script was reordered"
+    )
+    fixture = tmp_path / "dry.err"
+    fixture.write_text(dry_build_stderr)
+    probe = tmp_path / "seam.sh"
+    # The fixture path travels in the ENVIRONMENT, not in `$1`: `prefix` carries the
+    # script's own argument parser, which rejects an unknown positional with exit 2.
+    probe.write_text(
+        prefix
+        + '\nc=$(_drybuild_counts "$TS_SEAM_FIXTURE")\n'
+        'IFS="|" read -r b f m <<<"$c"\n'
+        'printf "%s\\n---\\n" "$c"\n'
+        '_gate_reasons 26.11 26.11 "$b" "$b" "$m" "$m" "$f" "$f"\n'
+    )
+    env = dict(os.environ, TS_SEAM_FIXTURE=str(fixture))
+    r = _run("bash", probe, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    counts, _, gate = r.stdout.partition("\n---\n")
+    return counts.strip(), gate.strip()
+
+
+# 🔴 `expect_mib` IS PINNED EXACTLY, NOT JUST "not 0.0". A first version of this test
+# asserted only that the size was not `0.0` and that SOME gate fired, and a mutant that
+# defaulted an unrecognised unit to MiB -- turning 4 EiB into 4.0 -- SURVIVED it: the
+# number was not 0.0, and the fetch-count gate caught the change for an unrelated reason.
+# Defence in depth is not a reason to leave the inner guard unpinned; the exact value is
+# the only assertion that can see that mutation.
+@pytest.mark.parametrize(
+    "label,line,expect_mib",
+    [
+        ("no size parenthetical", "these 2400 paths will be fetched:", "UNKNOWN"),
+        # A unit it DOES understand must be scaled, not refused -- 2.5 TiB read as
+        # 2.5 MiB would be six orders of magnitude of "this is fine".
+        ("TiB", "these 2400 paths will be fetched (2.5 TiB download, 9.0 TiB unpacked):",
+         "2621440.0"),
+        ("comma decimal separator",
+         "these 2400 paths will be fetched (4096,0 MiB download, 9000,0 MiB unpacked):",
+         "UNKNOWN"),
+        ("an unknown unit",
+         "these 2400 paths will be fetched (4.0 EiB download, 9.0 EiB unpacked):",
+         "UNKNOWN"),
+    ],
+)
+def test_a_world_sized_fetch_never_passes_the_gate_however_its_size_is_spelled(
+    tmp_path, label, line, expect_mib
+):
+    counts, gate = _gate_probe(tmp_path, line + "\n")
+    assert counts == f"0|2400|{expect_mib}", (
+        f"{label}: got {counts}, want 0|2400|{expect_mib}. An unreadable size must be "
+        "spelled UNKNOWN -- never as 0.0 (indistinguishable from nothing to download) "
+        "and never as a number invented by defaulting the unit."
+    )
+    assert gate, f"{label}: {counts} passed every gate in silence"
+
+
+def test_the_seam_still_allows_a_real_tailscale_sized_change(tmp_path):
+    """The control. Both directions, or the four cases above are satisfied by a gate that
+    refuses everything -- which is a permanent red light people learn to override."""
+    counts, gate = _gate_probe(
+        tmp_path,
+        "these 7 derivations will be built:\n"
+        "  /nix/store/aaaa-tailscale-1.102.3.drv\n"
+        "these 25 paths will be fetched (17.6 MiB download, 61.1 MiB unpacked):\n"
+        "  /nix/store/bbbb-thing\n",
+    )
+    assert counts == "7|25|17.6", counts
+    assert gate == "", f"the measured tailscale-only delta was refused:\n{gate}"
+
+
+def test_an_empty_dry_build_is_a_real_zero_and_is_allowed(tmp_path):
+    """`0.0` must still MEAN zero when there genuinely is nothing to fetch -- otherwise
+    the fix above would have turned the gate into an unconditional refusal."""
+    counts, gate = _gate_probe(tmp_path, "building the system configuration...\n")
+    assert counts == "0|0|0.0", counts
+    assert gate == "", gate
+
+
+def test_the_fetch_count_is_gated_and_not_merely_printed(tmp_path):
+    """The count was parsed correctly and printed in the summary table, and read by no
+    gate -- the identical 'decorative column' defect the download-volume gate was added
+    to fix. It is the axis that still has a number when the SIZE cannot be parsed."""
+    counts, gate = _gate_probe(
+        tmp_path, "these 2400 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n"
+    )
+    assert counts == "0|2400|1.0", counts
+    assert "FETCH COUNT" in gate, (
+        "2400 paths to fetch passed with a 1.0 MiB size -- both build gates and both "
+        f"download-volume gates are silent by construction here:\n{gate}"
+    )
 
 
 # --------------------------------------------------------------------------------------
@@ -340,6 +655,17 @@ def test_a_subnet_router_with_no_lan_route_still_fails(tmp_path):
         # is not a setting. Only the `[.={]` anchor rejects this; a bare
         # `services\.tailscale` match accepts it and reports the host as already done.
         ('  warnings = [ "services.tailscale is not enabled here" ];', False),
+        # 🔴 THE FIXTURES THAT DISCRIMINATE STRING-BLANKING FROM THAT ANCHOR. The case
+        # above has no `[.={]` after the attribute path, so the anchor alone rejects it
+        # and it stays False with every line of string handling deleted -- it cannot see
+        # that mutation. These two can: each is a string whose CONTENTS are a
+        # syntactically perfect declaration, and each made the script print "Nothing to
+        # do. Exiting 0" on a host where nothing had been applied.
+        ('  warnings = [ "you should run services.tailscale.enable = true; here" ];', False),
+        ("  text = ''\n    services.tailscale.enable = true;\n  '';", False),
+        # ...and the control against a scanner that blanks too much: a real declaration
+        # after a CLOSED string must still be found.
+        ('  warnings = [ "off" ];\n  services.tailscale.enable = true;', True),
         ("  services.tailscale.enable = true;", True),
         ("  services.tailscale = {\n    enable = true;\n  };", True),
         ("  services.tailscale={enable=true;};", True),

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -37,6 +37,11 @@ from pathlib import Path
 
 import pytest
 
+SCRIPTS = Path(__file__).resolve().parents[1]
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+from testlib.mockbin import write_exec  # noqa: E402
+
 REPO = Path(__file__).resolve().parents[2]
 APPLY = REPO / "nix" / "system" / "apply-tailscale.sh"
 CHECK = REPO / "nix" / "system" / "check-tailscale.sh"
@@ -198,9 +203,13 @@ def _fake_tailscale(tmp_path: Path, status: dict, prefs: dict | None) -> dict:
     (tmp_path / "status.json").write_text(json.dumps(status))
     if prefs is not None:
         (tmp_path / "prefs.json").write_text(json.dumps(prefs))
-    shim = bindir / "tailscale"
-    shim.write_text(
-        "#!/usr/bin/env bash\n"
+    # 🔴 `testlib.mockbin.write_exec` owns the shebang. A test-written stub carrying
+    # `#!/usr/bin/env bash` execs on this NixOS host and ENOENTs in the nix build
+    # sandbox, so the defect is invisible in the tier most people run. The bodies here
+    # are POSIX sh for the same reason. `test_runtime_shebangs.py` caught this file
+    # doing it by hand on its first gate run.
+    write_exec(
+        bindir / "tailscale",
         'case "$1 $2" in\n'
         f'  "status --json") cat "{tmp_path}/status.json"; exit 0 ;;\n'
         + (
@@ -208,9 +217,8 @@ def _fake_tailscale(tmp_path: Path, status: dict, prefs: dict | None) -> dict:
             if prefs is not None
             else '  "debug prefs") exit 1 ;;\n'
         )
-        + "esac\nexit 1\n"
+        + "esac\nexit 1\n",
     )
-    shim.chmod(0o755)
     proc = tmp_path / "proc"
     (proc / "sys/net/ipv4").mkdir(parents=True)
     (proc / "sys/net/ipv6/conf/all").mkdir(parents=True)
@@ -328,7 +336,7 @@ def test_shellcheck_is_clean_at_warning_level():
     # NEGATIVE CONTROL first: a clean report from a scanner that is not scanning is not
     # a clean report.
     bad = Path(os.environ.get("TMPDIR", "/tmp")) / f"ts-shellcheck-control-{os.getpid()}.sh"
-    bad.write_text("#!/usr/bin/env bash\nfoo=1\ncat $1 | grep x\n")
+    write_exec(bad, "foo=1\ncat $1 | grep x\n")
     try:
         control = _run(sc, "-S", "warning", bad)
         assert control.returncode != 0, "shellcheck reported a known-bad script as clean"

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -1,0 +1,342 @@
+"""Guards for `nix/system/apply-tailscale.sh` + `nix/system/check-tailscale.sh`.
+
+These two are the pre-departure BACKUP REMOTE PATH: nebula is currently the only way
+into the workbench, and the operator leaves the LAN for months. Nothing here can run the
+apply path (it needs root and a real `nixos-rebuild`), so these tests pin the parts that
+CAN be exercised without one, chosen for the defects that were actually found:
+
+  * the two scripts' `tailscale up` commands must be the SAME STRING. They are printed
+    by two different files -- the apply script as a next step, the checker as its "Fix:"
+    -- and an operator who follows one and then runs the other must not be told to run a
+    different command. This is where `--accept-dns=false` drifted onto the server role
+    only, silently handing the travelling laptop's resolver to MagicDNS.
+  * the checker's exit-code vocabulary and the apply script's handling of it must agree.
+    They disagreed: the checker returned 1 for a freshly-switched node and the apply
+    script rolled the config back for it, on the FIRST run, every time.
+  * the freshly-switched state (`NeedsLogin`, no address) must be rc 4, not a FAIL, and
+    must NOT print "keyexpiry : disabled" -- an absent `KeyExpiry` on an unauthenticated
+    node means "no node key exists", not "expiry is off".
+  * `--help` must print the comment header and stop -- not truncate it, not run past it
+    into `set -euo pipefail`.
+  * `--role` as the final argument must SAY something rather than exit 1 in silence.
+
+Both scripts' own `--self-test` suites are run here too, so their internal controls are
+part of the gate rather than something a human has to remember to invoke.
+
+    run:  pytest scripts/tests/test_tailscale_scripts.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+APPLY = REPO / "nix" / "system" / "apply-tailscale.sh"
+CHECK = REPO / "nix" / "system" / "check-tailscale.sh"
+
+SUBNET = "192.168.50.0/24"
+
+
+def _run(*argv, **kw):
+    return subprocess.run(
+        [str(a) for a in argv], capture_output=True, text=True, timeout=180, **kw
+    )
+
+
+def _header_comment_lines(path: Path) -> list[str]:
+    """The `#` block after the shebang -- the text `--help` is supposed to print."""
+    out = []
+    for i, line in enumerate(path.read_text().splitlines()):
+        if i == 0:
+            continue
+        if not line.startswith("#"):
+            break
+        out.append(re.sub(r"^# ?", "", line))
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# the two scripts must tell the operator to run the SAME command
+# --------------------------------------------------------------------------------------
+def _up_commands(path: Path) -> set[str]:
+    """Every `tailscale up ...` command line either script prints, normalised."""
+    found = set()
+    for line in path.read_text().splitlines():
+        m = re.search(r"(sudo tailscale up [^\"']*)", line)
+        if m:
+            cmd = m.group(1).strip()
+            # both files interpolate the subnet the same way; compare the resolved form
+            cmd = cmd.replace("${SUBNET}", SUBNET)
+            found.add(cmd)
+    return found
+
+
+def test_the_two_scripts_print_the_same_tailscale_up_commands():
+    apply_cmds = _up_commands(APPLY)
+    check_cmds = _up_commands(CHECK)
+    assert apply_cmds, "found no `tailscale up` command in apply-tailscale.sh"
+    assert check_cmds, "found no `tailscale up` command in check-tailscale.sh"
+    assert apply_cmds == check_cmds, (
+        "the apply script and the checker disagree about what the operator should run.\n"
+        f"  only in apply: {sorted(apply_cmds - check_cmds)}\n"
+        f"  only in check: {sorted(check_cmds - apply_cmds)}"
+    )
+
+
+def test_both_roles_keep_tailscale_out_of_the_host_resolver():
+    """`--accept-dns=false` on BOTH roles, not just the subnet router.
+
+    The reasoning ("dnsmasq and the .lan names already own this host's resolver") is
+    identical on the two machines, and the asymmetric version pointed MagicDNS at the
+    laptop -- the one machine that leaves the LAN and the one nobody can fix remotely.
+    """
+    cmds = _up_commands(APPLY)
+    assert len(cmds) == 2, f"expected one command per role, got {sorted(cmds)}"
+    server = [c for c in cmds if "--advertise-routes" in c]
+    client = [c for c in cmds if "--advertise-routes" not in c]
+    assert len(server) == 1 and len(client) == 1, sorted(cmds)
+    assert "--accept-dns=false" in server[0], server[0]
+    assert "--accept-dns=false" in client[0], (
+        "the CLIENT role does not pass --accept-dns=false, so MagicDNS takes over the "
+        f"laptop's resolver: {client[0]}"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# the exit-code vocabularies must agree
+# --------------------------------------------------------------------------------------
+def test_apply_handles_every_exit_code_the_checker_documents():
+    """A code the checker can return that the apply script does not name is a rollback
+    decision made by a `*)` fallthrough. rc 4 was born exactly there."""
+    documented = set(
+        re.findall(r"^#(?:\s+Exit:)?\s+([0-4]) = ", CHECK.read_text(), flags=re.M)
+    )
+    assert documented >= {"0", "1", "2", "3", "4"}, (
+        f"check-tailscale.sh's header documents only {sorted(documented)}"
+    )
+    verify = APPLY.read_text().split("chk_rc=0", 1)[1].split("esac", 1)[0]
+    handled = set()
+    for m in re.finditer(r"^\s{2}([0-9|]+)\)", verify, flags=re.M):
+        handled.update(m.group(1).split("|"))
+    assert handled == documented, (
+        "the apply script's post-switch `case` does not enumerate the same codes the "
+        f"checker documents.\n  documented: {sorted(documented)}\n  handled:    "
+        f"{sorted(handled)}"
+    )
+
+
+def test_the_not_yet_authenticated_code_is_not_a_rollback():
+    """rc 4 must be an accepted outcome. This is the whole first-run bug in one line."""
+    verify = APPLY.read_text().split("chk_rc=0", 1)[1].split("esac", 1)[0]
+    branch = re.search(r"^\s{2}4\)(.*?)^\s{4};;", verify, flags=re.M | re.S)
+    assert branch, "no `4)` branch in the post-switch case"
+    assert "die " not in branch.group(1), (
+        "rc 4 (configured, not yet authenticated) rolls back -- that is the state EVERY "
+        "first run lands in, because this script deliberately does not run `tailscale up`"
+    )
+    branch1 = re.search(r"^\s{2}1\)(.*?)^\s{4};;", verify, flags=re.M | re.S)
+    assert branch1 and "die " in branch1.group(1), (
+        "rc 1 (a definitive node-side failure) must STILL roll back -- otherwise the "
+        "guard was not fixed, it was removed"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# --help prints the header, all of it, and nothing after it
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("script", [APPLY, CHECK], ids=lambda p: p.name)
+def test_help_prints_exactly_the_comment_header(script):
+    want = _header_comment_lines(script)
+    got = _run("bash", script, "--help").stdout.splitlines()
+    assert got == want, (
+        f"{script.name} --help does not match its own comment header "
+        f"({len(got)} lines printed vs {len(want)} in the header). A hardcoded line "
+        "range truncated one of these mid-paragraph and ran the other past the end."
+    )
+    assert "set -euo pipefail" not in "\n".join(got)
+
+
+@pytest.mark.parametrize("script", [APPLY, CHECK], ids=lambda p: p.name)
+def test_role_as_the_final_argument_says_so(script):
+    r = _run("bash", script, "--role")
+    assert r.returncode != 0
+    assert "--role" in (r.stdout + r.stderr), (
+        f"{script.name} exited {r.returncode} printing NOTHING when --role was given as "
+        "the last argument (`shift 2` failing under `set -e`)"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# each script's own controls are part of the gate
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("script", [APPLY, CHECK], ids=lambda p: p.name)
+def test_self_test_passes(script):
+    r = _run("bash", script, "--self-test")
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "all controls passed" in r.stdout
+    # POSITIVE CONTROL: a self-test that ran nothing also "passes".
+    assert r.stdout.count("-> ok") > 10, (
+        f"{script.name} --self-test reported success having asserted almost nothing:\n"
+        + r.stdout
+    )
+
+
+# --------------------------------------------------------------------------------------
+# the freshly-switched node, driven end to end against a fake `tailscale`
+# --------------------------------------------------------------------------------------
+def _fake_tailscale(tmp_path: Path, status: dict, prefs: dict | None) -> dict:
+    """A PATH containing a `tailscale` that answers from fixtures, plus a fake /proc."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (tmp_path / "status.json").write_text(json.dumps(status))
+    if prefs is not None:
+        (tmp_path / "prefs.json").write_text(json.dumps(prefs))
+    shim = bindir / "tailscale"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$1 $2" in\n'
+        f'  "status --json") cat "{tmp_path}/status.json"; exit 0 ;;\n'
+        + (
+            f'  "debug prefs") cat "{tmp_path}/prefs.json"; exit 0 ;;\n'
+            if prefs is not None
+            else '  "debug prefs") exit 1 ;;\n'
+        )
+        + "esac\nexit 1\n"
+    )
+    shim.chmod(0o755)
+    proc = tmp_path / "proc"
+    (proc / "sys/net/ipv4").mkdir(parents=True)
+    (proc / "sys/net/ipv6/conf/all").mkdir(parents=True)
+    (proc / "sys/net/ipv4/ip_forward").write_text("1\n")
+    (proc / "sys/net/ipv6/conf/all/forwarding").write_text("1\n")
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["TS_PROC_ROOT"] = str(proc)
+    return env
+
+
+AUTHED_APPROVED = {
+    "BackendState": "Running",
+    "TailscaleIPs": ["100.100.10.5"],
+    "Self": {"Online": True, "PrimaryRoutes": [SUBNET]},
+}
+NEVER_AUTHED = {
+    "BackendState": "NeedsLogin",
+    "TailscaleIPs": [],
+    "Self": {"Online": False},
+}
+SERVER_PREFS = {"AdvertiseRoutes": [SUBNET], "RouteAll": False, "WantRunning": True}
+NO_PREFS = {"AdvertiseRoutes": None, "RouteAll": False, "WantRunning": False}
+
+
+def test_a_freshly_switched_node_is_rc_4_not_a_failure(tmp_path):
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, NO_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, (
+        "the state straight after apply-tailscale.sh (installed, running, never logged "
+        f"in) must be rc 4, not rc {r.returncode}. rc 1 makes the apply script roll back "
+        "the config it just installed.\n" + r.stdout + r.stderr
+    )
+    assert "FAIL:" not in r.stdout
+
+
+def test_absent_key_expiry_on_an_unauthenticated_node_is_unknown(tmp_path):
+    """The reassuring branch is the expensive one to guess: node-key expiry defaults to
+    180 days, which is shorter than the trip, and the lapse is silent."""
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, NO_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert "PASS  keyexpiry" not in r.stdout, (
+        "an absent KeyExpiry on a node that has never authenticated was resolved to "
+        "'expiry disabled':\n" + r.stdout
+    )
+    assert "NODE KEY EXPIRY IS UNKNOWN" in r.stdout
+
+
+def test_absent_key_expiry_on_an_authenticated_node_is_disabled(tmp_path):
+    """The other direction -- without this the test above is satisfied by a checker that
+    never says 'disabled' at all, and the operator can never reach rc 0."""
+    env = _fake_tailscale(tmp_path, AUTHED_APPROVED, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert "PASS  keyexpiry : disabled" in r.stdout, r.stdout + r.stderr
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_an_authenticated_but_broken_node_is_still_a_failure(tmp_path):
+    """rc 1 must remain reachable. Splitting 'not yet authenticated' out of FAIL is only
+    correct if what is left can still go red."""
+    broken = {
+        "BackendState": "Stopped",
+        "TailscaleIPs": ["100.100.10.5"],
+        "Self": {"Online": False, "PrimaryRoutes": [SUBNET]},
+    }
+    env = _fake_tailscale(tmp_path, broken, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "FAIL:" in r.stdout
+
+
+# --------------------------------------------------------------------------------------
+# idempotency: a MENTION is not a DECLARATION
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "body,declared",
+    [
+        ("  # TODO: consider services.tailscale one day", False),
+        # 🔴 THE DISCRIMINATING COMMENT CASE: a whole DECLARATION commented out. The
+        # TODO above is rejected by the shape of the words alone, so it stays False even
+        # with comment-stripping deleted -- it cannot see that mutation. This one can.
+        ("  # services.tailscale = { enable = true; };", False),
+        ("  /* services.tailscale = { enable = true; }; */", False),
+        ("  environment.systemPackages = [ pkgs.tailscale ];", False),
+        # 🔴 THE DISCRIMINATING NON-COMMENT CASE: `services.tailscale` in live code that
+        # is not a setting. Only the `[.={]` anchor rejects this; a bare
+        # `services\.tailscale` match accepts it and reports the host as already done.
+        ('  warnings = [ "services.tailscale is not enabled here" ];', False),
+        ("  services.tailscale.enable = true;", True),
+        ("  services.tailscale = {\n    enable = true;\n  };", True),
+        ("  services.tailscale={enable=true;};", True),
+    ],
+)
+def test_only_a_real_declaration_counts_as_already_configured(tmp_path, body, declared):
+    """`grep -q 'services\\.tailscale'` reported "Nothing to do. Exiting 0" for a config
+    whose only occurrence was a TODO comment -- telling the operator the backup path was
+    done on a host where nothing had been applied."""
+    cfg = tmp_path / "configuration.nix"
+    cfg.write_text("{ config, pkgs, ... }:\n{\n" + body + "\n}\n")
+    # drive the predicate the script uses, through the script itself
+    src = APPLY.read_text()
+    fn = src.split("_cfg_tailscale_decls() {", 1)[1].split("\n}\n", 1)[0]
+    probe = tmp_path / "probe.sh"
+    probe.write_text("_cfg_tailscale_decls() {" + fn + "\n}\n_cfg_tailscale_decls \"$1\"\n")
+    r = _run("bash", probe, cfg)
+    assert r.returncode == 0, r.stderr
+    got = bool(r.stdout.strip())
+    assert got is declared, f"{body!r} -> declared={got}, want {declared}\n{r.stdout}"
+
+
+def test_shellcheck_is_clean_at_warning_level():
+    sc = shutil.which("shellcheck")
+    if not sc:
+        pytest.skip("shellcheck not on PATH")
+    # NEGATIVE CONTROL first: a clean report from a scanner that is not scanning is not
+    # a clean report.
+    bad = Path(os.environ.get("TMPDIR", "/tmp")) / f"ts-shellcheck-control-{os.getpid()}.sh"
+    bad.write_text("#!/usr/bin/env bash\nfoo=1\ncat $1 | grep x\n")
+    try:
+        control = _run(sc, "-S", "warning", bad)
+        assert control.returncode != 0, "shellcheck reported a known-bad script as clean"
+    finally:
+        bad.unlink(missing_ok=True)
+    r = _run(sc, "-S", "warning", APPLY, CHECK)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -23,6 +23,23 @@ CAN be exercised without one, chosen for the defects that were actually found:
     "never authenticated", so an expired node printed "THIS NODE HAS NEVER AUTHENTICATED
     ... the EXPECTED state immediately after apply-tailscale.sh" beside the very address
     it had retained, and exited 4: "no defect found", about a dead backup path.
+  * 🔴 and the SHAPE of that which survives a RESTART. `TailscaleIPs`, `Self.Expired` and
+    `Self.KeyExpiry` are all netmap fields and the netmap is in-memory only, so one
+    reboot on a node whose key had lapsed wiped every detector at once and the dead path
+    read as a fresh install again -- rc 4, "no defect found". The durable evidence is the
+    persisted profile in `tailscale debug prefs` (`Config`/`ipn.Prefs.Persist`), and the
+    controls in the OTHER direction are the expensive ones: an EMPTY persisted profile is
+    what a never-logged-in daemon carries, and reading that as an identity would make
+    every first run rc 1 and roll the config back.
+  * a SELF-CONTRADICTORY daemon (a non-logged-out backend holding no address) must not be
+    rc 1. Its own message said "re-run this check before doing anything else"; apply's
+    answer to rc 1 is `die` -> restore `configuration.nix` -> report that the RUNNING
+    system was not restored, so the next `nixos-rebuild switch` by anyone would silently
+    delete the backup path. It is rc 4 now, and the checker takes the second sample
+    itself after a settle rather than telling a human to.
+  * a READ of an option is not a DECLARATION of it. `config.services.tailscale.enable` in
+    a `mkIf` or an assertion made the apply script print "already DECLARES ... Nothing to
+    do. Exiting 0" on a host with no tailscale at all.
   * the closure preflight's DOWNLOAD gate must fail CLOSED. `_drybuild_counts` used to
     return 0.0 MiB for any size string it could not parse -- indistinguishable from
     nothing to download -- so a 2400-path substitutable world rebuild passed all four
@@ -324,6 +341,15 @@ def _fake_tailscale(
     env = dict(os.environ)
     env["PATH"] = f"{bindir}:{env['PATH']}"
     env["TS_PROC_ROOT"] = str(proc)
+    # The settle re-read costs wall time and every case here is a STABLE fixture -- the
+    # stub answers identically however many times it is called, so a second read can only
+    # slow the suite down. `test_a_self_contradictory_daemon_is_re_read_after_a_settle`
+    # turns it back on, against a stub that deliberately answers differently the second
+    # time, so the mechanism itself is not left unexercised by this default.
+    env["TS_SETTLE_SECS"] = "0"
+    # The on-disk fallback must not read the REAL host's state file from a test. Pointed
+    # at a path that does not exist unless a case creates it.
+    env["TS_STATE_FILE"] = str(tmp_path / "tailscaled.state")
     return env
 
 
@@ -339,6 +365,26 @@ NEVER_AUTHED = {
 }
 SERVER_PREFS = {"AdvertiseRoutes": [SUBNET], "RouteAll": False, "WantRunning": True}
 NO_PREFS = {"AdvertiseRoutes": None, "RouteAll": False, "WantRunning": False}
+# `ipn.Prefs.Persist` is marshalled under the key `Config`. A non-empty NodeID/LoginName
+# means a login was COMPLETED on this host at some point, and -- unlike everything in the
+# netmap -- it is reloaded from `tailscaled.state` on every daemon start.
+PERSISTED_PREFS = {
+    "AdvertiseRoutes": [SUBNET],
+    "RouteAll": False,
+    "WantRunning": True,
+    "Config": {
+        "NodeID": "nEXAMPLECafeBeef",
+        "UserProfile": {"LoginName": "operator@example.test"},
+    },
+}
+# What a daemon that has NEVER logged in carries: the key is present, the profile is
+# empty. Reading this as an identity would make every first run a FAIL.
+EMPTY_PROFILE_PREFS = {
+    "AdvertiseRoutes": None,
+    "RouteAll": False,
+    "WantRunning": False,
+    "Config": {"NodeID": "", "UserProfile": {"LoginName": "", "DisplayName": ""}},
+}
 
 
 def test_a_freshly_switched_node_is_rc_4_not_a_failure(tmp_path):
@@ -457,6 +503,235 @@ def test_the_expired_shapes_are_not_reachable_by_the_fresh_install_path(tmp_path
     assert "HAS NEVER AUTHENTICATED" in r.stdout
 
 
+# --------------------------------------------------------------------------------------
+# 🔴 THE RESTART HOLE: all three netmap detectors go blind together, and only the DISK
+# still knows.
+#
+# `TailscaleIPs`, `Self.Expired` and `Self.KeyExpiry` are netmap fields, and the netmap is
+# in-memory only -- it is fed by control-plane map responses and there is no
+# restore-from-disk path. So one reboot, power cut or `nixos-rebuild switch` on a node
+# whose key has already lapsed wipes ALL THREE at once: the daemon mints a new node key,
+# control answers with an AuthURL, no map poll happens, and `tailscale status` reports
+# `NeedsLogin` with nothing in it -- byte-identical to a fresh install. Every one of the
+# three cases above then goes green while the backup path is dead, and the checker printed
+# "THIS NODE HAS NEVER AUTHENTICATED ... It is NOT a node-side defect", rc 4.
+#
+# `lost` only survived while the daemon had run CONTINUOUSLY since before the lapse. Over
+# a months-long absence that is not an assumption worth making.
+# --------------------------------------------------------------------------------------
+def test_an_expired_key_that_survived_a_restart_is_still_a_failure(tmp_path):
+    """The status document here has NO evidence in it at all -- that is the point. The
+    only thing separating it from a fresh install is the persisted profile in prefs."""
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, PERSISTED_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    out = r.stdout + r.stderr
+    assert r.returncode == 1, (
+        "a node whose key lapsed and which has since RESTARTED exited "
+        f"{r.returncode}, not 1. Its netmap is empty, so the address, `Self.Expired` and "
+        "`KeyExpiry` detectors are all blind and it reads as a fresh install -- while the "
+        "backup path is dead.\n" + out
+    )
+    assert "HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE" in r.stdout, out
+    assert "HAS NEVER AUTHENTICATED" not in out, out
+
+
+@pytest.mark.parametrize(
+    "label,prefs",
+    [
+        ("prefs carry an EMPTY profile, which is what a fresh daemon has",
+         EMPTY_PROFILE_PREFS),
+        ("prefs carry no `Config` key at all", NO_PREFS),
+    ],
+)
+def test_a_fresh_install_is_still_rc_4_whatever_its_prefs_look_like(tmp_path, label, prefs):
+    """THE CONTROL, and it is the expensive direction. If an empty persisted profile were
+    read as an identity, EVERY first run would be rc 1 and apply-tailscale.sh would roll
+    back the config it had just installed -- the exact bug this whole file exists over."""
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, prefs)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, f"{label}: {r.stdout}{r.stderr}"
+    assert "HAS NEVER AUTHENTICATED" in r.stdout
+    assert "FAIL:" not in r.stdout
+
+
+def test_the_on_disk_state_file_is_the_fallback_when_prefs_cannot_be_read(tmp_path):
+    """Prefs are the authority; when they cannot be read at all the daemon's own state
+    file is the only remaining durable evidence. Driven in BOTH directions, plus the
+    scoping control -- a readable prefs document must WIN over the file."""
+    state = tmp_path / "tailscaled.state"
+
+    # (a) prefs unreadable + a real profile entry on disk -> the identity was LOST.
+    state.write_text('{"_machinekey":"cHJpdmtleQ","profile-a1b2":"eyJVc2VyUHJvZmlsZSI6e319"}')
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, None)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE" in r.stdout
+
+    # (b) THE CONTROL. What a never-logged-in daemon writes: a machine key, and the
+    # `_current-profile` pointer at the EMPTY profile. Keying on that pointer instead of
+    # a `profile-` entry would fail every fresh host.
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "tailscaled.state").write_text(
+        '{"_machinekey":"cHJpdmtleQ","_current-profile":""}'
+    )
+    env = _fake_tailscale(tmp_path / "b", NEVER_AUTHED, None)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, r.stdout + r.stderr
+    assert "HAS NEVER AUTHENTICATED" in r.stdout
+
+    # (c) THE SCOPING CONTROL. Prefs READABLE and carrying no identity, with a profile
+    # entry sitting on disk: prefs win, because a second opinion that can only contradict
+    # the authority is not one worth acting on.
+    (tmp_path / "c").mkdir()
+    (tmp_path / "c" / "tailscaled.state").write_text('{"profile-a1b2":"eyJ4IjoxfQ"}')
+    env = _fake_tailscale(tmp_path / "c", NEVER_AUTHED, NO_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, r.stdout + r.stderr
+
+
+# The three EVIDENCE clauses the `lost` FAIL can carry, one per route into that state.
+# They are asserted as an EXCLUSIVE set -- the right one present and the other two absent
+# -- because the defect was not a missing sentence, it was the WRONG one: the text
+# asserted "the netmap addresses it was issued are still present: <none>" followed by "a
+# node that had never logged in would have NEITHER", printing the absence of its own
+# evidence as evidence. A guard that only checked the offending words is walkable by any
+# rewording that still names an address the run cannot see.
+LOST_EVIDENCE = {
+    "address": "still present:",
+    "persisted": "there is no netmap address left",
+    "expired-flag": "Self.Expired is the control plane's own word",
+}
+
+
+@pytest.mark.parametrize(
+    "route,ips,prefs",
+    [
+        # Reached via the retained netmap address.
+        ("address", ["100.100.10.5"], SERVER_PREFS),
+        # Reached via the persisted profile, netmap gone -- the restart shape.
+        ("persisted", [], PERSISTED_PREFS),
+        # Reached via `Self.Expired` alone, with nothing else to point at.
+        ("expired-flag", [], SERVER_PREFS),
+    ],
+)
+def test_the_expired_fail_names_the_evidence_it_actually_has(tmp_path, route, ips, prefs):
+    status = {
+        "BackendState": "Running",
+        "TailscaleIPs": ips,
+        "Self": {"Online": True, "Expired": True},
+    }
+    env = _fake_tailscale(tmp_path, status, prefs)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    flat = " ".join(r.stdout.split())
+    assert "HAD A TAILNET IDENTITY AND NO LONGER HAS A VALID ONE" in flat
+    for name, clause in LOST_EVIDENCE.items():
+        if name == route:
+            assert clause in flat, (
+                f"the {route} route does not name its own evidence:\n{r.stdout}"
+            )
+        else:
+            assert clause not in flat, (
+                f"the {route} route claims the {name} evidence, which this run does not "
+                f"have:\n{r.stdout}"
+            )
+    if route == "address":
+        assert "still present: 100.100.10.5" in flat, r.stdout
+    else:
+        # The exact shape of the original defect: an address slot rendered from nothing.
+        assert "still present: <none>" not in flat, r.stdout
+        assert "still present: ," not in flat, r.stdout
+        assert "would have NEITHER" not in flat, r.stdout
+
+
+# --------------------------------------------------------------------------------------
+# 🔴 A SELF-CONTRADICTORY DAEMON IS NOT A DEFECT -- AND rc 1 FOR IT WAS AN APPLY-TIME
+# ROLLBACK.
+#
+# The `incoherent` FAIL's own text says "if tailscaled was only just started it may still
+# be fetching its netmap -- re-run this check before doing anything else". Apply's answer
+# to rc 1 is `die` -> EXIT trap -> restore `$CFG` and report that the RUNNING system was
+# not restored. It never re-ran, and there was no settle window anywhere: apply goes
+# `systemctl is-active` -> `tailscale version` -> `bash "$CHECK"` with no sleep at all.
+# The cost of that spurious rollback is not a wasted run -- `configuration.nix` loses the
+# tailscale block while the running system keeps it, so the next `nixos-rebuild switch`
+# by anyone silently deletes the backup path.
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "label,backend",
+    [
+        ("Running with an empty netmap", "Running"),
+        # Reachable with a pre-existing state file: node key present, WantRunning=false,
+        # netmap not fetched.
+        ("Stopped with no address", "Stopped"),
+        # `tailscale up` on a freshly-restarted, previously-down node.
+        ("Starting with a nil netmap", "Starting"),
+    ],
+)
+def test_a_self_contradictory_daemon_is_not_a_rollback(tmp_path, label, backend):
+    status = {"BackendState": backend, "TailscaleIPs": [], "Self": {"Online": False}}
+    env = _fake_tailscale(tmp_path, status, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    out = r.stdout + r.stderr
+    assert r.returncode == 4, (
+        f"{label}: exited {r.returncode}. rc 1 makes apply-tailscale.sh `die`, restore "
+        "configuration.nix and leave the running system carrying a change the file no "
+        "longer has -- for a state whose own message says to re-run the check.\n" + out
+    )
+    assert "SELF-CONTRADICTORY" in r.stdout, out
+    assert "FAIL:" not in r.stdout, out
+    # ...and it must NOT be quietly reclassified as the fresh-install state either: those
+    # need different actions and only one of them is expected after an apply.
+    assert "HAS NEVER AUTHENTICATED" not in out, out
+
+
+def test_a_genuine_node_side_failure_is_still_rc_1_with_the_same_backend(tmp_path):
+    """The control for the three cases above: `Stopped` is one of them, so moving
+    `incoherent` off rc 1 must not have taken the real FAIL with it. Same backend, one
+    piece of evidence added -- the retained address -- and it goes red again."""
+    status = {
+        "BackendState": "Stopped",
+        "TailscaleIPs": ["100.100.10.5"],
+        "Self": {"Online": False, "PrimaryRoutes": [SUBNET]},
+    }
+    env = _fake_tailscale(tmp_path, status, SERVER_PREFS)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "FAIL:" in r.stdout
+
+
+def test_a_self_contradictory_daemon_is_re_read_after_a_settle(tmp_path):
+    """The settle is not decoration: the checker takes the second sample itself instead
+    of telling a human to. Driven with a stub that answers DIFFERENTLY the second time --
+    an incoherent first read, a healthy one after -- so a settle that never re-reads
+    reports rc 4 here instead of the rc 0 a working daemon deserves."""
+    env = _fake_tailscale(tmp_path, AUTHED_APPROVED, SERVER_PREFS)
+    bindir = tmp_path / "bin"
+    incoherent = {"BackendState": "Starting", "TailscaleIPs": [], "Self": {"Online": False}}
+    (tmp_path / "first.json").write_text(json.dumps(incoherent))
+    write_exec(
+        bindir / "tailscale",
+        'case "$1 $2" in\n'
+        '  "status --json")\n'
+        f'    if [ -f "{tmp_path}/called" ]; then cat "{tmp_path}/status.json";\n'
+        f'    else : >"{tmp_path}/called"; cat "{tmp_path}/first.json"; fi\n'
+        "    exit 0 ;;\n"
+        f'  "debug prefs") cat "{tmp_path}/prefs.json"; exit 0 ;;\n'
+        "esac\nexit 1\n",
+    )
+    env["TS_SETTLE_SECS"] = "1"
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert "settle  :" in r.stdout, (
+        "the checker rendered a verdict off ONE instantaneous sample of a daemon that had "
+        "not fetched its netmap yet:\n" + r.stdout
+    )
+    assert r.returncode == 0, (
+        "the settle did not actually RE-READ the daemon -- the second answer was healthy "
+        f"and the run still exited {r.returncode}:\n" + r.stdout + r.stderr
+    )
+    assert "SELF-CONTRADICTORY" not in r.stdout
+
+
 def test_a_key_expiry_date_in_the_past_is_a_failure(tmp_path):
     """The third, independent detector: a daemon still reporting Running with no Expired
     flag, whose KeyExpiry has nonetheless lapsed. It reads a different field from either
@@ -504,7 +779,11 @@ def test_an_unreadable_prefs_run_does_not_assert_what_the_node_advertises(tmp_pa
         "the run asserts the node advertises the route in the same breath as declaring "
         "that unknowable:\n" + r.stdout
     )
-    assert "carries NO traffic over tailscale right now" in flat, r.stdout
+    # 🔴 SCOPED TO THIS NODE. `Self.PrimaryRoutes` is a fact about this node only, so an
+    # unqualified "the subnet carries NO traffic right now" is a claim about the whole
+    # tailnet derived from one node's view -- and false the moment a second subnet router
+    # is approved for the same subnet, which is planned here.
+    assert "carries NO traffic over tailscale VIA THIS NODE right now" in flat, r.stdout
     # THE CONTROL: with prefs READABLE and the route genuinely advertised, the admin
     # console action must still fire. Otherwise this test is satisfied by deleting it.
     (tmp_path / "readable").mkdir()
@@ -537,10 +816,18 @@ def test_a_subnet_router_with_no_lan_route_still_fails(tmp_path):
 #
 # So this drives BOTH functions, out of the real script, exactly as a real run does.
 # --------------------------------------------------------------------------------------
-def _gate_probe(tmp_path: Path, dry_build_stderr: str) -> tuple[str, str]:
+def _gate_probe(
+    tmp_path: Path, dry_build_stderr: str, baseline_stderr: str | None = None
+) -> tuple[str, str]:
     """Run `_drybuild_counts` on `dry_build_stderr`, feed the result to `_gate_reasons`.
 
-    Returns (counts_record, gate_output). Empty gate output means "allowed".
+    Returns (counts_record, gate_output). Empty gate output means "allowed". The record
+    returned is always the CANDIDATE's.
+
+    🔴 `baseline_stderr` EXISTS SO THE TWO SIDES CAN DIFFER. Without it this probe fed the
+    same numbers to both the pending and the total axis of every gate, so each gate's twin
+    always fired with it -- and a test asserting "some gate fired" passed with either one
+    DELETED. Pass a different baseline and each gate can be isolated.
     """
     src = APPLY.read_text()
     # Everything up to the `--self-test` dispatcher: the limit variables and every
@@ -551,17 +838,27 @@ def _gate_probe(tmp_path: Path, dry_build_stderr: str) -> tuple[str, str]:
     )
     fixture = tmp_path / "dry.err"
     fixture.write_text(dry_build_stderr)
+    base_fixture = tmp_path / "base.err"
+    base_fixture.write_text(
+        dry_build_stderr if baseline_stderr is None else baseline_stderr
+    )
     probe = tmp_path / "seam.sh"
-    # The fixture path travels in the ENVIRONMENT, not in `$1`: `prefix` carries the
+    # The fixture paths travel in the ENVIRONMENT, not in `$1`: `prefix` carries the
     # script's own argument parser, which rejects an unknown positional with exit 2.
     probe.write_text(
         prefix
         + '\nc=$(_drybuild_counts "$TS_SEAM_FIXTURE")\n'
         'IFS="|" read -r b f m <<<"$c"\n'
+        'bc=$(_drybuild_counts "$TS_SEAM_BASELINE")\n'
+        'IFS="|" read -r bb bf bm <<<"$bc"\n'
         'printf "%s\\n---\\n" "$c"\n'
-        '_gate_reasons 26.11 26.11 "$b" "$b" "$m" "$m" "$f" "$f"\n'
+        '_gate_reasons 26.11 26.11 "$bb" "$b" "$bm" "$m" "$bf" "$f"\n'
     )
-    env = dict(os.environ, TS_SEAM_FIXTURE=str(fixture))
+    env = dict(
+        os.environ,
+        TS_SEAM_FIXTURE=str(fixture),
+        TS_SEAM_BASELINE=str(base_fixture),
+    )
     r = _run("bash", probe, env=env)
     assert r.returncode == 0, r.stdout + r.stderr
     counts, _, gate = r.stdout.partition("\n---\n")
@@ -600,6 +897,22 @@ def test_a_world_sized_fetch_never_passes_the_gate_however_its_size_is_spelled(
         "and never as a number invented by defaulting the unit."
     )
     assert gate, f"{label}: {counts} passed every gate in silence"
+    # 🔴 ASSERT WHICH GATE, NOT THAT SOME GATE FIRED. Every line here also trips the
+    # FETCH COUNT gate on its 2400 paths, so a bare `assert gate` is satisfied by that
+    # alone: `_is_num` could accept the literal string UNKNOWN, `_over_mib "UNKNOWN"`
+    # would then be silently false, the whole download-volume axis would be dead, and
+    # this test would stay green. Naming the reason is what can see that.
+    if expect_mib == "UNKNOWN":
+        assert "DOWNLOAD VOLUME COULD NOT BE MEASURED" in gate, (
+            f"{label}: an unreadable size did not REFUSE on the download-volume axis -- "
+            f"the only reasons given were:\n{gate}"
+        )
+    else:
+        assert "TOTAL DOWNLOAD VOLUME:" in gate, (
+            f"{label}: a size this script DOES understand must be compared, not refused "
+            f"as unmeasurable:\n{gate}"
+        )
+        assert "COULD NOT BE MEASURED" not in gate, gate
 
 
 def test_the_seam_still_allows_a_real_tailscale_sized_change(tmp_path):
@@ -627,14 +940,44 @@ def test_an_empty_dry_build_is_a_real_zero_and_is_allowed(tmp_path):
 def test_the_fetch_count_is_gated_and_not_merely_printed(tmp_path):
     """The count was parsed correctly and printed in the summary table, and read by no
     gate -- the identical 'decorative column' defect the download-volume gate was added
-    to fix. It is the axis that still has a number when the SIZE cannot be parsed."""
-    counts, gate = _gate_probe(
-        tmp_path, "these 2400 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n"
-    )
+    to fix. It is the axis that still has a number when the SIZE cannot be parsed.
+
+    🔴 THE TWO SIDES CARRY DIFFERENT NUMBERS, and that is the whole fix to this test. It
+    used to drive `pending == total == 2400`, which trips BOTH fetch gates, so `"FETCH
+    COUNT" in gate` was satisfied with either one deleted -- each masked the other's
+    absence. Each is now isolated: one case where only the pending limit (50) is crossed,
+    one where only the total limit (100) is.
+    """
+    small = "these 3 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n"
+    big = "these 2400 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n"
+
+    # TOTAL only: 3 pending (under 50), 2400 total (over 100).
+    counts, gate = _gate_probe(tmp_path, big, baseline_stderr=small)
     assert counts == "0|2400|1.0", counts
-    assert "FETCH COUNT" in gate, (
-        "2400 paths to fetch passed with a 1.0 MiB size -- both build gates and both "
-        f"download-volume gates are silent by construction here:\n{gate}"
+    assert "TOTAL FETCH COUNT" in gate, (
+        "2400 paths would be fetched, at a 1.0 MiB size that silences both "
+        f"download-volume gates, and nothing refused it:\n{gate}"
+    )
+    assert "PENDING FETCH COUNT" not in gate, (
+        f"the PENDING gate fired on a baseline of 3 paths (limit 50):\n{gate}"
+    )
+
+    # PENDING only: 2400 already queued by the CURRENT config (over 50), 60 in the
+    # candidate (under 100). `switch` applies the pending work too, which is why the
+    # baseline is gated at all.
+    (tmp_path / "pending").mkdir()
+    counts, gate = _gate_probe(
+        tmp_path / "pending",
+        "these 60 paths will be fetched (1.0 MiB download, 2.0 MiB unpacked):\n",
+        baseline_stderr=big,
+    )
+    assert counts == "0|60|1.0", counts
+    assert "PENDING FETCH COUNT" in gate, (
+        "2400 paths were already queued by the CURRENT config and nothing refused "
+        f"it:\n{gate}"
+    )
+    assert "TOTAL FETCH COUNT" not in gate, (
+        f"the TOTAL gate fired on a candidate of 60 paths (limit 100):\n{gate}"
     )
 
 
@@ -666,6 +1009,21 @@ def test_the_fetch_count_is_gated_and_not_merely_printed(tmp_path):
         # ...and the control against a scanner that blanks too much: a real declaration
         # after a CLOSED string must still be found.
         ('  warnings = [ "off" ];\n  services.tailscale.enable = true;', True),
+        # 🔴 A READ IS NOT A DECLARATION, and neither of these is a comment or a string --
+        # so nothing above can see the mutation that removes the lookbehind. Both were
+        # MEASURED classifying as declarations, which makes the script print "already
+        # DECLARES ... Nothing to do. Exiting 0" on a host with no tailscale at all.
+        ('  networking.firewall.checkReversePath = '
+         'lib.mkIf config.services.tailscale.enable "loose";', False),
+        ('  assertions = [ { assertion = config.services.tailscale.enable; '
+         'message = "x"; } ];', False),
+        # ...and the control against a lookbehind that swallows real declarations: one
+        # that does NOT start its line must still be found.
+        ("  config = { services.tailscale.enable = true; };", True),
+        # THE SECOND-RUN CONTROL: the shape this script itself appends must read as a
+        # declaration next time, or every re-run adds another copy.
+        ("  services.tailscale = {\n    enable = true;\n"
+         '    useRoutingFeatures = "server";\n    openFirewall = true;\n  };', True),
         ("  services.tailscale.enable = true;", True),
         ("  services.tailscale = {\n    enable = true;\n  };", True),
         ("  services.tailscale={enable=true;};", True),

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -31,6 +31,14 @@ CAN be exercised without one, chosen for the defects that were actually found:
     controls in the OTHER direction are the expensive ones: an EMPTY persisted profile is
     what a never-logged-in daemon carries, and reading that as an identity would make
     every first run rc 1 and roll the config back.
+  * 🔴 a `tailscaled` that is STOPPED or CRASHED must be rc 1. With the daemon down there
+    is no status and no prefs to read, so every claim came out unevaluated and the run
+    exited 4 -- "NOT YET DETERMINABLE (no defect found)" -- about a backup path that is
+    dead right now. The control in the other direction is the one that would cost most: a
+    host where tailscale was NEVER installed has no unit, and `systemctl is-active` prints
+    `inactive` there too, so the FAIL is gated on `LoadState=loaded` and the never-applied
+    host stays rc 4. rc 1 there is `die` + rollback in apply-tailscale.sh, on every first
+    run.
   * a SELF-CONTRADICTORY daemon (a non-logged-out backend holding no address) must not be
     rc 1. Its own message said "re-run this check before doing anything else"; apply's
     answer to rc 1 is `die` -> restore `configuration.nix` -> report that the RUNNING
@@ -288,7 +296,11 @@ def test_self_test_passes(script):
 # the freshly-switched node, driven end to end against a fake `tailscale`
 # --------------------------------------------------------------------------------------
 def _fake_tailscale(
-    tmp_path: Path, status: dict, prefs: dict | None, lan_route: bool = True
+    tmp_path: Path,
+    status: dict,
+    prefs: dict | None,
+    lan_route: bool = True,
+    unit: tuple[str, str] = ("active", "loaded"),
 ) -> dict:
     """A PATH containing fakes for everything the checker reads from the host.
 
@@ -310,10 +322,23 @@ def _fake_tailscale(
         '# passes --role explicitly, so an answer would be ignored anyway.\n'
         "exit 0\n",
     )
-    # `systemctl is-active` is CONTEXT ONLY in the checker (no verdict is keyed on it),
-    # but the sandbox has no systemd at all, so stub it rather than depend on the `||
-    # true` that currently covers its absence.
-    write_exec(bindir / "systemctl", 'echo active\nexit 0\n')
+    # 🔴 THE UNIT STUB ANSWERS BOTH READS THE CHECKER MAKES, AND THEY ARE DIFFERENT
+    # QUESTIONS. `is-active` is liveness; `show -p LoadState --value` is existence, and
+    # only the pair can separate "tailscaled is down" from "tailscale was never applied
+    # to this host" -- MEASURED on systemd 261, `is-active` prints `inactive` for BOTH.
+    # Default is a healthy unit; the cases below drive the other combinations. The
+    # sandbox has no systemd at all, so this is stubbed rather than left to the `|| true`.
+    unit_state, unit_load = unit
+    write_exec(
+        bindir / "systemctl",
+        'case "$1" in\n'
+        f'  is-active) printf "%s\\n" "{unit_state}"\n'
+        f'             [ "{unit_state}" = active ] || exit 3\n'
+        "             exit 0 ;;\n"
+        f'  show)      printf "%s\\n" "{unit_load}"; exit 0 ;;\n'
+        "esac\n"
+        "exit 0\n",
+    )
     (tmp_path / "status.json").write_text(json.dumps(status))
     if prefs is not None:
         (tmp_path / "prefs.json").write_text(json.dumps(prefs))
@@ -431,6 +456,75 @@ def test_an_authenticated_but_broken_node_is_still_a_failure(tmp_path):
     r = _run("bash", CHECK, "--role", "server", env=env)
     assert r.returncode == 1, r.stdout + r.stderr
     assert "FAIL:" in r.stdout
+
+
+# --------------------------------------------------------------------------------------
+# 🔴 A STOPPED OR CRASHED `tailscaled` IS A FAILURE -- AND A HOST THAT NEVER HAD ONE IS NOT
+#
+# With the daemon down there is no `tailscale status` and no `tailscale debug prefs`, and
+# the on-disk fallback needs root, so every claim in the checker comes out UNEVALUATED and
+# the run exited 4: "NOT YET DETERMINABLE (no defect found)" -- about a backup path that is
+# dead right now. Reproduced live against a real tailscaled 1.102.3: killing the daemon did
+# not move the exit code.
+#
+# The other direction is the expensive one and is pinned right below it. On a host where
+# tailscale was NEVER installed there is no unit at all, and `systemctl is-active` prints
+# `inactive` there too -- byte-identical to a stopped unit (measured, systemd 261). Failing
+# on `is-active` alone would make every first run a node-side FAIL, which is rc 1, which is
+# `die` + rollback in apply-tailscale.sh: the config deleted by the run that installed it.
+# `LoadState` is the signal that separates them.
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("unit_state", ["inactive", "failed"])
+def test_a_dead_tailscaled_unit_is_a_failure_not_incomplete(tmp_path, unit_state):
+    # No prefs: a daemon that is not running answers neither of the checker's reads. That
+    # is what makes the old verdict rc 4 -- there is nothing left to find a defect in.
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, None, unit=(unit_state, "loaded"))
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, (
+        f"a tailscaled unit that EXISTS and is '{unit_state}' exited {r.returncode}. The "
+        "backup path is down and rc 4 reports that as 'no defect found'.\n"
+        + r.stdout
+        + r.stderr
+    )
+    assert "IS INSTALLED ON THIS HOST BUT IS NOT RUNNING" in r.stdout, (
+        "the run failed, but not with the dead-unit finding -- some other verdict is "
+        "carrying this test:\n" + r.stdout
+    )
+    assert unit_state in r.stdout and "systemctl status tailscaled" in r.stdout
+
+
+@pytest.mark.parametrize(
+    "label,unit",
+    [
+        # `systemctl show -p LoadState` for a unit that does not exist.
+        ("tailscale was never applied to this host", ("inactive", "not-found")),
+        # No systemd at all, or a systemctl too old for `--value`: both reads come back
+        # empty. The guard must stay silent rather than guess.
+        ("nothing answers systemctl", ("", "")),
+    ],
+)
+def test_a_host_with_no_tailscaled_unit_is_still_rc_4(tmp_path, label, unit):
+    """🔴 THE REGRESSION THAT WOULD COST THE MOST. This is the pre-apply / first-run
+    state; rc 1 here makes apply-tailscale.sh roll back the config it just installed."""
+    env = _fake_tailscale(tmp_path, NEVER_AUTHED, NO_PREFS, unit=unit)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 4, (
+        f"{label}: exited {r.returncode}, not 4. The dead-unit FAIL must be gated on the "
+        "unit EXISTING -- `is-active` prints 'inactive' for an absent unit too.\n"
+        + r.stdout
+        + r.stderr
+    )
+    assert "FAIL:" not in r.stdout
+    assert "IS INSTALLED ON THIS HOST BUT IS NOT RUNNING" not in r.stdout
+
+
+def test_a_healthy_unit_draws_no_unit_finding(tmp_path):
+    """The control for both of the above: with the unit loaded AND active, rc 0 is still
+    reachable. Without this, a guard that failed on every unit state would pass them."""
+    env = _fake_tailscale(tmp_path, AUTHED_APPROVED, SERVER_PREFS, unit=("active", "loaded"))
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "IS INSTALLED ON THIS HOST BUT IS NOT RUNNING" not in r.stdout
 
 
 # --------------------------------------------------------------------------------------

--- a/scripts/tests/test_tailscale_scripts.py
+++ b/scripts/tests/test_tailscale_scripts.py
@@ -196,10 +196,33 @@ def test_self_test_passes(script):
 # --------------------------------------------------------------------------------------
 # the freshly-switched node, driven end to end against a fake `tailscale`
 # --------------------------------------------------------------------------------------
-def _fake_tailscale(tmp_path: Path, status: dict, prefs: dict | None) -> dict:
-    """A PATH containing a `tailscale` that answers from fixtures, plus a fake /proc."""
+def _fake_tailscale(
+    tmp_path: Path, status: dict, prefs: dict | None, lan_route: bool = True
+) -> dict:
+    """A PATH containing fakes for everything the checker reads from the host.
+
+    🔴 EVERY HOST INPUT IS STUBBED, INCLUDING THE ROUTING TABLE — and that is not
+    tidiness. The first version stubbed only `tailscale` and `/proc`, and let the real
+    `ip -4 -o route show` answer the LAN-route question. It passed here because this
+    workbench genuinely has a route to 192.168.50.0/24, and went RED in Tekton, whose
+    sandbox has neither the route nor `ip` — two tests, on a claim that had nothing to
+    do with the routing table. A fixture that lets the host decide is blind to exactly
+    the dimension it pins, in whichever tier happens to disagree.
+    """
     bindir = tmp_path / "bin"
     bindir.mkdir()
+    route = f"{SUBNET} dev eth0 proto kernel scope link src 192.168.50.250\n" if lan_route else ""
+    write_exec(
+        bindir / "ip",
+        f'if [ "$*" = "-4 -o route show" ]; then printf %s "{route}"; exit 0; fi\n'
+        '# the role probe: `ip -4 -o addr show nebula.mesh`. Silent -- every case here\n'
+        '# passes --role explicitly, so an answer would be ignored anyway.\n'
+        "exit 0\n",
+    )
+    # `systemctl is-active` is CONTEXT ONLY in the checker (no verdict is keyed on it),
+    # but the sandbox has no systemd at all, so stub it rather than depend on the `||
+    # true` that currently covers its absence.
+    write_exec(bindir / "systemctl", 'echo active\nexit 0\n')
     (tmp_path / "status.json").write_text(json.dumps(status))
     if prefs is not None:
         (tmp_path / "prefs.json").write_text(json.dumps(prefs))
@@ -288,6 +311,17 @@ def test_an_authenticated_but_broken_node_is_still_a_failure(tmp_path):
     r = _run("bash", CHECK, "--role", "server", env=env)
     assert r.returncode == 1, r.stdout + r.stderr
     assert "FAIL:" in r.stdout
+
+
+def test_a_subnet_router_with_no_lan_route_still_fails(tmp_path):
+    """The control for the stubbed routing table above: with the route REMOVED, a
+    subnet router is a definitive FAIL even though everything else is perfect. Without
+    this the `lan_route` stub is a fixture nothing can see, and `lan_route=True` would
+    be indistinguishable from not reading `ip route` at all."""
+    env = _fake_tailscale(tmp_path, AUTHED_APPROVED, SERVER_PREFS, lan_route=False)
+    r = _run("bash", CHECK, "--role", "server", env=env)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "no non-tailscale route" in r.stdout, r.stdout
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Rank 4 of the pre-departure hardening. **Nebula is currently the only remote path to the workbench**, and the operator leaves the LAN for months in ~3 days. Tailscale is the second door: different control plane, different relays, no shared component with nebula.

Two files, both in the idiom of `apply-nebula-relay.sh` / `check-nebula-relays.sh`.

## `nix/system/apply-tailscale.sh`

Adds `services.tailscale` to `/etc/nixos/configuration.nix`, then switches.

**Role discrimination.** 🔴 `hostname` CANNOT tell these machines apart — both answer `nixos`. The guard is the nebula mesh address, unique by construction: `10.42.0.30` → subnet router (`useRoutingFeatures = "server"`, IP forwarding, advertises `192.168.50.0/24`); `10.42.0.100` → plain client (`useRoutingFeatures = "client"`, which is what sets `checkReversePath = "loose"` so accepted subnet routes actually work). Anything else aborts before any write.

### 🔴 The closure preflight — the actual point of this PR

`nixos-rebuild switch` applies **everything pending**, not just your delta. A 4-line nebula edit once triggered a 26.05 → 26.11 jump that took **2h16m** and rebuilt the world (largely `wine-wow-11.0`). That was recorded as an **open defect on #1272 and never fixed**. This is the fix.

Three independent measurements before switching, all from a temp file — `/etc/nixos` is untouched until they pass, so a refusal has nothing to roll back:

1. **`dry-build` run TWICE**, against the current config *and* the patched one. Pending work is reported separately from the tailscale delta, so a channel bump can neither be blamed on tailscale nor hidden behind it.
2. **The nixpkgs release string**, extracted by *one* implementation from both store-path basenames and cross-checked against `/run/current-system/nixos-version` — without that control an extractor that is wrong on both sides agrees with itself and waves a release jump straight through. A release change is refused unconditionally.
3. **The closure as SETS** (`nix-store -qR | comm -3`), not a parse of `diff-closures` — that command prints nothing when closures match, so an empty result is indistinguishable from a command that never ran.

**Measured on the workbench, 2026-09-07:**

| | build | fetch | download |
|---|---|---|---|
| PENDING, with **no change at all** | 40 | 24 | 159.4 MiB |
| TOTAL with tailscale | 47 | 25 | 177.0 MiB |
| **DELTA (tailscale only)** | **+7** | **+1** | +17.6 MiB |

The `+1` is `tailscale-1.102.3`; the `+7` are regenerated unit/etc/activation derivations. The thresholds are calibrated from those numbers, so **the gate refuses on this host today** — correctly: 40 queued derivations are not what anyone asked for. It names the clean fix (run `nixos-rebuild switch` as its own deliberate operation first, then re-run) and prints `--allow-world-rebuild`.

🔴 **`readlink -f` on both sides, always.** `/nix/var/nix/profiles/system` is a symlink *to another symlink* — measured, it reads `system-389-link`, a bare name — while `/run/current-system` points straight at the store. Single-level `readlink` returns a name on one side and a store path on the other, so they can never compare equal and the mismatch is reported forever. `_store_path` resolves fully and refuses anything outside `/nix/store`, so an empty string cannot masquerade as agreement.

## `nix/system/check-tailscale.sh`

Read-only, no sudo, runnable before and after.

🔴 **It reads live runtime state**, not the nix config and not the unit file — `tailscale status --json`, `tailscale debug prefs`, `/proc/sys`, `ip route`. `systemctl cat` exits 0 for a dead unit, so a config that built but never activated reads as applied; that is exactly why `check-nebula-relays.sh` was rewritten, and this does not repeat it. `systemctl is-active` is printed as context with no verdict keyed on it.

🔴 **ADVERTISED and APPROVED are two different claims and both are printed.** A route the node advertises but which has not been approved in the admin console carries **no traffic**, and from the node's side that is indistinguishable from success. Approval is read from `Self.PrimaryRoutes`, which only the control plane populates.

🔴 **Node key expiry** is reported with its date and days remaining, and being *enabled at all* counts as outstanding — the 180-day default is shorter than the trip and the lapse is silent.

Four distinct exit codes: `0` all good · `3` node correct, an **admin-console** step outstanding · `1` node-side failure · `2` cannot determine. `3` exists so `apply-tailscale.sh` does not roll back a correct switch because a browser tab has not been clicked yet.

Role auto-detection degrades honestly: if `nebula.mesh` has no address — **the expected case when tailscale matters most** — it refuses and prints the `--role` remedy rather than guessing.

## What was tested

- Both `--self-test`s green. **8/8 mutants killed** on the verifier (substring route matching, PrimaryRoutes falling back to the node's own advertisement, both spellings of disabled key expiry, days arithmetic, three refuse-vs-answer paths) and **12/12** on the apply script (dry-build singular/plural/zero/GiB, `.drv` stripping, dashed hostnames, `readlink` vs `readlink -f`, the store-path check, and **both branches of the gate**) — each by its own named case, with an unmutated positive control, and two SURVIVED results traced to a broken mutation harness and re-run rather than reported.
- The verifier driven **end-to-end against a mock `tailscale`**: rc 0, 1, 2 and 3 all watched, including the forwarding and lanroute FAIL branches (`TS_PROC_ROOT` exists so the forwarding check's failing branch can be driven — neither host has IPv6 forwarding on today, so the passing branch alone would be all anyone ever saw).
- **The public-IP ratchet was watched go RED** naming `check-tailscale.sh` with a planted realistic IP, then green again byte-identical. Both content scans confirmed to enumerate the new files. Fixtures use CGNAT/RFC1918/`.example.test` only.
- shellcheck 0.11.0 clean. 290 tests green across the four content ratchets and the adjacent structural gates.
- **Validated against the real `tailscale` 1.102.3 binary** (the exact version the closure installs): `tailscale debug prefs` exists ("Print prefs") and `tailscale status --json` exists, and every JSON field the parser reads — `AdvertiseRoutes`, `RouteAll`, `WantRunning`, `BackendState`, `TailscaleIPs`, `PrimaryRoutes`, `KeyExpiry`, `HostName` — is present in the binary's string table. That probe was itself controlled: the first attempt reported 0 for *everything* because it was pointed at a 1378-byte bash wrapper, and the positive control (`tailscaled`, expected many, got 1) is what caught it; re-pointed at the 44 MB Go binary the control reads 106 and a fabricated field name still reads 0.
- **The verifier run end-to-end against that real binary with no daemon running**: rc **2 CANNOT DETERMINE**, surfacing tailscaled's own "it doesn't appear to be running" message — not a false FAIL and not a false PASS.
- The `--include nixos-config=` plumbing validated for real: a faithful copy of the live config produced the **identical** system derivation hash, and the patched one a different hash that evaluates cleanly — confirming the generated block causes no attribute conflict with the module's own `mkOverride 97` forwarding sysctls.

## 🔴 NOT verified

**Nothing has been applied to a live host.** `sudo` here is password-gated, so `nixos-rebuild build`, `nixos-rebuild switch`, the post-switch verify path, and and the response of a **live, authenticated** tailscaled are all **unexercised**. The CLI surface and field names are confirmed against the real 1.102.3 binary (above), but the exact JSON *nesting* is not — the fixtures are built from the documented `ipn.Prefs` / `ipnstate.Status` shapes, not captured from a running daemon. Treat the first real run as the verification.

## Prerequisites and manual steps

An operator needs a **Tailscale account/tailnet** first. Then, after the switch, three steps that **cannot be scripted** — the script prints all three and the verifier keeps reporting rc 3 until they are done:

1. `sudo tailscale up --advertise-routes=192.168.50.0/24 --accept-dns=false` (workbench) / `sudo tailscale up --accept-routes` (laptop) — needs a browser.
2. **Approve the subnet route** in the admin console. Until then it carries nothing.
3. **Disable node key expiry.** The 180-day default crosses the trip.

Related: #1272 (where this defect was recorded), #1287 (multi-path host reachability).

---

# Audit round 2 — 11 findings fixed (`65c391f6`)

Two were **blockers that made the script unusable as written**. Every fix below was
driven old-vs-new against the real scripts, with `nixos-rebuild`/`tailscale`/`ip`/
`systemctl` shimmed, so each control shows the OLD behaviour reproducing and the NEW one
correcting it.

## 🔴 F1 — the first apply run was GUARANTEED to roll back

This script deliberately does not run `tailscale up` (it needs a browser), so straight
after its switch the node has never authenticated: `NeedsLogin`, `Online` false, no
`TailscaleIPs`, nothing advertised. The verifier turned that into **four** entries in
`fails[]` and exited **1** — not 3 — while the post-switch verify accepted only rc 0/2/3
and `die`d on anything else, so the EXIT trap restored the backup. The comment claiming
"rc 3 is the EXPECTED state straight after a switch" was false, and the section above
that says `3` is one of four exit codes was describing a state the script could not
reach.

| | OLD (`fec530c1`) | NEW (`65c391f6`) |
|---|---|---|
| same fixture, successful switch | `ABORT … ROLLED BACK`, `grep -c services.tailscale` = **0** | `=== SWITCHED ===`, = **1** |
| verifier rc on that state | **1** (node-side FAILURE) | **4** (INCOMPLETE, no defect) |

**Not a wider rc allow-list.** "Never authenticated" is now a first-class state in the
verifier (`_authenticated`, two signals that must agree — an address in 100.64.0.0/10
*and* a `BackendState` that is not `NeedsLogin`/`NoState`) with its own **exit code 4 =
INCOMPLETE**, and the apply script's `case` enumerates all five codes with what each
means. **rc 1 still rolls back** — driven with forwarding off, and pinned by a test,
because a guard that can no longer go red was removed rather than fixed.

## 🔴 F8 — a partial `cp` left `/etc/nixos/configuration.nix` truncated, silently

`PATCHED=1` was set *after* `cp -p "$TMP" "$CFG"`. `cp` truncates then writes, so a
failure part way through (ENOSPC — `/` on this host is at 77%) aborted under `set -e`
with `PATCHED=0`, the trap's rollback branch was skipped, and the config was left
half-written with a good backup unused beside it and **nothing printed**. Measured with a
`cp` that writes 40 bytes and exits 1:

* OLD → `configuration.nix` is a **40-byte fragment ending mid-word**, no rollback, no message.
* NEW → rollback fires, file restored, and the message correctly says the switch was never started.

The auditor judged the original sequencing correct; it is not. Moving the flag first is
safe in the other direction — a `cp` that fails before writing restores a byte-identical
file.

## The rest

| # | Was | Now |
|---|---|---|
| **F7** | absent `Self.KeyExpiry` → `PASS keyexpiry : disabled`, printed on a node that had **never logged in** | absence is ambiguous; "disabled" is claimed only when the node IS authenticated, otherwise UNKNOWN |
| **F3** | rollback asserted *"The system was never switched"* from a flag that only records whether the switch **returned zero** | three states; only the establishable one is asserted, with the commands to check the other |
| **F4** | *"Largest pending items"*, alphabetical, `head -15` — on the real 38-drv queue every `steam-*` was hidden and `wine-wow-11.0` sorted **last** | all of them, labelled a name list and not a size ranking; a cap says how many it omitted |
| **F5** | fetch counts and MiB were printed and read by **no gate** — 0 to build / 4 GiB to fetch passed untouched (measured: OLD proceeded to `switch`) | download volume gated in its own right (`_over_mib`, floating point); header's "three ways" is now four, each with what it CANNOT see; the release gate's major.minor blind spot is stated where it reports |
| **F6** | `grep -q 'services\.tailscale'` — a config containing only `# TODO: consider services.tailscale one day` exited 0 **"Nothing to do"** | comments (`#` and `/* */`) stripped first, an actual setting required; a mention-only file is reported and then patched |
| **F9** | `--accept-dns=false` on the server only, so MagicDNS took the resolver of the **one machine that leaves the LAN** | both roles, cost stated out loud; a test pins the two scripts' `up` strings **equal** |
| **F10** | `--role` last → exit 1 printing **nothing** (both scripts) · `--help` a hardcoded range that truncated one file's SAFETY paragraph and ran the other into `set -euo pipefail` · no-trailing-newline aborted naming the wrong problem · *"Only -3 of the 37 are tailscale's"* · `"$CHECK"` invoked directly — a copy without its exec bit exits 126 and gets the config rolled back | each fixed and pinned |

### F2 — measured correction, reported honestly

The reported mechanism (*a SIGINT-killed foreground child does not trip errexit*) **did
not reproduce** on bash 5.3.15 here. With the signal confirmed to have landed — the
control being the killed child's wall time, since `kill` against a process with SIGINT
ignored returns 0 and looks identical to "the shell continued" — bash propagates the
child's SIGINT death and terminates the script, both child-only and process-group. The
first "it continued" observation was that ignored-signal case. The explicit capture
(`rc=0; nixos-rebuild switch || rc=$?`) is kept anyway and **is** reachable on
SIGTERM/SIGHUP, both driven against the real script: it names the signal instead of
aborting silently.

### 🔴 F11 — the AirVPN killswitch inverts the redundancy story (documented, NOT changed)

`scripts/airvpn-updown`'s degraded and fallback rulesets allow egress on a **literal**
interface list — `lo`, the airvpn tun, `nebula.mesh`, `cni0`, `flannel.1`, `docker0` —
and then `drop`. **`tailscale0` is not on it**, and unlike nebula (three carve-outs)
tailscale has **no DERP/control-plane bypass**. So if that killswitch ever arms
fail-closed, **nebula survives and tailscale dies** — the exact inverse of the
independence this PR is for.

AirVPN is **default-OFF** on these hosts, so this is a latent interaction and not a live
defect. `airvpn-updown` is deliberately **not** touched here: widening a killswitch's
allow-list is its own change with its own review, and doing it inside a PR about a
different subsystem is how a killswitch quietly stops being one. The interaction is
recorded in the generated Nix block's comment for **both** roles and in the apply
script's header.

## What was tested this round

* Both `--self-test`s green (apply 42 controls, check 27) and now **run by pytest**, so they are part of the gate rather than something a human has to remember.
* New `scripts/tests/test_tailscale_scripts.py` (22 tests): pins the two scripts' `tailscale up` strings **equal**, pins the exit-code vocabularies against each other, drives the freshly-switched state against a fake `tailscale`, and checks `--help` matches each file's own comment header exactly.
* **Mutation sweep: 17/17 mutants killed by their intended test**, run under `PYTHONDONTWRITEBYTECODE=1` in an isolated `cp -a` of the tree with its `.git` pointer removed. The first round had **2 not properly killed** — the F6 fixtures could see neither comment-stripping nor the `[.={]` anchor — and the discriminating cases (a commented-out *declaration*; `services.tailscale` named in a warning string) were added rather than the result being reported as green.
* `shellcheck -S warning` clean on both files, with the scanner itself negative-controlled against a known-bad script first.

## 🔴 NOT verified this round

* **Nothing was applied to a live host.** `sudo` is password-gated. The apply path is exercised only against shimmed `nixos-rebuild`, `tailscale`, `ip` and `systemctl`; no real `dry-build`, `build`, `switch` or activation ran.
* The **rc 0 and rc 3** verifier paths are driven from fixtures, not from a real authenticated daemon. JSON *nesting* is still from the documented shapes, unchanged from round 1.
* `tailscale up`, subnet-route approval and disabling key expiry remain untouched manual steps.
* The F11 interaction is **reasoned from `airvpn-updown`'s source, not observed** — the killswitch was never armed to watch tailscale drop.
