### PR TITLE
fix(neovim): adopt the 26.05 provider defaults instead of riding the legacy warning

### DIFF
--- a/nix/programs/neovim/default.nix
+++ b/nix/programs/neovim/default.nix
@@ -33,6 +33,37 @@ in
 {
   enable = true;
   defaultEditor = true;
+
+  # The ruby/python3 REMOTE-PLUGIN hosts (`:h provider-ruby`, `:h
+  # provider-python`) -- NOT the python LSP server, which is a separate process
+  # and unaffected. home-manager 26.05 flips both defaults to false; until
+  # `home.stateVersion` reaches 26.05 the legacy `true` is taken and each emits
+  # an eval warning on every switch. Adopted early rather than pinned, because
+  # nothing here uses them. Measured 2026-09-07 on the workbench:
+  #
+  #   - rplugin.vim is 71 bytes -- four empty section headers, zero registered
+  #     remote plugins -- on BOTH the generation's manifest and
+  #     ~/.local/share/nvim/rplugin.vim.
+  #   - None of the 4 nix plugins below nor the 25 packer-managed plugins in
+  #     .config/nvim/lua/plugins.lua ships an `rplugin/`, `pythonx/` or `ruby/`
+  #     directory.
+  #   - GNU grep (not the ugrep wrapper) over .config/nvim/ for
+  #     python|ruby|pynvim|provider|py3eval|*_host_prog finds only comments.
+  #   - Generation closure 8,708,381,320 -> 8,664,830,096 B, i.e. -43,551,224
+  #     (~41.5 MiB), measured at base 18bc1500 with `nix path-info -S`. The
+  #     saving is entirely ruby (ruby-3.4.9 + gems + the two provider envs);
+  #     withPython3 costs the neovim WRAPPER nothing, because home-manager
+  #     passes wrapRc = false and the host_prog line lands in this init.lua
+  #     rather than in the wrapper.
+  #
+  # Setting either option to either value silences the warning -- it hangs off
+  # the default thunk (lib/deprecations.nix, mkStateVersionOptionDefault), so
+  # merely being explicit is enough. `false` is chosen for the closure.
+  #
+  # Cost if this is ever wrong: `:python3`/`:ruby` and any remote plugin raise
+  # E319. Flip back to `true` and switch.
+  withRuby = false;
+  withPython3 = false;
   #package = pkgs.neovim;
   extraConfig = initVim;
   plugins = with pkgs.vimPlugins; with plugins; [


### PR DESCRIPTION
## What

`home-manager switch --flake ~/workspace/devrc --impure` printed two eval warnings on **every** run:

```
The default value of `programs.neovim.withRuby` has changed from `true` to `false`.
You are currently using the legacy default (`true`) because `home.stateVersion`
is less than "26.05".
```

…and the identical warning for `withPython3`. (Each prints twice per switch — once per eval pass, not two separate issues.)

These are the ruby/python3 **remote-plugin hosts** (`:h provider-ruby`, `:h provider-python`) — *not* the python LSP server, which is a separate process over LSP and is unaffected.

## Why this fix, and not the others

The warning hangs off the **default thunk** (home-manager `modules/lib/deprecations.nix`, `mkStateVersionOptionDefault`), so setting the option to *either* value silences it. Measured against home-manager `2c0350c7`, counting `default value of` lines from `nix build .#homeConfigurations.zach.activationPackage --impure`:

| variant | warnings |
|---|---|
| options unset (**negative control**) | **2** |
| `withRuby=false; withPython3=false` | **0** |
| `withRuby=true;  withPython3=true`  | **0** |

`false` chosen over pinning the legacy `true`, because nothing here uses the providers:

- `rplugin.vim` is **71 bytes** — four empty section headers, zero registered remote plugins — on *both* the generation manifest and `~/.local/share/nvim/rplugin.vim`.
- None of the 4 nix plugins nor the 25 packer-managed plugins in `.config/nvim/lua/plugins.lua` ships an `rplugin/`, `pythonx/` or `ruby/` directory.
- GNU `grep` (not the ugrep wrapper, which is `.gitignore`-blind) over `.config/nvim/` for `python|ruby|pynvim|provider|py3eval|*_host_prog` finds only comments.

**Verified it changes behaviour, not just the warning.** The generated `init.lua`'s two `vim.g.{ruby,python3}_host_prog='…'` lines are replaced by `vim.g.loaded_ruby_provider=0` / `vim.g.loaded_python3_provider=0`.

Generation closure **8,708,381,320 → 8,664,830,096 B** (−43,551,224, ~41.5 MiB) via `nix path-info -S` at base `18bc1500`. Entirely ruby — `withPython3` costs the neovim *wrapper* nothing, because home-manager passes `wrapRc = false` so the `host_prog` line lands in `init.lua` rather than in the wrapper.

## Deliberately not done

- **Not raising `home.stateVersion`.** It marks which defaults the on-disk state was built against, not how current the config is. Jumping 24.11 → 26.05 would additionally arm ~10 unrelated default changes, including a **Firefox profile-directory move** and the neovim plugin `config` flip from viml to Lua.
- **Not touching `nix flake update`.** Both inputs are already at head — nixpkgs `42f17a57f4f6` == `nixpkgs-unstable` head exactly, home-manager `2c0350c75968` == master head exactly.
- **Not patching the `'install' is a deprecated alias for 'add'` warning.** That's home-manager's own `modules/home-environment.nix:729`. Upstream fixed it (PR #8756) and **reverted it** (PR #8835) because `nix profile add` doesn't exist on Lix and `nixReplaceProfile` removes `home-manager-path` *before* re-adding — wrong verb leaves the home broken mid-activation. Issue #9598 is open, no PR.

## Gate

Run on the merged tree (branch is off `origin/main` @ `18bc1500`, fast-forward, so merged tree == branch).

| tier | verdict |
|---|---|
| `gate.sh` node (dev-host) | **PASS** — 41 files, 1449 tests, 0 fail |
| `nix build .#checks…nodetests` (sandbox) | **PASS** — 1449 tests, 0 fail, floor 1367 |
| `nix build .#checks…pytests` (sandbox) | **RED — pre-existing, see below** |

Built one at a time, never combined.

🔴 **The sandbox pytest tier is red on this branch AND on the unmodified base tree**, and the failing set here is a strict **subset** of base's:

```
base    (drv 4b036psy…)  failed=8   5 test functions
patched (drv qmsf6lx3…)  failed=7   4 test functions
diff: base has one extra — test_live_cotenants_sees_another_process_in_the_repo
```

So **no failure is introduced by this change**. The 4 shared failures are all `age`:

- `test_engine_is_the_version_every_measurement_is_keyed_to`
- `test_every_decrypt_family_VERDICT_is_pinned_WHOLE`
- `test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr`
- `test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret`

**Cause:** those tests pin age's *measured* behaviour (`MEASURED 2026-08-27, age v1.3.1` appears throughout `test_analyze_service_index_{escrow_verify,backup}.py`), and the recent lockfile bump (#1382) moved nixpkgs' age to **1.3.2**. `age --version` on the workbench is now `v1.3.2`. Symptoms: `age-keygen: error: failed to parse input: error at line 3: unknown identity type`, and `DECRYPT-FAILED` where `ARTIFACT-CORRUPT` was expected.

Not fixed here — separate concern, separate change. **Closing condition:** `nix build .#checks.x86_64-linux.pytests` exits 0 on `main`.

The extra base-only failure is the GUARD 10 co-tenant detector tripping on another live session in the shared checkout — environmental, not code.
