### PR TITLE
fix(toolchain): the 7 gate failures are nixpkgs drift, not a PR — re-derive the opencode pin, and re-key the age tamper verdict that 1.3.2 broke

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -359,7 +359,7 @@ disaster-recovery key gets rotated, or a tampered backup gets waved through:
 | `28` `NO-ARTIFACT` | zero objects under the prefix | wrong `--host`/prefix, or the backups are gone — `restore-verify.py` diagnoses which |
 | `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |
 | `30` `ARTIFACT-UNREADABLE` | failed before the key was used | diagnose the object, not the key |
-| `25` `DECRYPT-FAILED` | age wrote **nothing**: wrong key **or** damaged header — **not separable** | try a **different** artifact (`--scope <other>`) with the same escrowed copy: if another opens, the key is fine and this object's header is damaged. **Do not rotate first.** |
+| `25` `DECRYPT-FAILED` | age refused **before the payload**: wrong key **or** damaged header — **not separable**. ⚠ The same code also carries a second message, *"CANNOT SAY WHY"*, when age refuses in a way this tool cannot read — then **three** causes stay open, corruption included. Read the sentence, not just the number. | try a **different** artifact (`--scope <other>`) with the same escrowed copy: if another opens, the key is fine and this object's header is damaged. **Do not rotate first.** |
 | `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed the payload | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
 | `31` `ARTIFACT-EMPTY` | age exited **zero** on an empty payload (**the key worked**) | the artifact holds nothing; do not rotate |
 | `26` `RESTORE-FAILED` | decrypted fine, the git bundle is bad | artifact fault; do not rotate |
@@ -368,11 +368,35 @@ disaster-recovery key gets rotated, or a tampered backup gets waved through:
 the `--host` prefix trap `restore-verify.py` documents), and neither is a verdict
 on the escrow.
 
-Measured (age v1.3.1, many offsets and sizes): a wrong key or a damaged header
-leaves **no** plaintext file, while payload corruption and truncation leave one —
-because age writes output *before* authenticating the payload. That, plus a
-machine-readable cause published by `restore-verify.py`, is what separates the
-rows; none of it is parsed out of age's stderr.
+🔴 **HOW `25` AND `33` ARE TOLD APART — AND HOW THAT GOT WEAKER (2026-09-08).**
+
+Originally: measured on age **v1.3.1**, a wrong key or a damaged header left
+**no** plaintext file, while payload corruption and truncation left one, because
+age created its `--output` as soon as it had authenticated the header. File
+presence therefore *was* the discriminator, and none of it was parsed out of
+age's stderr.
+
+**age v1.3.2 took that away.** It creates `--output` **lazily**, on the first
+successful write — re-measured 2026-09-08 across 7 payload sizes × 5 manglings
+on both versions. So a tampered artifact **under 64 KiB leaves no file at all**,
+which is every artifact this subsystem produces. Left alone, that reported a
+TAMPERED backup as `25` — the row that points at your key.
+
+The distinction **survives**, but on weaker footing: it is now taken primarily
+from age's own refusal message (`failed to decrypt and authenticate payload
+chunk` vs `no identity matched any of the recipients` vs `failed to read
+header`), which is byte-identical on v1.3.1 and v1.3.2. File presence is kept as
+a second signal — still **sufficient**, no longer **necessary**. Both are
+combined in `escrow-verify.py`; the classification itself is
+`restore-verify.py::classify_age_refusal`.
+
+⚠ **Say plainly what that costs:** a substring match on another tool's prose is
+weaker than the phase observation it replaced, and this subsystem's own design
+notes argue against exactly that shape. The mitigation is that an
+**unrecognised** message is its own outcome — the verifier then says it *cannot
+say why* and names all three causes, rather than picking one. If you ever see
+that sentence, age has reworded: teach `classify_age_refusal` the new string
+rather than acting on a guess.
 
 ⚠ It cannot unlock the vault and will not try: every `bw` call runs with stdin on
 `/dev/null`, `--nointeraction`, and a timeout, so an unattended run **fails fast

--- a/claude/opencode-addendum.md
+++ b/claude/opencode-addendum.md
@@ -32,7 +32,7 @@ bash guard.
 | search file contents | `grep` | `rg` / `grep` via bash |
 | see what is in a dir | `glob` on `<dir>/*` | `ls` |
 
-There is **no `list` tool** on opencode 1.18.21 — verified against the resolved
+There is **no `list` tool** on opencode 1.18.29 — verified against the resolved
 tool map, which contains exactly `bash, edit, glob, grep, invalid, question,
 read, skill, task, todowrite, webfetch, write`. Use `glob` to enumerate a
 directory.

--- a/flake.nix
+++ b/flake.nix
@@ -332,11 +332,14 @@
             # 🔴 This ALSO makes the sandbox the tier that pins the VERSION.
             # `pkgs.opencode` here and in nix/pkgs/tools/default.nix resolve from
             # the same flake.lock, so CI tests the exact binary the hosts deploy
-            # (1.18.21 at rev c27cdad491a9). Cost, stated as deliberately as the
+            # (1.18.29 — derive the rev with `nix flake metadata --json | jq -r
+            # .locks.nodes.nixpkgs.locked.rev`; a rev spelled here would be an
+            # unguarded claim, since the version scanner sees only the version).
+            # Cost, stated as deliberately as the
             # nodejs and nix entries above: this check's closure grows by
             # opencode, and a nixpkgs bump that moves it invalidates the cache
             # AND turns the version assertion red. That red is the point — the
-            # config header's "measured on v1.18.21 — do not re-derive" claims are
+            # config header's "measured on v1.18.29 — do not re-derive" claims are
             # otherwise pinned to nothing.
             #
             # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -12,20 +12,32 @@ with pkgs; [
   # hosts, which drifted: MEASURED 2026-08-02, laptop 1.18.4 / workbench 1.18.9,
   # each movable independently by a `nix profile upgrade` that nothing records.
   # scripts/opencode/opencode.jsonc documents a large set of load-bearing
-  # behaviours annotated "measured on v1.18.21 — do not re-derive" (last-match-
+  # behaviours annotated "measured on v1.18.29 — do not re-derive" (last-match-
   # wins permission ordering, the hidden title/summary/compaction agents
   # inheriting the global permission block, the exact tool set). A few bullets
   # there — `ask` semantics under `opencode run` among them — are explicitly
   # CARRIED FORWARD at an older version instead, each saying so on its own line.
   # Those claims were pinned to a version nothing pinned.
   #
-  # This entry pins them: MEASURED at flake.lock's nixpkgs rev c27cdad491a9,
-  # `pkgs.opencode` is 1.18.21 — store path
-  # /nix/store/iqc8xfx692ym3pds6ky0vhqzscg6kgxd-opencode-1.18.21. (It was
-  # 1.18.4 at rev 9bc02893134c when this pin was introduced, and 1.18.16 at rev
-  # 044bfe75bfe4; the 2026-08-13 and 2026-08-19 bumps each re-derived the claims
-  # against the new binary rather than re-spelling them — see PINNED_VERSION in
-  # scripts/tests/test_opencode_engine.py.) A nixpkgs bump
+  # This entry pins them: at flake.lock's current nixpkgs rev, `pkgs.opencode`
+  # is 1.18.29 (re-derived 2026-09-08).
+  #
+  # 🔴 THE REV AND THE STORE PATH ARE DELIBERATELY NOT SPELLED HERE. Only the
+  # VERSION is, because only the version is guarded — `test_opencode_engine.py`'s
+  # PINNED_VERSION scanner fails on a stale version literal in this file and can
+  # see nothing else, so a hash written here would be an unguarded claim that
+  # rots silently. Both are one command away, and neither can be stale that way:
+  #     nix flake metadata ~/workspace/devrc --json \
+  #       | jq -r .locks.nodes.nixpkgs.locked.rev          # the rev
+  #     readlink -f "$(command -v opencode)"               # the store path
+  # (say WHICH shell you ran the second one in — `nix develop` and the login
+  # shell can carry different builds of the same tool.)
+  #
+  # It was 1.18.4 at rev 9bc02893134c when this pin was introduced, and 1.18.16
+  # at rev 044bfe75bfe4; the 2026-08-13, 2026-08-19, 2026-08-29 and 2026-09-08
+  # bumps each re-derived the claims against the new binary rather than
+  # re-spelling them — see PINNED_VERSION in
+  # scripts/tests/test_opencode_engine.py. A nixpkgs bump
   # that moves it now shows up as a flake.lock diff AND fails
   # scripts/tests/test_opencode_engine.py's version assertion, which is the
   # prompt to re-derive the header's measurements rather than let them rot.
@@ -37,6 +49,14 @@ with pkgs; [
   # bin/opencode is a HARD `nix profile` file collision — the switch FAILS with
   # "files in this package conflict with other packages". It is not silent
   # shadowing, so a missed prereq is loud, not wrong.
+  #
+  # 🔴 DONE, and do not reach for it again on a version-assertion red. Checked
+  # on the workbench 2026-09-08: `nix profile remove opencode` answers "does not
+  # match any packages in the profile" and the home-manager generation itself
+  # provides bin/opencode. Every version red since 2026-08 has been a LOCK
+  # MOVEMENT, which no profile removal and no switch can clear — the
+  # discriminating check is in the assertion message of
+  # test_engine_is_the_version_every_measurement_is_keyed_to.
   opencode
 ]
 ++ (import ./tmux-fuzzyclaw.nix { inherit pkgs workspace; })

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -371,12 +371,33 @@ EXIT_CODES: dict[str, int] = {
     # five-way version reported a TAMPERED or TRUNCATED artifact as
     # `ARTIFACT-EMPTY` — "THE ESCROW IS FINE … a valid encryption of an empty
     # payload" — because it read file PRESENCE as "age reported success". It does
-    # not: age writes output before authenticating the payload. Detecting
+    # not: on age v1.3.1 the output file appeared as soon as the HEADER
+    # authenticated, before the payload was checked. Detecting
     # tampering is the single most important thing a backup verifier does, and
     # that spelling reported it as nothing to worry about.
+    # ⚠ THAT SENTENCE IS ABOUT v1.3.1 AND STOPPED BEING GENERAL AT v1.3.2, which
+    # creates the output lazily on the first successful WRITE. The verdict split
+    # survives on a different signal — see the `_decrypt_phase_probe` block and
+    # `AGE_REFUSED_*` in restore-verify.py — but do not carry this sentence
+    # forward as a present-tense fact about age.
     "AGE-MISSING": 29,          # precondition: the tool is not installed
     "ARTIFACT-UNREADABLE": 30,  # the pipeline failed BEFORE decrypt was reached
-    "DECRYPT-FAILED": 25,       # age wrote NOTHING: wrong key OR damaged header
+    # 🔴 age REFUSED BEFORE THE PAYLOAD — *OR* refused in a way this tool could
+    # not read. ONE CODE, TWO MESSAGES, and that is the table's own doctrine
+    # ("split by REMEDY"), not a shortcut: both say "the cause is NOT asserted,
+    # do not rotate, go try another artifact with the same escrowed copy", which
+    # is the same action. What differs is how many causes remain open — two when
+    # age NAMED its refusal, three when it said something
+    # `restore_verify.classify_age_refusal` does not know — and that belongs in
+    # the sentence an operator reads, not in a number a timer branches on.
+    #
+    # ⚠ The second message is DEFENSIVE, NOT OBSERVED — the same status as
+    # `PUBKEY-DERIVATION-EMPTY` below and labelled for the same reason. On both
+    # measured age versions every refusal classifies. It exists because the
+    # discriminator now rests on an upstream tool's PROSE (see `AGE_REFUSED_*`
+    # in restore-verify.py): if age rewords, this admits it instead of picking
+    # whichever of the three answers the fall-through happened to reach.
+    "DECRYPT-FAILED": 25,
     # 🔴 RAISED BEFORE ANY `bw` CALL — see `preflight_decrypt_imports`. Its own
     # code because the remedy is unlike every other one here: nothing is wrong
     # with the escrow, the artifact or the vault; the INTERPRETER is missing a
@@ -808,15 +829,26 @@ def _rv():
 #     "corrupt payload" — both are PRESENT at size 0. So the rc==0 / rc!=0 split
 #     has to come from the module that knows, and it does:
 #     `restore_verify.DECRYPT_*` causes, published as values.
-#  2. Within a NON-ZERO age exit, file presence IS meaningful and is the only
-#     thing that separates a KEY fault from a DATA fault:
-#       * PLAIN ABSENT  -> age never wrote anything: the identity did not match
-#                          the recipients, OR the header is damaged. NOT
-#                          separable from outside, so neither is asserted.
+#  2. Within a NON-ZERO age exit, file presence USED TO BE the only thing that
+#     separated a KEY fault from a DATA fault. 🔴 IT NO LONGER IS, AND THE
+#     SENTENCE THAT SAID SO IS THE ONE A TOOLCHAIN BUMP MADE FALSE:
+#       * PLAIN ABSENT  -> on age v1.3.1 this meant age never wrote anything:
+#                          the identity did not match, OR the header is damaged.
+#                          🔴 ON v1.3.2 IT ALSO COVERS A TAMPERED PAYLOAD, because
+#                          v1.3.2 creates `--output` lazily on the first
+#                          successful WRITE — measured 2026-09-08, every payload
+#                          up to and including 64 KiB leaves NO file on a
+#                          tampered artifact.
 #       * PLAIN PRESENT -> age AUTHENTICATED THE HEADER, which requires the
 #                          identity to match, and then failed on a payload chunk
-#                          or ran out of input. The escrowed key WORKED; the
-#                          artifact is tampered, corrupt or truncated.
+#                          or ran out of input. STILL TRUE on both versions —
+#                          presence is SUFFICIENT evidence, it just stopped
+#                          being NECESSARY.
+#     So the primary discriminator moved to `restore_verify.classify_age_refusal`
+#     — age's own three refusal messages, which are byte-identical on v1.3.1 and
+#     v1.3.2. Read the `AGE_REFUSED_*` block there before touching this: it says
+#     plainly that substring-matching another tool's prose is WEAKER than the
+#     phase observation it replaces, and why it was taken anyway.
 @contextlib.contextmanager
 def _decrypt_phase_probe(RV):
     """Observe HOW FAR restore-verify's decrypt step got. Yields a state dict.
@@ -834,7 +866,7 @@ def _decrypt_phase_probe(RV):
     `finally`.
     """
     state = {"reached": False, "returned": False, "plain_present": None,
-             "cause": None}
+             "cause": None, "age_refusal": None}
     real = RV.decrypt
 
     def probe(cipher, plain, identity):
@@ -871,6 +903,12 @@ def _decrypt_phase_probe(RV):
             # owns it. `getattr` because a non-RestoreVerifyError has no cause;
             # None then means "no published cause", never a default one.
             state["cause"] = getattr(exc, "cause", None)
+            # 🔴 THE SECOND PUBLISHED VALUE, and the one that now carries the
+            # KEY-vs-DATA distinction (see `AGE_REFUSED_*` in restore-verify).
+            # `getattr` with None for the same reason as `cause` above: None
+            # means "this failure published no classification", and the
+            # classifier below must treat that as UNKNOWN, never as a default.
+            state["age_refusal"] = getattr(exc, "age_refusal", None)
             raise
         state["returned"] = True
 
@@ -1437,8 +1475,38 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                                 f"strength of this. Run `restore-verify.py` to "
                                 f"diagnose the artifact.",
                                 detail=str(exc))
-                        if (phase["cause"] == RV.DECRYPT_AGE_REFUSED
-                                and phase["plain_present"]):
+                        # 🔴 THE DISCRIMINATOR, RE-KEYED 2026-09-08 AFTER A
+                        # TOOLCHAIN BUMP TOOK THE OLD ONE AWAY.
+                        #
+                        # It used to be `plain_present` alone-with-cause. age
+                        # v1.3.2 creates `--output` LAZILY on the first
+                        # successful write, so on every artifact this subsystem
+                        # actually produces a TAMPERED payload now leaves no
+                        # file — and the branch fell through to DECRYPT-FAILED,
+                        # i.e. "your escrowed key may be wrong". That is the
+                        # verdict that gets a good disaster-recovery key
+                        # rotated while the real fault is a corrupt backup.
+                        #
+                        # TWO SIGNALS, OR-ed, and the OR is the point — neither
+                        # is sufficient alone across both versions:
+                        #   * `plain_present` — age flushed plaintext, which it
+                        #     can only do after authenticating the header. True
+                        #     on v1.3.1 for every tamper, and on v1.3.2 only
+                        #     once a whole 64 KiB chunk has gone out. Still
+                        #     SUFFICIENT; no longer NECESSARY.
+                        #   * `age_refusal == payload-auth-failed` — age itself
+                        #     saying it got to the payload. Byte-identical on
+                        #     v1.3.1 and v1.3.2, and the only signal that
+                        #     survives the lazy-create change.
+                        # An UNRECOGNISED refusal reaches NEITHER of the two
+                        # strong verdicts below — it gets DECRYPT-FAILED's
+                        # SECOND message, which names all three open causes.
+                        _corrupt = (
+                            phase["cause"] == RV.DECRYPT_AGE_REFUSED
+                            and (bool(phase["plain_present"])
+                                 or phase["age_refusal"]
+                                 == RV.AGE_REFUSED_PAYLOAD))
+                        if _corrupt:
                             # 🔴 THE CAUSE IS PART OF THE CONDITION, not decoration.
                             # This branch makes the strongest claim in the file —
                             # "the key worked, the BACKUP is tampered" — and it was
@@ -1461,38 +1529,74 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                             # the one that stops the strongest claim in the file
                             # being made about it by default.
                             #
-                            # age exited NON-ZERO having already written output.
-                            # Measured across 8 offsets x 4 sizes plus 3
-                            # truncations: reaching the payload at all means age
-                            # authenticated the HEADER, which requires the
+                            # age exited NON-ZERO after reaching the PAYLOAD —
+                            # witnessed either by output it had already flushed
+                            # or by its own "failed to decrypt and authenticate
+                            # payload chunk". Reaching the payload at all means
+                            # age authenticated the HEADER, which requires the
                             # identity to match. So the key worked and the bytes
                             # did not.
+                            #
+                            # 🔴 THE SENTENCE BELOW LOST THE WORDS "began
+                            # writing plaintext", and that is a CORRECTION, not
+                            # a reword: on age v1.3.2 a tampered artifact under
+                            # 64 KiB writes NO plaintext, so the old wording
+                            # asserted an act this branch can no longer observe.
+                            # What it CAN still assert — the header
+                            # authenticated with the escrowed key — is what it
+                            # now says, and nothing more.
                             raise EscrowError(
                                 "ARTIFACT-CORRUPT",
                                 f"🔴 {key} is TAMPERED, CORRUPT or TRUNCATED. age "
                                 f"authenticated the header with the ESCROWED key "
-                                f"— which a non-matching identity cannot do — "
-                                f"began writing plaintext, and then FAILED on the "
-                                f"payload. THE ESCROW IS FINE; THE BACKUP IS NOT. "
+                                f"— which a non-matching identity cannot do — and "
+                                f"then FAILED on the payload. THE ESCROW IS FINE; "
+                                f"THE BACKUP IS NOT. "
                                 f"This is the finding a backup verifier exists to "
                                 f"make: treat the artifact as unusable, check the "
                                 f"other retained objects for this scope, and do "
                                 f"NOT rotate the key.",
                                 detail=str(exc))
+                        # 🔴 NAMED REFUSALS ONLY. This verdict asserts that age
+                        # never reached the payload, and after the v1.3.2 change
+                        # the ABSENCE of plaintext no longer supports that — only
+                        # age's own message does. So it is reached only when age
+                        # SAID which of the two it was, and an unrecognised
+                        # refusal falls to the second DECRYPT-FAILED message
+                        # below instead of borrowing this one's claim.
+                        if phase["age_refusal"] in (RV.AGE_REFUSED_NO_IDENTITY,
+                                                    RV.AGE_REFUSED_HEADER):
+                            raise EscrowError(
+                                "DECRYPT-FAILED",
+                                f"age REFUSED {key} before reaching the payload at "
+                                f"all. TWO CAUSES PRODUCE THIS AND THEY ARE NOT "
+                                f"SEPARABLE FROM HERE: the escrowed identity does not "
+                                f"match this artifact's recipients, or the artifact's "
+                                f"HEADER is damaged. Neither is asserted. To tell them "
+                                f"apart, try a DIFFERENT artifact with this same "
+                                f"escrowed copy — `--scope <another scope>`, or "
+                                f"`restore-verify.py --all` for an older stamp: if "
+                                f"another artifact OPENS, the escrowed key is fine and "
+                                f"THIS object's header is damaged; if none open, the "
+                                f"key is the likely cause. Do NOT rotate the key "
+                                f"before running that.",
+                                detail=str(exc))
                         raise EscrowError(
                             "DECRYPT-FAILED",
-                            f"age REFUSED {key} without writing any plaintext at "
-                            f"all. TWO CAUSES PRODUCE THIS AND THEY ARE NOT "
-                            f"SEPARABLE FROM HERE: the escrowed identity does not "
-                            f"match this artifact's recipients, or the artifact's "
-                            f"HEADER is damaged. Neither is asserted. To tell them "
-                            f"apart, try a DIFFERENT artifact with this same "
-                            f"escrowed copy — `--scope <another scope>`, or "
-                            f"`restore-verify.py --all` for an older stamp: if "
-                            f"another artifact OPENS, the escrowed key is fine and "
-                            f"THIS object's header is damaged; if none open, the "
-                            f"key is the likely cause. Do NOT rotate the key "
-                            f"before running that.",
+                            f"age REFUSED {key} and this verifier CANNOT SAY WHY. "
+                            f"age exited non-zero without leaving plaintext, and "
+                            f"its message matched none of the three refusals this "
+                            f"tool knows how to read. THREE THINGS ARE NOW EQUALLY "
+                            f"CONSISTENT with what was seen and NONE is asserted: "
+                            f"the escrowed identity does not match, the artifact's "
+                            f"HEADER is damaged, or the PAYLOAD is tampered. "
+                            f"🔴 DO NOT ROTATE OR RE-ESCROW ON THIS. Read age's own "
+                            f"message in the detail below, then re-run "
+                            f"`restore-verify.py` by hand. If age has simply "
+                            f"reworded, teach `classify_age_refusal` the new "
+                            f"string — this refusal exists so that a reword "
+                            f"produces an ADMISSION rather than a confident wrong "
+                            f"answer.",
                             detail=str(exc))
                     raise EscrowError(
                         "RESTORE-FAILED",

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -276,6 +276,83 @@ DECRYPT_CAUSES = frozenset(
     {DECRYPT_AGE_MISSING, DECRYPT_AGE_REFUSED, DECRYPT_EMPTY_PLAINTEXT})
 
 
+# 🔴 WHICH REFUSAL IT WAS, INSIDE `age-refused`. A SECOND, NARROWER VALUE — and
+# it exists because a TOOLCHAIN BUMP took away the observable the consumer used.
+#
+# MEASURED 2026-09-08 in the dev shell (`nix develop`), age v1.3.1 vs v1.3.2, over
+# 7 payload sizes x 5 manglings + wrong-key + damaged-header, 84 runs:
+#
+#   v1.3.1  a payload-authentication failure ALWAYS leaves the `--output` file
+#           behind — at size 0 for anything under one 64 KiB chunk, partial
+#           above it. `--output` PRESENT therefore meant "age got past the
+#           header", which is what `escrow-verify.py` classified on.
+#   v1.3.2  the output file is created LAZILY, on the first successful write. A
+#           payload failure in the FIRST chunk leaves NO file at all — measured
+#           at 64 B, 1 KiB, 64 KiB-1, 64 KiB and 64 KiB+1; only the >= 64 KiB
+#           cases where an earlier chunk already flushed still leave one
+#           (196608 B of a 256 KiB payload, 983040 B of a 1 MiB one).
+#           A PRE-EXISTING file is left completely untouched (34-byte control
+#           read back intact), exactly like the wrong-key path — so it is lazy
+#           creation, not unlink-on-failure.
+#
+# So `--output` presence is now SUFFICIENT but no longer NECESSARY evidence that
+# the header authenticated, and for the artifact sizes this subsystem actually
+# produces it is usually absent. Left alone, a TAMPERED backup was classified as
+# "wrong key OR damaged header" — the verdict that sends an operator at the
+# escrow instead of at the artifact.
+#
+# 🔴 THE CLASSIFICATION IS A SUBSTRING MATCH ON ANOTHER TOOL'S PROSE, AND THAT IS
+# A DOWNGRADE — say so rather than let the next reader assume it is as solid as
+# the phase observation it replaces. The module docstring above argues against
+# exactly this shape, for good reasons that still apply. It is done anyway
+# because the alternative is losing the distinction entirely, and the three
+# strings are IDENTICAL on both measured versions:
+#
+#   "failed to decrypt and authenticate payload chunk"  -> payload
+#   "no identity matched any of the recipients"         -> wrong key
+#   "failed to read header"                             -> damaged header
+#
+# The mitigation is that an UNRECOGNISED stderr is its own published value, so a
+# future age that rewords does NOT silently fall into one of the three answers —
+# it produces a refusal that says it could not classify. Fail-safe, not
+# fail-quiet.
+AGE_REFUSED_PAYLOAD = "payload-auth-failed"      # header OK, payload bad
+AGE_REFUSED_NO_IDENTITY = "no-identity-matched"  # the identity does not match
+AGE_REFUSED_HEADER = "header-unreadable"         # the header itself is damaged
+AGE_REFUSED_UNRECOGNISED = "unrecognised"        # age said something new
+
+AGE_REFUSALS = frozenset({
+    AGE_REFUSED_PAYLOAD, AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER,
+    AGE_REFUSED_UNRECOGNISED})
+
+# 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with
+# the program name and appends a "report unexpected errors" URL line, and both
+# have moved between releases; matching the sentence in the middle survives that
+# while an anchored match would not. Each is the distinctive clause, with no
+# punctuation that could be re-styled.
+_AGE_REFUSAL_MARKERS = (
+    ("failed to decrypt and authenticate payload chunk", AGE_REFUSED_PAYLOAD),
+    ("no identity matched any of the recipients", AGE_REFUSED_NO_IDENTITY),
+    ("failed to read header", AGE_REFUSED_HEADER),
+)
+
+
+def classify_age_refusal(stderr: str) -> str:
+    """Which of age's three refusals this was — or that it was none of them.
+
+    🔴 NEVER GUESSES. An unmatched stderr returns `AGE_REFUSED_UNRECOGNISED`,
+    which the consumer must handle as "cannot classify", not as a default. That
+    is the whole reason this returns a fourth value instead of `None` or the
+    most likely of the three: the caller's strongest claim — "your backup is
+    tampered and your key is fine" — must never be reached by falling through.
+    """
+    low = (stderr or "").lower()
+    for marker, kind in _AGE_REFUSAL_MARKERS:
+        if marker in low:
+            return kind
+    return AGE_REFUSED_UNRECOGNISED
+
+
 # --------------------------------------------------------------------------- #
 # the classified refusals
 # --------------------------------------------------------------------------- #
@@ -340,13 +417,22 @@ class RestoreVerifyError(B.BackupError):
     """
 
     def __init__(self, message: str, *, cause: str | None = None,
-                 token: str | None = None):
+                 token: str | None = None, age_refusal: str | None = None):
         super().__init__(message)
         if cause is not None and cause not in DECRYPT_CAUSES:
             raise KeyError(
                 f"{cause!r} is not a published cause. The set is closed on "
                 f"purpose: a consumer branches on these, so inventing one "
                 f"silently lands in whatever `else` that consumer has.")
+        # 🔴 CLOSED FOR THE SAME REASON AS `cause`, and checked here rather than
+        # trusted from the call site: `escrow-verify.py` branches on this value
+        # to decide whether to tell an operator their BACKUP is tampered or
+        # their KEY is wrong, and an unpublished string would land in whichever
+        # branch happened to be last.
+        if age_refusal is not None and age_refusal not in AGE_REFUSALS:
+            raise KeyError(
+                f"{age_refusal!r} is not a published age refusal. The set is "
+                f"closed: {sorted(AGE_REFUSALS)}.")
         if token is not None and token not in EXIT_CODES:
             raise KeyError(
                 f"{token!r} is not in EXIT_CODES. A classified refusal is an "
@@ -354,6 +440,7 @@ class RestoreVerifyError(B.BackupError):
                 f"adding one means adding it to the table in the same commit as "
                 f"the test that pins it.")
         self.cause = cause
+        self.age_refusal = age_refusal
         self.token = token
         self.exit_code = EXIT_FAILED if token is None else EXIT_CODES[token]
 
@@ -671,13 +758,21 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             "artifact this cannot verify, and skipping it would report safety "
             "that was never measured.",
             cause=DECRYPT_AGE_MISSING)
-    # 🔴 A STALE OUTPUT FILE MAKES age's OWN FAILURE UNREADABLE. MEASURED: on
-    # BOTH the wrong-key and damaged-header paths age leaves a PRE-EXISTING
-    # `--output` file completely untouched (rc=1, file present, original 34-byte
-    # content intact) — it only creates the file once it has authenticated the
-    # header. Consumers therefore read the PRESENCE of `plain` as "age got past
-    # the header", and a leftover from an aborted earlier run turns that into a
-    # lie: a WRONG KEY reads as a corrupt artifact.
+    # 🔴 A STALE OUTPUT FILE MAKES age's OWN FAILURE UNREADABLE. MEASURED (age
+    # v1.3.1, and RE-MEASURED on v1.3.2 2026-09-08): on BOTH the wrong-key and
+    # damaged-header paths age leaves a PRE-EXISTING `--output` file completely
+    # untouched (rc=1, file present, original 34-byte content intact).
+    #
+    # ⚠ THE *REASON* CHANGED BETWEEN THE TWO VERSIONS AND THIS UNLINK GOT MORE
+    # IMPORTANT, NOT LESS. On v1.3.1 age created/truncated the output as soon as
+    # it authenticated the header, so presence meant "past the header". On
+    # v1.3.2 it creates the file LAZILY, on the first successful WRITE — so a
+    # payload failure inside the first 64 KiB chunk leaves nothing at all, and a
+    # leftover from an aborted run is now the ONLY thing that could make the
+    # consumer's `plain_present` true. A WRONG KEY would read as a corrupt
+    # artifact — the strongest and most misleading verdict in the subsystem.
+    # See `AGE_REFUSED_*` above for the measurement and for what replaced
+    # presence as the primary discriminator.
     #
     # `work_dir` is routinely REUSED — `B._private_dir` documents the
     # already-exists case as "every run after the first with an explicit
@@ -702,7 +797,12 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             f"is damaged. This is "
             f"NOT a corruption verdict about the git history inside — nothing "
             f"here has read it.",
-            cause=DECRYPT_AGE_REFUSED)
+            cause=DECRYPT_AGE_REFUSED,
+            # 🔴 CLASSIFIED HERE, WHERE age's OWN stderr IS IN HAND. The consumer
+            # gets a published VALUE, never this message to substring-match: it
+            # is the only place the raw stream exists, and pushing the parse out
+            # to the caller is how two callers end up with two different parsers.
+            age_refusal=classify_age_refusal(p.stderr))
     if not plain.is_file() or plain.stat().st_size == 0:
         # 🔴 MEASURED: `age` encrypts a ZERO-BYTE payload to a perfectly valid
         # 200-byte ciphertext, and decrypts it back at rc=0. So an object that

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2213,17 +2213,25 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   Because the gate runs **before** the tab is opened, a gate failure leaks no tab.
 
   *Prerequisite:* an opencode whose `debug agent` reports a browser-only tool set.
-  **Both hosts run 1.18.21** — verified at the consumer 2026-08-29, both
-  `readlink -f $(command -v opencode)` resolving to the same
-  `…-opencode-1.18.21` store path, so the pin and the deploy agree. There is no
-  version-skew caveat here any more; the hosts CONVERGED on 2026-08-15.
-  🔴 **But the browser-only RESOLUTION is last verified on 1.18.18**, not on
-  1.18.21 (2026-08-19: the gate replicated ON EACH HOST parses to exactly one
-  enabled tool, `browser`, with every host tool present and `false`; measured
-  identical on 1.18.4 and 1.18.16 before that). It was NOT re-derived at the
-  current pin, and nothing in CI would notice if it changed: `browser-agent` is
-  absent from the engine tests' `ENGINE_AGENTS`, and this repo's own
-  browser-agent tests drive a FAKE opencode stub rather than the real binary.
+  **The workbench runs 1.18.29** — verified at the consumer 2026-09-08,
+  `readlink -f $(command -v opencode)` in a login shell resolving to the store
+  path `flake.lock` pins, so the pin and the deploy agree there.
+  🔴 **The LAPTOP is UNVERIFIED at this pin.** It was unreachable when the pin
+  moved (ssh to its nebula address refused), so it was last checked at the
+  consumer on 2026-08-29, at the version this pin superseded. "Both hosts run
+  the same opencode" is therefore a claim nobody has re-checked — do not repeat
+  it until you have.
+  ✅ **The browser-only RESOLUTION *was* re-derived at the pin** (2026-09-08),
+  which the two bumps before this one had declined: the gate's scratch project
+  rebuilt exactly as the wrapper builds it and run against the REAL pinned
+  binary — and against the superseded one as a control — parses to exactly one
+  enabled tool, `browser`, out of 13, with every host tool present and `false`,
+  on both. It measured identical on 1.18.4, 1.18.16 and 1.18.18 before those two.
+  🔴 **But that was ON THE WORKBENCH ONLY, BY HAND, and nothing in CI observes
+  it**: `browser-agent` is absent from the engine tests' `ENGINE_AGENTS`, and
+  this repo's own browser-agent tests drive a FAKE opencode stub rather than the
+  real binary. A by-hand measurement is evidence, not a gate — the next bump
+  gets no red here if the resolution changes.
   🔴 **Do not read the version on the deploy as a measurement of the
   resolution** — this sentence used to conjoin the two, and a pin re-key then
   relabelled the unmeasured half along with the measured one. 🔴 The RAW dump is NOT byte-stable, on either binary: the
@@ -2318,13 +2326,16 @@ ln -sf ~/workspace/devrc/scripts/browser-bridge/opencode/tools/browser_tool_impl
 (The global def keeps the `__STEPS__`/`__MODEL__` placeholders — inert on its own;
 the wrapper substitutes them per run.)
 
-**opencode version.** Both hosts run 1.18.21 and that is what `flake.lock` pins.
+**opencode version.** `flake.lock` pins 1.18.29; the workbench consumer was
+verified at it on 2026-09-08 and the laptop was NOT (unreachable — see the
+runtime tool-set gate section above).
 The custom-tool mechanism (`.opencode/tools/*.js`, `permission: {"*": deny, …}`)
-is **last verified on 1.18.18** — not re-derived at 1.18.21, since the check
-below needs the real binary (measured identical on 1.18.4 before that) — `opencode debug agent
-browser-agent` resolves to `bash:false … browser:true`
-(exactly one enabled tool) on each, plus an end-to-end `opencode debug agent …
---tool browser` run against a fake bridge. The wrapper still writes the tool to
+**was re-derived at the pin** on 2026-09-08, on the workbench, by hand:
+`opencode debug agent browser-agent` resolves to `bash:false … browser:true`
+(exactly one enabled tool out of 13) against the pinned binary and against the
+superseded one alike. It was verified the same way on 1.18.4, 1.18.16 and
+1.18.18 in earlier passes, plus an end-to-end `opencode debug agent …
+--tool browser` run against a fake bridge on the first of those. The wrapper still writes the tool to
 BOTH `.opencode/tools/` and `.opencode/tool/` as cheap insurance against a future
 tool-dir rename. If you upgrade opencode and it stops resolving browser-only, the
 runtime tool-set gate refuses the run — that is the intended, safe outcome; fix

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -26,11 +26,13 @@ command unrunnable, which is why fixing the first didn't appear to help:
    be reached. Fixed by probing without injecting.
 
 🔴 **Every doc misattributed both symptoms to an opencode *version* problem for the
-entire arc.** They are not version-related — both hosts run 1.18.21 (verified at
-the consumer 2026-08-29), and the browser-only resolution was measured identical
-on 1.18.4, 1.18.16 and 1.18.18. It has NOT been re-derived at 1.18.21; it held
-across every bump that was measured, which is why the version hypothesis stays
-closed. Do not re-open it.
+entire arc.** They are not version-related — the browser-only resolution has now
+been measured identical at every version this repo has pinned, including the
+current one (re-derived 2026-09-08 against the real binary, on the workbench),
+and on 1.18.4, 1.18.16 and 1.18.18 in the passes before that. That is why the
+version hypothesis stays closed. Do not re-open it.
+(The DEPLOY is a separate claim: the workbench consumer was verified at the pin
+on 2026-09-08, the laptop was unreachable and is unverified.)
 
 ✅ **The `browser agent`-first default IS shipped** (SKILL.md → `## FIRST DECISION`).
 It was held back until capability was measured rather than argued from token
@@ -250,11 +252,13 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run 1.18.21** (verified at the consumer
-  2026-08-29); the browser-only resolution itself is last measured on 1.18.18,
-  and resolved identically on 1.18.4 and 1.18.16 before that — there is no
-  version-skew caveat between the hosts, but the resolution is not re-derived at
-  the current pin.
+  gate failure leaks no tab. **The workbench consumer runs the pinned version**
+  (verified 2026-09-08); the LAPTOP was unreachable and is unverified at this
+  pin. The browser-only resolution itself WAS re-derived at the pin on
+  2026-09-08 — on the workbench, by hand, against the real binary and against
+  the superseded one — and resolved identically on 1.18.4, 1.18.16 and 1.18.18
+  in the passes before those. Nothing in CI observes it, so it is evidence and
+  not a gate.
   - ⚠ **If you check the gate by hand, redirect to a FILE**
     (`opencode debug agent browser-agent > /tmp/gate.json`), never a pipe or
     `$(...)`: opencode doesn't reliably flush stdout before exiting into a pipe, so

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -269,7 +269,7 @@ existence guard**, and defined a `KC_PROD` that zsh did not have. Add a handle i
   (`*.env` → ask); a blanket allow is appended after it and silently defeats it
   on every agent. The default already allows every non-`.env` read, so the
   correct configuration is to say nothing.
-- **There is no `list` tool and no `websearch` tool** on 1.18.21. The resolved set
+- **There is no `list` tool and no `websearch` tool** on 1.18.29. The resolved set
   is exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
   todowrite, webfetch, write}. Naming a nonexistent tool is a silent no-op that
   reads like configuration.

--- a/scripts/opencode/agent/k8s.md
+++ b/scripts/opencode/agent/k8s.md
@@ -8,7 +8,10 @@ permission:
   write: deny
   # 🔴 NO `"*": allow` HERE. Agent rules are APPENDED AFTER the global block and
   # opencode is LAST-MATCH-WINS, so an agent-level wildcard NULLIFIES every
-  # global deny/ask at a stroke. Measured on 1.18.21: with `"*": allow` present
+  # global deny/ask at a stroke. Measured on 1.18.21 — a dated incident record,
+  # deliberately NOT re-derived at the pin because its counts describe a tree
+  # that no longer exists (66 global bash rules today, not 30), so no fresh
+  # measurement could confirm the sentence: with `"*": allow` present
   # it landed at index 74, after all 30 global rules, and only the 4 rules below
   # it survived — `git stash`, `git reset --hard`, `git add -A`, `rm -rf ~…`,
   # `sops -d`, `nixos-rebuild` and `home-manager switch` were all plain ALLOW on

--- a/scripts/opencode/agent/review.md
+++ b/scripts/opencode/agent/review.md
@@ -6,7 +6,7 @@ temperature: 0.1
 permission:
   edit: deny
   write: deny
-  # MEASURED on 1.18.21 (`opencode debug agent review`): the agent's bash rules
+  # MEASURED on 1.18.29 (`opencode debug agent review`): the agent's bash rules
   # are APPENDED AFTER the global block, so the resolved list is
   #   [0] allow *   … global asks/denies …   [N] deny *   [N+1…] these allows
   # Last-match-wins therefore makes [N] the effective default: any command that

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -44,7 +44,7 @@
 // patterns has known bypasses, which is the whole reason layer 2 exists.
 //
 // ==========================================================================
-// Mechanics of layer 1 (measured on v1.18.21 — do not re-derive)
+// Mechanics of layer 1 (measured on v1.18.29 — do not re-derive)
 // ==========================================================================
 //
 // 🔴 PERMISSION ORDERING IS LOAD-BEARING AND IS THE INVERSE OF CLAUDE CODE.
@@ -135,7 +135,7 @@
 // "restore consistency" by re-widening any of these four rules to infix without
 // reading those tests first.
 //
-// Other measured facts baked into this file (v1.18.21, EXCEPT where a bullet
+// Other measured facts baked into this file (v1.18.29, EXCEPT where a bullet
 // says otherwise — the 2026-08-19 re-derivation could not reach three of them,
 // and a claim relabelled to a version nothing measured it on is worse than a
 // stale one, because it looks fresh):
@@ -161,7 +161,7 @@
 //     `reference` (now `references`), `maxSteps` (now `steps`).
 //     `theme`/`keybinds`/`tui` moved to a separate ~/.config/opencode/tui.json
 //     and are NOT set here.
-//   * there is NO `list` tool and NO `websearch` tool on 1.18.21. The real set is
+//   * there is NO `list` tool and NO `websearch` tool on 1.18.29. The real set is
 //     exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
 //     todowrite, webfetch, write}. Naming a nonexistent tool here is a no-op.
 {
@@ -252,7 +252,7 @@
     // — a blanket `"read": "allow"` here lands AFTER those and silently defeats
     // the `.env` guard on every agent. The default already allows everything
     // except `.env`, so there is nothing to add.
-    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.21.
+    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.29.
     "glob": "allow",
     "grep": "allow",
     "edit": "allow",

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -58,7 +58,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 import backup as B  # noqa: E402
 from testlib.mockbin import write_exec  # noqa: E402
-from testlib import hermetic_git  # noqa: E402
+from testlib import hermetic_git, mockbin  # noqa: E402
 
 
 def _require(tool: str, why: str) -> str:
@@ -1157,7 +1157,19 @@ def test_a_valid_recipient_override_is_accepted(tmp_path, identity):
         os.environ.pop("ASIB_AGE_RECIPIENT", None)
 
 
-def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(tmp_path):
+# The v1.3.1 stderr, reproduced EXACTLY. Taken from a real run (`age-keygen -y`
+# on an identity with a leading space on the secret line) rather than
+# paraphrased, so a reader can diff it against the binary if they doubt it.
+_AGE_KEYGEN_V131_ECHO = (
+    'age-keygen: error: failed to parse input: error at line 3: '
+    'unknown identity type: "%s"\n'
+    'age-keygen: report unexpected or unhelpful errors at '
+    'https://filippo.io/age/report\n'
+)
+
+
+def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(
+        tmp_path, monkeypatch):
     """🔴 age-keygen's STDERR ECHOES THE LINE IT COULD NOT PARSE, and on a
     mangled identity that line is the SECRET KEY.
 
@@ -1172,6 +1184,22 @@ def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(tmp_pat
     putting `p.stderr` back into the `BackupError` — SURVIVED the entire suite,
     even though `escrow-verify.py`'s half of the same fix was covered.
 
+    🔴 THE LEAK NOW COMES FROM A STUB, NOT FROM THE INSTALLED BINARY (changed
+    2026-09-08). age-keygen v1.3.2 dropped the quoted line entirely — measured
+    over 17 manglings, 0 echo the secret and 0 echo ANY 12-byte run of the input,
+    against 6 of 17 on v1.3.1. That is an upstream FIX, and it silently made this
+    test's positive control impossible: the guard would have gone green while
+    proving nothing about our redaction.
+
+    🔴 THE RISK IS LIVE, NOT HISTORICAL. Both versions are installed on this host
+    right now (login shell v1.3.1, dev shell v1.3.2) and the deployed backup unit
+    takes whatever its PATH provides, so a message that quoted stderr would still
+    print a key today. A guard whose sensitivity depends on which of two
+    installed binaries answers is not a guard — so the leak is supplied
+    deterministically instead. `backup.py` invokes `age-keygen` as a bare literal
+    (see `age_public_key_bytes`), so PATH is the whole injection surface and
+    nothing in production changes.
+
     ⚠ CASE-INSENSITIVE, against the FIXTURE'S OWN secret: a case-sensitive check
     reads clean on the lowercased-prefix case while the whole key body is in the
     message.
@@ -1184,6 +1212,19 @@ def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(tmp_pat
               if ln.startswith("AGE-SECRET-KEY-")][0]
     body = secret.split("AGE-SECRET-KEY-", 1)[-1]
 
+    binx = tmp_path / "stubbin"
+    binx.mkdir()
+    # Echoes the OFFENDING LINE of whatever file it is handed, exactly as v1.3.1
+    # did — not hardcoded to this fixture, so it stays faithful if the fixture
+    # changes.
+    mockbin.write_exec(binx / "age-keygen", f"""
+line=$(sed -n '3p' "$2" 2>/dev/null)
+printf '{_AGE_KEYGEN_V131_ECHO}' "$line" >&2
+exit 1
+""")
+    monkeypatch.setenv("PATH", f"{binx}:{os.environ['PATH']}")
+    monkeypatch.delenv("ASIB_AGE_RECIPIENT", raising=False)
+
     for label, mangled in (
             ("a LEADING SPACE on the secret line",
              text.replace(secret, " " + secret)),
@@ -1195,14 +1236,14 @@ def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(tmp_pat
 
         # POSITIVE CONTROL: this input really does put the secret in stderr, so
         # the assertion below is about redaction and not about an empty stream.
-        probe = subprocess.run([AGE_KEYGEN, "-y", str(bad)], capture_output=True)
+        probe = subprocess.run(["age-keygen", "-y", str(bad)], capture_output=True)
         assert probe.returncode != 0, label
         assert secret.lower() in probe.stderr.decode("utf-8", "replace").lower(), (
-            f"{label}: age-keygen did not echo the secret, so this test cannot "
-            f"see a leak. Re-measure — the redaction it guards may now be "
-            f"untested rather than unnecessary.")
+            f"{label}: the STUB did not echo the secret, so this test cannot "
+            f"see a leak and the redaction assertion below is vacuous. Fix the "
+            f"stub — do NOT re-point this at the installed age-keygen, which "
+            f"stopped echoing at v1.3.2.")
 
-        os.environ.pop("ASIB_AGE_RECIPIENT", None)
         with pytest.raises(B.BackupError) as exc:
             B.resolve_recipient(bad)
         rendered = str(exc.value).lower()

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -4919,17 +4919,26 @@ exit 1
 @pytest.mark.parametrize("mangler,label,kind", _MANGLERS)
 def test_NO_pubkey_failure_message_EVER_carries_key_material(tmp_path, mangler,
                                                              label, kind):
-    """🔴 age-keygen's STDERR ECHOES ITS INPUT on the realistic manglings —
-    measured: an unrecognised identity TYPE comes back as `unknown identity
-    type: "<the line>"`, and on a leading-space or lowercased-prefix paste that
-    line is the SECRET KEY. Quoting it would leak the very thing this module
-    refuses to print, on exactly the failure it exists to report.
+    """age-keygen's STDERR ECHOED ITS INPUT on the realistic manglings —
+    measured on v1.3.1: an unrecognised identity TYPE came back as `unknown
+    identity type: "<the line>"`, and on a leading-space or lowercased-prefix
+    paste that line is the SECRET KEY. Quoting it would leak the very thing this
+    module refuses to print, on exactly the failure it exists to report.
 
-    🔴 THE GUARD IS ONLY AS GOOD AS ITS LEAKING FIXTURES. Two of the five
-    manglers put the real secret into age-keygen's stderr — proven by
-    `test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret` above,
-    which is this test's positive control. Interpolating `p.stderr` into the
-    NOT-AN-AGE-IDENTITY verdict is killed here by those two.
+    🔴 THIS TEST IS VACUOUS ON age-keygen >= v1.3.2, AND THE DOCSTRING USED TO
+    SAY THE OPPOSITE. It claimed "interpolating `p.stderr` into the
+    NOT-AN-AGE-IDENTITY verdict is killed here by those two". MEASURED
+    2026-09-08 with v1.3.2 installed: that mutation SURVIVES all five params.
+    v1.3.2 prints a bare `unknown identity type` with no quoted line, so no
+    fixture built from the live binary can put key material in the stream.
+
+    The mutation is killed by
+    `test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1`,
+    which supplies v1.3.1's stderr deterministically instead of hoping the
+    installed binary still leaks. THIS test is kept because it is still the only
+    one that walks all five manglings against the REAL binary and pins that none
+    of them reaches the message — a weaker claim, and it is stated as one rather
+    than left reading like the guard it used to be.
 
     ⚠ CASE-INSENSITIVE, against the FIXTURE'S OWN secret — a case-sensitive
     check reads clean on the lowercased-prefix case while the whole key body is

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1379,6 +1379,139 @@ def test_a_TAMPERED_or_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_not_EMPTY(
         assert ei.value.exit_code != EV.EXIT_CODES[wrong], (name, wrong)
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE RE-KEYED DISCRIMINATOR (2026-09-08). The test above passes on age
+# v1.3.1 through `plain_present` and on v1.3.2 through the stderr
+# classification, and it CANNOT tell you which — whichever age is installed
+# supplies one signal and the other never runs. The four tests below force each
+# signal in isolation, so both arms are pinned on EVERY host regardless of which
+# age the toolchain happens to hand us. That is the whole reason the toolchain
+# bump was able to reach production behaviour with a green suite.
+# --------------------------------------------------------------------------- #
+def _refusing_decrypt(RVmod, monkeypatch, *, refusal, write_plaintext):
+    """Install a `decrypt` that refuses exactly the way we want to test.
+
+    Writes the plaintext file (or not) BEFORE raising, because that is what the
+    probe observes — `plain_present` is read at the instant of the raise.
+    """
+    def refuse(cipher, plain, identity):
+        if write_plaintext:
+            Path(plain).write_bytes(b"partial plaintext")
+        raise RVmod.RestoreVerifyError(
+            "DECRYPT FAILED (synthetic)", cause=RVmod.DECRYPT_AGE_REFUSED,
+            age_refusal=refusal)
+    monkeypatch.setattr(RVmod, "decrypt", refuse)
+
+
+def test_a_TAMPERED_payload_is_ARTIFACT_CORRUPT_even_when_age_WROTE_NOTHING(
+        escrow_world, monkeypatch):
+    """🔴 THE REGRESSION THE age v1.3.1 -> v1.3.2 BUMP CAUSED, pinned.
+
+    v1.3.2 creates `--output` LAZILY, on the first successful write, so a
+    tampered payload inside the first 64 KiB chunk leaves NO file — measured
+    2026-09-08 at 64 B, 1 KiB, 64 KiB-1, 64 KiB and 64 KiB+1, against v1.3.1
+    which left one (at size 0) in every one of those cases.
+
+    With the classifier keyed on file presence alone that made a TAMPERED backup
+    report as DECRYPT-FAILED — "your escrowed identity may not match" — which is
+    the verdict that gets a good disaster-recovery key rotated while the real
+    fault is a corrupt artifact.
+
+    Here `plain_present` is FALSE and only age's own "failed to decrypt and
+    authenticate payload chunk" is available. The verdict must still be the
+    strong one.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_PAYLOAD, write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "ARTIFACT-CORRUPT"
+    assert ei.value.exit_code == 33
+    assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
+
+
+def test_a_TAMPERED_payload_is_ARTIFACT_CORRUPT_when_only_PLAINTEXT_says_so(
+        escrow_world, monkeypatch):
+    """🔴 THE OTHER ARM, and it is not redundant with the one above.
+
+    On a payload large enough that an earlier chunk already flushed, age leaves
+    partial plaintext — measured on BOTH versions (196608 B of a 256 KiB
+    payload, 983040 B of a 1 MiB one). Presence stopped being NECESSARY
+    evidence; it did NOT stop being SUFFICIENT, and dropping it would lose the
+    only signal that does not depend on age's wording.
+
+    So this forces an UNRECOGNISED refusal — age saying something the classifier
+    cannot read — with plaintext present, and requires the strong verdict.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_UNRECOGNISED,
+                      write_plaintext=True)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "ARTIFACT-CORRUPT"
+    assert ei.value.exit_code == 33
+
+
+@pytest.mark.parametrize("refusal_attr", ["AGE_REFUSED_NO_IDENTITY",
+                                          "AGE_REFUSED_HEADER"])
+def test_a_NAMED_pre_payload_refusal_is_DECRYPT_FAILED_and_asserts_NEITHER_cause(
+        escrow_world, monkeypatch, refusal_attr):
+    """The two refusals that really do leave the key/header question open.
+
+    🔴 The message must NOT be the unclassified one: age NAMED which side of the
+    payload it stopped on, so exactly two causes remain and the sentence says
+    two.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=getattr(RVmod, refusal_attr),
+                      write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "DECRYPT-FAILED"
+    assert ei.value.exit_code == 25
+    assert ei.value.exit_code != EV.EXIT_CODES["ARTIFACT-CORRUPT"]
+    assert ei.value.verdict.startswith(
+        f"age REFUSED {KEY_DELTA_NEW} before reaching the payload at all. TWO ")
+
+
+def test_an_UNRECOGNISED_refusal_with_NO_plaintext_ADMITS_it_cannot_classify(
+        escrow_world, monkeypatch):
+    """🔴 THE FAIL-SAFE THAT PAYS FOR KEYING ON ANOTHER TOOL'S PROSE.
+
+    The discriminator is now a substring match on age's stderr, which is
+    strictly weaker than the phase observation it replaced. The price of that is
+    that a future age which rewords must NOT quietly land in one of the three
+    answers. This is the branch that makes it land in an admission instead.
+
+    DEFENSIVE, NOT OBSERVED: on both measured age versions every refusal
+    classifies, so this arm is reachable today only from here. It carries the
+    SAME token and exit code as the named case — the remedy is identical — and
+    differs only in saying that THREE causes stay open, which is what
+    `test_every_decrypt_family_VERDICT_is_pinned_WHOLE` and
+    `test_EVERY_destructive_advice_message_is_pinned_WHOLE` hold to the letter.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_UNRECOGNISED,
+                      write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "DECRYPT-FAILED"
+    assert ei.value.exit_code == 25
+    msg = ei.value.verdict
+    assert msg.startswith(f"age REFUSED {KEY_DELTA_NEW} and this verifier "
+                          f"CANNOT SAY WHY.")
+    # 🔴 It must name the third possibility. The whole failure this replaces was
+    # a verdict that quietly dropped "the PAYLOAD is tampered" from the list.
+    assert "the PAYLOAD is tampered" in msg
+    assert "DO NOT ROTATE OR RE-ESCROW ON THIS" in msg
+    # ...and it must NOT make the two-cause claim it is not entitled to.
+    assert "TWO CAUSES PRODUCE THIS" not in msg
+
+
 def test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE(escrow_world, tmp_path):
     """🔴 AUDIT CASE 2 — THE ONE THAT GETS A GOOD DR KEY ROTATED.
 
@@ -1388,9 +1521,13 @@ def test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE(escrow_world, tmp
     DECRYPT-FAILED — "not (or no longer) a working identity" — for a key that
     had just worked. Acting on that verdict destroys the escrow.
 
-    The discriminator is MEASURED, not guessed (age v1.3.1): a refusal leaves NO
-    output file, a success-on-empty leaves one at size 0. `_decrypt_phase_probe`
-    reads exactly that.
+    The discriminator is MEASURED, not guessed, and it is the rc==0/rc!=0 split
+    published as `restore_verify.DECRYPT_EMPTY_PLAINTEXT` — NOT file presence.
+    That distinction is what kept this row correct across the age v1.3.1 ->
+    v1.3.2 bump, which changed WHEN the output file appears (re-measured
+    2026-09-08: v1.3.1 created it once the header authenticated, v1.3.2 creates
+    it lazily on the first successful write) and broke the sibling
+    ARTIFACT-CORRUPT row that WAS keyed on presence.
     """
     empty = tmp_path / "empty-payload"
     empty.write_bytes(b"")
@@ -1527,7 +1664,7 @@ def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
     assert ei.value.verdict == (
         f"🔴 {KEY_DELTA_NEW} is TAMPERED, CORRUPT or TRUNCATED. age "
         f"authenticated the header with the ESCROWED key — which a non-matching "
-        f"identity cannot do — began writing plaintext, and then FAILED on the "
+        f"identity cannot do — and then FAILED on the "
         f"payload. THE ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a "
         f"backup verifier exists to make: treat the artifact as unusable, check "
         f"the other retained objects for this scope, and do NOT rotate the key.")
@@ -1552,7 +1689,7 @@ def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
                store=escrow_world["store"], work_dir=escrow_world["work"],
                now=NOW, downloader_factory=lambda: d)
     assert ei.value.verdict == (
-        f"age REFUSED {KEY_DELTA_NEW} without writing any plaintext at all. TWO "
+        f"age REFUSED {KEY_DELTA_NEW} before reaching the payload at all. TWO "
         f"CAUSES PRODUCE THIS AND THEY ARE NOT SEPARABLE FROM HERE: the escrowed "
         f"identity does not match this artifact's recipients, or the artifact's "
         f"HEADER is damaged. Neither is asserted. To tell them apart, try a "
@@ -1796,7 +1933,8 @@ def test_the_phase_probe_OBSERVES_rather_than_reimplements(escrow_world):
         seen["state"] = state
     assert RVmod.decrypt is before, "the probe did not restore the original"
     assert seen["state"] == {"reached": False, "returned": False,
-                             "plain_present": None, "cause": None}
+                             "plain_present": None, "cause": None,
+                             "age_refusal": None}
     # And on a real run it records the success phase.
     v, _ = _decrypt_run(escrow_world)
     assert v.decrypt_checked is True
@@ -4231,18 +4369,31 @@ _PINNED_DESTRUCTIVE_TEXTS: frozenset[str] = frozenset({
         're-escrow or rotate on the strength of this. Run `restore-verify.py`'
         ' to diagnose the artifact.'
     ),
-    # ARTIFACT-CORRUPT  (escrow-verify.py:1470)
+    # ARTIFACT-CORRUPT
+    #
+    # 🔴 "began writing plaintext" IS GONE FROM THIS SENTENCE, and the pin is
+    # how you can tell it was a correction rather than a reword. age v1.3.2
+    # creates `--output` lazily, so on every artifact this subsystem produces a
+    # tampered payload writes NO plaintext — the old clause asserted an act the
+    # branch can no longer observe. What survives is the claim that is still
+    # supported: the header authenticated with the escrowed key.
     (
         '🔴 {key} is TAMPERED, CORRUPT or TRUNCATED. age authenticated the '
         'header with the ESCROWED key — which a non-matching identity cannot '
-        'do — began writing plaintext, and then FAILED on the payload. THE '
+        'do — and then FAILED on the payload. THE '
         'ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a backup '
         'verifier exists to make: treat the artifact as unusable, check the '
         'other retained objects for this scope, and do NOT rotate the key.'
     ),
-    # DECRYPT-FAILED  (escrow-verify.py:1482)
+    # DECRYPT-FAILED, message 1 of 2 — age NAMED a pre-payload refusal.
+    #
+    # 🔴 "without writing any plaintext at all" became "before reaching the
+    # payload at all", for the same reason as above in the mirror direction:
+    # the absence of plaintext is no longer EVIDENCE for this verdict on
+    # v1.3.2, so the sentence now states what age actually said rather than
+    # what the old file-presence observation used to imply.
     (
-        'age REFUSED {key} without writing any plaintext at all. TWO CAUSES '
+        'age REFUSED {key} before reaching the payload at all. TWO CAUSES '
         'PRODUCE THIS AND THEY ARE NOT SEPARABLE FROM HERE: the escrowed '
         "identity does not match this artifact's recipients, or the "
         "artifact's HEADER is damaged. Neither is asserted. To tell them "
@@ -4251,6 +4402,22 @@ _PINNED_DESTRUCTIVE_TEXTS: frozenset[str] = frozenset({
         ' stamp: if another artifact OPENS, the escrowed key is fine and THIS'
         " object's header is damaged; if none open, the key is the likely "
         'cause. Do NOT rotate the key before running that.'
+    ),
+    # DECRYPT-FAILED, message 2 of 2 — age refused in a way this tool could not
+    # read. SAME token and SAME exit code because the REMEDY is the same; the
+    # difference is that THREE causes stay open instead of two, and the sentence
+    # says so rather than borrowing the two-cause claim.
+    (
+        'age REFUSED {key} and this verifier CANNOT SAY WHY. age exited '
+        'non-zero without leaving plaintext, and its message matched none of '
+        'the three refusals this tool knows how to read. THREE THINGS ARE NOW '
+        'EQUALLY CONSISTENT with what was seen and NONE is asserted: the '
+        "escrowed identity does not match, the artifact's HEADER is damaged, "
+        'or the PAYLOAD is tampered. 🔴 DO NOT ROTATE OR RE-ESCROW ON THIS. '
+        "Read age's own message in the detail below, then re-run "
+        '`restore-verify.py` by hand. If age has simply reworded, teach '
+        '`classify_age_refusal` the new string — this refusal exists so that a '
+        'reword produces an ADMISSION rather than a confident wrong answer.'
     ),
     # EXPECT-PUBKEY-MALFORMED  (escrow-verify.py:1548)
     (
@@ -4538,6 +4705,32 @@ def _secret_line(text: str) -> str:
 # printed the whole 74-character secret key. The docstring said "a message that
 # echoed it would be caught here". It would not have been.
 #
+# 🔴 AND IT IS VERSION-DEPENDENT. RE-MEASURED 2026-09-08 over 17 inputs on BOTH
+# age-keygen v1.3.1 and v1.3.2, in the dev shell (`nix develop`):
+#
+#     v1.3.1   6 of 17 inputs put the FULL secret line in stderr
+#     v1.3.2   0 of 17 — and 0 of 17 echo ANY 12-byte run of the input at all
+#
+# v1.3.2 dropped the quoted line: `unknown identity type: "<line>"` became a bare
+# `unknown identity type`. That is an upstream FIX, and it makes the redaction
+# guarded here UNTESTABLE FROM THE LIVE BINARY — untested, NOT unnecessary. Both
+# versions are on this host right now (the login shell has v1.3.1, the dev shell
+# v1.3.2), the deployed backup unit takes whatever its PATH gives it, and the
+# redaction is a property of OUR code rather than a bet on age's wording.
+#
+# So the positive control MOVED to a stub age-keygen that reproduces v1.3.1's
+# echoing stderr verbatim — see
+# `test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1`. The
+# live binary is still exercised, but as an OBSERVATION of which regime is
+# installed, not as the thing that makes the guard non-vacuous. An upstream fix
+# must not be able to silence a guard about our own output.
+#
+# 🔴 v1.3.1 ALSO LEAKED ON THREE INPUTS THIS LEDGER NEVER LISTED — a TAB before
+# the secret line, the line wrapped in quotes, and the line indented four
+# spaces. All three are unrecognised-identity-TYPE shapes, i.e. the same
+# mechanism; the ledger was never a complete enumeration and should not be read
+# as one.
+#
 # MEASURED 2026-08-27, age v1.3.1, over six inputs, checking stderr
 # case-INSENSITIVELY against the fixture's own secret:
 #
@@ -4571,15 +4764,30 @@ _MANGLERS = [
 ]
 
 
-def test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret(tmp_path):
-    """🔴 THE POSITIVE CONTROL THE FIRST VERSION OF THIS GUARD LACKED.
+# 🔴 THE TWO age-keygen REGIMES THIS HOST HAS SEEN, as a closed set. A THIRD is
+# a finding, not a nit: it would mean age echoes on inputs neither measurement
+# covered, and the ledger above would be describing neither binary.
+_REGIME_ECHOES = "echoes the unparsed line (age-keygen <= v1.3.1)"
+_REGIME_SILENT = "never echoes the input (age-keygen >= v1.3.2)"
 
-    A "no key material in the message" assertion is worth exactly as much as the
-    input's ability to PUT key material there. This runs `age-keygen -y` directly
-    on each fixture and asserts the stderr of the two `_LEAKING` manglers really
-    does contain the secret — and that the three `_NON_LEAKING` ones really do
-    not. If age ever stops echoing, this goes red and tells you the guard below
-    has become vacuous, instead of leaving it silently green forever.
+
+def test_which_age_keygen_ECHO_REGIME_is_installed_is_OBSERVED_not_assumed(
+        tmp_path):
+    """🔴 AN OBSERVATION, NOT THE GUARD'S POSITIVE CONTROL — and the difference
+    is the whole lesson of the age v1.3.1 -> v1.3.2 bump.
+
+    This used to BE the positive control: it asserted that the two `_LEAKING`
+    manglers really do put the secret in age-keygen's stderr, so that the
+    redaction test below could not be vacuous. v1.3.2 stopped echoing entirely
+    (0 of 17 inputs, measured 2026-09-08), which took the control away and made
+    a guard about OUR OWN output fail for a reason that has nothing to do with
+    our output. A guard that an upstream FIX can silence is not a guard.
+
+    So the control moved to a stub (next test), and this became what it should
+    always have been: a live reading of which regime the installed binary is in,
+    reported as one of exactly two known ones. It goes red only on a THIRD
+    regime — e.g. a version that echoes on inputs this ledger calls
+    non-leaking — which is a real finding about age, not about us.
 
     ⚠ THE COMPARISON IS CASE-INSENSITIVE, and that is not fussiness: a
     case-SENSITIVE check returns a FALSE NEGATIVE on the lowercased-prefix case
@@ -4589,20 +4797,123 @@ def test_the_LEAKING_manglers_really_DO_make_age_keygen_echo_the_secret(tmp_path
     k = _new_identity(tmp_path, "escrowed.key")
     text = k.read_text(encoding="utf-8")
     secret = _secret_line(text)
-    seen = {_LEAKING: 0, _NON_LEAKING: 0}
+    leaked_labels, quiet_labels = [], []
     for mangler, label, kind in _MANGLERS:
         f = tmp_path / f"probe-{abs(hash(label))}.key"
         f.write_text(mangler(text), encoding="utf-8")
         p = subprocess.run([AGE_KEYGEN, "-y", str(f)], capture_output=True)
         assert p.returncode != 0, f"{label} was ACCEPTED by age-keygen"
         err = p.stderr.decode("utf-8", "replace").lower()
-        leaked = secret.lower() in err
-        assert leaked == (kind is _LEAKING), (
-            f"{label}: expected {kind}, stderr {'HAS' if leaked else 'lacks'} "
-            f"the secret. The ledger above is now wrong about this age version; "
-            f"re-measure before trusting the guard that reads it.")
-        seen[kind] += 1
-    assert seen[_LEAKING] >= 2 and seen[_NON_LEAKING] >= 3, seen
+        (leaked_labels if secret.lower() in err else quiet_labels).append(
+            (label, kind))
+
+    leaked_kinds = {kind for _, kind in leaked_labels}
+    if not leaked_labels:
+        regime = _REGIME_SILENT
+    elif leaked_kinds == {_LEAKING}:
+        regime = _REGIME_ECHOES
+    else:
+        regime = None
+    assert regime is not None, (
+        f"age-keygen is in a THIRD echo regime nobody has measured: it echoed "
+        f"the secret for {leaked_labels}, which includes at least one input the "
+        f"ledger above calls non-leaking. Re-measure the whole ledger — the "
+        f"comment describing WHICH shapes echo is now wrong, and the redaction "
+        f"guard's fixtures were chosen from it.")
+    # 🔴 REPORTED, not silently accepted. `-rA` or a failure elsewhere in this
+    # file is where a reader finds out which binary produced the run.
+    print(f"age-keygen echo regime: {regime} "
+          f"(leaking inputs: {[lbl for lbl, _ in leaked_labels]})")
+    # In the echoing regime the ledger must still be exactly right, because that
+    # is the regime whose fixtures the redaction guard was built from.
+    if regime is _REGIME_ECHOES:
+        assert all(kind is _LEAKING for _, kind in leaked_labels)
+        assert all(kind is _NON_LEAKING for _, kind in quiet_labels)
+
+
+# The v1.3.1 stderr, reproduced EXACTLY. Taken from a real run (`age-keygen -y`
+# on an identity with a leading space on the secret line) rather than
+# paraphrased, so a reader can diff it against the binary if they doubt it.
+_AGE_KEYGEN_V131_ECHO = (
+    'age-keygen: error: failed to parse input: error at line 3: '
+    'unknown identity type: "%s"\n'
+    'age-keygen: report unexpected or unhelpful errors at '
+    'https://filippo.io/age/report\n'
+)
+
+
+def test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1(
+        tmp_path, monkeypatch):
+    """🔴 THE POSITIVE CONTROL, MOVED OFF THE LIVE BINARY (2026-09-08).
+
+    The redaction in `backup.py::resolve_recipient` and in this module's
+    NOT-AN-AGE-IDENTITY verdict exists because age-keygen v1.3.1 echoes the
+    input line it could not classify, and on a mangled identity that line is the
+    SECRET KEY. v1.3.2 stopped echoing — an upstream fix — and that silently
+    turned the whole guard vacuous: the mutation "put `p.stderr` back into the
+    message" now survives against v1.3.2 for a reason that says NOTHING about
+    whether our code redacts.
+
+    🔴 AND THE RISK IS LIVE, not historical. Both versions are installed on this
+    host today (login shell v1.3.1, dev shell v1.3.2) and the deployed backup
+    unit takes whatever its PATH provides. A guard whose sensitivity depends on
+    which of two installed binaries answers is not a guard.
+
+    So the leak is supplied by a STUB on PATH that reproduces v1.3.1's stderr
+    byte for byte. `backup.py` invokes `age-keygen` as a bare literal (see
+    `age_public_key_bytes`'s note on why argv[0] must stay a literal), so PATH
+    is the whole injection surface and nothing in production changes.
+
+    NEGATIVE CONTROL IS BUILT IN: the stub is asserted to really put the secret
+    in stderr before the redaction is checked, so a stub that stopped working
+    fails loudly instead of certifying an empty stream.
+    """
+    k = _new_identity(tmp_path, "escrowed.key")
+    text = k.read_text(encoding="utf-8")
+    secret = _secret_line(text)
+    body = secret.split("AGE-SECRET-KEY-", 1)[-1]
+
+    mangled = tmp_path / "mangled.key"
+    mangled.write_text(text.replace(secret, " " + secret), encoding="utf-8")
+
+    binx = tmp_path / "stubbin"
+    binx.mkdir()
+    # The stub echoes the OFFENDING LINE of whatever file it is handed, exactly
+    # as v1.3.1 did — it is not hardcoded to this fixture's secret, so it stays
+    # a faithful stand-in if the fixture changes.
+    mockbin.write_exec(binx / "age-keygen", f"""
+line=$(sed -n '3p' "$2" 2>/dev/null)
+printf '{_AGE_KEYGEN_V131_ECHO}' "$line" >&2
+exit 1
+""")
+    monkeypatch.setenv("PATH", f"{binx}:{os.environ['PATH']}")
+
+    # POSITIVE CONTROL: the stub really does leak, so the assertions below are
+    # about redaction and not about an empty stream.
+    probe = subprocess.run(["age-keygen", "-y", str(mangled)],
+                           capture_output=True)
+    assert probe.returncode != 0
+    assert secret.lower() in probe.stderr.decode("utf-8", "replace").lower(), (
+        "the stub stopped echoing — this test can no longer see a leak, so the "
+        "redaction assertion below would be vacuous. Fix the stub.")
+
+    # The escrowed NOTE is the mangled identity: this is the whitespace-paste
+    # failure `--expect-pubkey` exists to catch, and the verdict it produces is
+    # the one that must not carry the key.
+    with pytest.raises(EV.EscrowError) as ei:
+        _pubkey_run(tmp_path, FakeBw(), note=mangled.read_text(encoding="utf-8"),
+                    expect=_sha_via_documented_shell(k))
+    rendered = str(ei.value).lower()
+    assert ei.value.token == "NOT-AN-AGE-IDENTITY"
+    assert secret.lower() not in rendered
+    # The BODY alone, so a message that dropped the prefix while keeping the key
+    # still fails — the half a `"AGE-SECRET-KEY-" not in msg` spelling check
+    # cannot see.
+    assert body.lower() not in rendered
+    assert "age-secret-key-" not in rendered
+    assert ei.value.detail is None, (
+        "a detail field was populated on a path where the only upstream stream "
+        "available is age-keygen's input-echoing stderr")
 
 
 @pytest.mark.parametrize("mangler,label,kind", _MANGLERS)

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -4253,3 +4253,132 @@ def test_restore_print_plan_is_SILENT_for_the_DEFAULT_identity(
                   max_lag_days=1.0, identity_source="$SOPS_AGE_KEY_FILE")
     out2 = capsys.readouterr().out
     assert "NOT the default identity" in out2, out2
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 classify_age_refusal — the INSTRUMENT the escrow verdicts are read from
+#
+# ADDED 2026-09-08, when a nixpkgs bump moved `age` 1.3.1 -> 1.3.2 and took away
+# the observable `escrow-verify.py` had been classifying on. v1.3.2 creates the
+# `--output` file LAZILY, on the first successful write, so a tampered payload
+# under one 64 KiB chunk now leaves NO file — and file presence, which used to
+# mean "age authenticated the header", stopped being available on every artifact
+# this subsystem actually produces.
+#
+# The distinction SURVIVED, through age's own three refusal messages. That is a
+# WEAKER footing than the phase observation it replaces — it is a substring match
+# on another tool's prose, which this module's own docstring argues against — so
+# the classifier is validated against the REAL binary here rather than against
+# strings someone typed. If age rewords, THIS goes red, and it goes red saying
+# which of the three it can no longer see.
+# --------------------------------------------------------------------------- #
+def _age_refusal_stderr(tmp_path, kind: str) -> str:
+    """Provoke one of age's three refusals with the REAL binary and return its
+    stderr. Built, never spelled — a hardcoded fixture cannot notice a reword.
+    """
+    ident = tmp_path / f"id-{kind}.key"
+    r = subprocess.run([AGE_KEYGEN, "-o", str(ident)], capture_output=True,
+                       text=True)
+    assert r.returncode == 0, r.stderr
+    pub = [ln.split(": ", 1)[1].strip() for ln in
+           ident.read_text(encoding="utf-8").splitlines()
+           if ln.startswith("# public key:")][0]
+
+    plain = tmp_path / f"plain-{kind}"
+    plain.write_bytes(os.urandom(4096))
+    cipher = tmp_path / f"c-{kind}.age"
+    r = subprocess.run([AGE, "--encrypt", "--recipient", pub, "--output",
+                        str(cipher), str(plain)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    blob = bytearray(cipher.read_bytes())
+
+    # The header ends at the newline that terminates the `--- <mac>` line.
+    hdr_end = blob.find(b"\n", blob.find(b"\n---") + 1) + 1
+    use_ident = ident
+    if kind == "payload":
+        # XOR, never a literal write: writing 0xff over a byte that already was
+        # 0xff is a NO-OP, and one such no-op nearly produced a measurement
+        # saying age fails to detect tampering.
+        before = blob[hdr_end + 8]
+        blob[hdr_end + 8] ^= 0xFF
+        assert blob[hdr_end + 8] != before
+    elif kind == "header":
+        before = blob[40]
+        blob[40] ^= 0xFF
+        assert blob[40] != before
+    elif kind == "no-identity":
+        other = tmp_path / f"other-{kind}.key"
+        r = subprocess.run([AGE_KEYGEN, "-o", str(other)], capture_output=True,
+                           text=True)
+        assert r.returncode == 0, r.stderr
+        use_ident = other
+    else:  # pragma: no cover - the caller's kinds are enumerated below
+        raise AssertionError(kind)
+
+    bad = tmp_path / f"bad-{kind}.age"
+    bad.write_bytes(bytes(blob))
+    out = tmp_path / f"out-{kind}"
+    r = subprocess.run([AGE, "--decrypt", "--identity", str(use_ident),
+                        "--output", str(out), str(bad)],
+                       capture_output=True, text=True)
+    assert r.returncode != 0, (
+        f"{kind}: age ACCEPTED an input this test needs it to refuse — the "
+        f"fixture no longer provokes the refusal it is named for")
+    return r.stderr
+
+
+@pytest.mark.parametrize("kind,expected_attr", [
+    ("payload", "AGE_REFUSED_PAYLOAD"),
+    ("no-identity", "AGE_REFUSED_NO_IDENTITY"),
+    ("header", "AGE_REFUSED_HEADER"),
+])
+def test_classify_age_refusal_reads_the_REAL_binarys_three_refusals(
+        tmp_path, kind, expected_attr):
+    """🔴 POSITIVE CONTROL, against the installed age — not against a string.
+
+    `escrow-verify.py` decides whether to tell an operator their BACKUP is
+    tampered or their KEY might be wrong by reading this function's answer. If
+    age rewords any of the three, this is what goes red, naming the one that
+    moved, instead of the verdict quietly becoming wrong.
+    """
+    err = _age_refusal_stderr(tmp_path, kind)
+    got = RV.classify_age_refusal(err)
+    assert got == getattr(RV, expected_attr), (
+        f"age's {kind} refusal now classifies as {got!r}. Its stderr was:\n"
+        f"{err}\n"
+        f"Re-measure and teach `_AGE_REFUSAL_MARKERS` the new string — do NOT "
+        f"widen a marker until it matches, and do NOT let this fall to "
+        f"`unrecognised` silently: escrow-verify's ARTIFACT-CORRUPT verdict is "
+        f"downstream of this answer.")
+
+
+def test_classify_age_refusal_NEVER_guesses_on_something_it_has_not_seen():
+    """🔴 NEGATIVE CONTROL. An instrument that can only ever return one of three
+    answers is indistinguishable from one wired to nothing.
+
+    The fall-through must be its own published value, because the consumer's
+    STRONGEST claim — "your backup is tampered and your key is fine" — must
+    never be reachable by default.
+    """
+    for text in ("", "age: error: something nobody has written yet",
+                 "totally unrelated output", "failed to decrypt"):
+        assert RV.classify_age_refusal(text) == RV.AGE_REFUSED_UNRECOGNISED, text
+    # And the published set is closed, so a consumer's branch cannot be
+    # bypassed by inventing a fourth value at a raise site.
+    with pytest.raises(KeyError):
+        RV.RestoreVerifyError("x", age_refusal="invented")
+
+
+def test_the_three_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
+    """A marker that another marker contains would make the answer depend on the
+    order of a tuple, which is not a property anyone should have to know."""
+    markers = [m for m, _ in RV._AGE_REFUSAL_MARKERS]
+    assert len(markers) == 3
+    assert len(set(markers)) == 3
+    for a in markers:
+        for b in markers:
+            if a is not b:
+                assert a not in b, (a, b)
+    # Every published refusal except the fall-through has exactly one marker.
+    kinds = {k for _, k in RV._AGE_REFUSAL_MARKERS}
+    assert kinds == RV.AGE_REFUSALS - {RV.AGE_REFUSED_UNRECOGNISED}

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -46,7 +46,7 @@ WHAT IS UNDER TEST (see scripts/opencode/README.md for the measurements):
      manual sweep into a standing assertion — after them, 10 of 77 survive, and
      all ten are non-bash tool rows.
 
-  3. The resolver model itself. opencode 1.18.21 resolves a permission by
+  3. The resolver model itself. opencode 1.18.29 resolves a permission by
      `findLast` over a FLAT ORDERED array (built-in defaults, then agent rules,
      then user config — later wins), matching with a hand-rolled glob→regex:
 
@@ -201,7 +201,7 @@ def agent_permission(name: str) -> dict:
 # --------------------------------------------------------------------------- #
 # 🔴 the resolver model
 #
-# Faithful port of opencode 1.18.21's `Wildcard.match` + the `findLast` resolver.
+# Faithful port of opencode 1.18.29's `Wildcard.match` + the `findLast` resolver.
 # See the module docstring for the verbatim source it was ported from and for
 # how it was validated against the real engine. THE PORT ITSELF now lives in
 # scripts/opencode/lib/oc_permissions.py (imported above) so that
@@ -1739,12 +1739,12 @@ def test_tool_level_permissions_are_pinned_exactly():
 
 @pytest.mark.parametrize("dead", ["list", "websearch"])
 def test_no_nonexistent_tools_in_permission_block(dead):
-    """There is no `list` and no `websearch` tool on 1.18.21. The resolved tool
+    """There is no `list` and no `websearch` tool on 1.18.29. The resolved tool
     map is exactly {bash, edit, glob, grep, invalid, question, read, skill,
     task, todowrite, webfetch, write}. Naming a nonexistent tool is a silent
     no-op that reads like configuration."""
     assert dead not in load_config()["permission"], (
-        f"{dead!r} is not a tool on opencode 1.18.21 — the key does nothing"
+        f"{dead!r} is not a tool on opencode 1.18.29 — the key does nothing"
     )
 
 
@@ -1953,7 +1953,7 @@ def test_nav_has_no_shell():
 def test_nav_is_kept_lean():
     """nav must not carry the skill catalogue or be able to recurse.
 
-    VERIFIED against `opencode debug agent nav` on 1.18.21: with these denies the
+    VERIFIED against `opencode debug agent nav` on 1.18.29: with these denies the
     resolved tool set is exactly {glob, grep, read} (+ the internal `invalid`).
     Without `skill: deny` it also carries {skill, task, todowrite, webfetch} —
     and `skill` alone injects the whole catalogue, measured at ~3,730 tokens on
@@ -1968,7 +1968,7 @@ def test_nav_is_kept_lean():
 
 
 def test_no_agent_promises_a_list_tool():
-    """There is NO `list` tool on opencode 1.18.21."""
+    """There is NO `list` tool on opencode 1.18.29."""
     targets = [AGENT_DIR / f"{n}.md" for n in EXPECTED_AGENTS] + [ADDENDUM]
     bad = []
     for p in targets:

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -11,7 +11,7 @@ duplicate of it).
   That is a real gap, and it is exactly the gap the version pin exists to cover:
   a config whose keys are unchanged can have its RESOLVED MEANING changed by the
   binary underneath it. opencode.jsonc's header documents a large set of
-  behaviours annotated "measured on v1.18.21 — do not re-derive" — last-match-
+  behaviours annotated "measured on v1.18.29 — do not re-derive" — last-match-
   wins ordering, hidden agents inheriting the global permission block, the exact
   tool set. A static test cannot see any of those change. This file runs the
   real engine and checks them.
@@ -91,7 +91,7 @@ ROOT = Path(__file__).resolve().parents[2]
 OC_DIR = ROOT / "scripts" / "opencode"
 TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 
-# 🔴 THE PIN. Every "measured on v1.18.21" claim in opencode.jsonc's header, in
+# 🔴 THE PIN. Every "measured on v1.18.29" claim in opencode.jsonc's header, in
 # scripts/opencode/README.md and in test_opencode_config.py's docstrings is keyed
 # to this exact version. It is pinned declaratively by nix/pkgs/tools/default.nix
 # resolving `pkgs.opencode` out of flake.lock's nixpkgs.
@@ -190,9 +190,60 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 #     not apply: `nix profile list` carries no opencode entry, and PATH resolves
 #     into /nix/store/...-opencode-1.18.21 out of the flake itself. This is a
 #     genuine lock movement, not per-host profile drift.
-PINNED_VERSION = "1.18.21"
+#
+# 🔴 RE-DERIVED 1.18.21 -> 1.18.29 (2026-09-08). Another nixpkgs bump moved
+# `pkgs.opencode` under an unchanged config. This pass ran the STRONGER control
+# that the 2026-08-29 entry above explicitly DECLINED — the dual-binary dump —
+# because the superseded binary was still realised in the local store
+# (`/nix/store/...-opencode-1.18.21`), so it cost nothing to rebuild. What was
+# measured, in the DEV SHELL (`nix develop`), which is the tier the gate runs in:
+#
+#   * SEVEN-AGENT DUAL DUMP. `debug agent <a> --pure` for all seven agents under
+#     BOTH binaries, from a config dir seeded out of this repo, canonicalised
+#     (every array sorted) with the harness's own TMPDIR normalised out:
+#     IDENTICAL on all seven — permissions as a set, the resolved tool map
+#     INCLUDING its key set, and the model. Unlike the pass two bumps back,
+#     even `compaction`'s built-in prompt did not move.
+#   * ORDERED bash rule arrays for the four primaries, compared position by
+#     position WITHOUT sorting: equal, at 66 / 67 / 68 / 93 rules
+#     (build / nav / k8s / review). Last-match-wins ordering is exactly what that
+#     comparison pins, and it did not move.
+#   * CONTROLS, reported as a PAIR rather than as a bare "identical":
+#       - same-binary control — two runs of the incoming binary collapse to
+#         identical for all seven agents, so the canonicalisation is validated
+#         and "identical" is not readdir noise being sorted away.
+#       - comparator negative control — flipping ONE boolean in one dump's tool
+#         map makes the comparator name that agent and that key, so "identical"
+#         is not a comparator wired to nothing.
+#   * `nav`'s ENABLED tool set (NAV_EXPECTED_TOOLS below) read off the engine on
+#     BOTH binaries: {glob, grep, invalid, read} on each, out of the same
+#     12-key map — so the "no `list` tool and no `websearch` tool" claim is
+#     re-derived, not re-spelled.
+#   * The browser-only tool-set gate (scripts/browser-bridge/browser-agent's
+#     fail-closed `debug agent browser-agent` check) replicated against BOTH
+#     binaries by rebuilding its scratch project exactly as the wrapper does:
+#     exactly one enabled tool, `browser`, out of 13, with every host tool
+#     present and false, on each. 🔴 ON ONE HOST ONLY — see the next bullet.
+#   * This whole file against the NEW binary with the OLD pin: 1 failed (exactly
+#     the version assertion below), 24 passed — the same load-bearing control the
+#     two entries above ran, and it says every other engine claim holds on the
+#     incoming binary rather than the harness being green by default.
+#
+# 🔴 NOT COVERED by this pass, named so nobody reads it as more than it is:
+#   * THE LAPTOP. Every "both hosts run <v>" line was re-verified AT THE CONSUMER
+#     on the workbench only (`readlink -f $(command -v opencode)` in a login
+#     shell -> the incoming store path). The laptop was UNREACHABLE at the time
+#     (ssh to its nebula address refused), so those sentences are now split: the
+#     workbench half carries the pin and is dated, the laptop half says
+#     explicitly that it is unverified. Do not re-conjoin them.
+#   * The DEV SHELL is not the interactive shell. `nix develop` and the login
+#     shell happened to agree on opencode here (both resolve the same store
+#     path), but they did NOT agree on `age` in the same session — so "the
+#     version on PATH" is a claim about ONE shell until you say which.
+PINNED_VERSION = "1.18.29"
 
-# MEASURED via `opencode debug agent nav --pure` at 1.18.21. This is the cost AND
+# MEASURED via `opencode debug agent nav --pure` at 1.18.29, on BOTH the incoming
+# and the superseded binary (identical). This is the cost AND
 # blast-radius pin that test_opencode_config.py's `test_nav_is_kept_lean` only
 # asserts about the CONFIG KEYS; here it is read off the engine's resolved tool
 # map. `skill` alone injects the ~3,730-token catalogue on every request.
@@ -661,6 +712,16 @@ def test_engine_is_the_version_every_measurement_is_keyed_to():
     signal, and it clears with the documented one-time per-host prerequisite:
 
         nix profile remove opencode   # then home-manager switch / ship.sh
+
+    🔴 BUT DO NOT REACH FOR THAT FIRST — it was the cause ONCE, in 2026-08, and
+    every red since has been a LOCK MOVEMENT instead. An empty result cannot tell
+    the two apart, so run the discriminating check rather than the plausible
+    remedy (2026-09-08: `nix profile remove opencode` answered "does not match
+    any packages in the profile", the home-manager generation ITSELF provided the
+    new binary, and `nix eval` of the generation's `home.packages` said a switch
+    would build the version already installed — i.e. no switch and no profile
+    removal could have cleared it). The assertion message below carries the
+    check.
     """
     exe = _opencode_bin()
     # Through `_run_opencode` like everything else. `--version` is ~7 bytes and
@@ -676,13 +737,25 @@ def test_engine_is_the_version_every_measurement_is_keyed_to():
         f"claim in scripts/opencode/opencode.jsonc, scripts/opencode/README.md "
         f"and scripts/tests/test_opencode_config.py is keyed to "
         f"{PINNED_VERSION!r}.\n"
-        f"  * On a DEV HOST this usually means the old imperative profile entry "
-        f"is still winning PATH. Fix: `nix profile remove opencode`, then "
-        f"`home-manager switch --flake ~/workspace/devrc --impure`.\n"
+        f"  * FIRST run the DISCRIMINATING check — there are two causes and they "
+        f"need opposite fixes, so do not guess:\n"
+        f"        nix profile list | grep -i opencode\n"
+        f"        readlink -f \"$(command -v opencode)\"\n"
+        f"    An imperative profile entry that wins PATH is a HOST problem: "
+        f"`nix profile remove opencode`, then `home-manager switch --flake "
+        f"~/workspace/devrc --impure`. NO profile entry, with PATH already "
+        f"resolving into a store path the flake built, is a LOCK MOVEMENT, and "
+        f"no amount of switching will change it.\n"
         f"  * If flake.lock genuinely moved opencode, do NOT just bump "
         f"PINNED_VERSION: re-derive the header's measurements against the new "
         f"binary first (the rest of this file tells you which ones changed), "
-        f"then update both together."
+        f"then update both together. The superseded binary is usually still "
+        f"realised in /nix/store (`ls -d /nix/store/*-opencode-*`), which makes "
+        f"the seven-agent dual dump the cheapest control available — run it "
+        f"rather than declining it.\n"
+        f"  * Say WHICH SHELL you measured in. `nix develop` and the login shell "
+        f"can carry different builds of the same tool, and the gate runs in the "
+        f"dev shell."
     )
 
 
@@ -797,6 +870,24 @@ _VERSION_RE = re.compile(
 # nothing and reads as an orphan. Snippets carry no version literal of their own,
 # or they would match themselves when this file is scanned.
 HISTORICAL_VERSION_CLAIMS = (
+    # 🔴 Added by the 2026-09-08 re-derivation pass. Each of
+    # these is a line in the PRIOR pass's own record — a statement about what was
+    # measured THEN, which does not become false when the pin moves and must not
+    # be relabelled to a version nobody ran that measurement on.
+    # (No version literals in this comment: it is scanned like every other line
+    # in this file.)
+    ("scripts/tests/test_opencode_engine.py", "and the harness is shown to",
+     "the prior pass's own account of the control it ran, at the version it ran it on"),
+    ("scripts/tests/test_opencode_engine.py", "out of the flake itself",
+     "the prior pass's record of the store path PATH resolved into at the time"),
+    ("scripts/tests/test_opencode_engine.py", "the same …-opencode-",
+     "the 2026-08-19 convergence record's store path; history"),
+    ("scripts/tests/test_opencode_engine.py", "Another nixpkgs bump moved",
+     "names the 2026-09-08 transition itself"),
+    ("scripts/tests/test_opencode_engine.py", "it cost nothing to rebuild",
+     "the superseded binary's store path, which is what made the dual dump cheap"),
+    ("scripts/opencode/agent/k8s.md", "a dated incident record,",
+     "the k8s index-74 record; its counts describe a tree that no longer exists"),
     # 🔴 Added by the 2026-08-29 re-derivation pass. Each is a claim the engine
     # tests do NOT re-derive, so re-keying it would have been relabelling a
     # measurement nobody repeated — the exact thing this ledger exists to stop.
@@ -898,18 +989,23 @@ HISTORICAL_VERSION_CLAIMS = (
     # session.) The sentences are now SPLIT: the host-version half
     # carries the pin and is re-derived, and each resolution half is dated to its
     # last real measurement and exempted here.
-    ("scripts/browser-bridge/README.md", "browser-only RESOLUTION is last verified",
-     "browser-agent resolution — not re-derived at the pin; nothing in CI observes it"),
-    ("scripts/browser-bridge/README.md", "It was NOT re-derived at the",
-     "the pre-bump measurements cited as evidence the bumps were no-ops"),
-    ("scripts/browser-bridge/README.md", "since the check",
-     "custom-tool mechanism — needs the real binary, not re-derived at the pin"),
-    ("scripts/browser-bridge/README.md", "below needs the real binary",
-     "the pre-bump measurement behind that custom-tool claim"),
-    ("scripts/browser-bridge/reference/agent.md", "It has NOT been re-derived at",
-     "the misattribution warning's evidence — measured at three older versions"),
-    ("scripts/browser-bridge/reference/agent.md", "resolution itself is last measured",
-     "browser-agent resolution for the gate claim — not re-derived at the pin"),
+    # 🔴 THE "NOT RE-DERIVED AT THE PIN" EXEMPTIONS FOR browser-agent ARE GONE,
+    # and their absence is the record. Six entries here used to exempt sentences
+    # saying the browser-only resolution was last verified two bumps back. The
+    # 2026-09-08 pass actually RAN it — the wrapper's own scratch project against
+    # the real pinned binary, and against the superseded one as a control — so
+    # those sentences now carry the pin and need no exemption. What replaced them
+    # is a narrower, TRUE caveat in the same paragraphs: measured on ONE host, by
+    # hand, with nothing in CI observing it. The entries below exempt the older
+    # versions those paragraphs still cite as prior art.
+    ("scripts/browser-bridge/README.md", "before those two.",
+     "the three earlier passes cited as prior art for the resolution claim"),
+    ("scripts/browser-bridge/README.md", "It was verified the same way on",
+     "same prior art, in the custom-tool-mechanism paragraph"),
+    ("scripts/browser-bridge/README.md", "in earlier passes, plus an end-to-end",
+     "the second line of that citation, incl. the one-off --tool browser run"),
+    ("scripts/browser-bridge/reference/agent.md", "in the passes before that.",
+     "the misattribution warning's prior art — measured at three older versions"),
     ("scripts/browser-bridge/reference/agent.md", "and resolved identically on",
      "the pre-bump measurements behind that gate claim"),
     ("scripts/tests/test_opencode_engine.py", 'Five lines said "both hosts run',
@@ -1166,7 +1262,7 @@ def test_engine_and_model_agree_on_every_pinned_command(engine_name, model_agent
 # --------------------------------------------------------------------------- #
 def test_engine_resolves_navs_tool_set_to_exactly_the_pinned_four():
     """test_opencode_config.py's `test_nav_is_kept_lean` docstring says "VERIFIED
-    against `opencode debug agent nav` on 1.18.21: the resolved tool set is
+    against `opencode debug agent nav` on 1.18.29: the resolved tool set is
     exactly {glob, grep, read} (+ the internal `invalid`)" — but that file
     asserts only the CONFIG KEYS, so the verification was a one-off nobody
     re-ran. This re-runs it every gate.


### PR DESCRIPTION
Two nixpkgs tools moved while the repo's pins and guards stayed put. **No PR caused
any of these 7 failures** — `#1389` documents the same red on `main` itself (docs-only,
zero file overlap with this branch); this is the fix.

| tool | login shell | **dev shell (where the gate runs)** | repo expected |
|---|---|---|---|
| `opencode` | 1.18.29 | **1.18.29** | `PINNED_VERSION = "1.18.21"` |
| `age` / `age-keygen` | **1.3.1** | **1.3.2** | 1.3.1's behaviour |

Every measurement below was taken in the **dev shell** unless it says otherwise. Both
age versions are installed on this host *right now*, which matters for half 2.

---

## Half 1 — opencode 1.18.21 → 1.18.29

The superseded binary was still realised in `/nix/store`, so this pass ran the
**seven-agent dual dump** that the 2026-08-29 entry explicitly declined.

**Re-derived, and CHANGED: nothing.**

| measurement | result |
|---|---|
| 7 agents, `debug agent --pure`, canonicalised + TMPDIR-normalised, both binaries | **identical on all 7** — permissions as a set, resolved tool map *including its key set*, and the model. Even `compaction`'s built-in prompt held (it moved at the 1.18.16→1.18.18 bump). |
| ordered bash rule arrays, 4 primaries, position-by-position, **unsorted** | equal at **66 / 67 / 68 / 93** (build / nav / k8s / review) |
| `nav`'s enabled tool set | `{glob, grep, invalid, read}` out of the same 12-key map, on both → "no `list`, no `websearch`" is re-derived, not re-spelled |
| browser-agent fail-closed tool-set gate, scratch project rebuilt exactly as the wrapper builds it, both binaries | exactly one enabled tool `browser` out of 13, every host tool present and `false`, on each |
| whole engine file, new binary + old pin | **1 failed** (exactly the version assertion), **24 passed** |

**Controls, reported as a pair:** same-binary control collapses to identical for all
seven (so the canonicalisation is validated and "identical" is not readdir noise being
sorted away); comparator negative control names the agent *and* the key when one boolean
is flipped.

**Not covered, said in-place rather than implied:**

- 🔴 **The laptop.** Every *"both hosts run &lt;v&gt;"* sentence is now **split** — the
  workbench half is verified at the consumer (`readlink -f $(command -v opencode)` in a
  login shell), the laptop was **unreachable** (ssh to its nebula address refused) and is
  explicitly unverified. Do not re-conjoin them.
- The browser-agent resolution *was* re-derived at the pin, which **retires six ledger
  exemptions** — but on **one host, by hand, with nothing in CI observing it**. That
  narrower caveat replaces the old one rather than disappearing.

**Two side-fixes that are not version bumps:**

- The version assertion sent the reader to `nix profile remove opencode` first.
  **Measured false here:** no profile entry exists, the home-manager generation itself
  provides the binary, and `nix eval` says a switch would build the version already
  installed. The two causes need opposite fixes, so the message now carries the
  *discriminating check* instead of the plausible remedy.
- `nix/pkgs/tools/default.nix` and `flake.nix` no longer spell the nixpkgs rev or the
  opencode store path in the present tense. Only the **version** is guarded by the
  scanner, so a hash written there rots unguarded — both are replaced by the one-liner
  that derives them.

---

## Half 2 — age 1.3.1 → 1.3.2 (the delicate one)

### The ARTIFACT-CORRUPT / DECRYPT-FAILED distinction: it SURVIVED, on weaker footing

Measured over 7 payload sizes × 5 manglings + wrong-key + damaged-header on **both**
binaries (84 runs):

- **v1.3.1** — a payload-authentication failure **always** left `--output` behind (size 0
  below one 64 KiB chunk, partial above it). Presence therefore *meant* "age
  authenticated the header", which is what `escrow-verify.py` classified on.
- **v1.3.2** — `--output` is created **lazily, on the first successful write**. A payload
  failure in the first chunk leaves **no file** — at 64 B, 1 KiB, 64 KiB−1, 64 KiB and
  64 KiB+1. Only ≥ 64 KiB cases where an earlier chunk already flushed still leave one
  (196608 B of 256 KiB; 983040 B of 1 MiB). A **pre-existing** file is left untouched
  (34-byte control read back intact), so it is **lazy creation, not unlink-on-failure**.

🔴 **Unfixed, that meant a TAMPERED backup of the size this subsystem actually produces
was reported as `DECRYPT-FAILED`** — *"your escrowed identity may not match"* — the
verdict that gets a good disaster-recovery key rotated while the real fault is a corrupt
artifact.

**The distinction is not gone.** age's three refusal messages are byte-identical on both
versions, so it is re-keyed to them: `restore-verify.py` publishes
`classify_age_refusal` + a closed `AGE_REFUSED_{PAYLOAD,NO_IDENTITY,HEADER,UNRECOGNISED}`
set on `RestoreVerifyError`, and `ARTIFACT-CORRUPT` now fires on `plain_present` **OR**
`age_refusal == payload-auth-failed`. Presence is still **sufficient**; it stopped being
**necessary**.

**What got weaker, said plainly in the code and in `SECRETS.md`:** this is a substring
match on another tool's prose, which `restore-verify.py`'s own docstring argues against.
The price is paid with a fail-safe — an **unrecognised** refusal reaches neither strong
verdict. It gets `DECRYPT-FAILED`'s *second* message (same token and exit code, because
the **remedy** is identical — the table's own "split by REMEDY" doctrine, and
`test_the_table_STOPS_below_restore_verifys_FLOOR` correctly refuses a new code), which
names all **three** remaining causes *including tampering* and says it cannot say why.

**Two operator-facing sentences were CORRECTED, not reworded** — the whole-text pins are
how you can tell:

- `ARTIFACT-CORRUPT` lost *"began writing plaintext"*: on v1.3.2 it asserts an act the
  branch can no longer observe.
- `DECRYPT-FAILED`'s *"without writing any plaintext at all"* became *"before reaching
  the payload at all"*: the absence of plaintext is no longer evidence for that verdict.

### The age-keygen redaction guard went VACUOUS, not unnecessary

Swept 17 manglings on both binaries: **v1.3.1 leaks the full secret on 6**; **v1.3.2 on
0**, and echoes no 12-byte run of the input at all (`unknown identity type: "<line>"`
became a bare `unknown identity type`). That is an upstream **fix** — and it silently
disarmed a guard about **our own** output.

**Proven, not argued:** with 1.3.2 installed, re-interpolating `p.stderr` into
escrow-verify's `NOT-AN-AGE-IDENTITY` verdict **survives**
`test_NO_pubkey_failure_message_EVER_carries_key_material` (5 params, all green). That
test's docstring claimed it killed exactly that mutation; the claim is corrected in place
in its own commit.

**The risk is live, not historical** — the login shell here is still 1.3.1 and the
deployed backup unit takes whatever its PATH gives it. So both positive controls moved
off the live binary onto a **stub `age-keygen` that reproduces v1.3.1's stderr verbatim**
(PATH injection only; `backup.py` invokes it as a bare literal). The live binary is still
exercised — as an **observation** of which of two known echo regimes is installed, red
only on a third.

Also recorded: v1.3.1 leaks on three inputs the ledger never listed (TAB prefix, quoted
line, 4-space indent). Same mechanism; the ledger was never complete and now says so.

---

## Red → green / mutation matrix

Every row measured in the dev shell.

| guard | how it was made red | its own assertion |
|---|---|---|
| `test_engine_is_the_version_every_measurement_is_keyed_to` | `origin/main` vs live binary | *"opencode on PATH is `'1.18.29'`, but every 'measured on v1.18.21' claim … is keyed to `'1.18.21'`"* |
| `test_no_file_in_the_pins_surface_still_claims_an_OLD_version` | new pin + `origin/main`'s `scripts/opencode/README.md` restored | *"1 version claim(s) in the pin's surface disagree with `PINNED_VERSION='1.18.29'`"* |
| `test_every_historical_version_claim_still_exists` | one retired ledger entry put back | *"… matches NO old-version line"* |
| `..._is_ARTIFACT_CORRUPT_not_EMPTY` ×3 + `..._VERDICT_is_pinned_WHOLE` | `origin/main` vs live age | got `DECRYPT-FAILED`, expected `ARTIFACT-CORRUPT` |
| **NEW** `..._even_when_age_WROTE_NOTHING` | revert the OR to `plain_present` only | `token == "ARTIFACT-CORRUPT"` |
| **NEW** `..._when_only_PLAINTEXT_says_so` | drop `plain_present` from the OR | `+ DECRYPT-FAILED` |
| **NEW** `..._UNRECOGNISED_refusal..._ADMITS_it_cannot_classify` | named-refusal gate → `if True` | `.startswith("… CANNOT SAY WHY.")` |
| `test_resolve_recipient_NEVER_quotes_...` | re-interpolate stderr in `backup.py` | secret present in the rendered message |
| **NEW** `..._against_a_STUB_that_echoes_like_age_v1_3_1` | re-interpolate stderr in escrow's verdict | secret present — **on a host where the pre-existing guard survives the same mutation** |

New `classify_age_refusal` guards carry their own controls: the positive one provokes
each of the three refusals from the **real** binary (built, never spelled); the negative
one pins that an unseen message returns `unrecognised` and that the published set is
closed.

---

## Not verified

- **The laptop.** Unreachable throughout (ssh to its nebula address refused), so no
  "both hosts" claim was re-derived. The docs now say so instead of implying otherwise.
- **The browser-agent resolution in CI.** Re-derived by hand on the workbench; nothing in
  CI observes it, and the next bump gets no red there if it changes.
- **age's UNRECOGNISED branch in the wild.** Defensive, not observed — on both measured
  versions every refusal classifies. Labelled as such, the same status as
  `PUBKEY-DERIVATION-EMPTY`.

Do not merge without a look at the two corrected operator sentences — they are the ones
that decide whether a key gets rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Both tiers, one at a time, on the REBASED tree (base moved 5 commits mid-work)

Counts, not "BUILD OK". Both tiers collected the **same 20948**.

| tier | result |
|---|---|
| **dev host** `scripts/run-tests.sh .` | `TOTAL collected=20948 passed=20945 skipped=2 failed=1`, all **28 per-target floors PASS** |
| **nix sandbox** `nix build .#checks.x86_64-linux.pytests` | `TOTAL collected=20948 passed=20946 skipped=2 failed=0` — **EXIT=0, RESULT: PASS** |

The dev-host tier's single failure is **not this branch and not either toolchain**:
`test_subsystem_touch.py::TestCommitNegativeControls::
test_the_LENGTH_bound_is_not_vacuous_git_WOULD_have_expanded_it`. The test asserts
`git rev-parse --disambiguate=<sha[:3]>` returns exactly one sha; this run's throwaway
repo produced `2d2805be…` and `2d2d47e3…` — **both starting `2d2`** — so it returned two.

- Not in this branch's diff (last touched by `#1254`).
- Passed **5/5** on immediate re-run.
- Passed in the **nix sandbox** run of the same file.
- Not load: 12902 other tests in the same run passed, and the failure is an assertion,
  not a timeout.

🔴 **It is a real test defect, not just bad luck** — a 3-hex-char prefix collides at
roughly 1/4096 per extra object, so this will recur. Filed below rather than fixed here;
it belongs in a different subsystem's PR.

**Follow-up task (out of scope for this PR):** widen that fixture's prefix, or assert
`sha in expanded` instead of `expanded == [sha]`, in `scripts/tests/test_subsystem_touch.py`.
*Closing condition:* a merged PR after which that test passes with a deliberately
collision-inducing fixture — mechanically checkable, no human judgement needed.
