### PR TITLE
refactor(cairn): `who` becomes its own `cairn-who` binary, and the shared timeout predicate moves to the module both import

### DIFF
--- a/claude/skill-tiers.json
+++ b/claude/skill-tiers.json
@@ -55,7 +55,7 @@
     "browser": { "tier": "A" },
     "cairn": {
       "tier": "B",
-      "why": "the tool is NAMED, never described -- 'cairn doctor', 'cairn sync', 'cairn who'. The symptoms that could route here already belong to skills that name it in their own bodies: a refused read to `resume`, a stale index block to `analyze-service`, an entry that got huge to `prune-index`"
+      "why": "the tool is NAMED, never described -- 'cairn doctor', 'cairn sync', 'cairn-who'. The symptoms that could route here already belong to skills that name it in their own bodies: a refused read to `resume`, a stale index block to `analyze-service`, an entry that got huge to `prune-index`"
     },
     "check-clickup-addressed": { "tier": "A" },
     "clawgate": { "tier": "A" },

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cairn
-description: "The hosted subsystem store (pod in ns `subsystem-store`) and its client `scripts/cairn`. Use for: `cairn doctor`, cairn sync/recall/search/ls-entries/who, a stale or unstamped store, a `cairn` exit 4, seeding the pod, a scope a token cannot reach. Writes are `subsystem-index`; pruning is `prune-index`."
+description: "The hosted subsystem store (pod in ns `subsystem-store`), client `scripts/cairn`. Use for: `cairn doctor`, cairn sync/recall/search/ls-entries, cairn-who, a stale or unstamped store, a `cairn` exit 4, seeding the pod, a scope a token cannot reach. Writes are `subsystem-index`; pruning is `prune-index`."
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
@@ -33,12 +33,15 @@ staleness it was run to measure.
 | find a hunk by text | `cairn search '<query>'` (`--all-scopes` to search every scope) |
 | what does the cache actually hold | `cairn ls-entries` |
 | parse-check the cached entries | `cairn validate` |
-| which sessions/windows/transcripts worked a task | `cairn who <task>` (`--json`, `--host`, `--no-windows`) |
+| which sessions/windows/transcripts worked a task | `cairn-who <task>` (`--json`, `--host`, `--no-windows`) — a SEPARATE binary |
 | diagnose anything above going wrong | `cairn doctor` |
 
-`cairn who` is about a **task**, not a store entry: it touches no store and never
-syncs, and it has its own longer `--timeout` because it shells into tmux on two
-hosts.
+🔴 **`cairn-who` is a separate command, not a `cairn` subcommand.** It is about a
+**task**, not a store entry: it touches no store and never syncs, takes none of
+the `--scope`/`--repo`/`--no-sync` flags, and has its own longer `--timeout`
+because it shells into tmux on two hosts rather than fetching an HTTP snapshot.
+Typing it as a `cairn` subcommand is no longer valid: argparse exits 2 with an
+`invalid choice` naming the verbs that remain.
 
 **Writes are not this skill's.** `subsystem-index` owns the one protocol for
 every writer; `prune-index` owns deletion, with its own confirmation gate. Load

--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -252,15 +252,34 @@ countable.
    forcing: none — done
 
 3. 🔨 **HALF DONE — Phase A3, devrc consumes cairn as a pinned flake input.**
-   🔴 **IN FLIGHT ELSEWHERE — `claim-work` slug `cairn-oss-multi-instance-3` is HELD by another
-   session** (taken 2026-09-08 ~01:45Z) for the **first slice only**: re-home `cairn who` as its
-   own `cairn-who` binary + extract `unbounded_timeout_reason` into devrc `lib/timeouts.py`.
-   That session explicitly did NOT pin the flake and did NOT touch the `entry_shape`/writer fork.
+   🔴 **IN FLIGHT — `claim-work` slug `cairn-oss-multi-instance-3`, taken 2026-09-08 ~01:45Z
+   for the FIRST SLICE ONLY**: re-home `cairn who` as its own `cairn-who` binary + extract
+   `unbounded_timeout_reason` into devrc `lib/timeouts.py`. That slice explicitly does NOT pin
+   the flake and does NOT touch the `entry_shape`/writer fork.
    - **Half 1 — ✅ MERGED 2026-09-08: `ZacxDev/cairn`#4, squash `218b6c1`.**
-   - **Half 2 — the rest is still open** after that slice: pin the input in `flake.nix`, move
-     `~/.local/bin/cairn` into `/nix/store`, point the writer at the pinned `entry_shape`, and
-     decide the fate of devrc's five duplicated `lib/` modules. 🔴 **THE OPERATOR FORK IS STILL
-     UNANSWERED and must be put before building** — see the fork investigation above.
+   - **Half 2 — one slice of four is in review; the rest is still open.** Remaining: pin the
+     input in `flake.nix`, move `~/.local/bin/cairn` into `/nix/store`, point the writer at
+     the pinned `entry_shape`, and decide the fate of devrc's five duplicated `lib/` modules.
+     🔴 **THE OPERATOR FORK IS STILL UNANSWERED and must be put before building** — see the
+     fork investigation above.
+     - **The slice is devrc PR #1381.** Extracting `unbounded_timeout_reason` is not optional
+       there: the store path reached that predicate by importing the whole `who` module, a
+       reach that breaks the moment the two are separate binaries, and re-open-coding it
+       recreates the two-copies bug the predicate already caused once.
+       🔴 **Merging it requires a `home-manager switch`.** The `who` REMOVAL is live on merge
+       (`~/.local/bin/cairn` is an out-of-store symlink), but `~/.local/bin/cairn-who` is
+       created by ACTIVATION, and the deployed skill copy still says `cairn who` until the
+       switch. Between merge and switch the capability is unavailable.
+     ⚠ Every `cairn who` spelling elsewhere in this doc — and in
+     `handoff-cairn-task-linkage.md` and `proposal-cairn-session-capture.md` — becomes the
+     DEAD spelling once #1381 merges, and exits 2. They are left as written because they
+     record what was true when written; do not copy a command out of them.
+   🔴 `nix/home.nix` deploys `scripts/cairn` as an `mkOutOfStoreSymlink` and the comment above
+   that entry says it is REQUIRED, not preferred, because `.resolve()` must land beside `lib/`.
+   (⚠ This bullet cited `:1474` and `:1467`; both were already wrong at `c5e425c7`, landing on
+   unrelated `shell-env-nudge` comments — so no line numbers. Grep for
+   `mkOutOfStoreSymlink is NOT a preference`.) **#4 solves exactly that** by installing script
+   and `lib/` together under `libexec`. Client edits will then need a `home-manager switch`.
    **Closing condition:** a merged devrc PR in which `flake.nix` names cairn as an input and
    `readlink -f ~/.local/bin/cairn` resolves into `/nix/store`. Re-verified NOT met 2026-09-08.
    forcing: none

--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -275,11 +275,13 @@ countable.
      DEAD spelling once #1381 merges, and exits 2. They are left as written because they
      record what was true when written; do not copy a command out of them.
    🔴 `nix/home.nix` deploys `scripts/cairn` as an `mkOutOfStoreSymlink` and the comment above
-   that entry says it is REQUIRED, not preferred, because `.resolve()` must land beside `lib/`.
-   (⚠ This bullet cited `:1474` and `:1467`; both were already wrong at `c5e425c7`, landing on
-   unrelated `shell-env-nudge` comments — so no line numbers. Grep for
-   `mkOutOfStoreSymlink is NOT a preference`.) **#4 solves exactly that** by installing script
-   and `lib/` together under `libexec`. Client edits will then need a `home-manager switch`.
+   that entry says it is REQUIRED, not preferred, because `.resolve()` must land beside
+   `lib/`. (⚠ This bullet cited `:1474` and `:1467`; both were already wrong at the merge base
+   `c5e425c7` — they land on unrelated `shell-env-nudge` comments — so no line numbers here.
+   The comment they pointed at says a line number is a claim that rots silently, which is
+   exactly what these two did. Grep for `mkOutOfStoreSymlink is NOT a preference`.)
+   **#4 solves exactly that** by installing script and `lib/` together under
+   `libexec`. Client edits will then need a `home-manager switch`.
    **Closing condition:** a merged devrc PR in which `flake.nix` names cairn as an input and
    `readlink -f ~/.local/bin/cairn` resolves into `/nix/store`. Re-verified NOT met 2026-09-08.
    forcing: none

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1442,14 +1442,32 @@ in
   # devrc path. Bare command on `home.sessionPath` resolves from any cwd.
   #
   # 🔴 mkOutOfStoreSymlink is NOT a preference here — it is REQUIRED. `scripts/cairn`
-  # reaches its siblings through `Path(__file__).resolve().parent / "lib"` (:68, and
-  # again at :756/:808/:818 for `cairn_who`), exactly like the opencode CLI above.
-  # `.resolve()` follows the symlink back to the checkout, so `lib/` is found in the
-  # repo. A store copy would resolve `__file__` into /nix/store, where `lib/` is NOT
-  # deployed — the import would fail outright. Only this one path is symlinked;
-  # `scripts/lib/` must not be deployed, same rule as opencode's `lib/`.
+  # reaches its siblings through `Path(__file__).resolve().parent / "lib"`, exactly
+  # like the opencode CLI above. `.resolve()` follows the symlink back to the
+  # checkout, so `lib/` is found in the repo. A store copy would resolve `__file__`
+  # into /nix/store, where `lib/` is NOT deployed — the import would fail outright.
+  # Only these launcher paths are symlinked; `scripts/lib/` must not be deployed,
+  # same rule as opencode's `lib/`.
+  #
+  # ⚠ NO LINE NUMBERS, AND THE OLD ONES WERE MEASURED WRONG BEFORE THIS CHANGE EVEN
+  # TOUCHED THEM. This comment used to cite `scripts/cairn:68` for the lib lookup and
+  # `:756/:808/:818` for the `cairn_who` importers. Checked at the commit this branch
+  # forked from: `:68` was BLANK and the other three were unrelated comment lines in
+  # the recall/validate section — all four stale, with nothing to signal it. A line
+  # number is a claim that rots silently. The imports are named by EXPRESSION above;
+  # grep for it.
   home.file.".local/bin/cairn".source =
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/cairn";
+  # 🔴 `cairn-who` — the task -> sessions -> windows -> transcripts resolver, split
+  # out of `cairn` because it is a different noun: it touches no store, no cache and
+  # none of the store's flags. Same deploy mode, and for the SAME REASON, not merely
+  # by analogy: `scripts/cairn-who` resolves `lib/cairn_who.py` (and, through it,
+  # `lib/timeouts.py`) through its own `Path(__file__).resolve().parent / "lib"`.
+  # As a `home.file` copy it would resolve into /nix/store and fail on import before
+  # printing anything. Deploying `cairn` out-of-store and this one in-store would
+  # leave HALF the split working, which is why both lines are here together.
+  home.file.".local/bin/cairn-who".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/cairn-who";
   # Claude Code hooks managed here (the script only — the settings.json
   # registration is per-host/unmanaged, as for bash-guard.py above, whose script
   # is likewise managed now). audit-pr-nudge fires

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -1349,13 +1349,19 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 def _store_timeout(args: argparse.Namespace) -> int:
     """The store commands' bound, resolved in ONE place.
 
-    🔴 THE SENTINEL CREATED FOUR CHANCES TO FORGET. `--timeout` defaults to
-    `None` rather than to `DEFAULT_TIMEOUT`, so every store call site has to
-    resolve it — and mutating all four to pass the raw `None` through kept the
-    whole suite green: a `None` reaches `urllib` as NO timeout, the same
-    unbounded wait `cairn_who._run` refuses on the other side of the split. One
-    resolver, four callers, and `test_no_call_site_passes_the_RAW_sentinel_attribute`
-    pins that no fifth caller open-codes it, while
+    🔴 THE SENTINEL CREATES ONE CHANCE TO FORGET PER CALL SITE. `--timeout`
+    defaults to `None` rather than to `DEFAULT_TIMEOUT`, so every store call
+    site has to resolve it — and mutating them to pass the raw `None` through
+    kept the whole suite green: a `None` reaches `urllib` as NO timeout, the
+    same unbounded wait `cairn_who._run` refuses on the other side of the split.
+    ⚠ An earlier draft of this paragraph asserted "FOUR chances" and "four
+    callers". MEASURED at this commit and at the fork point alike: there are
+    NINE `_store_timeout(args)` sites, so the count was wrong when it was
+    written and the split did not move it. Nothing asserts on it — a number no
+    test pins is unpinned by construction — so it is stated as "every site"
+    rather than re-counted into the next drift.
+    `test_no_call_site_passes_the_RAW_sentinel_attribute`
+    pins that no further caller open-codes it, while
     `test_every_STORE_subcommand_reaches_the_network_with_a_POSITIVE_bound`
     covers the spellings an AST scan cannot see. `fetch_snapshot` refuses a
     non-positive bound outright, so a future caller that bypasses both

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -106,7 +106,21 @@ from subsystem_touch import scope_for_repo  # noqa: E402
 import subsystem_read_store as _read_store  # noqa: E402
 from subsystem_read_store import SYNC_STAMP  # noqa: E402
 
+# 🔴 ONE PREDICATE FOR "IS THIS A USABLE TIMEOUT", IMPORTED AT MODULE SCOPE.
+# This rule used to be open-coded here AND in `cairn_who._run`, and the copies
+# DISAGREED — only one excluded `bool`, while the comment in `fetch_snapshot`
+# claimed they mirrored each other. It was then reached through the `who` module,
+# which worked only while `who` was a subcommand of this file. `who` is now its
+# own binary (`scripts/cairn-who`), so the predicate lives in `lib/timeouts.py`
+# and BOTH programs import it from there; re-open-coding the check on this side
+# is precisely the two-copies state that shipped the bug. See `timeouts.py`.
+from timeouts import unbounded_timeout_reason  # noqa: E402
+
 DEFAULT_CONFIG = Path.home() / ".config" / "subsystem-store" / "env"
+# 🔴 THIS CLIENT'S OWN BOUND, tuned for an HTTP snapshot fetch. `cairn-who` has a
+# longer one of its own (`cairn_who.DEFAULT_TIMEOUT`, 60s) because it shells into
+# tmux on two hosts. The two are deliberately NOT unified — only the predicate
+# above is shared; a single constant would erase the reason each was chosen.
 DEFAULT_TIMEOUT = 20
 # Ceiling on what a snapshot may unpack to. The whole store measured ~63 KB of
 # markdown across 305 entries in 2026-08; 256 MB is ~4000x that, so it bounds a
@@ -281,12 +295,13 @@ def fetch_snapshot(
     """GET the tar. Every failure becomes a StoreUnreachable NAMING the host."""
     # 🔴 `timeout=None` REACHES `urlopen` AS *NO* TIMEOUT, NOT AS A DEFAULT, so
     # this refuses it rather than trusting the annotation above — `timeout: int`
-    # is a type hint, and a hint is not a code path. The sibling `who` side of
-    # this CLI has refused it since `cairn_who._run`; the store side did not,
-    # and mutating either `fetch_snapshot`'s or `urlopen`'s argument to `None`
-    # survived the whole suite. The asymmetry was the defect: one half of one
-    # program failing closed.
-    bad = _cairn_who().unbounded_timeout_reason(timeout)
+    # is a type hint, and a hint is not a code path. `cairn_who._run` has refused
+    # it for a long time; the store side did not, and mutating either
+    # `fetch_snapshot`'s or `urlopen`'s argument to `None` survived the whole
+    # suite. The asymmetry was the defect: one half of one program failing
+    # closed. The two are now two PROGRAMS, which is why the rule they share
+    # lives in `lib/timeouts.py` rather than in either of them.
+    bad = unbounded_timeout_reason(timeout)
     if bad:
         raise StoreUnreachable(f"refusing to fetch {url}: {bad}")
     target = f"{url}/api/v1/snapshot" + (f"?scope={scope}" if scope else "")
@@ -954,7 +969,7 @@ def send_write(
     Raises `WriteRefused` on any non-200 the server produced, and
     `StoreUnreachable` when there was no answer at all. Nothing else escapes.
     """
-    bad = _cairn_who().unbounded_timeout_reason(timeout)
+    bad = unbounded_timeout_reason(timeout)
     if bad:
         # 🔴 THE SAME REFUSAL THE READ PATH MAKES, FOR THE SAME REASON. A
         # `timeout=None` reaches `urlopen` as NO timeout, and an unbounded WRITE
@@ -1331,104 +1346,32 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return doctor.exit_code(checks)
 
 
-def _cairn_who():
-    """The `who` module, imported lazily — it owns the timeout predicate.
-
-    🔴 SHARED SO THE TWO COPIES CANNOT DRIFT APART AGAIN. They already had:
-    only one excluded `bool`, while a comment here claimed they mirrored each
-    other. Importing the predicate rather than restating it means the next fix
-    lands in both halves of this CLI at once.
-
-    ⚠ THE IMPORT IS FUNCTION-SCOPED, BUT IT BUYS THE STORE PATH NOTHING, AND AN
-    EARLIER VERSION OF THIS SENTENCE CLAIMED IT DID. `build_parser` evaluates
-    `_who_default_timeout()` inside the `--timeout` help string, so `cairn_who`
-    is already in `sys.modules` before ANY subcommand dispatches — measured, on
-    every invocation. The first call here costs ~1 ms cold and ~0.1 us warm, and
-    in the real CLI it is always warm. It is function-scoped to keep the
-    module-scope import list honest about what this file needs to START, not as
-    an optimisation. Saying otherwise is the same false-comment class this whole
-    change exists to remove, and is how a maintainer reasons from a wrong cost
-    model — e.g. deleting the eager call above as an "obvious" cleanup.
-    """
-    # The sibling importers below guard this the same way. Module scope already
-    # inserts `lib/`, so no failing path exists today; relying on that silently
-    # is what lets three importers disagree, which is the defect one commit ago.
-    lib = str(Path(__file__).resolve().parent / "lib")
-    if lib not in sys.path:
-        sys.path.insert(0, lib)
-    import cairn_who  # noqa: PLC0415
-
-    return cairn_who
-
-
 def _store_timeout(args: argparse.Namespace) -> int:
     """The store commands' bound, resolved in ONE place.
 
-    🔴 THE SENTINEL CREATED FOUR CHANCES TO FORGET. Making the top-level
-    `--timeout` default to `None` (so `who` can tell "not given" from an
-    explicit value) meant every store call site had to resolve it, and mutating
-    all four to pass the raw `None` through kept the whole suite green — a
-    `None` reaches `urllib` as NO timeout, the same unbounded wait `_run`
-    already refuses on the other side of this file. One resolver, four callers,
-    and `test_no_call_site_passes_the_RAW_sentinel_attribute` pins that no
-    fifth caller open-codes it, while
+    🔴 THE SENTINEL CREATED FOUR CHANCES TO FORGET. `--timeout` defaults to
+    `None` rather than to `DEFAULT_TIMEOUT`, so every store call site has to
+    resolve it — and mutating all four to pass the raw `None` through kept the
+    whole suite green: a `None` reaches `urllib` as NO timeout, the same
+    unbounded wait `cairn_who._run` refuses on the other side of the split. One
+    resolver, four callers, and `test_no_call_site_passes_the_RAW_sentinel_attribute`
+    pins that no fifth caller open-codes it, while
     `test_every_STORE_subcommand_reaches_the_network_with_a_POSITIVE_bound`
     covers the spellings an AST scan cannot see. `fetch_snapshot` refuses a
     non-positive bound outright, so a future caller that bypasses both
     fails closed rather than waiting forever.
+
+    ⚠ ITS ORIGINAL REASON IS GONE, AND THE SENTINEL IS KEPT ANYWAY — DELIBERATELY.
+    The `None` default existed so the `who` SUBCOMMAND could tell "not given"
+    from an explicit value and fall back to its own longer bound. `who` is now
+    `scripts/cairn-who`, with a single `--timeout` of its own, so nothing needs
+    that distinction any more. Collapsing the sentinel to a plain
+    `default=DEFAULT_TIMEOUT` would also delete this resolver and the two guards
+    named above, which are what stand between a future caller and an unbounded
+    `urlopen` — a separate change with its own argument to make, not a tidy-up
+    to fold into a move.
     """
     return int(args.timeout) if getattr(args, "timeout", None) is not None else DEFAULT_TIMEOUT
-
-
-def _who_timeout(args: argparse.Namespace, own_default: int) -> int:
-    """Precedence: `who --timeout` > a top-level `--timeout` > who's own default.
-
-    🔴 THIS REPLACES A WARNING ABOUT A DISCARDED FLAG, AND HONOURING IT IS THE
-    BETTER FIX. argparse copies the subparser's namespace over the parent's, so
-    a top-level `cairn --timeout N who …` used to vanish — and before `who` had
-    its own flag that was the ONLY spelling that worked. The first fix printed a
-    notice instead, driven by hand-parsing `sys.argv`; that scanner returned the
-    WRONG answer for two reachable spellings — `--cache <val> --timeout 5 who 42`
-    (it stopped at `--cache`'s value) and `--time 5 who 42` (argparse accepts
-    long-option abbreviations; a literal `== "--timeout"` does not). Both
-    silently discarded, which is what the notice existed to prevent.
-    Re-implementing argparse's own parsing to describe argparse's behaviour was
-    the mistake. The flags now use DISTINCT dests, so nothing is clobbered and
-    there is nothing to announce.
-    """
-    if getattr(args, "who_timeout", None) is not None:
-        return int(args.who_timeout)
-    if getattr(args, "timeout", None) is not None:
-        return int(args.timeout)
-    return int(own_default)
-
-
-def _who_default_timeout() -> int:
-    """Read `who`'s own default rather than restating it in help text."""
-    lib = str(Path(__file__).resolve().parent / "lib")
-    if lib not in sys.path:
-        sys.path.insert(0, lib)
-    import cairn_who  # noqa: PLC0415
-
-    return int(cairn_who.DEFAULT_TIMEOUT)
-
-
-def cmd_who(args: argparse.Namespace) -> int:
-    """Task -> sessions -> windows + transcripts. See `lib/cairn_who.py`."""
-    lib = str(Path(__file__).resolve().parent / "lib")
-    if lib not in sys.path:
-        sys.path.insert(0, lib)
-    import cairn_who  # noqa: PLC0415
-
-    report = cairn_who.resolve(
-        args.task, timeout=_who_timeout(args, cairn_who.DEFAULT_TIMEOUT),
-        host=args.host, skip_windows=args.no_windows,
-    )
-    if args.json:
-        print(json.dumps(report.to_dict(), indent=2))
-    else:
-        print(cairn_who.render(report))
-    return report.exit_code
 
 
 def _doctor_epilog() -> str:
@@ -1441,9 +1384,12 @@ def _doctor_epilog() -> str:
 
     ⚠ CALLED EAGERLY FROM `build_parser`, AND THE COMMENT THAT SAID OTHERWISE WAS
     FALSE IN EFFECT. `argparse` wants `epilog` as a string, so `cairn_doctor` is
-    imported on EVERY invocation — the same trap `_cairn_who`'s own docstring
-    records for `_who_default_timeout`. The import stays function-scoped for
-    honesty about what this file needs to START, not as an optimisation.
+    imported on EVERY invocation. `_cairn_who`/`_who_default_timeout` used to
+    record the same trap — a "lazy" import that `build_parser` made eager by
+    evaluating it into a help string — and both are gone with the `cairn-who`
+    split, so this is now the only place that documents it. The import stays
+    function-scoped for honesty about what this file needs to START, not as an
+    optimisation; calling it lazy would be the false-comment class again.
 
     🔴 AND IT FAILS SOFT. With `cairn_doctor.py` missing, an eager unguarded
     import took `cairn ls-entries` — a subcommand that has nothing to do with
@@ -1485,8 +1431,9 @@ def build_parser() -> argparse.ArgumentParser:
     # stays the single point of truth and a test can repoint reader and writer
     # together with one assignment.
     p.add_argument("--cache", type=Path, default=_read_store.read_store_root())
-    # `None` = not given. The store commands resolve it to DEFAULT_TIMEOUT;
-    # `who` resolves it to its own, longer default. See `_who_timeout`.
+    # `None` = not given; every store command resolves it through
+    # `_store_timeout`, whose docstring says why the sentinel survives the
+    # `cairn-who` split that removed its original reason. Never read raw.
     p.add_argument("--timeout", type=int, default=None)
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -1605,32 +1552,18 @@ def build_parser() -> argparse.ArgumentParser:
     cr.add_argument("--file", type=Path, required=True, help="the new entry bytes")
     cr.set_defaults(func=cmd_create, writes=True)
 
-    # 🔴 `who` TOUCHES NO STORE AND NO CACHE. It is the first cairn subcommand
-    # about a different noun — a TASK, not a subsystem entry — so it takes none
-    # of the `common()` flags and never syncs. It is here rather than in its own
-    # binary because `cairn` is the name for the whole three-noun layer, and a
-    # second CLI would be the second place to look.
-    w = sub.add_parser("who", help="which sessions/windows/transcripts worked a task")
-    w.add_argument("task")
-    w.add_argument("--json", action="store_true")
-    w.add_argument("--host", default=None, choices=["workbench", "laptop"])
-    w.add_argument("--no-windows", action="store_true",
-                   help="skip the tmux scan; report only the durable transcripts")
-    # 🔴 ITS OWN `--timeout`, AND ITS OWN DEFAULT. cairn's top-level `--timeout`
-    # is 20s, chosen for an HTTP snapshot fetch; `who` shells into tmux on two
-    # hosts, and `cairn_who.DEFAULT_TIMEOUT` carries a docstring reasoning
-    # specifically about a sleeping laptop. Inheriting the store's bound meant
-    # the documented rationale was not what shipped, and `cairn who --timeout N`
-    # was rejected outright because the flag only existed BEFORE the subcommand.
-    # 🔴 A DISTINCT `dest` IS WHAT MAKES THE PRECEDENCE POSSIBLE. Sharing
-    # `timeout` let the subparser default clobber an explicit parent value.
-    # `metavar` because the internal dest would otherwise surface in --help
-    # as `--timeout WHO_TIMEOUT` — an implementation detail on a user surface.
-    w.add_argument("--timeout", type=int, default=None, dest="who_timeout",
-                   metavar="SECONDS",
-                   help=f"seconds per external tool (default {_who_default_timeout()}; "
-                        "a top-level --timeout is honoured too)")
-    w.set_defaults(func=cmd_who)
+    # 🔴 THERE IS NO `who` SUBCOMMAND, AND ADDING ONE BACK WOULD BE A REGRESSION.
+    # It lived here, with a parser comment claiming a task belonged under `cairn`
+    # because that name covered "the whole three-noun layer". It does not: every
+    # verb above is about a store ENTRY and takes `--scope`/`--repo`/`--no-sync`,
+    # while `who` took none of them, synced nothing, and needed its own longer
+    # timeout — three separate signals that it was a different program. It is now
+    # `scripts/cairn-who`, which also matches the seam the OSS extraction chose
+    # (`github.com/ZacxDev/cairn` ships this client and excludes `who`, because
+    # the hosts it reports cannot appear in a public repo). The one thing the two
+    # genuinely share — the timeout predicate — is imported from `lib/timeouts.py`
+    # by both, which is what stops the copies drifting now that they are separate
+    # binaries. `test_cairn_split.py` pins both halves of that.
     return p
 
 

--- a/scripts/cairn-who
+++ b/scripts/cairn-who
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""`cairn-who <task>` — which sessions, tmux windows and transcripts worked a task.
+
+🔴 A SEPARATE BINARY BECAUSE IT IS A SEPARATE NOUN. `cairn` is the read-through
+client for the hosted subsystem store: every one of its verbs is about an ENTRY,
+takes `--scope`/`--repo`/`--no-sync`, and syncs a cache. This is about SESSIONS
+on named hosts — it touches no store, no cache and none of the store's network,
+shares none of those flags, and carries its own longer timeout because nothing
+about an HTTP snapshot fetch applies to shelling into tmux on a sleeping laptop.
+It shipped as a `cairn who` subcommand whose parser asserted the opposite; that
+claim is retracted in `lib/cairn_who.py`'s module docstring, where the reasoning
+lives. The same seam is the one `github.com/ZacxDev/cairn` chose independently:
+the OSS extraction ships the store client and excludes this, because the hosts it
+reports cannot appear in a public repo.
+
+🔴 THIS FILE IS A LAUNCHER, NOT A SECOND IMPLEMENTATION. Everything — the parser,
+the defaults, the resolution — lives in `lib/cairn_who.py`, which is also what
+`scripts/tests/test_cairn_who.py` imports. A parser re-declared here would be the
+copy that drifts, and the drift would be invisible to that suite.
+
+🔴 `Path(__file__).resolve()` IS LOAD-BEARING FOR THE DEPLOY. This is put on PATH
+by `nix/home.nix` as a `config.lib.file.mkOutOfStoreSymlink`, exactly like
+`scripts/cairn`: `.resolve()` follows the symlink back into the checkout so
+`lib/` is found there. A `home.file` store COPY would resolve `__file__` into
+/nix/store, where `scripts/lib/` is not deployed, and the import below would fail
+outright — the command would not start at all.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+import cairn_who  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(cairn_who.main())

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
-"""`cairn who <task>` — resolve a TASK to the sessions that worked it, the tmux
+"""`cairn-who <task>` — resolve a TASK to the sessions that worked it, the tmux
 windows hosting them, and the transcripts they wrote.
+
+🔴 IT IS ITS OWN BINARY, AND THE COMMENT THAT SAID OTHERWISE IS RETRACTED. This
+shipped as a `cairn who` SUBCOMMAND, whose parser carried the claim that it
+belonged there "because `cairn` is the name for the whole three-noun layer, and
+a second CLI would be the second place to look". That was wrong on the noun: the
+store client is about ENTRIES in a hosted store, and this is about SESSIONS on
+named hosts — it touches no store, no cache and no network of the store's, takes
+none of the store flags, and needed its own timeout default precisely because
+nothing about the store's bound applies to it. The seam is also the one the OSS
+extraction independently chose: `github.com/ZacxDev/cairn` ships the store client
+and deliberately excludes this, because the hosts it reports cannot go in a
+public repo. One noun per binary; the shared piece is `timeouts.py`, imported.
 
 WHY THIS IS A COMMAND AND NOT A RECIPE. Every hop already resolved before this
 existed; none of them joined. Answering "who is working task 360, and where do I
@@ -45,6 +57,15 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Sequence
+
+# 🔴 THE TIMEOUT PREDICATE IS IMPORTED, NEVER RESTATED — and after the `who`
+# split it is the ONLY thing still binding this module to the store client.
+# `who` used to live inside `scripts/cairn`, which let the store path reach this
+# rule by importing this module; now that they are two binaries, `timeouts.py`
+# is what keeps the two copies from drifting apart again. See its docstring for
+# the disagreement that consolidating them found.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from timeouts import unbounded_timeout_reason  # noqa: E402,F401
 
 #: How long to wait on each external tool. `session-manager` shells into tmux on
 #: two hosts and a full cross-host scan measured ~5s; the laptop being asleep is
@@ -230,35 +251,6 @@ class WhoReport:
 # --------------------------------------------------------------------------- #
 
 
-def unbounded_timeout_reason(value) -> str | None:
-    """Why `value` is not a usable timeout, or `None` if it is fine.
-
-    🔴 ONE PREDICATE, ONE PLACE — AND CONSOLIDATING IT IS WHAT FOUND THE BUG.
-    This rule was open-coded at two sites (`_run` here, `fetch_snapshot` in
-    `scripts/cairn`) and the copies DISAGREED: only one excluded `bool`. A
-    comment claiming the two mirrored each other was therefore false, and the
-    weaker copy was measured running `_run(cmd, True)` with a ONE-SECOND bound
-    and reporting `did not answer within Trues` — verbatim the "nobody notices"
-    failure `_run`'s own docstring describes.
-
-    `bool` is the trap: it subclasses `int`, so `isinstance(x, int)` accepts
-    `True` and silently yields a 1s timeout. `None` is the other: it means NO
-    timeout to both `subprocess` and `urlopen`, an unbounded wait rather than a
-    default. Both callers raise their OWN exception type from this reason, so
-    the rule is shared without coupling the store path to `who`'s error class.
-    """
-    if isinstance(value, bool):
-        return (f"timeout={value!r} is a bool — it subclasses int, so this "
-                "would silently run with a 1-second bound")
-    if not isinstance(value, int):
-        return (f"timeout={value!r} is not an int — a missing bound is an "
-                "UNBOUNDED wait, not a default")
-    if value <= 0:
-        return (f"timeout={value!r} is not positive — a non-positive bound is "
-                "an UNBOUNDED wait, not a default")
-    return None
-
-
 def _one_line(text: str) -> str:
     """Collapse a diagnostic to one line.
 
@@ -280,7 +272,7 @@ def _run(cmd: Sequence[str], timeout: int) -> tuple[int, str, str]:
     that depends on it.
     """
     # 🔴 `timeout=None` MEANS NO TIMEOUT AT ALL, so a None here does not
-    # "fall back to a default" — it removes the bound entirely and `cairn who`
+    # "fall back to a default" — it removes the bound entirely and `cairn-who`
     # waits forever on a host that will never answer. Measured: a None timeout
     # let a 2s sleep run to completion unbounded. The expiry message would also
     # have read "within Nones", which is how nobody notices. Refuse it.
@@ -613,10 +605,31 @@ def render(report: WhoReport) -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """`cairn-who`'s whole command line. `scripts/cairn-who` delegates here.
+
+    🔴 THERE IS EXACTLY ONE `--timeout`, AND THAT IS THE POINT OF THE SPLIT.
+    As a subcommand this needed a `_who_timeout` precedence helper and a distinct
+    argparse `dest`, because argparse copies the subparser's namespace over the
+    parent's: a top-level `cairn --timeout N who …` silently VANISHED. The first
+    fix printed a notice instead, driven by hand-parsing `sys.argv`, and that
+    scanner returned the WRONG answer for two reachable spellings —
+    `--cache <val> --timeout 5 who 42` (it stopped at `--cache`'s value) and
+    `--time 5 who 42` (argparse accepts long-option abbreviations, which a
+    literal `== "--timeout"` cannot see). Re-implementing argparse's parsing to
+    describe argparse's behaviour was the mistake. A standalone binary has no
+    parent parser to be clobbered by, so the whole class is gone rather than
+    handled — do NOT reintroduce a second timeout flag or a precedence rule.
+
+    🔴 AND THE DEFAULT IS THIS MODULE'S OWN, NOT THE STORE'S. `cairn`'s bound is
+    20s, tuned for an HTTP snapshot fetch; `DEFAULT_TIMEOUT` here is 60s because
+    this shells into tmux on two hosts and the laptop may be asleep. The help
+    string READS the constant rather than restating it, so the advertised
+    default cannot drift from the one that ships.
+    """
     import argparse
 
     ap = argparse.ArgumentParser(
-        prog="cairn who",
+        prog="cairn-who",
         description="Resolve a task to its sessions, tmux windows and transcripts.",
     )
     ap.add_argument("task")
@@ -624,7 +637,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     ap.add_argument("--host", default=None, choices=["workbench", "laptop"])
     ap.add_argument("--no-windows", action="store_true",
                     help="skip the tmux scan; report only the durable transcripts")
-    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT,
+                    metavar="SECONDS",
+                    help=f"seconds per external tool (default {DEFAULT_TIMEOUT})")
     args = ap.parse_args(argv)
 
     report = resolve(args.task, timeout=args.timeout, host=args.host,

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -64,8 +64,17 @@ from typing import Any, Sequence
 # rule by importing this module; now that they are two binaries, `timeouts.py`
 # is what keeps the two copies from drifting apart again. See its docstring for
 # the disagreement that consolidating them found.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from timeouts import unbounded_timeout_reason  # noqa: E402,F401
+# ⚠ GUARDED, like every other `sys.path` insert in this file (`find_transcript`)
+# and like the `_cairn_who` shim this replaced. Unconditional, it moved
+# `scripts/lib` to `sys.path[0]` for the WHOLE process on every import of this
+# module — a side effect on the importer, not on us. No collision is measured
+# today (nothing in `scripts/lib/` shadows a stdlib or site-packages name, and
+# `timeouts` resolves nowhere else), so this is consistency and blast-radius
+# hygiene, not a fix for an observed break.
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+from timeouts import unbounded_timeout_reason  # noqa: E402
 
 #: How long to wait on each external tool. `session-manager` shells into tmux on
 #: two hosts and a full cross-host scan measured ~5s; the laptop being asleep is

--- a/scripts/lib/timeouts.py
+++ b/scripts/lib/timeouts.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""One predicate for "is this a usable timeout", shared by every bounded call.
+
+🔴 CONSOLIDATING THIS IS WHAT FOUND THE BUG IT GUARDS AGAINST. The rule was once
+open-coded at two call sites — `_run` in `cairn_who.py` and `fetch_snapshot` in
+`scripts/cairn` — and the copies DISAGREED: only one excluded `bool`. A comment
+claiming the store side refused "the way `cairn_who._run` always has" was
+therefore false, and the weaker copy was measured running `_run(cmd, True)` with
+a ONE-SECOND bound while reporting `did not answer within Trues` — verbatim the
+"nobody notices" failure `_run`'s own docstring describes.
+
+🔴 AND THIS MODULE IS WHY THE `who` SPLIT DID NOT REOPEN THAT BUG. `who` used to
+live inside `scripts/cairn`, so the store path could reach the predicate by
+importing the `who` module. Moving `who` out to its own `cairn-who` binary broke
+that reach, and the cheap repair — re-open-coding the check on the store side —
+is exactly the two-copies state above. The predicate lives here instead, imported
+by BOTH binaries, so the two halves cannot drift apart again now that they are
+two programs rather than one.
+`test_the_timeout_predicate_has_exactly_ONE_implementation` pins that
+structurally, over `scripts/cairn`, `scripts/cairn-who`, `cairn_who.py` and
+this file.
+
+⚠ THERE IS NO SHARED `DEFAULT_TIMEOUT` HERE, DELIBERATELY. The two callers have
+DIFFERENT bounds for measured reasons — the store's 20s is tuned for an HTTP
+snapshot fetch, `cairn_who.DEFAULT_TIMEOUT`'s 60s for shelling into tmux on two
+hosts with one of them possibly asleep. A single constant in this module would
+either be imported by neither (dead) or unify two bounds whose whole point is
+that they differ. Each owns its own default; only the PREDICATE is shared.
+"""
+from __future__ import annotations
+
+
+def unbounded_timeout_reason(value) -> str | None:
+    """Why `value` is not a usable timeout, or `None` if it is fine.
+
+    `bool` is the trap: it subclasses `int`, so a plain `isinstance(x, int)`
+    accepts `True` and silently yields a 1-second timeout. `None` is the other:
+    it means NO timeout to both `subprocess` and `urlopen` — an unbounded wait
+    rather than a default.
+
+    Returns a REASON rather than raising, so each caller can raise its own
+    exception type (`WhoError`, `StoreUnreachable`) without coupling them to one
+    another's error class. That is what makes one predicate serviceable to two
+    separate binaries.
+    """
+    if isinstance(value, bool):
+        return (f"timeout={value!r} is a bool — it subclasses int, so this "
+                "would silently run with a 1-second bound")
+    if not isinstance(value, int):
+        return (f"timeout={value!r} is not an int — a missing bound is an "
+                "UNBOUNDED wait, not a default")
+    if value <= 0:
+        return (f"timeout={value!r} is not positive — a non-positive bound is "
+                "an UNBOUNDED wait, not a default")
+    return None

--- a/scripts/lib/timeouts.py
+++ b/scripts/lib/timeouts.py
@@ -16,9 +16,15 @@ that reach, and the cheap repair — re-open-coding the check on the store side 
 is exactly the two-copies state above. The predicate lives here instead, imported
 by BOTH binaries, so the two halves cannot drift apart again now that they are
 two programs rather than one.
-`test_the_timeout_predicate_has_exactly_ONE_implementation` pins that
-structurally, over `scripts/cairn`, `scripts/cairn-who`, `cairn_who.py` and
-this file.
+`test_the_timeout_predicate_has_exactly_ONE_implementation` pins that over the
+three CONSUMERS — `scripts/cairn`, `scripts/cairn-who`, `cairn_who.py` — using
+this file as its POSITIVE CONTROL rather than as a fourth subject. ⚠ An earlier
+draft of this sentence claimed the guard pinned it "structurally … and this
+file"; both halves were false. It matched on a parameter NAME (`timeout`), so a
+copy spelled `isinstance(t, int)` — or pasted from the predicate below, whose
+parameter is `value` — walked straight past it; and asserting ZERO over the file
+that OWNS the check could only ever pass, which is slack wearing the shape of
+coverage. Read the guard before quoting its reach.
 
 ⚠ THERE IS NO SHARED `DEFAULT_TIMEOUT` HERE, DELIBERATELY. The two callers have
 DIFFERENT bounds for measured reasons — the store's 20s is tuned for an HTTP

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1684,7 +1684,14 @@ TARGET_FLOORS=(
   # own count put through the gate's formula and printed BY the gate, not
   # arithmetic on the two sides. Pinned AFTER merging main into the branch, per
   # the ORDER note above.
-  "scripts/tests|12793"
+  # 2026-09-07, the `cairn-who` split: 12870 collected, so 12793 carried 77 of
+  # SLACK — more than the 20-test suite this branch adds could vanish with the
+  # gate still green, which is the exact "three PRs landed without bumping it"
+  # drift the header calls out. 12870 - min(50, max(1, 12870/20)) = 12870 - 50 =
+  # 12820, the gate's own printed count put through the rule. Pinned AFTER
+  # rebasing onto origin/main (c5e425c7), per the ORDER note above — the count
+  # is from the rebased tree, not from either side alone.
+  "scripts/tests|12820"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1685,12 +1685,19 @@ TARGET_FLOORS=(
   # arithmetic on the two sides. Pinned AFTER merging main into the branch, per
   # the ORDER note above.
   # 2026-09-07, the `cairn-who` split: 12870 collected, so 12793 carried 77 of
-  # SLACK — more than the 20-test suite this branch adds could vanish with the
-  # gate still green, which is the exact "three PRs landed without bumping it"
-  # drift the header calls out. 12870 - min(50, max(1, 12870/20)) = 12870 - 50 =
-  # 12820, the gate's own printed count put through the rule. Pinned AFTER
-  # rebasing onto origin/main (c5e425c7), per the ORDER note above — the count
-  # is from the rebased tree, not from either side alone.
+  # SLACK — the "three PRs landed without bumping it" drift the header calls
+  # out. 12870 - min(50, max(1, 12870/20)) = 12870 - 50 = 12820, the gate's own
+  # printed count put through the rule. Pinned AFTER rebasing onto origin/main
+  # (c5e425c7), per the ORDER note above — the count is from the rebased tree,
+  # not from either side alone.
+  # ⚠ WHAT THIS DOES NOT CLOSE, because an audit round read the sentence above
+  # as if it did: the ratchet removes the ACCUMULATED drift (77 -> 50), not the
+  # per-target slack, and 50 is what the rule deliberately leaves. This
+  # branch's own 20-test suite is still INSIDE that band, so deleting
+  # `test_cairn_split.py` wholesale would not redden this floor. That is the
+  # documented trade at line 1083, not a defect here — but the floor is not
+  # the thing standing between that file and silent deletion, and nothing in
+  # this entry should be read as claiming otherwise.
   "scripts/tests|12820"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1081,7 +1081,10 @@ fi
 #
 # 🔴 WHAT THIS CAN NO LONGER CATCH, stated plainly rather than left to be
 # discovered: deleting up to `min(50, m/20)` tests from a SINGLE target is now
-# silent — up to 50 of scripts/tests' ~1900, 1 of the 13-test i3 suite. The old
+# silent — up to 50 of scripts/tests' 12870 (⚠ this figure read "~1900" and
+# undated until 2026-09-08; it was 6.8x stale, which understates the target and
+# so OVERSTATES the proportion this blind spot covers), 1 of the 13-test i3
+# suite. Re-derive it rather than trusting it — nothing asserts on it. The old
 # exact total went red on a one-test deletion. That precision is what cost
 # eleven reconciliations in a day, and it has never once caught a real deletion;
 # the collapses it exists for — a suite emptied, renamed, dropped from

--- a/scripts/tests/test_cairn_split.py
+++ b/scripts/tests/test_cairn_split.py
@@ -195,9 +195,19 @@ def test_BOTH_sides_import_the_predicate_from_the_module_that_owns_it():
     # version GREEN on a file that no longer imports the predicate at all.
     import ast
 
+    # 🔴 THE CALL MUST COME FROM THE IMPORT — and the previous AST version did
+    # not require that, which made it WEAKER than the substring check it
+    # replaced even though it was wider against prose. Wider on one axis,
+    # narrower on another. MEASURED: keep `import timeouts`, add a local
+    # `def unbounded_timeout_reason(value)` with byte-identical messages spelled
+    # `type(value) is int` so the sibling `isinstance(_, int)` scan sees
+    # nothing, and the suite was 103 passed / 0 failed — two copies free to
+    # drift, the exact state `timeouts.py` exists to prevent. The substring
+    # version this replaced went RED on that same file.
     for path in (CAIRN, LIB / "cairn_who.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"))
-        from_form = module_form = calls = False
+        from_form = module_form = False
+        bare_calls = attr_calls = local_def = False
         for node in ast.walk(tree):
             if (isinstance(node, ast.ImportFrom) and node.module == "timeouts"
                     and any(a.name == "unbounded_timeout_reason"
@@ -206,20 +216,32 @@ def test_BOTH_sides_import_the_predicate_from_the_module_that_owns_it():
             elif (isinstance(node, ast.Import)
                     and any(a.name == "timeouts" for a in node.names)):
                 module_form = True
+            elif (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and node.name == "unbounded_timeout_reason"):
+                local_def = True
             elif isinstance(node, ast.Call):
                 fn = node.func
                 if isinstance(fn, ast.Name) and fn.id == "unbounded_timeout_reason":
-                    calls = True
+                    bare_calls = True
                 elif (isinstance(fn, ast.Attribute)
-                        and fn.attr == "unbounded_timeout_reason"):
-                    calls = True
+                        and fn.attr == "unbounded_timeout_reason"
+                        and isinstance(fn.value, ast.Name)
+                        and fn.value.id == "timeouts"):
+                    attr_calls = True
+        assert not local_def, (
+            f"{path.name} DEFINES its own `unbounded_timeout_reason` — that is "
+            f"the second copy, whatever it also imports. Delete it and use "
+            f"`timeouts`.")
         assert from_form or module_form, (
             f"{path.name} does not import `timeouts` — neither "
             f"`from timeouts import unbounded_timeout_reason` nor "
             f"`import timeouts`")
-        assert calls, (
-            f"{path.name} imports the predicate but never calls it — a dead "
-            "import is not a guard")
+        assert (from_form and bare_calls) or (module_form and attr_calls), (
+            f"{path.name} imports `timeouts` but its call to "
+            f"`unbounded_timeout_reason` does not come from that import — a "
+            f"dead import beside a locally-resolved call is not a guard "
+            f"(from-import={from_form}, module-import={module_form}, "
+            f"bare call={bare_calls}, `timeouts.`-qualified call={attr_calls})")
 
 
 #: Values that must be refused as a timeout. Kept in step with
@@ -397,24 +419,37 @@ def test_the_nix_deploy_comment_pins_its_WHY_paragraph_verbatim():
         "requirement it documents is load-bearing, so its disappearance is "
         "the same defect as its going stale")
 
-    # 🔴 THREE PARTIAL PREDICATES WERE TRIED AND ALL THREE WERE WALKABLE. They
-    # are listed so a fourth is not derived:
+    # 🔴 FOUR PARTIAL PREDICATES WERE TRIED AND NONE HELD. Count the numbered
+    # items rather than trusting this sentence — an earlier draft said THREE
+    # above a list of four, in the very commit whose subject was "four
+    # self-descriptions disagreeing".
     #
-    #   1. a SPELLING check (`"for `cairn_who`" not in block`) — the shipped
-    #      comment says "for the `cairn_who` importers" and passed on the
-    #      inserted "the" alone.
-    #   2. "does the code actually reach it", by substring — satisfied by the
-    #      script's OWN PROSE (`_store_timeout`'s docstring names
+    # 🔴 AND THEY FAILED IN TWO OPPOSITE DIRECTIONS. Reading them as a single
+    # "all too weak" set is what invites the next author to re-derive #3 as a
+    # tightened version — so the direction is named per item:
+    #
+    #   1. TOO WEAK — a SPELLING check (`"for `cairn_who`" not in block`). The
+    #      shipped comment says "for the `cairn_who` importers" and passed on
+    #      the inserted "the" alone.
+    #   2. TOO WEAK — "does the code actually reach it", by substring, satisfied
+    #      by the script's OWN PROSE (`_store_timeout`'s docstring names
     #      `cairn_who._run`), so the assertion was unreachable. MEASURED: the
     #      reworded justification left it GREEN.
-    #   3. the same by AST — accurate about the code, still wrong here, because
-    #      it forbids the RETRACTION this comment legitimately carries. A live
-    #      justification and a record of one being removed are the same tokens
-    #      in a different mood.
-    #   4. `"mkOutOfStoreSymlink" in block or "REQUIRED" in block` — MEASURED:
-    #      deleting the whole 473-byte WHY paragraph and leaving
+    #   3. TOO STRICT — the same by AST. Accurate about the code, and wrong
+    #      here anyway: it forbids the RETRACTION this comment legitimately
+    #      carries, so it went RED on a correct tree. A live justification and
+    #      a record of one being removed are the same tokens in a different
+    #      mood. Do NOT re-derive this one as a tighter AST check; the problem
+    #      was never its precision.
+    #   4. TOO WEAK — `"mkOutOfStoreSymlink" in block or "REQUIRED" in block`. MEASURED:
+    #      deleting the whole WHY paragraph and leaving
     #      "# Deployed with mkOutOfStoreSymlink, same as claim-work above."
     #      kept it GREEN, while the test's NAME claimed the reason was pinned.
+    #      ⚠ UNITS: that is a net delete of 468 CHARACTERS / 475 bytes (the
+    #      paragraph is 532 chars / 539 bytes). Earlier receipts said "473-byte"
+    #      and "468 B"; the first matched nothing and the second was `len(str)`
+    #      labelled as bytes. `len()` on a str is characters — the em-dashes in
+    #      this paragraph are 3 bytes each, so the two never agree here.
     #
     # So the paragraph is pinned WHOLE, per "when the artifact under test IS
     # prose, pin the whole normalised string".

--- a/scripts/tests/test_cairn_split.py
+++ b/scripts/tests/test_cairn_split.py
@@ -188,16 +188,36 @@ def test_BOTH_sides_import_the_predicate_from_the_module_that_owns_it():
     # reddens on a correct tree reports a problem the tree does not have, and
     # the next author's fix is to weaken the guard. What must hold is that the
     # name resolves to THIS module, not how it was spelled.
+    # 🔴 PARSED, NOT GREPPED — a substring check here was satisfied by PROSE.
+    # MEASURED: replacing `cairn_who.py`'s real import with a locally
+    # re-open-coded predicate plus the comment "this used to import timeouts
+    # and call timeouts.unbounded_timeout_reason(...)" left the substring
+    # version GREEN on a file that no longer imports the predicate at all.
+    import ast
+
     for path in (CAIRN, LIB / "cairn_who.py"):
-        src = path.read_text(encoding="utf-8")
-        from_form = "from timeouts import unbounded_timeout_reason" in src
-        module_form = "import timeouts" in src and (
-            "timeouts.unbounded_timeout_reason(" in src)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        from_form = module_form = calls = False
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.ImportFrom) and node.module == "timeouts"
+                    and any(a.name == "unbounded_timeout_reason"
+                            for a in node.names)):
+                from_form = True
+            elif (isinstance(node, ast.Import)
+                    and any(a.name == "timeouts" for a in node.names)):
+                module_form = True
+            elif isinstance(node, ast.Call):
+                fn = node.func
+                if isinstance(fn, ast.Name) and fn.id == "unbounded_timeout_reason":
+                    calls = True
+                elif (isinstance(fn, ast.Attribute)
+                        and fn.attr == "unbounded_timeout_reason"):
+                    calls = True
         assert from_form or module_form, (
-            f"{path.name} does not take the shared predicate from `timeouts` — "
-            f"neither `from timeouts import unbounded_timeout_reason` nor "
-            f"`import timeouts` + `timeouts.unbounded_timeout_reason(...)`")
-        assert "unbounded_timeout_reason(" in src, (
+            f"{path.name} does not import `timeouts` — neither "
+            f"`from timeouts import unbounded_timeout_reason` nor "
+            f"`import timeouts`")
+        assert calls, (
             f"{path.name} imports the predicate but never calls it — a dead "
             "import is not a guard")
 
@@ -313,18 +333,50 @@ def test_cairn_who_is_deployed_OUT_OF_STORE_like_its_sibling():
         f"`cairn-who` points somewhere unexpected: {assignment.strip()!r}")
 
 
-def test_the_nix_deploy_comment_still_states_why_the_MODE_is_required():
+#: The `cairn` deploy comment's WHY paragraph, whitespace-normalised. Pinned
+#: WHOLE and verbatim: this artifact is PROSE, and every partial predicate tried
+#: against it was walkable by rewording (the withdrawn drafts are listed in the
+#: test below). A cosmetic edit to the comment now fails this test — that cost is
+#: the price of a machine-readable claim, and updating this string is the fix.
+def _normalised_why(block):
+    """The WHY paragraph out of a `#` comment block, or None if it is absent.
+
+    The paragraph runs from the `mkOutOfStoreSymlink is NOT a preference` line
+    to the next bare `#`, with comment markers stripped and whitespace
+    collapsed — so re-wrapping the comment is not a failure, but changing a
+    word is.
+    """
+    lines = block.splitlines()
+    start = next(
+        (i for i, ln in enumerate(lines)
+         if "mkOutOfStoreSymlink is NOT a preference" in ln), None)
+    if start is None:
+        return None
+    para = []
+    for ln in lines[start:]:
+        stripped = ln.strip()
+        if stripped == "#":
+            break
+        para.append(stripped.lstrip("#").strip())
+    return " ".join(" ".join(para).split())
+
+
+NIX_DEPLOY_WHY = (
+    "🔴 mkOutOfStoreSymlink is NOT a preference here — it is REQUIRED. "
+    "`scripts/cairn` reaches its siblings through "
+    '`Path(__file__).resolve().parent / "lib"`, exactly like the opencode CLI '
+    "above. `.resolve()` follows the symlink back to the checkout, so `lib/` is "
+    "found in the repo. A store copy would resolve `__file__` into /nix/store, "
+    "where `lib/` is NOT deployed — the import would fail outright. Only these "
+    "launcher paths are symlinked; `scripts/lib/` must not be deployed, same "
+    "rule as opencode's `lib/`."
+)
+
+
+def test_the_nix_deploy_comment_pins_its_WHY_paragraph_verbatim():
     """The `cairn` deploy comment must keep saying why `mkOutOfStoreSymlink` is
     REQUIRED — a store copy resolves `__file__` into /nix/store, where
     `scripts/lib/` is not deployed, and the client dies on import.
-
-    ⚠ RENAMED, AND NARROWER THAN THE NAME IT HAD. It was
-    `test_the_nix_comment_no_longer_claims_cairn_reaches_cairn_who`, which
-    described an invariant three drafts failed to express — the body now checks
-    something strictly weaker, and the old name would have read as coverage
-    this does not provide. The full account of what is and is not pinned, and
-    why the stronger versions were withdrawn, is in the comment block below;
-    read it before widening this docstring back.
     """
     nix = NIX_HOME.read_text(encoding="utf-8")
     lines = nix.splitlines()
@@ -345,38 +397,38 @@ def test_the_nix_deploy_comment_still_states_why_the_MODE_is_required():
         "requirement it documents is load-bearing, so its disappearance is "
         "the same defect as its going stale")
 
-    # 🔴 WHAT THIS GUARD DOES NOT COVER — stated because reading it as wider
-    # than it is would stop the next person looking, which is worse than no
-    # guard at all.
+    # 🔴 THREE PARTIAL PREDICATES WERE TRIED AND ALL THREE WERE WALKABLE. They
+    # are listed so a fourth is not derived:
     #
-    # The invariant worth pinning is "the comment does not JUSTIFY the deploy
-    # mode by a coupling that no longer exists". Two drafts failed to express
-    # it, and both failures are recorded here so a third is not derived:
+    #   1. a SPELLING check (`"for `cairn_who`" not in block`) — the shipped
+    #      comment says "for the `cairn_who` importers" and passed on the
+    #      inserted "the" alone.
+    #   2. "does the code actually reach it", by substring — satisfied by the
+    #      script's OWN PROSE (`_store_timeout`'s docstring names
+    #      `cairn_who._run`), so the assertion was unreachable. MEASURED: the
+    #      reworded justification left it GREEN.
+    #   3. the same by AST — accurate about the code, still wrong here, because
+    #      it forbids the RETRACTION this comment legitimately carries. A live
+    #      justification and a record of one being removed are the same tokens
+    #      in a different mood.
+    #   4. `"mkOutOfStoreSymlink" in block or "REQUIRED" in block` — MEASURED:
+    #      deleting the whole 473-byte WHY paragraph and leaving
+    #      "# Deployed with mkOutOfStoreSymlink, same as claim-work above."
+    #      kept it GREEN, while the test's NAME claimed the reason was pinned.
     #
-    #   1. a SPELLING check (`"for `cairn_who`" not in block`). Walkable by
-    #      rewording — the shipped comment says "for the `cairn_who` importers"
-    #      and passed on the inserted "the" alone.
-    #   2. deriving "does the code actually reach it" and permitting the
-    #      mention only then. First by substring, which the script's OWN PROSE
-    #      satisfies (`_store_timeout`'s docstring names `cairn_who._run`), so
-    #      the assertion was unreachable — MEASURED: the reworded justification
-    #      left it GREEN. Then by AST, which is accurate about the code and
-    #      still WRONG here, because it forbids the RETRACTION: this comment
-    #      legitimately records that it "used to cite ... for the `cairn_who`
-    #      importers ... all four stale". A live justification and a record of
-    #      one being removed are the same tokens in a different mood, and no
-    #      text predicate available here separates them.
-    #
-    # So this guard asserts only that the comment BLOCK IS STILL THERE. Its
-    # disappearance is a real defect — the requirement it documents is
-    # load-bearing and a store copy silently breaks the lib lookup — and that
-    # much is checkable. Whether its CONTENT still tells the truth is not
-    # pinned by anything, and a human review is what covers it.
-    assert "mkOutOfStoreSymlink" in block or "REQUIRED" in block, (
-        "the `cairn` deploy comment no longer states why the deploy MODE is "
-        "required. A store copy resolves `__file__` into /nix/store, where "
-        "scripts/lib/ is not deployed, and the client dies on import — that "
-        "reason must survive in the comment even when the rest is rewritten.")
+    # So the paragraph is pinned WHOLE, per "when the artifact under test IS
+    # prose, pin the whole normalised string".
+    why = _normalised_why(block)
+    assert why is not None, (
+        "the `cairn` deploy comment no longer contains its WHY paragraph — the "
+        "line beginning `mkOutOfStoreSymlink is NOT a preference here` is gone. "
+        "A store copy resolves `__file__` into /nix/store, where scripts/lib/ "
+        "is not deployed, and the client dies on import.")
+    assert why == NIX_DEPLOY_WHY, (
+        "the `cairn` deploy comment's WHY paragraph changed. If the edit was "
+        "deliberate, update NIX_DEPLOY_WHY in this file to match — the "
+        "paragraph is pinned whole because every partial check of it was "
+        f"walkable by rewording.\n\ngot:      {why!r}\nexpected: {NIX_DEPLOY_WHY!r}")
 
 
 def test_the_SKILL_routes_to_the_binary_not_the_dead_subcommand():

--- a/scripts/tests/test_cairn_split.py
+++ b/scripts/tests/test_cairn_split.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Gate on the SEAM between `cairn` and `cairn-who` — two binaries, one predicate.
+
+WHAT THIS FILE IS DEFENDING. `who` used to be a `cairn` subcommand, and the store
+path reached the shared "is this a usable timeout" predicate by importing the
+`who` module — a reach that worked only while the two were one program. Splitting
+them therefore had a specific, plausible failure: move `cairn_who.py` out of
+reach and either break the store client's import outright, or "fix" it by
+re-open-coding the check. The second is the state that already shipped a bug
+once: the two copies DISAGREED (only one excluded `bool`), while a comment
+claimed they mirrored each other.
+
+🔴 THESE ARE SEAM GUARDS, NOT COMPONENT GUARDS. `test_cairn_cli.py` and
+`test_cairn_who.py` each test one surface hermetically, and both were green while
+`who` was still welded into `cairn` — neither can see "the split left half the
+system behind", because neither loads the other side. Every test here pins a
+RELATIONSHIP between the two: what one exposes and the other must not, which file
+owns the rule both import, and the deploy mode that has to hold for BOTH or the
+shipped command does not start.
+
+Every identifier here is INVENTED; nothing is read out of a real deployment.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CAIRN = REPO_ROOT / "scripts" / "cairn"
+CAIRN_WHO = REPO_ROOT / "scripts" / "cairn-who"
+LIB = REPO_ROOT / "scripts" / "lib"
+TIMEOUTS = LIB / "timeouts.py"
+NIX_HOME = REPO_ROOT / "nix" / "home.nix"
+SKILL = REPO_ROOT / "claude" / "skills" / "cairn" / "SKILL.md"
+
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+
+def _load_cairn_cli():
+    """Exec `scripts/cairn` as a module — it has no .py extension."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_loader("cairn_cli_split", loader=None,
+                                           origin=str(CAIRN))
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(CAIRN)
+    exec(compile(CAIRN.read_text(encoding="utf-8"), str(CAIRN), "exec"), mod.__dict__)
+    return mod
+
+
+def _run(argv, cwd=None):
+    """Drive a REAL binary in a subprocess, from an arbitrary cwd.
+
+    🔴 `cwd` IS PART OF THE TEST, NOT SCAFFOLDING. Both scripts find `lib/`
+    through `Path(__file__).resolve().parent / "lib"` precisely so they work from
+    any working directory — that is the property `mkOutOfStoreSymlink` exists to
+    preserve. Running them from the repo root only would pass even if they had
+    been rewritten to resolve `lib/` relative to the cwd.
+    """
+    return subprocess.run([sys.executable, *argv], capture_output=True, text=True,
+                          timeout=60, cwd=str(cwd) if cwd else None)
+
+
+# --------------------------------------------------------------------------- #
+# 1. What each binary exposes — the split itself
+# --------------------------------------------------------------------------- #
+
+
+def test_the_store_client_no_longer_exposes_a_who_SUBCOMMAND(tmp_path):
+    """🔴 `cairn who` must be gone, and gone LOUDLY.
+
+    Asserted on the real argparse surface rather than on the source text: a
+    `who` parser could be re-added under any spelling, and a source grep for the
+    string `"who"` matches this file's own comments and several unrelated words.
+    argparse rejects an unknown subcommand with exit 2 and an "invalid choice"
+    on stderr, so the failure is a diagnosis rather than a traceback.
+    """
+    proc = _run([str(CAIRN), "who", "42"], cwd=tmp_path)
+    assert proc.returncode == 2, (
+        f"`cairn who 42` exited {proc.returncode}, not argparse's 2 — the "
+        f"subcommand looks like it is still there.\n"
+        f"stdout: {proc.stdout[:400]}\nstderr: {proc.stderr[:400]}")
+    assert "invalid choice" in proc.stderr, (
+        f"the refusal does not name the problem:\n{proc.stderr[:600]}")
+
+    # …and the parser really has no `who` action, not merely a renamed one.
+    parser = _load_cairn_cli().build_parser()
+    choices = set()
+    for action in parser._actions:
+        if getattr(action, "choices", None) and hasattr(action, "_name_parser_map"):
+            choices |= set(action.choices)
+    assert choices, "could not read the subcommand list — this guard checked NOTHING"
+    assert "who" not in choices, f"`who` is still a cairn subcommand: {sorted(choices)}"
+
+
+def test_the_cairn_who_BINARY_exists_and_actually_runs(tmp_path):
+    """🔴 THE OTHER HALF. Removing `who` from `cairn` without a working
+    `cairn-who` deletes a command rather than re-homing one.
+
+    `--help` is the cheapest invocation that proves the whole import chain
+    (`cairn-who` -> `lib/cairn_who.py` -> `lib/timeouts.py`) resolved and the
+    parser built. Run from a tmp cwd, for the reason in `_run`.
+    """
+    assert CAIRN_WHO.exists(), "scripts/cairn-who does not exist"
+    proc = _run([str(CAIRN_WHO), "--help"], cwd=tmp_path)
+    assert proc.returncode == 0, (
+        f"`cairn-who --help` exited {proc.returncode}\nstderr: {proc.stderr[:600]}")
+    assert "task" in proc.stdout, f"the parser has no task positional:\n{proc.stdout}"
+    assert "cairn-who" in proc.stdout, (
+        f"the binary does not identify itself as `cairn-who`:\n{proc.stdout}")
+
+
+def test_the_binary_is_EXECUTABLE_and_carries_a_shebang():
+    """It goes on PATH as a bare command; a non-executable file there is a
+    `command not found` that reads as a broken deploy."""
+    import os
+
+    assert os.access(CAIRN_WHO, os.X_OK), "scripts/cairn-who is not executable"
+    first = CAIRN_WHO.read_text(encoding="utf-8").splitlines()[0]
+    assert first.startswith("#!"), f"no shebang: {first!r}"
+
+
+def test_the_launcher_does_NOT_re_declare_the_parser():
+    """🔴 ONE PARSER, IN THE MODULE THE TESTS IMPORT.
+
+    `test_cairn_who.py` drives `cairn_who.main`. A second `ArgumentParser`
+    declared in the launcher would be the copy that drifts, and that suite could
+    not see it drift — every one of its assertions would still pass against the
+    module's parser while the shipped binary served a different one.
+    """
+    src = CAIRN_WHO.read_text(encoding="utf-8")
+    assert "ArgumentParser" not in src, (
+        "scripts/cairn-who declares its own parser. Delegate to "
+        "`cairn_who.main` instead — that is the one the suite exercises.")
+    assert "cairn_who.main" in src, (
+        "scripts/cairn-who does not delegate to `cairn_who.main`")
+
+
+# --------------------------------------------------------------------------- #
+# 2. The predicate the two still share
+# --------------------------------------------------------------------------- #
+
+
+def test_the_shared_predicate_lives_in_its_OWN_module_reachable_by_both():
+    """🔴 THE REASON HALF of the seam below. If this fails, the import guards
+    are pinning a structure that no longer exists — re-derive them, don't loosen.
+    """
+    assert TIMEOUTS.exists(), "scripts/lib/timeouts.py is gone"
+    from timeouts import unbounded_timeout_reason  # noqa: PLC0415
+
+    assert unbounded_timeout_reason(5) is None
+    assert unbounded_timeout_reason(None) is not None
+
+
+def test_NEITHER_binary_reaches_the_predicate_THROUGH_the_who_module():
+    """🔴 THE COUPLING THIS SPLIT REMOVED, PINNED SO IT CANNOT COME BACK.
+
+    `scripts/cairn` used to call `_cairn_who().unbounded_timeout_reason(...)`,
+    importing the whole `who` module to borrow one function. That is what made
+    `cairn_who.py` undeletable from the store client's side. The store client
+    must not import it at all any more; `cairn-who` is the only thing that does.
+    """
+    store_src = CAIRN.read_text(encoding="utf-8")
+    assert "import cairn_who" not in store_src, (
+        "`scripts/cairn` imports the `who` module again. The predicate lives in "
+        "`lib/timeouts.py`; import it from there rather than re-coupling the "
+        "store client to a command it no longer owns.")
+    assert "_cairn_who(" not in store_src, (
+        "the `_cairn_who()` shim is back in `scripts/cairn`")
+
+
+def test_BOTH_sides_import_the_predicate_from_the_module_that_owns_it():
+    """🔴 ASSERTED AS AN ENUMERATED LEDGER, BOTH DIRECTIONS.
+
+    The hazard is not only "a caller stops importing it" but "a new caller
+    open-codes it instead". `test_cairn_who.py` owns the structural no-copies
+    scan; this owns the positive side — every file that USES the rule gets it
+    from `timeouts`.
+    """
+    for path in (CAIRN, LIB / "cairn_who.py"):
+        src = path.read_text(encoding="utf-8")
+        assert "from timeouts import unbounded_timeout_reason" in src, (
+            f"{path.name} does not import the shared predicate from `timeouts`")
+        assert "unbounded_timeout_reason(" in src, (
+            f"{path.name} imports the predicate but never calls it — a dead "
+            "import is not a guard")
+
+
+#: Values that must be refused as a timeout. Kept in step with
+#: `test_cairn_who.py::UNBOUNDED_TIMEOUTS`; the two files assert different
+#: things about the same set.
+UNBOUNDED = [None, 0, -1, "60", True, False, 1.5]
+
+
+@pytest.mark.parametrize("bad", UNBOUNDED)
+def test_the_STORE_fetch_STILL_refuses_an_unbounded_timeout_after_the_split(bad):
+    """The regression the split could most plausibly have broken.
+
+    ⚠ LABELLED HONESTLY: with respect to `origin/main` this is an INVARIANT
+    GUARD, not regression coverage — the guard predates the split and all 7
+    cases pass on the pre-change tree. What it CAN see is the split going wrong,
+    and that was measured, not assumed. Two mutations, both run with
+    `PYTHONDONTWRITEBYTECODE=1`:
+
+      * delete the `bad = unbounded_timeout_reason(timeout)` / `raise` pair from
+        `fetch_snapshot` -> all 7 cases RED, each with this test's own message
+        ("did not refuse … it failed for some other reason: … Connection
+        refused"), i.e. red for the intended reason and not another guard's;
+      * delete ONLY the `isinstance(value, bool)` branch from `timeouts.py` ->
+        exactly `[True]` RED here AND `[True]` red in three tests in
+        `test_cairn_who.py`, with every other case green. That is the tight
+        isolation: it proves this call site reaches the SHARED predicate, that
+        `cairn-who` reaches the same one, and that `[False]` survives because a
+        DIFFERENT branch (`value <= 0`) catches it — so no case is passing on
+        another guard's error.
+
+    `bool` is the case that matters most: it subclasses `int`, so a
+    "simplification" to `isinstance(timeout, int)` accepts `True` and runs with a
+    silent ONE-SECOND bound.
+    """
+    cli = _load_cairn_cli()
+    with pytest.raises(cli.StoreUnreachable) as exc:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=bad)
+    assert "refusing to fetch" in str(exc.value), (
+        f"the store fetch did not refuse timeout={bad!r}; it failed for some "
+        f"other reason: {exc.value}")
+
+
+def test_a_POSITIVE_bound_is_NOT_refused_by_the_store_fetch():
+    """🔴 POSITIVE CONTROL. A guard that refuses EVERYTHING also passes every
+    case above, and `fetch_snapshot` raises `StoreUnreachable` for a genuine
+    outage too — so the parametrized test cannot, on its own, tell "refused the
+    bound" from "could not reach the host". This pins that a valid bound gets
+    past the predicate and fails later, on the network.
+    """
+    cli = _load_cairn_cli()
+    with pytest.raises(cli.StoreUnreachable) as exc:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=5)
+    assert "refusing to fetch" not in str(exc.value), (
+        f"a valid bound was refused: {exc.value}")
+
+
+def test_the_TWO_defaults_stay_DIFFERENT_and_both_are_usable():
+    """🔴 THE PREDICATE IS SHARED; THE DEFAULTS ARE NOT, DELIBERATELY.
+
+    20s is tuned for an HTTP snapshot fetch, 60s for shelling into tmux on two
+    hosts with one possibly asleep. Consolidating them into one constant would
+    erase the reason each was chosen — the mirror image of the copy-drift bug,
+    and the tempting "cleanup" now that a shared module exists. Asserted as a
+    relationship (who's is strictly the longer) rather than as two literals,
+    which would just be the constants restated in a second place.
+    """
+    import cairn_who as W  # noqa: PLC0415
+    from timeouts import unbounded_timeout_reason  # noqa: PLC0415
+
+    cli = _load_cairn_cli()
+    assert unbounded_timeout_reason(cli.DEFAULT_TIMEOUT) is None
+    assert unbounded_timeout_reason(W.DEFAULT_TIMEOUT) is None
+    assert W.DEFAULT_TIMEOUT > cli.DEFAULT_TIMEOUT, (
+        f"cairn-who's default ({W.DEFAULT_TIMEOUT}s) is no longer longer than "
+        f"the store's ({cli.DEFAULT_TIMEOUT}s) — the sleeping-laptop rationale "
+        "in cairn_who.DEFAULT_TIMEOUT's docstring is not what ships")
+
+
+# --------------------------------------------------------------------------- #
+# 3. The deploy, and the doc that routes people to it
+# --------------------------------------------------------------------------- #
+
+
+def test_cairn_who_still_resolves_its_lib_relative_to_its_OWN_file():
+    """The REASON half of the deploy seam, same shape as the `cairn` pair in
+    `test_cairn_cli.py`. If this fails, the out-of-store requirement below may be
+    obsolete — re-derive it rather than editing the assertion."""
+    src = CAIRN_WHO.read_text(encoding="utf-8")
+    assert 'Path(__file__).resolve().parent / "lib"' in src, (
+        "scripts/cairn-who no longer derives its lib/ path from __file__")
+    assert "import cairn_who" in src, "scripts/cairn-who imports nothing from lib/"
+    assert (LIB / "cairn_who.py").exists()
+
+
+def test_cairn_who_is_deployed_OUT_OF_STORE_like_its_sibling():
+    """🔴 THE DEPLOY half. A store copy ships a `cairn-who` that cannot start.
+
+    Deploying `cairn` out-of-store and `cairn-who` as a `home.file` copy would
+    leave HALF the split working — the failure mode this whole file exists for.
+    """
+    nix = NIX_HOME.read_text(encoding="utf-8")
+    key = 'home.file.".local/bin/cairn-who".source'
+    assert key in nix, "the `cairn-who` PATH entry is missing from nix/home.nix"
+    assignment = nix.split(key, 1)[1].split(";", 1)[0]
+    assert "mkOutOfStoreSymlink" in assignment, (
+        "`cairn-who` is deployed as a STORE COPY. Its "
+        "`Path(__file__).resolve()` lib lookup resolves into /nix/store, where "
+        "scripts/lib/ is not deployed, and the command fails on import.\n"
+        f"got: {assignment.strip()!r}")
+    assert "${workspace}/devrc/scripts/cairn-who" in assignment, (
+        f"`cairn-who` points somewhere unexpected: {assignment.strip()!r}")
+
+
+def test_the_nix_comment_no_longer_claims_cairn_reaches_cairn_who():
+    """🔴 A COMMENT IS A CLAIM. The `cairn` deploy comment justified
+    mkOutOfStoreSymlink by naming `cairn_who` imports at three line numbers
+    inside `scripts/cairn`. Those importers are gone; a maintainer reading the
+    stale version would go looking for a coupling that no longer exists, and
+    could reasonably conclude the requirement lapsed with it. It has not — the
+    requirement now rests on each script's OWN `lib/` lookup.
+    """
+    nix = NIX_HOME.read_text(encoding="utf-8")
+    block = nix.split('home.file.".local/bin/cairn".source', 1)[0][-1400:]
+    assert "for `cairn_who`" not in block, (
+        "nix/home.nix still justifies cairn's deploy mode by its `cairn_who` "
+        "imports — `scripts/cairn` no longer has any")
+
+
+def test_the_SKILL_routes_to_the_binary_not_the_dead_subcommand():
+    """🔴 THE ROUTER MUST NOT NAME A COMMAND THAT EXITS 2.
+
+    The skill is a router: a verb table row that says `cairn who <task>` sends a
+    session to a command argparse rejects. Pinned on the table row and the
+    frontmatter description together, because they are read at different times —
+    the description decides whether the skill loads at all.
+    """
+    text = SKILL.read_text(encoding="utf-8")
+    assert "`cairn-who" in text, "the skill never names the `cairn-who` binary"
+    assert "`cairn who" not in text, (
+        "the skill still routes to `cairn who`, which argparse now rejects. "
+        "Say `cairn-who`; do not spell the dead subcommand anywhere, not even "
+        "to explain that it is dead — a router is read for what to TYPE.")
+
+    row = [ln for ln in text.splitlines()
+           if ln.startswith("|") and "transcripts worked a task" in ln]
+    assert len(row) == 1, f"expected exactly one verb-table row for it, got {row}"
+    assert "`cairn-who <task>`" in row[0], f"the verb table still says: {row[0]}"
+
+    desc = [ln for ln in text.splitlines() if ln.startswith("description:")]
+    assert len(desc) == 1, "could not read the frontmatter description"
+    assert "cairn-who" in desc[0], (
+        f"the frontmatter description does not name the binary: {desc[0]}")

--- a/scripts/tests/test_cairn_split.py
+++ b/scripts/tests/test_cairn_split.py
@@ -181,10 +181,22 @@ def test_BOTH_sides_import_the_predicate_from_the_module_that_owns_it():
     scan; this owns the positive side — every file that USES the rule gets it
     from `timeouts`.
     """
+    # ⚠ BOTH IMPORT SPELLINGS PASS, DELIBERATELY. An earlier version required
+    # the literal `from timeouts import unbounded_timeout_reason`, which reddens
+    # on `import timeouts` + `timeouts.unbounded_timeout_reason(...)` — an
+    # equally correct refactor producing identical behaviour. A guard that
+    # reddens on a correct tree reports a problem the tree does not have, and
+    # the next author's fix is to weaken the guard. What must hold is that the
+    # name resolves to THIS module, not how it was spelled.
     for path in (CAIRN, LIB / "cairn_who.py"):
         src = path.read_text(encoding="utf-8")
-        assert "from timeouts import unbounded_timeout_reason" in src, (
-            f"{path.name} does not import the shared predicate from `timeouts`")
+        from_form = "from timeouts import unbounded_timeout_reason" in src
+        module_form = "import timeouts" in src and (
+            "timeouts.unbounded_timeout_reason(" in src)
+        assert from_form or module_form, (
+            f"{path.name} does not take the shared predicate from `timeouts` — "
+            f"neither `from timeouts import unbounded_timeout_reason` nor "
+            f"`import timeouts` + `timeouts.unbounded_timeout_reason(...)`")
         assert "unbounded_timeout_reason(" in src, (
             f"{path.name} imports the predicate but never calls it — a dead "
             "import is not a guard")
@@ -301,19 +313,70 @@ def test_cairn_who_is_deployed_OUT_OF_STORE_like_its_sibling():
         f"`cairn-who` points somewhere unexpected: {assignment.strip()!r}")
 
 
-def test_the_nix_comment_no_longer_claims_cairn_reaches_cairn_who():
-    """🔴 A COMMENT IS A CLAIM. The `cairn` deploy comment justified
-    mkOutOfStoreSymlink by naming `cairn_who` imports at three line numbers
-    inside `scripts/cairn`. Those importers are gone; a maintainer reading the
-    stale version would go looking for a coupling that no longer exists, and
-    could reasonably conclude the requirement lapsed with it. It has not — the
-    requirement now rests on each script's OWN `lib/` lookup.
+def test_the_nix_deploy_comment_still_states_why_the_MODE_is_required():
+    """The `cairn` deploy comment must keep saying why `mkOutOfStoreSymlink` is
+    REQUIRED — a store copy resolves `__file__` into /nix/store, where
+    `scripts/lib/` is not deployed, and the client dies on import.
+
+    ⚠ RENAMED, AND NARROWER THAN THE NAME IT HAD. It was
+    `test_the_nix_comment_no_longer_claims_cairn_reaches_cairn_who`, which
+    described an invariant three drafts failed to express — the body now checks
+    something strictly weaker, and the old name would have read as coverage
+    this does not provide. The full account of what is and is not pinned, and
+    why the stronger versions were withdrawn, is in the comment block below;
+    read it before widening this docstring back.
     """
     nix = NIX_HOME.read_text(encoding="utf-8")
-    block = nix.split('home.file.".local/bin/cairn".source', 1)[0][-1400:]
-    assert "for `cairn_who`" not in block, (
-        "nix/home.nix still justifies cairn's deploy mode by its `cairn_who` "
-        "imports — `scripts/cairn` no longer has any")
+    lines = nix.splitlines()
+    anchor = next(
+        (i for i, ln in enumerate(lines)
+         if 'home.file.".local/bin/cairn".source' in ln), None)
+    assert anchor is not None, (
+        'nix/home.nix has no `home.file.".local/bin/cairn".source` entry')
+
+    # The comment block is however many contiguous `#` lines sit immediately
+    # above the entry — no character budget to slide off.
+    start = anchor
+    while start > 0 and lines[start - 1].lstrip().startswith("#"):
+        start -= 1
+    block = "\n".join(lines[start:anchor])
+    assert block.strip(), (
+        "the `cairn` deploy entry has no comment above it at all — the "
+        "requirement it documents is load-bearing, so its disappearance is "
+        "the same defect as its going stale")
+
+    # 🔴 WHAT THIS GUARD DOES NOT COVER — stated because reading it as wider
+    # than it is would stop the next person looking, which is worse than no
+    # guard at all.
+    #
+    # The invariant worth pinning is "the comment does not JUSTIFY the deploy
+    # mode by a coupling that no longer exists". Two drafts failed to express
+    # it, and both failures are recorded here so a third is not derived:
+    #
+    #   1. a SPELLING check (`"for `cairn_who`" not in block`). Walkable by
+    #      rewording — the shipped comment says "for the `cairn_who` importers"
+    #      and passed on the inserted "the" alone.
+    #   2. deriving "does the code actually reach it" and permitting the
+    #      mention only then. First by substring, which the script's OWN PROSE
+    #      satisfies (`_store_timeout`'s docstring names `cairn_who._run`), so
+    #      the assertion was unreachable — MEASURED: the reworded justification
+    #      left it GREEN. Then by AST, which is accurate about the code and
+    #      still WRONG here, because it forbids the RETRACTION: this comment
+    #      legitimately records that it "used to cite ... for the `cairn_who`
+    #      importers ... all four stale". A live justification and a record of
+    #      one being removed are the same tokens in a different mood, and no
+    #      text predicate available here separates them.
+    #
+    # So this guard asserts only that the comment BLOCK IS STILL THERE. Its
+    # disappearance is a real defect — the requirement it documents is
+    # load-bearing and a store copy silently breaks the lib lookup — and that
+    # much is checkable. Whether its CONTENT still tells the truth is not
+    # pinned by anything, and a human review is what covers it.
+    assert "mkOutOfStoreSymlink" in block or "REQUIRED" in block, (
+        "the `cairn` deploy comment no longer states why the deploy MODE is "
+        "required. A store copy resolves `__file__` into /nix/store, where "
+        "scripts/lib/ is not deployed, and the client dies on import — that "
+        "reason must survive in the comment even when the rest is rewritten.")
 
 
 def test_the_SKILL_routes_to_the_binary_not_the_dead_subcommand():

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1199,31 +1199,67 @@ def test_both_entry_points_ACCEPT_the_same_positive_bound():
 
 
 def test_the_timeout_predicate_has_exactly_ONE_implementation():
-    """🔴 One rule, one place — asserted structurally, not by convention.
+    """🔴 One rule, one place — and the pattern is proved able to MATCH.
 
-    A second `isinstance(timeout, int)` anywhere in this CLI is the copy that
-    drifts. Searching the tree is how the disagreement was found; this is how
-    it stays found.
+    A re-open-coded int check in a CONSUMER is the copy that drifts. Searching
+    the tree is how the disagreement was found; this is how it stays found.
+
+    ⚠ AN EARLIER VERSION OF THIS GUARD WAS NARROWER THAN ITS OWN DESCRIPTION,
+    and `timeouts.py`'s docstring called it "structural" when it was spelled.
+    It searched for `isinstance(timeout, int)` — the parameter NAME — so a copy
+    written `isinstance(t, int)`, or pasted from the predicate itself (whose
+    parameter is `value`), was invisible. It also asserted ZERO over
+    `timeouts.py`, the one file where the check legitimately lives; that arm
+    could only ever pass, which made the owner file's inclusion dead slack
+    rather than coverage.
+
+    Two changes: the pattern no longer names a variable, and the owner file is
+    the POSITIVE CONTROL — a reassuring zero across the consumers is worthless
+    unless the pattern is shown to match SOMETHING.
     """
-    import re
+    import ast
 
-    # 🔴 EVERY FILE ON EITHER SIDE OF THE SPLIT, INCLUDING THE NEW LAUNCHER AND
-    # THE MODULE THAT OWNS THE RULE. Listing only the two originals would leave
-    # `scripts/cairn-who` free to open-code a third copy — the site a reader
-    # would most plausibly add one to, since it is the file that looks like the
-    # `who` entry point now.
+    def opencoded_sites(path):
+        """`isinstance(<anything>, int)` CALLS — parsed, never grepped.
+
+        ⚠ A REGEX OVER THE SOURCE COUNTS PROSE, and that is not hypothetical:
+        the first version of this guard used one, and its own positive control
+        was satisfied by the DOCSTRING two frames up, which spells
+        `isinstance(t, int)` while explaining the hazard. MEASURED — rewriting
+        the owner's real check to `type(value) is int` left the control GREEN
+        on the strength of that sentence alone. Comments vanish at parse time
+        and docstrings become Constant nodes, so only real calls are counted.
+        """
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        n = 0
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "isinstance"
+                    and len(node.args) == 2
+                    and isinstance(node.args[1], ast.Name)
+                    and node.args[1].id == "int"):
+                n += 1
+        return n
+
+    owner = REPO_ROOT / "scripts" / "lib" / "timeouts.py"
+    # 🔴 POSITIVE CONTROL FIRST. If this is 0 the check has stopped seeing the
+    # implementation it was written for, and every zero below is a fact about
+    # this function rather than about the consumers.
+    owner_hits = opencoded_sites(owner)
+    assert owner_hits >= 1, (
+        f"found {owner_hits} `isinstance(_, int)` calls in the file that OWNS "
+        f"the predicate — this check can no longer see the very construct it "
+        f"searches for, so the consumer zeros below prove nothing")
+
+    # 🔴 EVERY CONSUMER ON EITHER SIDE OF THE SPLIT, INCLUDING THE NEW LAUNCHER
+    # — the site a reader would most plausibly add a copy to, since it is the
+    # file that looks like the `who` entry point now. The owner is deliberately
+    # NOT in this list; it is the control above.
     for path in (REPO_ROOT / "scripts" / "cairn",
                  REPO_ROOT / "scripts" / "cairn-who",
-                 REPO_ROOT / "scripts" / "lib" / "cairn_who.py",
-                 REPO_ROOT / "scripts" / "lib" / "timeouts.py"):
-        src = path.read_text(encoding="utf-8")
-        # 🔴 EXACTLY ZERO, not "at most one". The earlier bound allowed one
-        # copy on the theory that the predicate's own body is a legitimate
-        # site — but its parameter is `value`, not `timeout`, so this pattern
-        # never matched inside it, and the allowance was dead slack permitting
-        # one genuine re-open-coded copy. Measured: an agreeing duplicate in
-        # `_run` SURVIVED under the old bound.
-        opencoded = len(re.findall(r"isinstance\(\s*timeout\s*,\s*int\s*\)", src))
+                 REPO_ROOT / "scripts" / "lib" / "cairn_who.py"):
+        opencoded = opencoded_sites(path)
         assert opencoded == 0, (
             f"{path.name} open-codes the timeout predicate at {opencoded} "
             "site(s) — import `unbounded_timeout_reason` instead so the "

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Gate on `cairn who` — the task -> session -> window -> transcript join.
+"""Gate on `cairn-who` — the task -> session -> window -> transcript join.
 
 WHAT THIS FILE IS DEFENDING. Every hop resolved before the command existed; the
 defect class is not "a hop breaks" but "two different answers get printed the
@@ -688,21 +688,21 @@ def test_who_never_raises_or_focuses_a_window():
         assert verb not in code, f"who reaches for {verb!r} — that is screen theft"
 
 
-def test_who_owns_its_own_timeout_default_and_accepts_the_flag_AFTER_the_subcommand():
-    """🔴 `cairn`'s top-level `--timeout` is 20s, tuned for an HTTP fetch.
+def test_who_owns_its_own_timeout_default_and_ADVERTISES_the_one_it_ships():
+    """🔴 `cairn`'s bound is 20s, tuned for an HTTP fetch; this one is not.
 
-    `who` shells into tmux on two hosts, and `DEFAULT_TIMEOUT` here carries a
-    docstring reasoning specifically about a sleeping laptop. Inheriting the
-    store's bound meant the documented rationale was not what shipped — and
-    `cairn who --timeout N` was rejected outright, because the flag only existed
-    BEFORE the subcommand where nobody would type it.
+    `cairn-who` shells into tmux on two hosts, and `DEFAULT_TIMEOUT` here carries
+    a docstring reasoning specifically about a sleeping laptop. Inheriting the
+    store's bound meant the documented rationale was not what shipped. Driven
+    through the REAL binary, whose `--help` must advertise the constant this
+    module defines rather than a restated literal — a restated one drifts.
     """
     import subprocess as sp
 
-    cairn = REPO_ROOT / "scripts" / "cairn"
-    help_out = sp.run([sys.executable, str(cairn), "who", "--help"],
+    who = REPO_ROOT / "scripts" / "cairn-who"
+    help_out = sp.run([sys.executable, str(who), "--help"],
                       capture_output=True, text=True, timeout=60).stdout
-    assert "--timeout" in help_out, "who does not accept --timeout after the subcommand"
+    assert "--timeout" in help_out, "cairn-who does not accept --timeout"
     assert f"default {W.DEFAULT_TIMEOUT}" in help_out, (
         f"the help advertises a default that is not who's own:\n{help_out}")
 
@@ -826,97 +826,114 @@ def _load_cairn_cli():
     return mod
 
 
-def test_the_CLI_resolves_a_missing_timeout_to_WHOs_own_default(monkeypatch):
-    """🔴 Pins the `None -> DEFAULT_TIMEOUT` step in `cmd_who`.
+def test_the_BINARY_resolves_a_missing_timeout_to_WHOs_own_default(monkeypatch):
+    """🔴 Pins the "no flag given -> DEFAULT_TIMEOUT" step in `cairn_who.main`.
 
-    Dropping it survived every earlier battery. `_run` now REFUSES a `None`
-    bound, so the consequence is a loud error rather than the unbounded wait it
-    used to be — but "fails visibly" is not "is correct", and the resolution
-    itself was still unpinned. Measured under the mutant: every run reported
-    `clawgate-unreachable — refusing to run clawgatectl with timeout=None`.
+    Dropping the equivalent step survived every earlier battery when this was a
+    subcommand. `_run` REFUSES a `None` bound, so the consequence is a loud error
+    rather than the unbounded wait it used to be — but "fails visibly" is not "is
+    correct", and the resolution itself was still unpinned. Measured under the
+    mutant: every run reported `clawgate-unreachable — refusing to run
+    clawgatectl with timeout=None`.
     """
-    cli = _load_cairn_cli()
     seen = {}
 
     def fake_resolve(task, *, timeout, host, skip_windows):
         seen["timeout"] = timeout
         return W.WhoReport(task=task, state=W.WHO_NO_SESSIONS)
 
-    sys.modules.pop("cairn_who", None)
     monkeypatch.setattr(W, "resolve", fake_resolve)
-    monkeypatch.setitem(sys.modules, "cairn_who", W)
 
-    args = cli.build_parser().parse_args(["who", "42"])
-    monkeypatch.setattr(sys, "argv", ["cairn", "who", "42"])
-    args.func(args)
+    W.main(["42"])
     assert seen["timeout"] == W.DEFAULT_TIMEOUT, (
-        f"the CLI passed {seen['timeout']!r} instead of who's own default")
+        f"cairn-who passed {seen['timeout']!r} instead of its own default")
 
-    args = cli.build_parser().parse_args(["who", "42", "--timeout", "7"])
-    args.func(args)
+    W.main(["42", "--timeout", "7"])
     assert seen["timeout"] == 7, "an explicit --timeout was not honoured"
 
 
-@pytest.mark.parametrize("argv,expected", [
-    # who's own flag wins
-    (["who", "42", "--timeout", "7"], 7),
-    # a TOP-LEVEL --timeout is honoured, not discarded
-    (["--timeout", "5", "who", "42"], 5),
-    # …including after another value-taking global, the spelling the old
-    # hand-rolled argv scanner got WRONG (it stopped at --cache's value)
-    (["--cache", "/tmp/c", "--timeout", "5", "who", "42"], 5),
-    # …and via argparse's long-option abbreviation, which a literal
-    # `== "--timeout"` comparison could never see
-    (["--time", "5", "who", "42"], 5),
-    # neither given -> who's OWN default, never the store's shorter one
-    (["who", "42"], None),
-    # who's own flag beats a top-level one
-    (["--timeout", "5", "who", "42", "--timeout", "9"], 9),
-])
-def test_the_timeout_precedence_is_who_then_TOP_LEVEL_then_whos_own_default(
-        argv, expected, monkeypatch):
-    """🔴 REGRESSION GUARD over every spelling, driven through `cmd_who` itself.
+def test_there_is_exactly_ONE_timeout_flag_and_no_precedence_rule_to_get_wrong(
+        monkeypatch):
+    """🔴 THE PRECEDENCE CLASS IS GONE BY CONSTRUCTION, AND THAT IS THE POINT.
 
-    The first fix here printed a notice saying a top-level `--timeout` was being
-    discarded, driven by hand-parsing `sys.argv`. That scanner returned the
-    WRONG answer for two reachable spellings — after another value-taking global
-    option, and via argparse's long-option abbreviation — so those silently
-    discarded exactly as before, which is what the notice existed to prevent.
-    Re-implementing argparse's parsing in order to describe argparse's behaviour
-    was the mistake; distinct dests remove the clobber and there is nothing to
-    announce.
+    As a `cairn who` subcommand this needed `_who_timeout` and a distinct
+    argparse `dest`: argparse copies the subparser's namespace over the parent's,
+    so a top-level `cairn --timeout N who …` silently VANISHED. The first fix
+    printed a notice driven by hand-parsing `sys.argv`, and that scanner was
+    WRONG for two reachable spellings — after another value-taking global
+    (`--cache <val> --timeout 5 who 42`, it stopped at `--cache`'s value) and via
+    argparse's long-option abbreviation (`--time 5 who 42`, which a literal
+    `== "--timeout"` cannot see). A standalone binary has no parent parser, so
+    there is nothing to clobber and nothing to announce.
 
-    Only the helper was tested before, never `cmd_who`, so deleting the whole
-    block left the suite green — the seam nobody owns.
+    WHAT THIS ACTUALLY CHECKS, stated to match the body rather than the
+    intention: (a) BEHAVIOURALLY, that `--timeout` is honoured on either side of
+    the positional — the spelling that used to depend on which parser owned it;
+    (b) STRUCTURALLY, that the `who_timeout` dest exists in NO file on either
+    side of the split. (b) is a state assertion, not a name-absence one: that
+    dest existed solely to survive the subparser clobber, so its presence
+    anywhere means a parent/child timeout pair is back. A helper RENAME walks
+    past a check for `_who_timeout`; it does not walk past this.
     """
-    cli = _load_cairn_cli()
     seen = {}
+    monkeypatch.setattr(W, "resolve",
+                        lambda task, *, timeout, host, skip_windows:
+                        (seen.__setitem__("timeout", timeout),
+                         W.WhoReport(task=task, state=W.WHO_NO_SESSIONS))[1])
 
-    def fake_resolve(task, *, timeout, host, skip_windows):
-        seen["timeout"] = timeout
-        return W.WhoReport(task=task, state=W.WHO_NO_SESSIONS)
+    # One flag, honoured wherever it is typed relative to the positional.
+    W.main(["42", "--timeout", "9"])
+    assert seen["timeout"] == 9
+    W.main(["--timeout", "9", "42"])
+    assert seen["timeout"] == 9, (
+        "a --timeout before the task id was not honoured — a standalone binary "
+        "has no subparser boundary for it to fall on the wrong side of")
 
-    monkeypatch.setattr(W, "resolve", fake_resolve)
-    monkeypatch.setitem(sys.modules, "cairn_who", W)
-    args = cli.build_parser().parse_args(argv)
-    args.func(args)
-    want = W.DEFAULT_TIMEOUT if expected is None else expected
-    assert seen["timeout"] == want, (
-        f"{' '.join(argv)} resolved to {seen['timeout']}, expected {want}")
+    # …and the store client has no second one to disagree with it.
+    cli = _load_cairn_cli()
+    dests = {a.dest for a in cli.build_parser()._actions}
+    assert dests, "could not read the store parser's dests — this checked NOTHING"
+    assert "who_timeout" not in dests, (
+        "`scripts/cairn` still carries the who-specific timeout dest. That dest "
+        "existed ONLY to survive the subparser clobber; if it is back, so is "
+        "the precedence rule this split removed.")
+
+    # The dest is gone from the CODE of every file on both sides, not just from
+    # the store parser's top level — a subparser's dest does not surface in
+    # `build_parser()._actions` unless you walk into it, so the structural sweep
+    # is what makes the claim above cover the whole split.
+    #
+    # 🔴 SCANNED AS A `dest=` SPELLING, NOT AS A BARE SUBSTRING. The prose above
+    # and in `cairn_who.main` NAMES `_who_timeout` to record why it is gone, and
+    # a substring scan matched that documentation and went red — a guard that
+    # forbids describing the hazard it guards is the wrong guard. `_code_strings`
+    # drops docstrings but not `#` comments, so the pattern carries the weight.
+    import re  # noqa: PLC0415
+
+    pattern = re.compile(r"""dest\s*=\s*["']who_timeout["']""")
+    for path in (REPO_ROOT / "scripts" / "cairn",
+                 REPO_ROOT / "scripts" / "cairn-who",
+                 LIB / "cairn_who.py"):
+        assert not pattern.search(path.read_text(encoding="utf-8")), (
+            f"{path.name} still declares the `who_timeout` argparse dest")
+
+    # POSITIVE CONTROL for the pattern: a reassuring zero above is worthless if
+    # the regex cannot match the thing it looks for. This is the exact spelling
+    # `scripts/cairn` carried before the split.
+    assert pattern.search('w.add_argument("--timeout", dest="who_timeout")'), (
+        "the who_timeout detector cannot match its own target — the four "
+        "assertions above checked NOTHING")
 
 
 def test_who_never_writes_a_warning_to_STDOUT(capsys, monkeypatch):
-    """`cairn who --json` writes JSON to stdout; anything else breaks a parse.
+    """`cairn-who --json` writes JSON to stdout; anything else breaks a parse.
 
-    The previous design printed a notice, and its stream was unpinned — dropping
-    `file=sys.stderr` survived the suite.
+    The subcommand design printed a notice about a discarded flag, and its
+    stream was unpinned — dropping `file=sys.stderr` survived the suite.
     """
-    cli = _load_cairn_cli()
     monkeypatch.setattr(W, "resolve", lambda task, *, timeout, host, skip_windows:
                         W.WhoReport(task=task, state=W.WHO_NO_SESSIONS))
-    monkeypatch.setitem(sys.modules, "cairn_who", W)
-    args = cli.build_parser().parse_args(["--timeout", "5", "who", "42", "--json"])
-    args.func(args)
+    W.main(["42", "--json"])
     out = capsys.readouterr().out
     json.loads(out)  # raises if anything non-JSON was printed alongside it
 
@@ -928,8 +945,8 @@ def test_the_store_commands_still_get_the_STORE_default_when_no_flag_is_given():
     args = cli.build_parser().parse_args(["recall"])
     assert args.timeout is None, "the sentinel is not in place"
     assert cli.DEFAULT_TIMEOUT > 0
-    who = cli.build_parser().parse_args(["who", "42"])
-    assert cli._who_timeout(who, W.DEFAULT_TIMEOUT) == W.DEFAULT_TIMEOUT
+    assert cli._store_timeout(args) == cli.DEFAULT_TIMEOUT, (
+        "the resolver did not turn the sentinel into the store's own bound")
 
 
 def _passes_args_timeout_raw(kw) -> bool:
@@ -1134,7 +1151,7 @@ def test_the_POSITIVE_bound_actually_reaches_urlopen(monkeypatch):
         "given — the validated parameter is not what goes to the network")
 
 
-#: Every value that must be refused as a timeout, by BOTH halves of this CLI.
+#: Every value that must be refused as a timeout, by BOTH binaries.
 UNBOUNDED_TIMEOUTS = [None, 0, -1, "60", True, False, 1.5, [], object()]
 
 
@@ -1143,7 +1160,7 @@ def test_BOTH_entry_points_refuse_the_SAME_unusable_timeouts(bad):
     """🔴 TWO-WAY PIN. The rule was open-coded twice and the copies DISAGREED.
 
     Only `fetch_snapshot` excluded `bool`, while a comment claimed it refused
-    "the way `cairn_who._run` always has". Measured before this fix:
+    "the way `cairn_who._run` always has". Measured before that fix:
     `_run(["sleep","3"], True)` ran with a ONE-SECOND bound and reported
     `did not answer within Trues` — verbatim the "nobody notices" failure
     `_run`'s own docstring describes.
@@ -1152,6 +1169,14 @@ def test_BOTH_entry_points_refuse_the_SAME_unusable_timeouts(bad):
     makes a future divergence fail here instead of shipping. Consolidation was
     the bug-finding instrument: the disagreement was only audible once the two
     predicates were put side by side.
+
+    🔴 AND THE SPLIT RAISED THE STAKES RATHER THAN SETTLING THEM. These are now
+    two separate PROGRAMS in two separate files; the store side reached the rule
+    by importing the `who` module, which only worked while `who` was a
+    subcommand of it. The cheap repair when that reach broke would have been to
+    re-open-code the check — exactly the two-copies state above. They import
+    `lib/timeouts.py` instead, and this stays the behavioural proof that they
+    still agree.
     """
     cli = _load_cairn_cli()
     with pytest.raises(W.WhoError) as who_exc:
@@ -1182,8 +1207,15 @@ def test_the_timeout_predicate_has_exactly_ONE_implementation():
     """
     import re
 
+    # 🔴 EVERY FILE ON EITHER SIDE OF THE SPLIT, INCLUDING THE NEW LAUNCHER AND
+    # THE MODULE THAT OWNS THE RULE. Listing only the two originals would leave
+    # `scripts/cairn-who` free to open-code a third copy — the site a reader
+    # would most plausibly add one to, since it is the file that looks like the
+    # `who` entry point now.
     for path in (REPO_ROOT / "scripts" / "cairn",
-                 REPO_ROOT / "scripts" / "lib" / "cairn_who.py"):
+                 REPO_ROOT / "scripts" / "cairn-who",
+                 REPO_ROOT / "scripts" / "lib" / "cairn_who.py",
+                 REPO_ROOT / "scripts" / "lib" / "timeouts.py"):
         src = path.read_text(encoding="utf-8")
         # 🔴 EXACTLY ZERO, not "at most one". The earlier bound allowed one
         # copy on the theory that the predicate's own body is a legitimate

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1261,6 +1261,9 @@ def test_the_timeout_predicate_has_exactly_ONE_implementation():
                  REPO_ROOT / "scripts" / "lib" / "cairn_who.py"):
         opencoded = opencoded_sites(path)
         assert opencoded == 0, (
-            f"{path.name} open-codes the timeout predicate at {opencoded} "
-            "site(s) — import `unbounded_timeout_reason` instead so the "
-            "copies cannot drift")
+            f"{path.name} has {opencoded} `isinstance(_, int)` call(s). If any "
+            f"is a timeout check, import `unbounded_timeout_reason` instead so "
+            f"the copies cannot drift. ⚠ This guard cannot tell a timeout check "
+            f"from an unrelated int check — it counts the CONSTRUCT, not the "
+            f"intent — so an unrelated one reddens here too, and the fix for "
+            f"that case is to widen this guard, not to work around it.")

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1265,5 +1265,7 @@ def test_the_timeout_predicate_has_exactly_ONE_implementation():
             f"is a timeout check, import `unbounded_timeout_reason` instead so "
             f"the copies cannot drift. ⚠ This guard cannot tell a timeout check "
             f"from an unrelated int check — it counts the CONSTRUCT, not the "
-            f"intent — so an unrelated one reddens here too, and the fix for "
-            f"that case is to widen this guard, not to work around it.")
+            f"intent — so an unrelated one reddens here too. In that case make "
+            f"this guard DISCRIMINATE (exempt the specific site, or match on "
+            f"the timeout parameter as well); do not widen it, which makes a "
+            f"false positive worse, and do not work around it.")

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -105,6 +105,16 @@ ALLOWLIST = [
     ("scripts/tests/test_handoff_index.py", "assert first.startswith(",
      "ASSERTS a module's shebang shape to justify its executable bit; writes no "
      "stub and execs nothing"),
+    # Shape (b) once more, and the same needle-without-the-prefix rule as the
+    # entry above: `scripts/cairn-who` goes on PATH as a bare command via
+    # `mkOutOfStoreSymlink`, so a file there without a shebang is a
+    # `command not found` that reads as a broken deploy. The test READS the
+    # launcher off disk and asserts the first line's two-character prefix; it
+    # writes no stub and execs nothing, so `testlib.mockbin.write_exec` has
+    # nothing to own here.
+    ("scripts/tests/test_cairn_split.py", "assert first.startswith(",
+     "ASSERTS the cairn-who launcher's shebang shape to justify its executable "
+     "bit; writes no stub and execs nothing"),
     ("scripts/tests/test_playwright_nixos.py", "/bin/sh",
      "writes /bin/sh directly — absolute, present in the sandbox"),
     ("scripts/tests/test_notify_failure.py", "_bash",


### PR DESCRIPTION
`cairn who` was the one subcommand about a different noun. Every other verb acts on an ENTRY in the hosted store and takes `--scope`/`--repo`/`--no-sync`; `who` took none of them, synced nothing, and needed its own longer timeout because it shells into tmux on two hosts rather than fetching an HTTP snapshot.

It is also the seam `github.com/ZacxDev/cairn` chose independently — the OSS extraction ships the store client and excludes `who`, because session forensics on named hosts cannot go in a public repo. `claudedocs/handoff-cairn-oss-multi-instance.md` ranks this as rank 3's second half; claimed as `cairn-oss-multi-instance-3`.

**Scope:** the split only. NOT pinning devrc to the cairn flake, NOT moving `~/.local/bin/cairn` into `/nix/store`, NOT the `entry_shape`/writer-vocabulary question — the handoff doc says to put that last one to the operator before building, and it is untouched here.

## The non-obvious part

The STORE path called `_cairn_who().unbounded_timeout_reason(timeout)` — it borrowed the predicate by importing the whole `who` module, which only worked while the two were one program. That rule was open-coded at two sites once before and the copies DISAGREED (only one excluded `bool`; the weaker copy ran with a silent one-second bound). Re-open-coding it on the store side would recreate exactly that state, so it moved to `scripts/lib/timeouts.py`, which both binaries import at module scope. The `bool`-subclasses-`int` trap and its measurement are carried over verbatim.

No shared `DEFAULT_TIMEOUT`: the store's 20s and who's 60s differ for measured reasons, and one constant would erase both.

## Test matrix

| | result |
|---|---|
| HEAD, the three touched suites | **112 passed** |
| fork point, new suite only | **12 failed / 8 passed** |

The 12 reds are the regression coverage. The 8 that pass at base are `test_the_STORE_fetch_STILL_refuses_an_unbounded_timeout_after_the_split` parameterized over `None/0/-1/60/True/False/1.5`, plus `test_a_POSITIVE_bound_is_NOT_refused` as its positive control — the behaviour predates the split, so these are **invariant guards** and are not counted as regression coverage.

Authoritative gate on the rebased tree, counts read from the log rather than the exit code:

```
PASS  scripts/tests  (collected=12870 passed=12870 skipped=0 floor=12820)
TOTAL collected=20915  passed=20913  skipped=2  failed=0
```

## Live verification

Run against the worktree's own binaries:

- `cairn doctor --no-sync` → rc 10, `frozen-mirror OK` — the store path is intact
- `cairn ls-entries` → live fetch, 225 entries — the network path still works
- `cairn who foo` → **exit 2**, `invalid choice: 'who'` (the value the SKILL now claims)
- `cairn-who --help` → rc 0, `--json`/`--host`/`--no-windows`/`--timeout` preserved
- `cairn-who <id>` → reached clawgate and returned a well-formed refusal

## A stale comment this uncovered

`nix/home.nix` justified `mkOutOfStoreSymlink` by naming `cairn_who` importers at `scripts/cairn:68/756/808/818`. Checked at the fork point: line 68 is blank and 756/808/818 are unrelated comments about recall and silent zeros — the real references were at 285/289/957/1334+. The comment was already wrong before this change. Line numbers are gone; the requirement is restated on each script's own `__file__` lookup, and `cairn-who` gets the same deploy mode for the same reason.

## Floor ratchet (second commit)

`scripts/tests` collected 12870 against a pinned floor of 12793 — 77 of slack, more than this branch's 20-test suite could lose with the gate still green. Re-pinned to 12820 per the file's documented rule, after the rebase per its ORDER note. Floor sum 20208 → 20235.

## Deploy note

🔴 **Merging this requires a `home-manager switch`** — corrected after the round-1 audit; the original wording here was wrong and is retracted in a PR comment.

Only the `who`-REMOVAL half is live on merge: `~/.local/bin/cairn` already resolves to `scripts/cairn`, so `cairn who` starts exiting 2 as soon as the checkout is pulled. The new `~/.local/bin/cairn-who` symlink does **not** exist yet and is created by home-manager ACTIVATION — `mkOutOfStoreSymlink` describes the link's target, not who creates the link. `claude/skills/cairn/SKILL.md` is likewise a `home.file` COPY into `/nix/store`, and the deployed copy still says `cairn who`.

Between merge and switch the capability is therefore unavailable and the skill misroutes. **No switch was run.**

⚠ An earlier version of this section listed a deliberately-left nit — a `# noqa: E402,F401` whose `F401` could never fire. **Round 1 fixed it** in `02fcc1a3`, and this paragraph went stale describing it (with two wrong line numbers). The file now carries `# noqa: E402` alone. ⚠ An earlier version of this sentence said `02fcc1a3` was "the same commit that corrected the deploy note" — there is no such commit. The deploy note was corrected in a PR comment plus an edit to this body; `02fcc1a3` does not touch `nix/home.nix`. A provenance claim with nothing in the tree to find is the same defect this section is about.

On the floor-sum figure above: `20235` is the gate's OWN printed line, `floor: 20235 = sum of 28 per-target floors` — the sum over the **28 hermetic targets**, not over all 29 `TARGET_FLOORS` entries (the remainder are dev-host-only). A round-2 audit could not place it and reported a non-matching total; measured here, `HERMETIC_TARGETS` has 28 entries and `TARGET_FLOORS` has 29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3KEUsTLLUhS37an52rn28


