### PR TITLE
fix(mention-open): a bare `#N` the pane guesses is now overridable too

### DIFF
--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -16,8 +16,12 @@ authority, and a match the scanner rejects opens nothing.
 
 RESOLUTION
 ----------
-  1 openable candidate   -> xdg-open it.
+  1 openable candidate   -> xdg-open it, UNLESS the repository was guessed from
+                            the tmux pane — see `repo_source` in `main()`.
   2+ (a bare `#N`)       -> rofi picker, one row per platform, showing the URL.
+  any of the above whose repository was GUESSED
+                         -> the same rows, FIRST, with the fuzzy universe
+                            appended beneath them so the guess is overridable.
   0                      -> the FUZZY repo picker over the LOCAL universe, and
                             only if that cannot or should not be shown, a
                             notification saying WHICH empty this is.
@@ -856,44 +860,56 @@ def universe_note(subject: str, offered: int, path: Path | None = None) -> str:
             f"scripts/regen-known-repos.py")
 
 
-def guessed_note(subject: str, offered: int = 1) -> str:
-    """The line shown ABOVE the picker when the FIRST repository on offer was
-    GUESSED — `repo_source == "default"`, i.e. the tmux pane rather than
-    anything the clicked text said.
+def guessed_note(subject: str, below: int = 0, rank: int = 1) -> str:
+    """The line shown ABOVE the picker when one of the rows on offer was GUESSED
+    — `repo_source == "default"`, i.e. the tmux pane rather than anything the
+    clicked text said.
 
-    🔴 A ONE-ROW PICKER WITH NO EXPLANATION READS AS A BUG. Suppressing the
-    auto-open is the safety property; saying WHY is what stops the operator
-    concluding the handler is broken and going back to typing the URL. It is
-    the same argument as `universe_note`: rofi cannot report a reason after the
-    fact, so the reason goes above the choice.
+    `rank` is that row's 1-based position, and `below` is how many SEARCHABLE
+    repository rows sit UNDER it. Both are measured by `main()` from the list it
+    is about to hand `pick()`; neither is inferred from the shape of the text.
 
-    🔴 TWO WORDINGS, BECAUSE THE TWO SITUATIONS NEED DIFFERENT ACTIONS — and
-    the one-row wording was MEASURED WRONG in practice. Reported from the real
-    click path 2026-09-07: `audit-pr 1291` said "names no repository" over a
-    single row, and the only moves were to accept the guess or dismiss. When the
-    pane guess is wrong — which the operator reports is the common case — that
-    is a dead end wearing an explanation. So when alternatives are on offer the
-    note must say the ROW IS A GUESS *and* that the rest are searchable;
-    "confirm or dismiss" would now be false, since neither is what to do.
+    🔴 A PICKER WITH NO EXPLANATION READS AS A BUG. Suppressing the auto-open is
+    the safety property; saying WHY is what stops the operator concluding the
+    handler is broken and going back to typing the URL. It is the same argument
+    as `universe_note`: rofi cannot report a reason after the fact, so the
+    reason goes above the choice.
 
-    ⚠ The one-row wording is KEPT rather than deleted: the universe can be empty
-    (no mapping file yet, or an unreadable one), and a lone guessed row is still
-    reachable then. It is no longer the common path, and the `offered` default
-    stays 1 so the narrower claim is what a caller gets by omission.
+    🔴 TWO WORDINGS, KEYED ON `below` RATHER THAN ON A ROW COUNT, AND THE KEY IS
+    THE FIX. `below` is the only thing that decides which INSTRUCTION is true:
+    "type to search" is nonsense with nothing to search, and "confirm, or
+    dismiss" is a dead end when there are alternatives. A row count cannot tell
+    those apart — a bare `#N` on a host whose universe holds only the pane's own
+    repo offers TWO rows (the clawgate task and the guess) with nothing
+    searchable under either, and keying on the count claimed 392 rows that were
+    not there.
 
-    🔴 IT NAMES THE CLICKED TEXT AND A COUNT, NOTHING ELSE — never the
+    🔴 `rank` EXISTS BECAUSE THE GUESS IS NOT ALWAYS FIRST. `audit-pr N` offers
+    it at row 1; a bare `#N` puts the clawgate task above it, at row 2. The
+    previous wording said "The FIRST row is a guess" unconditionally, which was
+    true of the only shape that then reached this note and became false the
+    moment the bare-`#N` shape did (2026-09-08). Naming the row NUMBER is the
+    one claim that stays true for both without this function having to know
+    which platforms are above it.
+
+    ⚠ The `below <= 0` wording is KEPT rather than deleted: the universe can be
+    empty (no mapping file yet, or an unreadable one), and a guessed row is
+    still reachable then. It is no longer the common path, and the `below`
+    default stays 0 so the narrower claim is what a caller gets by omission.
+
+    🔴 IT NAMES THE CLICKED TEXT AND TWO COUNTS, NOTHING ELSE — never the
     repository, never the mapping. The candidate ROW already shows the repo,
     which is the whole point of asking; the note must not become a second place
     a name can leak from, and `_every_sink`'s guards would not see this one (it
     goes to rofi).
     """
-    if offered <= 1:
-        return (f"{subject} names no repository — the one offered was measured "
-                "from the tmux pane, which may not be the pane you clicked in. "
-                "Confirm, or dismiss.")
-    return (f"{subject} names no repository. The FIRST row is a guess from the "
-            f"tmux pane, which may not be the pane you clicked in — the other "
-            f"{offered - 1} are every repository this host knows. Type to "
+    if below <= 0:
+        return (f"{subject} names no repository — the GitHub row offered was "
+                "measured from the tmux pane, which may not be the pane you "
+                "clicked in. Confirm, or dismiss.")
+    return (f"{subject} names no repository. Row {rank} is a guess from the "
+            f"tmux pane, which may not be the pane you clicked in — the {below} "
+            f"rows below it are every repository this host knows. Type to "
             f"search, or dismiss.")
 
 
@@ -1196,34 +1212,57 @@ def main(argv: list[str] | None = None) -> int:
     # fuzzy-matched, so 392 rows cost the operator a few keystrokes rather than
     # a scroll.
     #
-    # 🔴 THE GUESS STAYS FIRST, and that is the whole reason this is an APPEND
-    # rather than a replace. It is the most likely answer and it is one Enter
-    # away, so the common case does not get slower; the universe below it is
-    # what makes the uncommon case possible at all. Same shape as the bare-`#N`
-    # arm above, which keeps the clawgate candidate first for the same reason.
-    # 🔴 SCOPED TO THE GUESS THAT IS *ALONE*, AND THE NARROWING IS DELIBERATE.
-    # A bare `#N` the pane attributes already offers TWO rows — the clawgate
-    # task and the pane's GitHub repo — and `test_a_bare_hash_N_that_the_PANE_
-    # already_attributes_does_NOT_get_the_universe` pins that on purpose: it is
-    # the single most common interaction in this handler, and burying two good
-    # rows under several hundred options is a regression dressed as a feature.
-    # A one-row picker is a different thing entirely — there is nothing to bury,
-    # and no way to say "not that one".
+    # 🔴 THE MEASURED ROWS STAY ON TOP, and that is the whole reason this is an
+    # APPEND rather than a replace. The guess is the most likely answer and it
+    # stays one or two Enters away, so the common case does not get slower; the
+    # universe below it is what makes the uncommon case possible at all. Same
+    # shape as the bare-`#N` arm in PASS 3, which keeps the clawgate candidate
+    # first for the same reason.
     #
-    # ⚠ THE SAME COMPLAINT DOES PARTLY APPLY TO THAT TWO-ROW CASE — if the pane
-    # guess is wrong there, the operator still cannot reach the right repo — but
-    # fixing it costs every ordinary click a full-height picker, which is a
-    # trade for the operator to make rather than one to smuggle in beside a bug
-    # fix. Left alone, and written down instead.
-    guessed_alone = guessed and len(candidates) == 1 and not offered_universe
+    # 🔴 IT IS NOT SCOPED TO THE GUESS THAT IS *ALONE* ANY MORE, AND THE
+    # WIDENING IS THE OPERATOR'S CALL (2026-09-08: "fix the bare-#N and any
+    # other cases left unfixed"). #1380 shipped this arm as `guessed_alone`,
+    # reasoning that a bare `#N` the pane attributes already offers TWO good
+    # rows and that burying them under several hundred was "a regression dressed
+    # as a feature" — `test_a_bare_hash_N_that_the_PANE_already_attributes_does_
+    # NOT_get_the_universe` pinned exactly that. The same commit wrote down the
+    # complaint against its own narrowing: if the pane guess is wrong in the
+    # two-row case, the right repo is still unreachable. It is the SAME defect
+    # one rung along, the operator hit it, and the trade has now been made in
+    # their favour. The cost is bounded by the ordering: rows 1 and 2 are
+    # unchanged and `rofi` opens on row 1, so the common case is still one Enter.
+    #
+    # 🔴 THE PREDICATE IS `repo_source == default`, NOT A SHAPE. `guessed` is
+    # computed above from `mention_scan`'s own constant, so `--default-repo`
+    # rides the same rung as the tmux pane and any future no-owner shape
+    # inherits this for free.
+    guessed_offer = guessed and not offered_universe
 
-    if guessed_alone and universe:
+    # The guess's 1-based row, measured BEFORE the append so a universe row —
+    # which is also a GitHub row — cannot be mistaken for it. In the terminal
+    # profile a span carries at most one GitHub candidate: `audit-pr N` puts it
+    # at row 1, a bare `#N` puts the clawgate task above it at row 2.
+    guess_rank = next((i for i, c in enumerate(candidates, 1)
+                       if c["platform"] == PLATFORM_GITHUB), 1) if guessed else 1
+
+    # How many SEARCHABLE repository rows end up under the guess. 0 means the
+    # append added nothing, and `guessed_note` needs that rather than a row
+    # count — see its docstring.
+    below = 0
+    if guessed_offer and universe:
         seen = {c["url"] for c in candidates}
         # Deduped: the pane's repo is usually IN the universe too, and offering
-        # it twice makes the first row look like a rendering bug rather than a
-        # recommendation.
-        candidates = candidates + [c for c in universe if c["url"] not in seen]
-        offered_universe = True
+        # it twice makes the recommended row look like a rendering bug rather
+        # than a recommendation.
+        extra = [c for c in universe if c["url"] not in seen]
+        # 🔴 GUARDED ON `extra`, NOT ON `universe`. A host whose whole universe
+        # is the pane's own repo dedupes to nothing, and setting
+        # `offered_universe` there would claim rows that are not in the list —
+        # both to the auto-open guard below and to the note.
+        if extra:
+            candidates = candidates + extra
+            offered_universe = True
+            below = len(extra)
 
     # 🔴 `and not offered_universe`: see PASS 3. One candidate is enough to open
     # only when that candidate is EVIDENCE about the reference — an explicit
@@ -1234,22 +1273,31 @@ def main(argv: list[str] | None = None) -> int:
         return open_url(candidates[0]["url"])
 
     # 🔴 THE NOTE IS ATTACHED ONLY WHEN THE PICKER WOULD OTHERWISE BE
-    # UNEXPLAINED. A picker over real candidates — the clawgate/GitHub pair for
-    # a bare `#N` — is not a dead end and needs no explanation; adding one there
-    # would put a line of apology above the single most common interaction in
-    # this handler. So the guessed note rides on the ONE case the branch above
-    # created: a single row, which without a reason reads as a broken handler
-    # asking the operator to confirm the obvious.
+    # UNEXPLAINED, and there are exactly two such pickers: one carrying a GUESS
+    # the operator is being asked to confirm or override, and one that is the
+    # universe as a last resort. A picker over rows that are all evidence —
+    # the clawgate/GitHub pair for a bare `#N` on a host with nothing else to
+    # offer — is not a dead end and needs no explanation, so it still gets none.
+    #
+    # ⚠ `below or len(candidates) == 1` IS THE "WOULD OTHERWISE BE UNEXPLAINED"
+    # TEST, WRITTEN OUT. `below` covers the picker whose bottom is a searchable
+    # universe; `len(candidates) == 1` covers the lone guessed row, which
+    # without a reason reads as a broken handler asking the operator to confirm
+    # the obvious. The remaining case — a guess beside a clawgate row and
+    # nothing under either — is the ordinary two-row picker and keeps `""`.
+    #
     # 🔴 `guessed` IS TESTED FIRST, AND THE ORDER IS THE WHOLE POINT. Both
     # conditions are now true on the common path — the guessed arm above sets
-    # `offered_universe` — and the two notes make OPPOSITE claims about the top
-    # row. `universe_note` opens "nothing here knows X", which is false when the
-    # first row is a recommendation the handler is asking about; putting it
-    # first would have described the fix as a dead end. Swap these two branches
-    # and the picker still works, so no behavioural test catches it: the guard
-    # is `test_a_guessed_picker_is_NOT_described_as_nothing_here_knows`.
-    mesg = (guessed_note(span["raw"], len(candidates))
-            if guessed_alone and span is not None
+    # `offered_universe` — and the two notes make OPPOSITE claims about the
+    # rows. `universe_note` opens "nothing here knows X", which is false when
+    # the top rows are a task and a recommendation the handler is asking about;
+    # putting it first would have described the fix as a dead end. Swap these
+    # two branches and the picker still works, so no behavioural test catches
+    # it: the guard is
+    # `test_a_guessed_picker_is_NOT_described_as_nothing_here_knows`.
+    mesg = (guessed_note(span["raw"], below, guess_rank)
+            if guessed_offer and span is not None
+               and (below or len(candidates) == 1)
             else universe_note(span["raw"] if span is not None else text,
                                len(candidates)) if offered_universe
             else "")

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -453,6 +453,32 @@ MUTANTS: list[tuple] = [
      # resolves, which is the same test's second half and covers the mirror
      # mutation (a widened scanner bound).
      "a TRUNCATED audit-pr number reaches the handler"),
+    # ---- F9: A GUESS THE OPERATOR CANNOT OVERRIDE --------------------------
+    # #1380 fixed the shape where the guess was ALONE; the bare `#N` the pane
+    # attributes was left on purpose and the operator asked for it on
+    # 2026-09-08. These three rows are the ways that widening can be undone or
+    # mis-worded while every OTHER mention test stays green.
+    ("K45", "deletion", "the guessed-repo offer narrows back to the guess that "
+                        "is ALONE, so a bare `#N` the pane mis-attributes is "
+                        "again a two-row picker with no way to say 'not that "
+                        "repo'",
+     "    guessed_offer = guessed and not offered_universe\n",
+     "    guessed_offer = (guessed and not offered_universe\n"
+     "                     and len(candidates) == 1)\n",
+     "the two-row picker is unchanged"),
+    ("K46", "deletion", "the guessed row's POSITION stops being measured and is "
+                        "hardcoded to 1, so a bare `#N` tells the operator the "
+                        "clawgate task is the guess and the guess is the task",
+     '    guess_rank = next((i for i, c in enumerate(candidates, 1)\n'
+     '                       if c["platform"] == PLATFORM_GITHUB), 1) if guessed else 1\n',
+     "    guess_rank = 1\n",
+     "#1291 names no repository. Row 1"),
+    ("K47", "widening", "the universe is PREPENDED rather than appended, so the "
+                        "common case opens on a fuzzy-matched stranger instead "
+                        "of the clawgate task",
+     "            candidates = candidates + extra\n",
+     "            candidates = extra + candidates\n",
+     "the MEASURED rows must stay on top"),
     ("K36", "deletion", "the alacritty wrapper drops `pkgs.git` from the hint's "
                         "PATH: `git` is then absent under the display manager's "
                         "environment, FileNotFoundError is caught as OSError, "
@@ -475,6 +501,7 @@ TARGETS: dict[str, pathlib.Path] = {
     "K29": OPEN_, "K30": OPEN_, "K31": OPEN_, "K32": OPEN_,
     "K33": OPEN_, "K34": OPEN_, "K35": OPEN_,
     "K37": OPEN_, "K38": OPEN_, "K39": OPEN_,
+    "K45": OPEN_, "K46": OPEN_, "K47": OPEN_,
     "K40": ALACRITTY, "K41": SCAN, "K42": ALACRITTY,
     # 🔴 A FOURTH FILE, AND A NIX ONE. The wrapper's PATH is a seam between two
     # files in two languages that agree only by coincidence, and both directions

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -1653,20 +1653,40 @@ def test_the_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
     _no_universe_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
 
 
-def test_the_note_is_NOT_attached_to_the_ordinary_bare_hash_N_picker(monkeypatch):
-    """🔴 THE NEGATIVE CONTROL FOR THE NOTE, and it guards the most common
-    interaction in this handler. A bare `#N` with a pane repo has been a
-    two-row picker since before any of this; putting a line of apology above it
-    would tax every single click. The note rides ONLY on the one-row picker the
-    suppression created."""
+def test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess(monkeypatch):
+    """🔴 SUPERSEDES `test_the_note_is_NOT_attached_to_the_ordinary_bare_hash_N_
+    picker`, WHICH PINNED `mesg == ""` AND `2` ROWS ON PURPOSE.
+
+    That test's claim was that a bare `#N` with a pane repo is not a dead end,
+    so a note above it would be "a line of apology" taxing every click. Half of
+    it survives — the two measured rows are still FIRST, so the common case is
+    still one Enter — and half is OVERRULED: the OPERATOR asked for the universe
+    here on 2026-09-08 ("fix the bare-#N and any other cases left unfixed"),
+    because when the pane guess is wrong the right repo was unreachable. Once
+    several hundred rows are in the list, an unexplained picker is the bug and
+    the note is what stops it reading as one.
+
+    ⚠ THE NOTE MUST NAME THE ROW, NOT "THE FIRST ROW". The guess is at row 2
+    here — the clawgate task is above it — and #1380's wording said FIRST
+    unconditionally, which was true only of the `audit-pr` shape."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [])
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     seen = {}
-    monkeypatch.setattr(MO, "pick",
-                        lambda c, mesg="": seen.update(n=len(c), mesg=mesg) or "")
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
     assert MO.main(["#1291"]) == 0
-    assert seen["n"] == 2, seen
-    assert seen["mesg"] == "", seen
+    urls = [c["url"] for c in seen["rows"]]
+    # clawgate, the pane guess, then the three FAKE_UNIVERSE repos.
+    assert len(urls) == 5, urls
+    assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", urls
+    assert "wrongorg/wrongrepo" in urls[1], urls
+    assert "Row 2" in seen["mesg"], seen["mesg"]
+    assert "3 rows below it" in seen["mesg"], seen["mesg"]
+    assert "guess" in seen["mesg"].lower(), seen["mesg"]
+    assert "nothing here knows" not in seen["mesg"], seen["mesg"]
+    _no_universe_token_anywhere(seen["mesg"], "BARE-HASH-N GUESS NOTE")
 
 
 @pytest.mark.parametrize("text,expected", [
@@ -2108,9 +2128,18 @@ def test_the_picker_NOTE_never_names_a_universe_row(universe, monkeypatch,
 
 
 def test_the_ORDINARY_picker_gets_no_note(spy, monkeypatch):
-    """The bare `#N` picker — clawgate plus a pane-attributed GitHub row — is
-    not a dead end. Putting a line of apology above the single most common
-    interaction in this handler would be a regression dressed as a diagnosis."""
+    """A picker whose every row is EVIDENCE is not a dead end and needs no
+    explanation.
+
+    🔴 ITS SCOPE NARROWED ON 2026-09-08 AND THE DOCSTRING IS REWRITTEN RATHER
+    THAN LEFT TO ROT. It used to claim the bare `#N` picker never carries a
+    note. That is no longer true on a real host: the universe is now appended
+    beneath the guess, and a several-hundred-row picker with no explanation is
+    the bug, not the note. What this pins now is the DEGENERATE host the `spy`
+    fixture happens to build — its whole universe is the pane's own repo, so the
+    dedupe appends nothing, there is nothing to search, and the two measured
+    rows still speak for themselves. A comment claiming the wider coverage would
+    read as a guard on the common path while guarding only this corner."""
     seen = {}
     monkeypatch.setattr(
         MO, "pick",
@@ -2148,12 +2177,28 @@ def test_the_picker_passes_its_NOTE_to_rofi_as_mesg(monkeypatch):
     assert "-mesg" not in seen["cmd"], seen["cmd"]
 
 
-def test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe(
+def test_a_bare_hash_N_that_the_PANE_attributes_gets_the_universe_BELOW_it(
         spy, universe):
-    """The universe is the LAST resort. A measured pane repo is evidence, and
-    burying it under 300 options would be a regression dressed as a feature."""
+    """🔴 SUPERSEDES `test_a_bare_hash_N_that_the_PANE_already_attributes_does_
+    NOT_get_the_universe`, WHOSE ASSERTION WAS `("pick", 2) in spy`.
+
+    Its argument — "the universe is the LAST resort; a measured pane repo is
+    evidence, and burying it under 300 options would be a regression dressed as
+    a feature" — is a real prior decision, taken in #1380 and written down
+    there. The OPERATOR overruled it on 2026-09-08, asking explicitly for "the
+    bare-#N and any other cases left unfixed": a pane repo is evidence about the
+    WINDOW, not about the reference, and when it is wrong the two-row picker
+    offered no way to say so. Same defect as `audit-pr N`, one rung along.
+
+    🔴 WHAT SURVIVES OF THE OLD CLAIM IS PINNED HERE, NOT DROPPED. The two
+    MEASURED rows stay first, in their old order — clawgate, then the pane's
+    GitHub repo — so the common case is still one Enter and rofi still opens on
+    the clawgate row. The universe is strictly APPENDED."""
     assert MO.main(["#370"]) == 0
-    assert ("pick", 2) in spy, spy
+    # clawgate + the pane repo + the three FAKE_UNIVERSE repos, deduped.
+    assert ("pick", 5) in spy, spy
+    assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks/370"), (
+        "the clawgate row must still be the first, default-selected one")
 
 
 @pytest.fixture
@@ -2664,7 +2709,7 @@ def test_systemctl_is_MENTIONED_but_never_SPAWNED():
 # everywhere else a repository cannot be named; this arm just never reached it.
 # --------------------------------------------------------------------------- #
 def _guessed_picker(monkeypatch, *, universe, pane="wrongorg/wrongrepo",
-                    mapping=FAKE_UNIVERSE):
+                    mapping=FAKE_UNIVERSE, text="audit-pr 1291"):
     """Drive `main()` down the guessed-repo path and return what `pick` saw.
 
     ⚠ `mapping` IS A PARAMETER BECAUSE `universe=[]` DOES NOT EMPTY THE UNIVERSE.
@@ -2672,14 +2717,19 @@ def _guessed_picker(monkeypatch, *, universe, pane="wrongorg/wrongrepo",
     caller that clears only the file still gets every mapped repo — my own
     empty-universe test asserted 1 row and got 4 for exactly that reason. The
     empty case needs BOTH sources cleared, and that is worth a parameter rather
-    than a comment, because the trap is silent in the other direction too."""
+    than a comment, because the trap is silent in the other direction too.
+
+    ⚠ `text` IS A PARAMETER BECAUSE THE DEFECT HAS TWO SHAPES, and they differ
+    in exactly the way that broke the note: `audit-pr N` offers the guess at row
+    1, a bare `#N` offers the clawgate task first and the guess at row 2. A
+    helper hard-wired to one of them is how the second went unfixed."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(mapping))
     monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: list(universe))
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: pane)
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
-    assert MO.main(["audit-pr 1291"]) == 0
+    assert MO.main([text]) == 0
     return seen
 
 
@@ -2766,3 +2816,295 @@ def test_an_EXPLICIT_owner_still_opens_directly_and_gets_NO_picker(monkeypatch):
     assert MO.main(["civitai/talos-infra#1065"]) == 0
     assert picked == [], "an explicit owner must not raise a picker"
     assert opened == ["https://github.com/civitai/talos-infra/issues/1065"], opened
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE SAME DEFECT ONE RUNG ALONG — THE BARE `#N` THE PANE ATTRIBUTES
+#
+# 2026-09-08, operator: "fix the bare-#N and any other cases left unfixed".
+#
+# #1380 closed the shape where the guess was ALONE (`audit-pr N`) and wrote
+# down, in the handler and in
+# `test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe`,
+# that it was deliberately leaving the two-row shape alone: "burying two good
+# rows under several hundred is a regression dressed as a feature", and the
+# trade belonged to the operator. The operator has now made it. The rows that
+# were MEASURED stay on top — that half of the old claim is still pinned, in the
+# superseding test above and in the ordering test below — and the universe goes
+# underneath.
+#
+# Everything here drives `main()` rather than a helper, because a correct helper
+# `main()` never calls is the failure mode this file has already had.
+# --------------------------------------------------------------------------- #
+def test_a_bare_hash_N_offers_the_universe_UNDER_the_two_measured_rows(
+        monkeypatch):
+    """🔴 THE REGRESSION FOR THE 2026-09-08 REPORT. Red before this change: the
+    picker held exactly TWO rows and the pane's repo was the only GitHub one, so
+    a wrong pane guess left the right repository unreachable."""
+    seen = _guessed_picker(monkeypatch, text="#1291",
+                           universe=[UNIVERSE_ONLY, "acme/widget"])
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) > 2, f"the two-row picker is unchanged: {urls}"
+    assert any(UNIVERSE_ONLY in u for u in urls), (
+        f"the universe never reached the bare-#N picker: {urls}")
+    assert any("acme/widget" in u for u in urls), urls
+    assert all(u.endswith("/1291") for u in urls), urls
+
+
+def test_the_bare_hash_N_ORDER_is_clawgate_then_the_guess_then_the_universe(
+        monkeypatch):
+    """🔴 THE HALF OF THE SUPERSEDED TEST'S CLAIM THAT SURVIVES, PINNED AS AN
+    ORDERING RATHER THAN AS A ROW COUNT.
+
+    The common case must stay one or two keystrokes: rofi opens on row 1, so the
+    clawgate task is still one Enter and the pane's repo is one arrow key away.
+    Every universe row must sit BELOW both.
+
+    ⚠ THE ROW-COUNT FLOOR IS WHAT MAKES THIS A REGRESSION TEST RATHER THAN AN
+    INVARIANT GUARD. Without it the two positional assertions are satisfied by
+    the PRE-CHANGE two-row picker — there is simply nothing at index 2 to be
+    out of order — so it would have been green at base while claiming to pin the
+    ordering the change introduces."""
+    seen = _guessed_picker(monkeypatch, text="#1291",
+                           universe=[UNIVERSE_ONLY, "acme/widget"])
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) == 7, urls
+    assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", (
+        f"the MEASURED rows must stay on top: {urls}")
+    assert urls[1] == "https://github.com/wrongorg/wrongrepo/issues/1291", (
+        f"the MEASURED rows must stay on top: {urls}")
+    assert not any(UNIVERSE_ONLY in u or "acme/widget" in u for u in urls[:2]), urls
+    assert UNIVERSE_ONLY in "\n".join(urls[2:]), urls
+
+
+def test_the_bare_hash_N_note_names_the_GUESSED_ROWS_POSITION(monkeypatch):
+    """🔴 THE WORDING DEFECT WIDENING THE ARM CREATES, AND THE REASON
+    `guessed_note` GREW A `rank`. #1380's multi-row wording opened "The FIRST
+    row is a guess from the tmux pane" — true of `audit-pr N`, FALSE here, where
+    row 1 is the clawgate task and the guess is row 2. Pointing the operator at
+    the wrong row is worse than saying nothing: they would distrust the clawgate
+    task and trust the guess.
+
+    Pinned as the WHOLE normalised string, because a guard on the words `guess`
+    and `tmux pane` is walkable by a reword that still names the wrong row."""
+    seen = _guessed_picker(monkeypatch, text="#1291",
+                           universe=[UNIVERSE_ONLY, "acme/widget"])
+    assert seen["mesg"] == (
+        "#1291 names no repository. Row 2 is a guess from the tmux pane, which "
+        "may not be the pane you clicked in — the 5 rows below it are every "
+        "repository this host knows. Type to search, or dismiss."), seen["mesg"]
+    _no_universe_token_anywhere(seen["mesg"], "BARE-#N GUESS-NOTE DISCLOSURE")
+
+
+def test_the_audit_pr_note_still_names_ROW_1(monkeypatch):
+    """The other half of the same pin — the shape #1380 fixed must not have its
+    row number silently shifted by the `rank` parameter. Its guess is row 1."""
+    seen = _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY, "acme/widget"])
+    assert seen["mesg"] == (
+        "audit-pr 1291 names no repository. Row 1 is a guess from the tmux "
+        "pane, which may not be the pane you clicked in — the 5 rows below it "
+        "are every repository this host knows. Type to search, or dismiss."), (
+            seen["mesg"])
+
+
+def test_the_bare_hash_N_guess_is_NEVER_opened_unconfirmed(monkeypatch):
+    """🔴 THE SAFETY PROPERTY, RE-ASSERTED FOR THIS SHAPE. Widening the offer
+    must not weaken the rule. `open_url` is reachable here only through a
+    selection, and there is none.
+
+    ⚠ INVARIANT GUARD, NOT A REGRESSION TEST — green at base 18bc1500 too,
+    because #1336 already suppressed the auto-open for this rung. It is here to
+    catch the widening WEAKENING it, which is a different failure from the one
+    being fixed."""
+    opened = []
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    _guessed_picker(monkeypatch, text="#1291", universe=[UNIVERSE_ONLY])
+    assert opened == [], f"a guessed repo was opened without a selection: {opened}"
+
+
+def test_a_bare_hash_N_whose_universe_ADDS_NOTHING_keeps_the_two_row_picker(
+        monkeypatch):
+    """⚠ THE DEGENERATE HOST, AND THE REASON THE APPEND IS GUARDED ON `extra`
+    RATHER THAN ON `universe`. When the only repository this host knows IS the
+    pane's, the dedupe leaves nothing to append — so there is nothing to
+    explain, and a note claiming "the N rows below it" would name rows that are
+    not in the list. The picker stays two rows and stays silent.
+
+    ⚠ INVARIANT GUARD — green at base 18bc1500 too. It pins the boundary the
+    widening must NOT cross, not behaviour the widening created."""
+    seen = _guessed_picker(monkeypatch, text="#1291",
+                           universe=["wrongorg/wrongrepo"],
+                           mapping={"wr": "wrongorg/wrongrepo"})
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) == 2, urls
+    assert seen["mesg"] == "", seen["mesg"]
+
+
+def test_the_guessed_row_is_not_offered_twice_on_the_bare_hash_N_path_either(
+        monkeypatch):
+    """The dedupe is at the `main()` level rather than inside the `audit-pr`
+    arm, so it covers this shape too. A pane repo that is ALSO in the universe
+    appears exactly once.
+
+    ⚠ THE COUNT IS ASSERTED FIRST FOR THE SAME REASON AS THE ORDERING TEST: a
+    two-row picker has no duplicates either, so without it this would be green
+    at base. Three mapped repos + two universe rows = five distinct
+    repositories, one of which IS the pane's, so the append contributes four
+    beneath the two measured rows."""
+    seen = _guessed_picker(monkeypatch, text="#1291",
+                           universe=["wrongorg/wrongrepo", "acme/widget"])
+    urls = [c["url"] for c in seen["rows"]]
+    assert len(urls) == 6, urls
+    assert len(urls) == len(set(urls)), f"duplicate rows: {urls}"
+    assert sum("wrongorg/wrongrepo" in u for u in urls) == 1, urls
+
+
+def test_the_DEFAULT_REPO_FLAG_rides_the_same_rung_as_the_pane(monkeypatch):
+    """🔴 `--default-repo` IS THE SAME LADDER RUNG AS `tmux_pane_repo()`, and the
+    predicate is `repo_source == default` rather than "the pane answered". With
+    the pane silent, the flag alone must still produce an overridable offer —
+    otherwise a caller could re-open the exact hole this change closes by
+    handing the guess in from outside."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    seen = {}
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
+    assert MO.main(["--default-repo", "wrongorg/wrongrepo", "#1291"]) == 0
+    urls = [c["url"] for c in seen["rows"]]
+    assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", urls
+    assert urls[1] == "https://github.com/wrongorg/wrongrepo/issues/1291", urls
+    assert any(UNIVERSE_ONLY in u for u in urls), urls
+    assert "Row 2" in seen["mesg"], seen["mesg"]
+
+
+def test_a_bare_hash_N_with_NO_pane_repo_is_UNCHANGED_by_this_widening(
+        monkeypatch):
+    """🔴 THE UNTOUCHED NEIGHBOUR. Nothing attributed this `#N`, so there is no
+    guess to override and PASS 3's own arm — not the guessed one — appends the
+    universe. It must still do so, and it must still carry NO note: the rows are
+    a real clawgate task plus a list, with nothing being recommended.
+
+    ⚠ INVARIANT GUARD — green at base 18bc1500 too, by design: "unchanged" is
+    the whole claim."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    seen = {}
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": seen.update(rows=list(c), mesg=mesg) or "")
+    assert MO.main(["#1291"]) == 0
+    urls = [c["url"] for c in seen["rows"]]
+    assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", urls
+    assert len(urls) == 4, urls
+    assert seen["mesg"] == "", seen["mesg"]
+
+
+@pytest.mark.parametrize("text,expected", [
+    # `mapped` — the operator named the repo, the mapping supplied the owner.
+    # DELIBERATELY NOT WIDENED, and the reasoning is in the PR body: the TEXT is
+    # evidence about the REFERENCE, `regen-known-repos.py` drops a bare name two
+    # owners share rather than picking one (so a `mapped` hit is unique on this
+    # host by construction), and the mapping's AGE already reaches the operator
+    # through `staleness_note`. Putting a several-hundred-row picker in front of
+    # every `repo#N` would tax the shape that carries its own evidence.
+    ("loamfield#12", "https://github.com/gardenersguild/trowelcast/issues/12"),
+    # `explicit` — the strongest rung there is.
+    ("civitai/talos-infra#1065",
+     "https://github.com/civitai/talos-infra/issues/1065"),
+])
+def test_the_TEXTS_OWN_evidence_still_opens_with_ZERO_keystrokes(monkeypatch,
+                                                                text, expected):
+    """🔴 THE NEGATIVE CONTROL FOR THE WIDENING. A rule that appended the
+    universe to every candidate — or that read `guessed` as "the text named no
+    OWNER" rather than "the ladder answered from `default`" — would satisfy
+    every assertion above while putting a picker in front of the two shapes that
+    already know the answer. Both must still open directly, and a WRONG pane
+    repo is loaded so a guess leaking into these paths is visible.
+
+    ⚠ INVARIANT GUARD / NEGATIVE CONTROL — green at base 18bc1500 too."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": pytest.fail(f"asked about {text}"))
+    opened = []
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    assert MO.main([text]) == 0
+    assert opened == [expected], opened
+
+
+def test_a_SIX_DIGIT_click_is_STILL_a_toast_with_a_pane_repo_loaded(monkeypatch):
+    """🔴 THE OTHER NEGATIVE CONTROL. `#282828` is a colour literal; every row a
+    picker could offer names an issue no repository has. `colour` bars the
+    universe before any of this, and a pane repo must not sneak it back in — the
+    scanner refuses the text, so `span is None`, so `guessed` is False.
+
+    ⚠ INVARIANT GUARD / NEGATIVE CONTROL — green at base 18bc1500 too."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": pytest.fail("raised a picker"))
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(tuple(a)))
+    assert MO.main(["#282828"]) == 1
+    assert notices, "no toast at all"
+    body = " ".join(notices[-1])
+    assert "colour literal" in body, body
+    _no_universe_token_anywhere(body, "COLOUR-TOAST DISCLOSURE")
+
+
+def test_PRINT_mode_on_a_bare_hash_N_lists_the_CANDIDATES_not_the_universe(
+        monkeypatch, capsys):
+    """🔴 THE DISCLOSURE CONTROL FOR THE WIDENED ARM. `--print` returns before
+    the guessed branch AND `may_offer_universe` is false under it, so the
+    universe is doubly barred — but widening an arm is exactly the kind of
+    change that reaches a path by accident, and the leak here would be private
+    repository names on stdout.
+
+    ⚠ INVARIANT GUARD / NEGATIVE CONTROL — green at base 18bc1500 too."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    monkeypatch.setattr(MO, "pick",
+                        lambda c, mesg="": pytest.fail("--print raised a picker"))
+    assert MO.main(["--print", "#1291"]) == 0
+    out = capsys.readouterr().out
+    # POSITIVE CONTROL: it really did resolve and print something.
+    assert "https://clawgate.zacx.dev/tasks/1291" in out, out
+    assert len(out.strip().splitlines()) == 2, out
+    assert UNIVERSE_ONLY not in out, out
+    _no_universe_token_anywhere(out, "PRINT-MODE DISCLOSURE")
+
+
+def test_the_universe_reaches_ROFI_AND_NO_OTHER_SINK_on_the_bare_hash_N_path(
+        monkeypatch, capsys, real_notify):
+    """🔴 THE WIDENED ARM'S DISCLOSURE GUARD, through the REAL `notify()`.
+    `_every_sink` folds stdout, stderr and every `notify-send` argv into one
+    string; a universe row may appear in the rofi rows and NOWHERE in it.
+
+    POSITIVE CONTROL: the same run's picker rows are asserted to CONTAIN a
+    universe token, so a version of this test that scanned an empty universe
+    could not pass by finding nothing."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: [UNIVERSE_ONLY])
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    seen = {}
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": seen.update(rows=MO.picker_rows(c), mesg=mesg) or "")
+    assert MO.main(["#1291"]) == 0
+    rows = "\n".join(seen["rows"])
+    assert UNIVERSE_ONLY in rows, (
+        f"POSITIVE CONTROL FAILED — no universe row was offered at all: {rows}")
+    assert any(t in rows for t in FAKE_UNIVERSE_TOKENS), rows
+    blob = _every_sink(capsys, real_notify)
+    _no_universe_token_anywhere(blob, "BARE-#N EVERY SINK")
+    for token in (UNIVERSE_ONLY, UNIVERSE_ONLY.split("/")[0],
+                  UNIVERSE_ONLY.split("/")[1]):
+        assert token not in blob, (
+            f"a universe row reached a sink that is not rofi: {token!r}")


### PR DESCRIPTION
## The defect, and what #1380 left open

A candidate the handler offers can come from several rungs of `mention_scan`'s
attribution ladder. In the **terminal** profile only three occur: `explicit`
(the operator wrote `owner/repo#N`), `mapped` (the text named the repo, the
mapping supplied the owner) and `default` (the repo came from
`tmux_pane_repo()` or `--default-repo`). The first two are evidence **about the
reference**; `default` is evidence **about the window**, and it is frequently
wrong.

The defect class is *a guessed repository the operator cannot override.*
#1380 closed it for the shape where the guess was **alone** (`audit-pr N`) and
deliberately left the bare `#N` alone, writing the trade down in the handler
and in `test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe`:
burying two good rows under several hundred looked like "a regression dressed
as a feature", and the choice belonged to the operator.

**The operator made it on 2026-09-08** — *"fix the bare-#N and any other cases
left unfixed"* — because when the pane guess is wrong the right repository is
unreachable. Same defect, one rung along.

## What changed

The offer is now scoped to `repo_source == default` **alone**, not to that rung
*plus* being the only row. Everything already in the list keeps its position;
the fuzzy universe is appended beneath it.

Two things the widening required:

* **`guessed_note` grew a `rank`.** Its multi-row wording opened *"The FIRST row
  is a guess"* — true of `audit-pr N`, **false** of a bare `#N`, where row 1 is
  the clawgate task and the guess is row 2. Pointing the operator at the wrong
  row is worse than saying nothing: they would distrust the task and trust the
  guess. The note now names the measured row number.
* **The append is guarded on what it actually ADDS**, not on the universe being
  non-empty. A host whose whole universe is the pane's own repo dedupes to
  nothing, and `offered_universe` would then have claimed rows that were not in
  the list — to the auto-open guard as well as to the note. `guessed_note` is
  keyed on `below` (rows genuinely searchable under the guess) rather than a row
  count for the same reason: "type to search" is nonsense with nothing to
  search.

## The whole class, enumerated and classified

Every terminal path through `main()`. "Unoverridable?" means: does the handler
act on, or offer without alternatives, a repository the operator cannot correct?

| # | shape | rung | before | after | unoverridable? |
|---|---|---|---|---|---|
| 1 | `868abc123` (ClickUp) | n/a | opens directly | unchanged | no — the id *is* the reference |
| 2 | `owner/repo#N` | `explicit` | opens directly, 0 keystrokes | **unchanged** | no — negative control |
| 3 | `repo#N`, mapping resolves | `mapped` | opens directly | **unchanged, deliberately** — see below | no (argued) |
| 4 | `repo#N`, mapping does not resolve | none | universe picker + `universe_note` | unchanged | no |
| 5 | **`#N` + pane repo** | `default` | **2 rows, no note, no way out** | clawgate, guess, then the universe; note names row 2 | **WAS YES — FIXED** |
| 6 | `#N`, no pane repo | none | clawgate + universe, no note | unchanged | no |
| 7 | `audit-pr N` + pane repo | `default` | guess + universe (#1380) | unchanged behaviour, note reworded | no — re-verified |
| 8 | `audit-pr N`, no pane repo | none | universe picker | unchanged | no |
| 9 | `--default-repo X` with 5 or 7 | `default` | same rung as the pane | same fix, via the same predicate | covered |
| 10 | `#282828` (six digits) | n/a | named toast, no picker | **unchanged** | no — deliberately not a picker |
| 11 | `--print <unresolvable>` | n/a | refuses, never lists repos | **unchanged** | no |
| 12 | `--print <resolvable>` | any | prints the URL(s) | unchanged | no |
| 13 | `--no-discovery` | n/a | text-only resolution | unchanged | no |

### Not fixed, on purpose

**Case 3, `mapped`.** A stale or wrong mapping row *is* an answer the operator
cannot override in the picker — but I think it is correct as-is, and I did not
change it:

* the TEXT named the repository, so the answer is evidence **about the
  reference**, not about the window. That is the whole distinction the
  suppression is built on;
* `regen-known-repos.py` **drops a bare name two owners share** rather than
  picking one (measured there: 7 collisions, 14 repos), so a `mapped` hit is
  unique on this host by construction — it is not a coin flip;
* the mapping's staleness already reaches the operator: `staleness_note()` fires
  past `STALE_MAPPING_DAYS` and names the failing refresh unit, and
  `universe_note` carries the generation date above every universe picker;
* the cost of "fixing" it is a several-hundred-row picker in front of every
  `repo#N`, which is exactly what the `explicit` negative control forbids.

The residual — a mapping that is *silently wrong* — is answered by writing
`owner/repo#N` (already the advice `refuse()` prints) or regenerating. **Flagging
it rather than changing it.**

**Case 6, `#N` with no pane repo**, gets the universe with **no note**. The
picker's rows are a real clawgate task plus a list, with nothing being
recommended, so there is no guess to explain — but the several-hundred-row list
is arguably unexplained. Left alone: it is a cosmetic question, not the defect
class, and it is a separate decision from the one asked for.

**Case 12 observation, not changed:** `--print '#N'` with a pane repo prints the
pane-guessed GitHub URL alongside the clawgate one. `--print` is non-interactive
and prints *every* candidate by contract; it never gets the universe (pinned).
Recording it here rather than silently altering a machine-readable contract.

## Superseded, not deleted

Two tests pinned the old behaviour on purpose. Both are rewritten to assert the
new intent and to record **who asked and when**, keeping the half of their claim
that survives — the measured rows come FIRST, in that order:

* `test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe`
  → `test_a_bare_hash_N_that_the_PANE_attributes_gets_the_universe_BELOW_it`
* `test_the_note_is_NOT_attached_to_the_ordinary_bare_hash_N_picker`
  → `test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess`

`test_the_ORDINARY_picker_gets_no_note` keeps its name but its docstring is
rewritten: it used to claim the bare `#N` picker *never* carries a note, which
is now false on a real host. What it pins now is the degenerate universe its
fixture builds.

## Test matrix — base `18bc1500`, head `b2190536`

**9 red at base, all 185 green at head.** Measured by extracting `18bc1500` with
`git archive | tar -x` and dropping the NEW test file on the PRISTINE base
handler (blob `7afe7396`, verified by `git hash-object`). Every one is a real
assertion FAILURE at base, not a collection error.

```
FAILED test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess
FAILED test_a_bare_hash_N_that_the_PANE_attributes_gets_the_universe_BELOW_it
FAILED test_a_bare_hash_N_offers_the_universe_UNDER_the_two_measured_rows
FAILED test_the_bare_hash_N_ORDER_is_clawgate_then_the_guess_then_the_universe
FAILED test_the_bare_hash_N_note_names_the_GUESSED_ROWS_POSITION
FAILED test_the_audit_pr_note_still_names_ROW_1
FAILED test_the_guessed_row_is_not_offered_twice_on_the_bare_hash_N_path_either
FAILED test_the_DEFAULT_REPO_FLAG_rides_the_same_rung_as_the_pane
FAILED test_the_universe_reaches_ROFI_AND_NO_OTHER_SINK_on_the_bare_hash_N_path
9 failed, 176 passed          # at base
185 passed                    # at head
```

Two of these were **vacuous on the first attempt** and were strengthened after
watching them pass at base: the ordering test and the dedupe test are both
satisfied by a two-row picker (nothing at index 2 can be out of order; two rows
have no duplicates). Both now assert a row-count floor first, and both go red.

The remaining new tests are **INVARIANT GUARDS, labelled as such in their own
docstrings** — green at base too, by design: the auto-open suppression, the
degenerate-universe boundary, the untouched `#N`-with-no-pane neighbour, and the
three negative controls.

### Negative controls (all green at base and head)

* `owner/repo#N` and `repo#N` still open with **zero keystrokes**, driven with a
  WRONG pane repo loaded so a guess leaking into those paths would be visible.
* `#282828` still produces the named colour-literal toast, no picker, with a
  pane repo loaded.
* `--print '#N'` prints exactly its 2 candidates, raises no picker, and no
  universe token reaches stdout.

### Disclosure

`test_the_universe_reaches_ROFI_AND_NO_OTHER_SINK_on_the_bare_hash_N_path`
drives the widened arm through the **real** `notify()` and folds stdout, stderr
and every `notify-send` argv through `_every_sink`, then asserts
`_no_universe_token_anywhere` plus the three `UNIVERSE_ONLY` spellings. Its
**positive control** asserts a universe row really did reach the picker rows, so
it cannot pass by scanning an empty universe. The note itself is checked with
`_no_universe_token_anywhere` too.

### Mutation coverage

Three rows added to `scripts/tests/mutation_battery_mentions.py`, anchors
verified unique by `test_mutation_battery_anchors.py`, and **watched to kill**:

```
P1   control      KILLED              f=20  p=419   positive control — the battery can observe
K45  deletion     KILLED(attributed)  f=8   p=431   the offer narrows back to the guess that is ALONE
K46  deletion     KILLED(attributed)  f=3   p=436   guess_rank hardcoded to 1
K47  widening     KILLED(attributed)  f=5   p=434   the universe is PREPENDED, not appended
4/4 killed for the stated reason; problems: none
```

Tree restored afterwards and verified by `git hash-object`, not by the
battery's own `restore: OK` line.

## Gate — both tiers, on the MERGED tree

`origin/main` is `18bc1500` and this branch fast-forwards from it, so the merged
tree **is** `b2190536`. Both tiers run against that sha.

**Dev host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`:

```
FAIL  scripts/tests  (collected=12877 passed=12870 skipped=0 failed=7 errors=0)
PASS  node  (suites=5 files=41 tests=1449 pass=1449 fail=0)
GATE: RESULT=FAIL exit=1
```

**Sandbox** (the tier Tekton runs), extracted with `git archive HEAD | tar -x`
into a dir with no `.git`, built **one derivation at a time**:

```
nix build path:<tmpdir>#checks.x86_64-linux.pytests    RESULT: FAIL (exit=1)
    FAIL  scripts/tests  (collected=12877 passed=12870 skipped=0 failed=7 errors=0)
nix build path:<tmpdir>#checks.x86_64-linux.nodetests  RESULT: PASS (exit=0)
    TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0
```

🔴 **The 7 pytest failures are PRE-EXISTING RED ON `main`, not this change** —
and that is a measurement, not a theory. The discriminating control was run in
**both** tiers against base `18bc1500`:

* dev host, base: the same 7 test names fail (`7 failed, 406 passed`);
* sandbox, base: `nix build path:<base>#…pytests` → `FAIL  scripts/tests
  (collected=12863 passed=12856 skipped=0 failed=7 errors=0)`.

Base vs head in the sandbox tier: **collected +14, passed +14, failed unchanged
at 7** — the +14 is exactly this PR's new tests.

The 7 are `age`-version behaviour and an `opencode`-version pin, in files this
diff does not touch:

```
test_analyze_service_index_escrow_verify.py::test_a_TAMPERED_or_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_not_EMPTY  (x3)
test_analyze_service_index_escrow_verify.py::test_every_decrypt_family_VERDICT_is_pinned_WHOLE
test_analyze_service_index_escrow_verify.py::test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret
test_analyze_service_index_backup.py::test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr
test_opencode_engine.py::test_engine_is_the_version_every_measurement_is_keyed_to   # opencode on PATH is 1.18.29, pin says 1.18.21
```

They are a real problem on `main` and somebody should own them; they are not
this diff's, and the delta above is what says so.

## Live click path — measured, nothing raised

`rofi`, `xdg-open` and `notify-send` replaced by stubs on `PATH` (rofi dumps
stdin and exits 1 = dismissed), against the REAL host mapping, universe and tmux
pane. **No window was raised and no workspace was switched.** The handler blob
probed is `c30ee598`, byte-identical to `HEAD:scripts/mention-open.py`. Rows are
joined with `\n`, so the counts below add the one `wc -l` under-reports.

| click | rows (base → head) | first row | note |
|---|---|---|---|
| `audit-pr 1291` | 392 → **392** | `github 1291 — …/innovation-upstream/devrc/issues/1291` (the pane guess) | reworded: *"…Row 1 is a guess from the tmux pane… the 391 rows below it are every repository this host knows. Type to search, or dismiss."* |
| `#1291` | **2 → 393** | `clawgate task 1291 — https://clawgate.zacx.dev/tasks/1291` (unchanged) | **new**: *"#1291 names no repository. Row 2 is a guess from the tmux pane… the 391 rows below it are every repository this host knows. Type to search, or dismiss."* |
| `civitai/talos-infra#1065` | 0 → **0** | — (no picker) | none; `xdg-open https://github.com/civitai/talos-infra/issues/1065`, rc 0 |
| `#282828` | 0 → **0** | — (no picker) | none; toast *"cannot resolve '#282828' / #282828 is six digits — that looks like a colour literal…"*, rc 1 |

The `#1291` row is the fix: 2 rows → 393, **with row 1 and row 2 unmoved**, so
the common case is still one Enter and the wrong guess is now escapable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1h5KrSQj42u746XYVWiGh
