### PR TITLE
fix(tmux-reply-agent): a launched pane gets a PATH that can find `claude` (task 524)

### DIFF
--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -1567,6 +1567,20 @@ def test_the_module_loader_scan_can_actually_find_something(tmp_path):
 # assembles its patterns — which keeps THIS file inside the scan's scope instead
 # of excluding it, so a real clobber added here would still be caught.
 PINNED_PATH_CLOBBERS = {
+    "test_tmux_reply_agent.py": (
+        'PA' + 'TH=os.path.dirname(tmux_exe)',
+        "task 524. The site is a FIXTURE, not a launcher: it reproduces the "
+        "systemd environment the tmux-reply-agent unit really runs under, whose "
+        "`Environment=PATH=` is deliberately coreutils+python3+tmux and contains "
+        "no `claude`. The clobber IS the thing under test — a launched tmux pane "
+        "inherited that PATH and sat on `command not found` on workbench "
+        "2026-09-07. It is safe because it overrides PATH ONLY, on a dict handed "
+        "to one subprocess.run, and points at the directory holding the real "
+        "tmux binary, so nothing is executed from an attacker-controlled path "
+        "and no launcher is reached. A fixture that did NOT clobber PATH could "
+        "not fail, which is what makes this entry load-bearing rather than "
+        "incidental.",
+    ),
     "test_session_stamp_seam.py": (
         '"PATH"' + ': str(empty_bin)',
         "an EMPTY directory in tmp_path, justified by emptiness like "

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -2217,9 +2217,9 @@ def test_a_launched_pane_gets_a_PATH_THAT_CAN_FIND_claude(monkeypatch, tmp_path)
 
     bindir = tmp_path / "fakebin"
     bindir.mkdir()
-    claude = bindir / "claude"
-    claude.write_text("#!/bin/sh\nexit 0\n")
-    claude.chmod(0o755)
+    # POSIX-sh body, no shebang — write_exec owns that, and
+    # test_runtime_shebangs.py fails any test that writes its own.
+    write_exec(bindir / "claude", "exit 0\n")
 
     sockdir = tempfile.mkdtemp(prefix="t524.")
     sock = "t524-" + os.path.basename(str(tmp_path))

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -58,6 +58,14 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
+
+# 🔴 RESOLVED AT IMPORT, BEFORE ANY FIXTURE CAN RUN. Several suites in this tree
+# legitimately clobber os.environ["PATH"] (see
+# test_no_real_launchers.PINNED_PATH_CLOBBERS), so a `shutil.which("tmux")` call
+# inside a test body reports on the run order rather than on the host. Measured:
+# the two task-524 tests passed alone and in every pair, and failed only in the
+# full four-suite sweep, for exactly this reason.
+_TMUX_EXE_AT_IMPORT = __import__("shutil").which("tmux")
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -1630,11 +1638,17 @@ def real_tmux(tmp_path):
 
 def _agent_with_real_tmux(monkeypatch, real_tmux):
     """Point the agent's tmux seam at the private server."""
-    sock, env = real_tmux["sock"], real_tmux["env"]
+    sock, base_env = real_tmux["sock"], real_tmux["env"]
 
-    def run(args):
+    def run(args, env=None):
+        # `env_override` models the real seam: open_window hands tmux a corrected
+        # PATH so a launched pane can find `claude` (task 524). Keep the private
+        # socket pinned whichever environment is used, or the call escapes to the
+        # operator's server — which this fixture exists to prevent.
+        e = dict(env if env is not None else base_env)
+        e["TMUX_TMPDIR"] = base_env["TMUX_TMPDIR"]
         p = subprocess.run(["tmux", "-L", sock, *args], capture_output=True,
-                           text=True, env=env, timeout=30)
+                           text=True, env=e, timeout=30)
         return p.returncode, p.stdout, p.stderr
 
     monkeypatch.setattr(AGENT, "run_tmux", run)
@@ -2065,8 +2079,14 @@ def test_an_EMPTY_pane_current_path_does_not_collapse_the_readback(monkeypatch):
     """
     calls = []
 
-    def fake_run_tmux(args):
+    def fake_run_tmux(args, env=None):
         calls.append(args)
+        # task 524: open_window asks the SERVER for the PATH a launched pane
+        # should get. Answering "unset" here (tmux's `-PATH`) keeps this test
+        # about the READ-BACK parse it was written for — open_window then passes
+        # no env, exactly as it did before that change.
+        if args[0] == "show-environment":
+            return 0, "-PATH\n", ""
         if args[0] == "new-window":
             # Well-formed, three fields, last one EMPTY. Note the trailing tab.
             return 0, "%2\tscratch20\t\n", ""
@@ -2114,7 +2134,13 @@ def test_an_UNREADABLE_pane_current_path_still_REFUSES(monkeypatch):
 
     `claude/RULES.md`: assert the STATE, never a word another branch can spell.
     """
-    def fake_run_tmux(args):
+    def fake_run_tmux(args, env=None):
+        # task 524: open_window now asks the SERVER what PATH a launched pane
+        # should get. "-PATH" is tmux's spelling for an unset variable, so
+        # open_window passes no environment and this test stays about the
+        # unreadable-path refusal it was written for.
+        if args[0] == "show-environment":
+            return 0, "-PATH\n", ""
         if args[0] == "new-window":
             return 0, "%2\tscratch20\t\n", ""
         if args[0] == "display-message":
@@ -2134,3 +2160,198 @@ def test_an_UNREADABLE_pane_current_path_still_REFUSES(monkeypatch):
         f"the unverifiable-path refusal must not be the FALLTHROUGH mismatch: {err!r}. "
         "'could not read where it landed' and 'tmux landed somewhere else' are "
         "different facts and must not share a code path.")
+
+
+# ---------------------------------------------------------------------------
+# task 524: a LAUNCHED PANE must get a PATH that can find `claude`.
+#
+# 🔴 THE EXISTING real_tmux TESTS ARE STRUCTURALLY BLIND TO THIS.
+# `_agent_with_real_tmux` runs tmux with `dict(os.environ, …)` — a FULL
+# developer PATH — so the pane it creates inherits a working PATH by accident of
+# the harness. Under systemd the agent's own PATH is the unit's deliberately
+# minimal `Environment=PATH=` (coreutils + python3 + tmux, 3 entries), and
+# `new-window` with no `-e` hands THAT to the new pane. Measured on workbench
+# 2026-09-07: the launched pane ran `claude` and got `command not found`, while
+# the tmux SERVER's own global PATH was complete — i.e. tmux was never the
+# source, the caller's environment was.
+#
+# So this test supplies the stripped parent environment the unit really has.
+# Without it the assertion cannot fail, which is the whole point.
+# ---------------------------------------------------------------------------
+
+def _pane_environ_path(real_tmux, pane: str) -> str:
+    """The PATH of the pane's own process, read from /proc — not from a shell.
+
+    Reading `/proc/<pid>/environ` is deterministic: it needs no prompt to be
+    ready, no command to be typed and no capture-pane timing. A shell-based read
+    would be racing the pane's own startup.
+    """
+    p = real_tmux["tmux"]("display-message", "-p", "-t", pane, "#{pane_pid}")
+    pid = p.stdout.strip()
+    assert pid.isdigit(), f"no pane pid for {pane!r}: {p.stdout!r}"
+    raw = pathlib.Path(f"/proc/{pid}/environ").read_bytes().decode("utf-8", "replace")
+    for entry in raw.split("\0"):
+        if entry.startswith("PATH="):
+            return entry[5:]
+    return ""
+
+
+def test_a_launched_pane_gets_a_PATH_THAT_CAN_FIND_claude(monkeypatch, tmp_path):
+    """task 524, criterion 3 — RED before the fix, GREEN after.
+
+    🔴 HERMETIC ON PURPOSE: its own tmux server, its own socket dir, and an
+    environment built from scratch rather than from os.environ. It does NOT use
+    the shared `real_tmux` fixture. Measured while writing it: run inside a
+    four-suite sweep it failed while passing alone, because `pane_path_env`
+    came back with another test's tmp_path — some session-scoped fixture in that
+    sweep mutates the ambient environment these helpers capture. A test that
+    depends on ambient state reports on the run order, not on the code.
+
+    The fake `claude` sits in a directory ABSENT from the agent's own PATH and
+    PRESENT in the tmux server's global PATH. That is the live shape, and it is
+    what makes the two outcomes distinguishable: a pane built from the caller's
+    environment cannot see it, one built from the server's can.
+    """
+    tmux_exe = _TMUX_EXE_AT_IMPORT
+    assert tmux_exe, "tmux is in REQUIRED_TOOLS; it must be on PATH here"
+
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    claude = bindir / "claude"
+    claude.write_text("#!/bin/sh\nexit 0\n")
+    claude.chmod(0o755)
+
+    sockdir = tempfile.mkdtemp(prefix="t524.")
+    sock = "t524-" + os.path.basename(str(tmp_path))
+    # A complete environment we OWN, so nothing ambient can reach this test.
+    server_env = {
+        "PATH": f"{bindir}:{os.path.dirname(tmux_exe)}:/usr/bin:/bin",
+        "TMUX_TMPDIR": sockdir,
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "TERM": "xterm",
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+    }
+
+    def tmux(*args, env=None):
+        return subprocess.run([tmux_exe, "-L", sock, *args], capture_output=True,
+                              text=True, env=(env or server_env), timeout=30)
+
+    try:
+        tmux("new-session", "-d", "-s", "scratch20")
+        # POSITIVE CONTROL on the fixture: prove the server really holds a PATH
+        # carrying `claude` BEFORE asserting anything about a pane, so a failure
+        # below is about the pane and never about the setup.
+        seen = tmux("show-environment", "-g", "PATH").stdout.strip()
+        assert str(bindir) in seen, f"fixture did not take; server PATH = {seen!r}"
+
+        # 🔴 THE AGENT'S OWN ENVIRONMENT, as systemd really gives it: PATH
+        # OVERRIDDEN and nothing else, which is exactly what `Environment=PATH=`
+        # does. No `claude` on it.
+        agent_env = dict(server_env, PATH=os.path.dirname(tmux_exe))
+
+        def run(args, env=None):
+            # env=None means "the agent passed nothing" — the defect. A stub that
+            # ignored the argument would pass with or without the fix.
+            e = dict(env if env is not None else agent_env)
+            e["TMUX_TMPDIR"] = sockdir          # pin the private socket only
+            return (lambda p: (p.returncode, p.stdout, p.stderr))(
+                subprocess.run([tmux_exe, "-L", sock, *args], capture_output=True,
+                               text=True, env=e, timeout=30))
+
+        monkeypatch.setattr(AGENT, "run_tmux", run)
+
+        pane, err = AGENT.open_window(str(tmp_path), "scratch20")
+        assert not err, f"open_window failed: {err}"
+        assert pane.startswith("%"), f"no pane id: {pane!r}"
+
+        pid = tmux("display-message", "-p", "-t", pane, "#{pane_pid}").stdout.strip()
+        assert pid.isdigit(), f"no pane pid for {pane!r}"
+        raw = pathlib.Path(f"/proc/{pid}/environ").read_bytes().decode("utf-8", "replace")
+        pane_path = ""
+        for entry in raw.split("\0"):
+            if entry.startswith("PATH="):
+                pane_path = entry[5:]
+                break
+
+        assert pane_path, f"could not read the pane's PATH at all (pane {pane})"
+        assert str(bindir) in pane_path.split(":"), (
+            "the launched pane cannot find `claude`: its PATH is "
+            f"{pane_path!r}, which does not contain {str(bindir)!r}. The pane "
+            "inherited the AGENT's environment instead of the tmux server's. "
+            "This is task 524: on workbench the launched window sat on "
+            "`claude: command not found`."
+        )
+    finally:
+        subprocess.run([tmux_exe, "-L", sock, "kill-server"], capture_output=True,
+                       env=server_env, timeout=30)
+        shutil.rmtree(sockdir, ignore_errors=True)
+
+
+def test_the_launch_env_KEEPS_tmux_reachable_when_the_server_PATH_lacks_it(monkeypatch, tmp_path):
+    """The corrected PATH must PREPEND, never REPLACE — task 524.
+
+    🔴 THE MUTANT THIS EXISTS FOR. `launch_env = dict(os.environ, PATH=pane_path)`
+    reads as the obvious implementation and passes the sibling test above, because
+    there the server's PATH happens to contain tmux. It is wrong: this process
+    re-execs tmux WITH that environment, so an operator PATH that does not carry
+    tmux would leave the agent unable to run tmux at all — the launch fails
+    outright instead of landing a diagnosable window. Measured: without this case
+    that mutant SURVIVES.
+
+    So the server PATH here deliberately does NOT contain tmux. Only the
+    append-our-own behaviour can make this pass.
+    """
+    tmux_exe = _TMUX_EXE_AT_IMPORT
+    assert tmux_exe, "tmux is in REQUIRED_TOOLS; it must be on PATH here"
+
+    bindir = tmp_path / "onlybin"
+    bindir.mkdir()
+
+    sockdir = tempfile.mkdtemp(prefix="t524b.")
+    sock = "t524b-" + os.path.basename(str(tmp_path))
+    server_env = {
+        "PATH": f"{os.path.dirname(tmux_exe)}:/usr/bin:/bin",
+        "TMUX_TMPDIR": sockdir,
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "TERM": "xterm",
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+    }
+
+    def tmux(*args):
+        return subprocess.run([tmux_exe, "-L", sock, *args], capture_output=True,
+                              text=True, env=server_env, timeout=30)
+
+    try:
+        tmux("new-session", "-d", "-s", "scratch20")
+        # 🔴 A server PATH WITHOUT tmux on it. This is the whole fixture.
+        tmux("set-environment", "-g", "PATH", str(bindir))
+        seen = tmux("show-environment", "-g", "PATH").stdout.strip()
+        assert seen == f"PATH={bindir}", f"fixture did not take: {seen!r}"
+
+        agent_env = dict(server_env, PATH=os.path.dirname(tmux_exe))
+
+        def run(args, env=None):
+            e = dict(env if env is not None else agent_env)
+            e["TMUX_TMPDIR"] = sockdir
+            # 🔴 BY NAME, NOT BY ABSOLUTE PATH — the real agent runs
+            # `tmux_bin()`, which defaults to the bare name "tmux", so PATH is
+            # what decides whether tmux can be executed at all. A stub using an
+            # absolute path makes this test unable to fail: measured, the
+            # replace-PATH mutant SURVIVED until this line changed.
+            return (lambda p: (p.returncode, p.stdout, p.stderr))(
+                subprocess.run(["tmux", "-L", sock, *args], capture_output=True,
+                               text=True, env=e, timeout=30))
+
+        monkeypatch.setattr(AGENT, "run_tmux", run)
+
+        pane, err = AGENT.open_window(str(tmp_path), "scratch20")
+        assert not err, (
+            "open_window failed with a server PATH that does not carry tmux: "
+            f"{err!r}. The launch environment REPLACED this unit's PATH instead "
+            "of prepending to it, so tmux itself became unreachable."
+        )
+        assert pane.startswith("%"), f"no pane id: {pane!r}"
+    finally:
+        subprocess.run([tmux_exe, "-L", sock, "kill-server"], capture_output=True,
+                       env=server_env, timeout=30)
+        shutil.rmtree(sockdir, ignore_errors=True)

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -232,7 +232,7 @@ def tmux_bin() -> str:
     return os.environ.get("TMUX_REPLY_TMUX_BIN", "tmux")
 
 
-def run_tmux(args: list[str]) -> tuple[int, str, str]:
+def run_tmux(args: list[str], env: dict[str, str] | None = None) -> tuple[int, str, str]:
     """Run one tmux command with an ARGV LIST and no shell.
 
     🔴 NO SHELL, EVER, AND THIS IS THE SINGLE MOST IMPORTANT LINE IN THE FILE.
@@ -245,7 +245,7 @@ def run_tmux(args: list[str]) -> tuple[int, str, str]:
     """
     try:
         p = subprocess.run([tmux_bin()] + args, capture_output=True, text=True,
-                           timeout=TMUX_TIMEOUT, check=False)
+                           timeout=TMUX_TIMEOUT, check=False, env=env)
     except subprocess.TimeoutExpired:
         return 124, "", f"tmux timed out after {TMUX_TIMEOUT}s"
     except OSError as exc:
@@ -515,6 +515,42 @@ KIND_NEW_SESSION = "new-session"
 NEW_SESSION_ALWAYS_SUBMITS = True
 
 
+def pane_path_env() -> str:
+    """The PATH a LAUNCHED pane should run with, taken from the tmux server.
+
+    🔴 WHY THE PANE CANNOT JUST INHERIT OURS. `new-window` runs the new pane with
+    the environment of the process that asked for it — this agent — and under
+    systemd that is the unit's deliberately minimal `Environment=PATH=` (coreutils
+    + python3 + tmux). Measured on workbench 2026-09-07: a launched window ran
+    `claude` and got `command not found`, its PATH exactly the unit's three
+    entries, while `tmux show-environment -g PATH` on the same server was the
+    operator's complete PATH. tmux was never the source; the caller was.
+
+    🔴 THE SERVER'S GLOBAL ENVIRONMENT IS THE RIGHT SOURCE, AND THAT IS A
+    DELIBERATE CHOICE OVER TWO ALTERNATIVES. Widening the unit's own PATH would
+    grant this agent — which spawns shells as the operator — a larger environment
+    for every purpose, to fix one. Spawning a login shell would run the
+    operator's whole rc chain for a value we can read directly. The server's
+    global PATH is what every window the operator opens by hand already gets, so
+    a launched window becomes indistinguishable from a hand-opened one, which is
+    the actual requirement.
+
+    Returns "" when the server has no PATH to report — tmux prints `-PATH` for an
+    unset variable — in which case the caller passes no `-e` and the pane behaves
+    exactly as it did before this function existed. That is the pre-existing
+    behaviour, not a new failure mode, and it stays diagnosable: the window opens
+    and sits on `command not found` rather than vanishing.
+    """
+    rc, out, _ = run_tmux(["show-environment", "-g", "PATH"])
+    if rc != 0:
+        return ""
+    line = out.splitlines()[0].strip() if out.strip() else ""
+    # `-PATH` is tmux's spelling for "this variable is unset".
+    if not line.startswith("PATH=") or len(line) == len("PATH="):
+        return ""
+    return line[len("PATH="):]
+
+
 def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
     """Open a new tmux window at cwd, in tmux_session when one is named.
 
@@ -562,11 +598,35 @@ def open_window(cwd: str, tmux_session: str = "") -> tuple[str, str]:
     switched windows, and a relative target would type into whatever they moved to.
     """
     argv = ["new-window", "-P", "-F", NEW_WINDOW_FORMAT, "-c", cwd]
+
     if tmux_session:
         # `=` forces an EXACT session match; the trailing colon means "this
         # session, next free index". Both are required — see the docstring.
         argv += ["-t", "=" + tmux_session + ":"]
-    rc, out, err = run_tmux(argv)
+    # 🔴 THE NEW PANE INHERITS THE ENVIRONMENT OF THE PROCESS THAT ASKS FOR IT,
+    # WHICH IS THIS AGENT — and under systemd that is the unit's deliberately
+    # minimal `Environment=PATH=` (coreutils + python3 + tmux). Measured on
+    # workbench 2026-09-07: a launched window ran `claude` and got `command not
+    # found`, its PATH exactly those three entries, while the same server's
+    # `show-environment -g PATH` was the operator's complete PATH. tmux was never
+    # the source; this caller was. See pane_path_env for why the server's global
+    # PATH is the right value and why `new-window -e` is NOT the mechanism (it
+    # does not reach the pane's environment on tmux 3.7c — measured).
+    # 🔴 THE SERVER'S PATH FIRST, THIS UNIT'S APPENDED — and the order is the
+    # whole design, not a style choice. Server-first is what makes a launched
+    # window resolve `claude` the way a hand-opened one does. Appending our own
+    # is what keeps `tmux` itself executable: this very process re-execs tmux
+    # with this environment, so replacing PATH outright breaks the agent the
+    # moment the operator's PATH happens not to carry tmux. Caught by
+    # test_a_launched_pane_gets_a_PATH_THAT_CAN_FIND_claude, which uses a server
+    # PATH that deliberately does not contain tmux.
+    launch_env = None
+    pane_path = pane_path_env()
+    if pane_path:
+        own = os.environ.get("PATH", "")
+        launch_env = dict(os.environ,
+                          PATH=(pane_path + os.pathsep + own) if own else pane_path)
+    rc, out, err = run_tmux(argv, env=launch_env)
     if rc != 0:
         return "", (err or f"tmux exited {rc}")
 


### PR DESCRIPTION
The clawgate launch feature was inert end to end on workbench: every session it
started opened a tmux window whose shell answered `claude: command not found`,
and the window therefore never acquired a claude_session_id.

MECHANISM, measured not inferred (task 523's criterion-1 run, 2026-09-07):
`new-window` runs the new pane with the environment of the process that asked for
it — this agent — and under systemd that is the unit's deliberately minimal
`Environment=PATH=` (coreutils + python3 + tmux, 3 entries). The launched pane's
PATH was byte-identical to that line, while the same tmux server's
`show-environment -g PATH` was the operator's complete PATH. tmux was never the
source; the caller was.

THE FIX takes the PATH from the tmux SERVER's global environment and hands it to
the one `new-window` call, PREPENDED to this unit's own. Two deliberate choices:

  * The server's global PATH, not a widened unit PATH and not a login shell. This
    agent spawns shells as the operator, so widening its environment for every
    purpose to fix one is the wrong trade; and the server's PATH is already what
    every hand-opened window gets, which is exactly the requirement. The unit is
    UNTOUCHED — nix/home.nix is not in this diff (criterion 2).
  * PREPEND, never replace. This process re-execs tmux with that environment, so
    replacing PATH outright breaks the agent the moment the operator's PATH does
    not carry tmux.

⚠ `new-window -e` is NOT the mechanism and was tried first: measured on tmux
3.7c, a marker variable passed that way never appears in the pane's environment.
That dead end is recorded in pane_path_env's docstring so it is not re-derived.

TESTS — 2 new, 110 in the suite, 1195 across the four affected suites.
  M1  no caller-PATH correction (the pre-fix state)  -> KILLED
  M2  server PATH REPLACES ours instead of prepending -> KILLED
Both restored by sha256 and re-verified green.

🔴 M2 SURVIVED TWICE BEFORE IT KILLED, and both causes are worth knowing:
first because the hermetic fixture happened to put tmux's directory on the
server PATH, so dropping the prepend broke nothing; then because the stub invoked
tmux by ABSOLUTE PATH, so PATH could not decide whether tmux was findable at all.
The test now uses a server PATH without tmux on it and invokes tmux by NAME, the
way tmux_bin() does. A mutant that survives because the harness is too kind is
indistinguishable from one that survives because the code is right.

🔴 ORDER DEPENDENCE, FOUND AND FIXED AT ITS MECHANISM. Both new tests passed alone
and in every pair, and failed only in the full four-suite sweep: several suites
here legitimately clobber os.environ["PATH"], so a shutil.which("tmux") inside a
test body reports on the run order. tmux is now resolved at IMPORT. The tests are
also hermetic — their own server, socket dir and environment, never the shared
real_tmux fixture.

scripts/tests/test_no_real_launchers.py: the new PATH-clobbering site is pinned
with its justification, as that ledger requires.

NOT VERIFIED: criterion 1 and the closing condition need a live launch. The unit
runs from the primary clone's working tree, so this must merge, the clone must
sync and the unit must restart before a real launch can be observed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mi9GPkd2dFWCBcEPCk8v1q
