### PR TITLE
fix(mention-open): a guessed repo you cannot override is a prompt with one wrong answer

### DIFF
--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -856,8 +856,8 @@ def universe_note(subject: str, offered: int, path: Path | None = None) -> str:
             f"scripts/regen-known-repos.py")
 
 
-def guessed_note(subject: str) -> str:
-    """The line shown ABOVE the picker when the ONLY repository on offer was
+def guessed_note(subject: str, offered: int = 1) -> str:
+    """The line shown ABOVE the picker when the FIRST repository on offer was
     GUESSED — `repo_source == "default"`, i.e. the tmux pane rather than
     anything the clicked text said.
 
@@ -867,14 +867,34 @@ def guessed_note(subject: str) -> str:
     the same argument as `universe_note`: rofi cannot report a reason after the
     fact, so the reason goes above the choice.
 
-    🔴 IT NAMES THE CLICKED TEXT AND NOTHING ELSE — never the repository, never
-    the mapping. The candidate ROW already shows the repo, which is the whole
-    point of asking; the note must not become a second place a name can leak
-    from, and `_every_sink`'s guards would not see this one (it goes to rofi).
+    🔴 TWO WORDINGS, BECAUSE THE TWO SITUATIONS NEED DIFFERENT ACTIONS — and
+    the one-row wording was MEASURED WRONG in practice. Reported from the real
+    click path 2026-09-07: `audit-pr 1291` said "names no repository" over a
+    single row, and the only moves were to accept the guess or dismiss. When the
+    pane guess is wrong — which the operator reports is the common case — that
+    is a dead end wearing an explanation. So when alternatives are on offer the
+    note must say the ROW IS A GUESS *and* that the rest are searchable;
+    "confirm or dismiss" would now be false, since neither is what to do.
+
+    ⚠ The one-row wording is KEPT rather than deleted: the universe can be empty
+    (no mapping file yet, or an unreadable one), and a lone guessed row is still
+    reachable then. It is no longer the common path, and the `offered` default
+    stays 1 so the narrower claim is what a caller gets by omission.
+
+    🔴 IT NAMES THE CLICKED TEXT AND A COUNT, NOTHING ELSE — never the
+    repository, never the mapping. The candidate ROW already shows the repo,
+    which is the whole point of asking; the note must not become a second place
+    a name can leak from, and `_every_sink`'s guards would not see this one (it
+    goes to rofi).
     """
-    return (f"{subject} names no repository — the one offered was measured from "
-            "the tmux pane, which may not be the pane you clicked in. Confirm, "
-            "or dismiss.")
+    if offered <= 1:
+        return (f"{subject} names no repository — the one offered was measured "
+                "from the tmux pane, which may not be the pane you clicked in. "
+                "Confirm, or dismiss.")
+    return (f"{subject} names no repository. The FIRST row is a guess from the "
+            f"tmux pane, which may not be the pane you clicked in — the other "
+            f"{offered - 1} are every repository this host knows. Type to "
+            f"search, or dismiss.")
 
 
 def colour_literal_offer(span: dict | None, text: str) -> str:
@@ -1159,6 +1179,52 @@ def main(argv: list[str] | None = None) -> int:
     # `--print`, which is what it is for.
     guessed = span is not None and span["repo_source"] == SOURCE_DEFAULT
 
+    # 🔴 A GUESS THE OPERATOR CANNOT OVERRIDE IS NOT AN OFFER — IT IS A PROMPT
+    # WITH ONE WRONG ANSWER. Reported from the real click path 2026-09-07:
+    # `audit-pr 1291` produced a ONE-ROW picker holding the pane's repo and the
+    # note "names no repository". The row happened to be right that time, and
+    # the operator's point stands — in practice the pane guess is often wrong,
+    # and when it is, the picker offers no way to say so. Confirm the wrong
+    # repo, or dismiss and type the URL by hand. Both are worse than the
+    # refusal this branch replaced.
+    #
+    # The suppression above is still exactly right: a `default`-sourced repo is
+    # evidence about the WINDOW, not about the reference, so it must never open
+    # unconfirmed. What was missing is the other half — having declined to act
+    # on the guess, offer the alternatives. The universe is already built and
+    # already the answer everywhere else a repository cannot be named, and it is
+    # fuzzy-matched, so 392 rows cost the operator a few keystrokes rather than
+    # a scroll.
+    #
+    # 🔴 THE GUESS STAYS FIRST, and that is the whole reason this is an APPEND
+    # rather than a replace. It is the most likely answer and it is one Enter
+    # away, so the common case does not get slower; the universe below it is
+    # what makes the uncommon case possible at all. Same shape as the bare-`#N`
+    # arm above, which keeps the clawgate candidate first for the same reason.
+    # 🔴 SCOPED TO THE GUESS THAT IS *ALONE*, AND THE NARROWING IS DELIBERATE.
+    # A bare `#N` the pane attributes already offers TWO rows — the clawgate
+    # task and the pane's GitHub repo — and `test_a_bare_hash_N_that_the_PANE_
+    # already_attributes_does_NOT_get_the_universe` pins that on purpose: it is
+    # the single most common interaction in this handler, and burying two good
+    # rows under several hundred options is a regression dressed as a feature.
+    # A one-row picker is a different thing entirely — there is nothing to bury,
+    # and no way to say "not that one".
+    #
+    # ⚠ THE SAME COMPLAINT DOES PARTLY APPLY TO THAT TWO-ROW CASE — if the pane
+    # guess is wrong there, the operator still cannot reach the right repo — but
+    # fixing it costs every ordinary click a full-height picker, which is a
+    # trade for the operator to make rather than one to smuggle in beside a bug
+    # fix. Left alone, and written down instead.
+    guessed_alone = guessed and len(candidates) == 1 and not offered_universe
+
+    if guessed_alone and universe:
+        seen = {c["url"] for c in candidates}
+        # Deduped: the pane's repo is usually IN the universe too, and offering
+        # it twice makes the first row look like a rendering bug rather than a
+        # recommendation.
+        candidates = candidates + [c for c in universe if c["url"] not in seen]
+        offered_universe = True
+
     # 🔴 `and not offered_universe`: see PASS 3. One candidate is enough to open
     # only when that candidate is EVIDENCE about the reference — an explicit
     # owner, a measured checkout, a mapping hit. A universe row is an OPTION,
@@ -1174,10 +1240,18 @@ def main(argv: list[str] | None = None) -> int:
     # this handler. So the guessed note rides on the ONE case the branch above
     # created: a single row, which without a reason reads as a broken handler
     # asking the operator to confirm the obvious.
-    mesg = (universe_note(span["raw"] if span is not None else text,
-                          len(candidates))
-            if offered_universe else
-            guessed_note(span["raw"]) if (guessed and len(candidates) == 1)
+    # 🔴 `guessed` IS TESTED FIRST, AND THE ORDER IS THE WHOLE POINT. Both
+    # conditions are now true on the common path — the guessed arm above sets
+    # `offered_universe` — and the two notes make OPPOSITE claims about the top
+    # row. `universe_note` opens "nothing here knows X", which is false when the
+    # first row is a recommendation the handler is asking about; putting it
+    # first would have described the fix as a dead end. Swap these two branches
+    # and the picker still works, so no behavioural test catches it: the guard
+    # is `test_a_guessed_picker_is_NOT_described_as_nothing_here_knows`.
+    mesg = (guessed_note(span["raw"], len(candidates))
+            if guessed_alone and span is not None
+            else universe_note(span["raw"] if span is not None else text,
+                               len(candidates)) if offered_universe
             else "")
     url = pick(candidates, mesg=mesg)
     return open_url(url) if url else 0

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -191,7 +191,9 @@ MUTANTS: list[tuple] = [
      "REFUSAL-PATH DISCLOSURE"),
     ("K38", "disclosure", "the same KEY leak on the PICKER path, where it rides "
                           "out on stdout instead of a toast",
+     "        # outright. Either way the operator now gets a choice instead of a toast.\n"
      "        offered_universe = True\n",
+     "        # outright. Either way the operator now gets a choice instead of a toast.\n"
      "        offered_universe = True\n"
      '        print("did you mean:", ", ".join(sorted(load_known_repos())))\n',
      "PICKER-PATH DISCLOSURE"),
@@ -286,7 +288,10 @@ MUTANTS: list[tuple] = [
     # ---- F6: OFFERED is not RESOLVED ---------------------------------------
     ("K19", "deletion", "a universe row becomes auto-openable again, so a click "
                         "on a hex colour opens an unrelated repo's issue",
-     "        offered_universe = True\n", "        offered_universe = False\n",
+     "        # outright. Either way the operator now gets a choice instead of a toast.\n"
+     "        offered_universe = True\n",
+     "        # outright. Either way the operator now gets a choice instead of a toast.\n"
+     "        offered_universe = False\n",
      "bypassing the picker"),
     ("K20", "widening", "`_OFFER_NUM_RE` loses its bound and drifts away from "
                         "the Alacritty hint regex it mirrors",

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -1624,21 +1624,30 @@ def test_a_GUESSED_repo_is_never_auto_opened_whatever_the_shape(monkeypatch, tex
     assert "https://github.com/wrongorg/wrongrepo/issues/1291" in seen["urls"], seen
 
 
-def test_the_one_row_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
-    """A single-row picker with no explanation reads as a broken handler asking
-    the operator to confirm the obvious. rofi cannot report a reason after a
-    dismissal (see `pick`), so the reason goes above the choice.
+def test_the_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
+    """A picker whose top row was GUESSED, with no explanation, reads as a broken
+    handler asking the operator to confirm the obvious. rofi cannot report a
+    reason after a dismissal (see `pick`), so the reason goes above the choice.
 
-    🔴 AND THE NOTE NAMES THE CLICKED TEXT, NEVER A REPOSITORY OR THE MAPPING —
-    the ROW already carries the repo, and `_every_sink`'s disclosure guards
-    cannot see a string that goes to rofi."""
+    ⚠ THIS TEST USED TO ASSERT `n == 1` AND WAS RENAMED FROM
+    `test_the_one_row_picker_...`. That single row was the defect the operator
+    reported from the real click path on 2026-09-07 — the guess could not be
+    overridden — so the row COUNT it pinned is superseded. What survives
+    unchanged is the claim its name makes and the disclosure rule, both of which
+    matter more than the count: the note must explain itself, and it must not
+    name a repository.
+
+    The count is now pinned by
+    `test_a_GUESSED_repo_is_offered_WITH_the_whole_universe_beneath_it`, which
+    is the regression for the report."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(n=len(c), mesg=mesg) or "")
     assert MO.main(["audit-pr 1291"]) == 0
-    assert seen["n"] == 1, seen
+    assert seen["n"] > 1, ("the guess must not be the ONLY option — that is the "
+                           "reported defect, not the design")
     assert "audit-pr 1291" in seen["mesg"], seen
     assert "tmux pane" in seen["mesg"], seen
     _no_universe_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
@@ -2637,3 +2646,123 @@ def test_systemctl_is_MENTIONED_but_never_SPAWNED():
     assert "systemctl" not in _spawn_argv0_literals(HANDLER), (
         "mention-open.py now SPAWNS systemctl — the ACKNOWLEDGED_UNSTUBBED "
         "entry covering it is an unreachability claim and is now FALSE")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 A GUESSED REPO MUST BE OVERRIDABLE — REPORTED FROM THE REAL CLICK PATH
+#
+# 2026-09-07, operator, clicking `audit-pr 1291` in Alacritty: a ONE-ROW picker
+# holding the tmux pane's repo, above the note "audit-pr 1291 names no
+# repository". Their words: "in this case the guess is right, but in practice
+# it's not."
+#
+# That is the whole defect. Suppressing the auto-open (#1336) was correct — a
+# `default`-sourced repo is evidence about the WINDOW, not about the reference,
+# so it must never open unconfirmed. But having declined to act on the guess,
+# the handler offered nothing else: confirm the wrong repo, or dismiss and type
+# the URL by hand. The universe was already built and already the answer
+# everywhere else a repository cannot be named; this arm just never reached it.
+# --------------------------------------------------------------------------- #
+def _guessed_picker(monkeypatch, *, universe, pane="wrongorg/wrongrepo",
+                    mapping=FAKE_UNIVERSE):
+    """Drive `main()` down the guessed-repo path and return what `pick` saw.
+
+    ⚠ `mapping` IS A PARAMETER BECAUSE `universe=[]` DOES NOT EMPTY THE UNIVERSE.
+    `repo_universe()` unions the generated file with `discover_repos()`, so a
+    caller that clears only the file still gets every mapped repo — my own
+    empty-universe test asserted 1 row and got 4 for exactly that reason. The
+    empty case needs BOTH sources cleared, and that is worth a parameter rather
+    than a comment, because the trap is silent in the other direction too."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(mapping))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: list(universe))
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: pane)
+    seen = {}
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
+    assert MO.main(["audit-pr 1291"]) == 0
+    return seen
+
+
+def test_a_GUESSED_repo_is_offered_WITH_the_whole_universe_beneath_it(monkeypatch):
+    """🔴 THE REGRESSION FOR THE REPORTED SYMPTOM. Red before this change: the
+    picker held exactly ONE row.
+
+    The guess must still be FIRST — it is the most likely answer and stays one
+    Enter away — and everything else must be reachable by typing."""
+    seen = _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY, "acme/widget"])
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) > 1, f"a guess with no alternatives is a dead end: {urls}"
+    assert "wrongorg/wrongrepo" in urls[0], (
+        f"the guess must stay FIRST — one Enter for the common case: {urls[0]}")
+    assert any(UNIVERSE_ONLY in u for u in urls), (
+        f"the universe never reached the guessed picker: {urls}")
+    assert all(u.endswith("/1291") for u in urls), urls
+
+
+def test_the_guessed_row_is_NOT_offered_twice(monkeypatch):
+    """The pane's repo is usually in the universe too. Two identical rows read
+    as a rendering bug rather than as a recommendation, and the operator cannot
+    tell which one is the 'real' one — because neither is."""
+    seen = _guessed_picker(monkeypatch,
+                           universe=["wrongorg/wrongrepo", "acme/widget"])
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) == len(set(urls)), f"duplicate rows: {urls}"
+    assert sum("wrongorg/wrongrepo" in u for u in urls) == 1, urls
+
+
+def test_a_guessed_picker_is_NOT_described_as_nothing_here_knows(monkeypatch):
+    """🔴 THE ORDER GUARD, and it pins a defect no behavioural test can see.
+
+    After the fix BOTH `guessed` and `offered_universe` are true on this path,
+    so the note is chosen by the ORDER of two branches. `universe_note` opens
+    "nothing here knows X" — which is false here: the first row is a
+    recommendation the handler is explicitly asking about. Swap the branches and
+    the picker still shows the right rows in the right order, so only the words
+    are wrong, and only this test says so."""
+    seen = _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY])
+    assert "nothing here knows" not in seen["mesg"], seen["mesg"]
+    assert "guess" in seen["mesg"].lower(), seen["mesg"]
+    assert "tmux pane" in seen["mesg"], seen["mesg"]
+    # …and it must say the rest are SEARCHABLE, because "confirm or dismiss" —
+    # the old wording — is now false: neither is what the operator should do.
+    assert "search" in seen["mesg"].lower(), seen["mesg"]
+    _no_universe_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
+
+
+def test_the_ONE_ROW_wording_survives_for_an_EMPTY_universe(monkeypatch):
+    """⚠ The narrow wording is kept, not deleted: with no mapping file (or an
+    unreadable one) the universe is empty and a lone guessed row is still
+    reachable. "Confirm, or dismiss" is the correct instruction THERE, and
+    telling the operator to "type to search" over one row would be nonsense."""
+    seen = _guessed_picker(monkeypatch, universe=[], mapping={})
+    assert len(seen["rows"]) == 1, seen["rows"]
+    assert "Confirm, or dismiss" in seen["mesg"], seen["mesg"]
+    assert "search" not in seen["mesg"].lower(), seen["mesg"]
+
+
+def test_the_guessed_repo_is_still_NEVER_opened_unconfirmed(monkeypatch):
+    """🔴 THE SAFETY PROPERTY #1336 ADDED, RE-ASSERTED HERE because this change
+    touches the branch that enforces it. Widening the offer must not weaken the
+    rule: a repo measured from the tmux pane is evidence about the WINDOW, and
+    opening it unconfirmed is the confident-wrong-page failure the whole handler
+    is anchored against. `open_url` must not be reached without a selection."""
+    opened = []
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY])
+    assert opened == [], f"a guessed repo was opened without a selection: {opened}"
+
+
+def test_an_EXPLICIT_owner_still_opens_directly_and_gets_NO_picker(monkeypatch):
+    """🔴 THE NEGATIVE CONTROL FOR THE WHOLE CHANGE. A rule that appended the
+    universe to every candidate would satisfy every assertion above while
+    putting a 392-row picker in front of `owner/repo#N`, which carries its own
+    evidence and must still open with zero keystrokes."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    picked, opened = [], []
+    monkeypatch.setattr(MO, "pick", lambda c, mesg="": picked.append(c) or "")
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    assert MO.main(["civitai/talos-infra#1065"]) == 0
+    assert picked == [], "an explicit owner must not raise a picker"
+    assert opened == ["https://github.com/civitai/talos-infra/issues/1065"], opened


### PR DESCRIPTION
Reported from the real click path 2026-09-07. Clicking `audit-pr 1291` in Alacritty
gave a **one-row picker** holding the tmux pane's repo, above the note "audit-pr 1291
names no repository". The operator's words:

> in this case the guess is right, but in practice it's not

## The defect

#1336 was right to suppress the auto-open — a `default`-sourced repo is evidence about
the **window**, not about the reference, so it must never open unconfirmed. But having
declined to act on the guess, the handler offered nothing else: confirm the wrong repo,
or dismiss and type the URL by hand. Both are worse than the refusal the picker
replaced, and it defeats the 392-row fuzzy universe from #1369 — which was already
built and sitting right there, unreached by this one arm.

The guess now **leads** a picker instead of being all of it: still first (most likely
answer, one Enter), with the universe appended and deduped beneath it.

## Scoped to the guess that is ALONE — this is the substance, not a detail

A bare `#N` the pane attributes already offers two rows (clawgate task + the pane's
repo), and `test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe`
pins that deliberately: it's the most common interaction in this handler, and burying
two good rows under several hundred is a regression dressed as a feature. **My first
version wasn't scoped and broke exactly that test — the suite caught it.**

⚠ **The same complaint partly applies there**: if the pane guess is wrong on a bare
`#N`, the right repo is still unreachable. Fixing it costs every ordinary click a
full-height picker — the operator's trade to make, not one to smuggle in beside a bug
fix. Left alone and written down; **open question on the PR.**

## The note needed two wordings

"Confirm, or dismiss" is now **false** on the common path — neither is what to do. With
alternatives on offer it says the first row is a guess and the rest are searchable. The
one-row wording is **kept**, not deleted: with no mapping file the universe is empty and
a lone guessed row is still reachable.

🔴 The note is chosen by **branch order**, and both conditions are now true at once.
`universe_note` opens "nothing here knows X", which is false when the first row is a
recommendation the handler is asking about. Swapping the branches leaves the rows
correct and only the words wrong, so no behavioural test sees it —
`test_a_guessed_picker_is_NOT_described_as_nothing_here_knows` is the guard.

## Superseded, not deleted

`test_the_one_row_picker_for_a_guessed_repo_SAYS_WHY` asserted `n == 1` — which **is**
the reported defect. Renamed and now asserts `n > 1`; its real claims (the note explains
itself, and never names a repository) are unchanged.

## Caught by the gates, not by review

The new branch adds a second `offered_universe = True`, which made mutation-battery rows
**K38 and K19** match 2 sites instead of 1. A 2× anchor mutates a place the row doesn't
describe. Re-anchored onto unique context — and, per the guard's own instruction,
**re-ran the battery** rather than stopping at "the anchors parse now":

```
P1  control     KILLED                (the battery can observe)
K38 disclosure  KILLED(attributed)    f=1
K19 deletion    KILLED(attributed)    f=6
3/3 killed for the stated reason, restore OK
```

## Verification

Real click path, `rofi` stubbed so no window is raised:

| clicked | before | after |
|---|---|---|
| `audit-pr 1291` | 1 row, no way out | **392 rows**, guess first, "type to search" |
| `#1291` | 2 rows, no note | unchanged |
| `civitai/talos-infra#1065` | opens directly | unchanged |

Both tiers green on the merged tree `fb57872f` (`origin/main` confirmed an ancestor):
dev-host `gate.sh --tier both` **PASS** (20,904 pytest + 1,449 node, 0 failed);
sandbox built one derivation at a time from a `git archive` extract — `pytests` **PASS**,
`nodetests` **PASS**.

⚠ One of my own new tests was wrong in a way worth recording: `universe=[]` does **not**
empty the universe, because `repo_universe()` unions the generated file with
`discover_repos()`. It asserted 1 row and got 4. The helper now takes the mapping as a
parameter so the empty case is actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FENxxrZztNTsrKgChnGT1X
