### PR TITLE
test(audit-dispatch): #1342's controls are reachable — and there are EIGHT, not six

### DIFF
--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -146,10 +146,11 @@ retained as DONE markers; do not re-claim them.
    forcing: none
 6. **DONE (2026-09-07) — the three 🟡s fixed, then a blind audit of the fix PR found 2 more,
    which were also fixed.** `#1342` → squash **`08ef1d5a`**, four-leg gate green on the merged
-   tree at base `3f8c81bb`. Claim `audit-pr-ladder-6` RELEASED. ⚠ One item deliberately left
-   open rather than chased — see "UNVERIFIED at merge" under Open investigations: whether
-   #1342's six new control assertions are reachable. The fix round before the merge changed
-   ZERO payload lines, so one more round would have fired the attribution gate.
+   tree at base `3f8c81bb`. Claim `audit-pr-ladder-6` RELEASED. ⚠ One item was deliberately left
+   open rather than chased — whether #1342's new control assertions are reachable. **That is
+   now CLOSED by rank 11 (2026-09-08): eight controls, not six, all reachable, none vacuous.**
+   The fix round before the merge changed ZERO payload lines, so one more round would have
+   fired the attribution gate.
    forcing: none
 7. **Decide the `scripts/testlib/**` payload-vs-scaffolding classification and write it into
    `claude/skills/audit-pr/reference/round-ladder-evidence.md`.** It is the whole of the #1132
@@ -171,11 +172,12 @@ retained as DONE markers; do not re-claim them.
     measurement additionally reports, per ladder, the churn between the first block's `from`
     and the head that no block's range covers.
     forcing: none
-11. **Verify #1342's six control assertions are reachable** (the item rank 6 left open).
-    Mutate each individually under `PYTHONDONTWRITEBYTECODE=1`; each must fail with its OWN
-    message, not a neighbour's; keep a known-caught mutant as positive control and report the
-    pair. *Closes when* all six are shown to fail for their own reason, or one is shown vacuous
-    and fixed.
+11. **DONE (2026-09-08) — #1342's control assertions are REACHABLE, and there are EIGHT of
+    them, not six.** Every one kills its own mutant and fails with its own message; nothing is
+    vacuous. Landed as `TESTLIB_ROWS` in `scripts/tests/mutants-audit-dispatch.py` so the claim
+    is re-derivable rather than believed. Claim `audit-pr-ladder-11` RELEASED. Closing condition
+    met — see "RESOLVED — #1342's controls" under Open investigations for the numbers and the
+    two harness controls.
     forcing: none
 12. **Ship #1316 and #1342 to both hosts and re-verify fleet parity.** Neither has been
     shipped; parity was last verified at `a4529101` on 2026-09-01 and is stale. *Closes when*
@@ -788,6 +790,36 @@ retained as DONE markers; do not re-claim them.
   "leave it alone", so the run is silent. **When an item closes, update the RANKED LIST in the
   same delta, not just the status header.**
 
+- 🔴 **A MUTATION BATTERY KEYED ON *WHICH TEST* FAILED IS BLIND TO EVERY CONTROL THAT SHARES A
+  TEST — and it reports that blindness as coverage.** `mutants-audit-dispatch.py` grades a row
+  by the SET OF TEST NAMES that must kill it, which is the right unit for a payload mutation and
+  the wrong one for #1342's eight parser controls: all eight live in the body of ONE test, so
+  eight rows would each report `killed by exactly 1: test_the_cached_build_fallback_…` and be
+  indistinguishable from one another *and* from any other assertion in that test firing. The
+  battery's own docstring already names this hazard ("a mutant can die to a DIFFERENT test's
+  error and be scored as covered while its own assertion is unreachable") — it just could not
+  express the finer unit. **Ask what unit your battery discriminates BEFORE reading its greens**:
+  a second table matching the failing assertion's own MESSAGE is what these needed.
+- 🔴 **A NEGATIVE CONTROL FOR THE HARNESS IS NOT THE SAME AS A POSITIVE CONTROL FOR THE MUTANTS,
+  AND ONLY THE FIRST TELLS YOU "ALL KILLED" MEANS ANYTHING.** Nine rows all reporting KILLED is
+  exactly what a battery wired to nothing prints if every mutation makes the module fail to
+  import. The row that made the other eight readable was one that had to SURVIVE: mutating a
+  `shell_code` branch no fixture reaches. It is `T9` in the committed table for that reason —
+  a control that is not committed is a control nobody re-runs.
+- 🔴 **THE MISCOUNT AGAIN, AND THIS TIME IN THE ITEM DESCRIBING WHAT TO VERIFY.** The ranked item
+  and the investigation block both said "six control assertions"; the block holds **5 `assert`
+  statements** carrying **8 distinct claims** (a 4-iteration loop is 4 controls, not one). Six
+  reconciles with neither reading. That is the fourth instance in this thread of a number this
+  effort produced and then re-quoted instead of re-deriving — and the first where the wrong
+  number was the *specification of the verification*, which means a session that verified
+  exactly six would have stopped two controls short and reported the item closed.
+- 🔴 **VERIFY A CONTROL BY MUTATING WHAT IT WATCHES, NEVER THE CONTROL ITSELF.** The item's own
+  "Next probe" said to *"mutate each of the six control assertions individually"*. Doing that
+  literally proves only that the assertion exists and that pytest runs the file — it cannot
+  distinguish a reachable control from one sitting behind an early `return`. The mutation has to
+  land on the PARSER, arranged so exactly one control's claim breaks and it is the FIRST to
+  fail; the control's own message is then the evidence.
+
 ## How to verify
 ```bash
 # --- rank 5's audit actually ran against the range the doc names ---
@@ -806,6 +838,17 @@ gh pr view 1316 --repo innovation-upstream/devrc --json mergedAt,mergeCommit
 
 # --- the claim is still held by this effort ---
 claim-work --list | grep audit-pr-ladder-5
+
+# --- rank 11: the eight controls, re-derived rather than believed ---
+# Expect the TESTLIB block to print 8 rows `killed by its OWN control` plus
+# `T9 ... SURVIVED as required (control)`. 🔴 If T9 says KILLED, the other eight
+# are uninterpretable — the battery is reacting to the edit, not the semantics.
+nix develop ~/workspace/devrc -c python3 \
+  ~/workspace/devrc/scripts/tests/mutants-audit-dispatch.py | sed -n '/^TESTLIB/,$p'
+
+# The count, re-derived from the file instead of quoted (expect 5 asserts / 8 claims:
+# 4 explicit + a 4-iteration loop). Read the block, do not grep a number out of prose.
+sed -n '2950,2970p' ~/workspace/devrc/scripts/tests/test_audit_dispatch.py
 ```
 ## Open investigations — live diagnosis state
 
@@ -1017,12 +1060,60 @@ claim-work --list | grep audit-pr-ladder-5
   moves `grep -c` back to the end and reinstates F4's inversion verbatim. via: assumed
 - **Next probe:** none — fix the comment and widen the assertion to require the verdict grep last.
 
-### UNVERIFIED at merge: are #1342's six new control assertions reachable?
-- **Symptom + exact repro:** #1342 added six control assertions pinning both overshoot
+### RESOLVED — #1342's controls are reachable, and there are EIGHT of them, not six
+🔴 **This block was EDITED IN PLACE, not appended to.** `Open investigations` is an append-only
+section under `handoff_doc.py`, and this doc already records that a correction appended to a
+different section leaves the original still making its claim ~140 lines above. The heading and
+the count below are corrections to text that was wrong; the original wording is quoted where it
+is load-bearing rather than left standing as a live claim.
+
+- **The count in the original entry was WRONG, and it is the shape this thread keeps finding.**
+  It read "six control assertions … plus the four separators", which reconciles with nothing:
+  the block is **5 `assert` statements** carrying **8 distinct control claims** (2 `shell_code`
+  overshoot directions + 2 `last_command` overshoot directions + a 4-iteration loop over the
+  separators `;`, `||`, `|`, `&&`). Re-derived by reading the block, not by re-quoting the
+  handoff — the same rule this doc already carries three times over.
+- **REACHABILITY, measured first, because it was the live risk.** The controls sit after an
+  early `return` in `test_the_cached_build_fallback_is_emitted_with_its_guards` (line ~3085:
+  the test bails when the brief fences no sandbox tier) **and** after a `len(blocks) == 1`
+  assert. Either would have made all eight vacuous while the suite stayed green. Measured at
+  `39c31521`: `run_main(["900"])` → rc 0, the precondition string IS present, and exactly
+  **one** `nix log` fenced block is emitted. So the block executes.
+- **OWN-REASON, measured per control.** Each of the eight was isolated by mutating the PARSER —
+  never the assertion, which would only prove the assertion exists — so that exactly one
+  control's claim breaks and it is the FIRST to fail. All eight: **KILLED, carrying their own
+  message.** The four separator iterations are discriminated by the sep token their message
+  names (`';'` / `'||'` / `'|'` / `'&&'`); `"reached by '|'"` is not a substring of
+  `"reached by '||'"`, checked, which is what makes those two rows different measurements.
+- 🔴 **BOTH HARNESS CONTROLS RUN, and the second is the one that makes the first readable.**
+  Positive: `shell_code` stubbed to `return ""` is KILLED (the batch's known-caught mutant, so
+  a stale `.pyc` scoring SURVIVED would show). Negative: mutating `shell_code`'s
+  backslash-inside-double-quotes branch — which no fixture and no line of the emitted block
+  reaches — **SURVIVED**, proving the harness can report SURVIVED at all. Run under
+  `PYTHONDONTWRITEBYTECODE=1` with `-p no:cacheprovider`, each mutation asserted to have landed
+  on disk before the run, and the file restored from a `cp -a` copy (never `git checkout --`,
+  per this doc's own incident).
+- 🔴 **A KILLER SET CANNOT SEE THESE, AND THAT IS A SEAM, NOT A DETAIL.**
+  `mutants-audit-dispatch.py` expects each row to name the TESTS that must kill it; all eight
+  controls live inside ONE test, so eight rows would report the same single name and read as
+  coverage while measuring one. They landed as a second table, `TESTLIB_ROWS`, which mutates
+  `scripts/tests/test_audit_dispatch.py` (not `audit-dispatch.py`) and matches the failing
+  assertion's own MESSAGE, failing a row when ANOTHER row's message appears.
+- **And the ledger that grades the fix matrix could not see them either** —
+  `_known_mutant_ids()` read `mod.ROWS` alone, so a future matrix row citing `T5` would have
+  been rejected as "a mutant the harness does not carry". Widened to both tables; it is a
+  membership set, so widening cannot turn a passing row red, and deleting `TESTLIB_ROWS` now
+  breaks the suite at import rather than silently.
+- **Ruled out:** that the mutants could be scored without executing — the negative control
+  above is what rules it out, not the `PYTHONDONTWRITEBYTECODE=1` flag on its own.
+
+### (historical) UNVERIFIED at merge: are #1342's new control assertions reachable?
+- **Symptom + exact repro:** #1342 added control assertions pinning both overshoot
   directions of the new `shell_code()` / `last_command()` parsers, plus the four separators the
   scanner must recognise. **Nobody checked they are REACHABLE and fail for their OWN reason.**
   The round-2 delta audit of #1342 was stopped by the operator after clearing items 1–3 and
-  before reaching this one.
+  before reaching this one. 🔴 **CLOSED — see the RESOLVED block directly above.** The original
+  wording said "six"; there are eight.
 - **Observed (with values):** items 5 and 6 WERE closed by hand against `origin/main`:
   FIX_MATRIX = **106 rows** read from the file, `MIN_FIX_MATRIX_ROWS = 101`, and the repo
   formula `106 − min(50, max(1, 106//20)) = 101` agrees. All four rows present (`r18/F1`,

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -3193,12 +3193,128 @@ ROWS = [
 ]
 
 
-def failing(root: Path):
-    """-> (killer test names, raw output). Reads the CONTENT, never an exit code."""
+# --------------------------------------------------------------------------- #
+# TESTLIB_ROWS — the CONTROLS that guard this suite's own parsers.
+# --------------------------------------------------------------------------- #
+# 🔴 A SECOND TABLE, BECAUSE A KILLER SET CANNOT SEE THESE. V68 and V69 above
+# forced `shell_code` and `last_command` into existence, and the fix landed
+# EIGHT control assertions beside them pinning that the new parsers do not
+# OVERSHOOT — the two one-line repairs that were offered (`"#" not in line`,
+# `re.split(r'[;&|]+', …)`) each break correct code, and nothing else in the
+# module would notice. All eight live inside the body of ONE test, so `ROWS`'
+# name-based expectation would report the same single killer for every one of
+# them: eight rows reading as coverage while measuring one. These rows match
+# the failing assertion's own MESSAGE instead, and a row fails if ANOTHER
+# row's message shows up — that is the in-test spelling of EXTRA-KILLER.
+#
+# 🔴 THEY MUTATE `TEST_REL`, NOT `SCRIPT_REL`. The thing under test here is
+# the suite's own parser, so the payload/scaffolding line falls the other way
+# round from every row above. Stated rather than left to be inferred, because
+# a reader who assumes one target file will mis-read every verdict below.
+#
+# 🔴 WHY THESE EXIST AT ALL: #1342 merged with the eight assertions UNVERIFIED
+# — nobody had shown they were REACHABLE. They sit after an early `return` in
+# `test_the_cached_build_fallback_is_emitted_with_its_guards` (the test bails
+# when the brief fences no sandbox tier) and after a `len(blocks) == 1`
+# assert, either of which would have made all eight vacuous while the suite
+# stayed green. Measured 2026-09-08: the precondition holds, exactly one
+# `nix log` block is emitted, and each row below kills its own control.
+# The last row is the harness's own negative control — see `T9`.
+
+def _testlib_swap(old: str, new: str, what: str):
+    """A UNIQUE literal substring of the TEST module, replaced once."""
+    def f(t: str) -> str:
+        _require_unique(t.count(old), what)
+        return t.replace(old, new, 1)
+    return f
+
+
+_HASH_BRANCH = '        if ch == "#" and (not out or out[-1].isspace()):\n'
+_SHELL_QUOTE = ('        if ch in "\'\\"":\n            quote = ch\n'
+                '            out.append(ch)\n')
+_LASTC_QUOTE = ('        if ch in "\'\\"":\n            quote = ch\n'
+                '            i += 1\n')
+_SEP_SCAN = '        if ch in ";|" or code[i:i + 2] == "&&":\n'
+_SHELL_ESCAPE = ('            if ch == "\\\\" and quote == \'"\' and '
+                 'i + 1 < len(line):\n')
+
+TESTLIB_ROWS = [
+    # (label, the failing assertion's own message, mutation)
+    ("T1  shell_code: any `#` opens a comment",
+     "part of a flake ref",
+     _testlib_swap(_HASH_BRANCH, '        if ch == "#":\n',
+                   "shell_code's start-of-word comment test")),
+    ("T2  shell_code: quote-blind",
+     "inside a quoted diagnosis",
+     _testlib_swap(_SHELL_QUOTE,
+                   '        if False:\n            quote = ch\n'
+                   '            out.append(ch)\n',
+                   "shell_code's quote-open branch")),
+    ("T3  last_command: quote-blind",
+     "inside a quoted regex",
+     _testlib_swap(_LASTC_QUOTE,
+                   '        if False:\n            quote = ch\n'
+                   '            i += 1\n',
+                   "last_command's quote-open branch")),
+    ("T4  last_command: a bare `&` separates",
+     "of a `2>&1` redirection",
+     _testlib_swap(_SEP_SCAN, '        if ch in ";|&":\n',
+                   "last_command's separator scan")),
+    # The four separators, each made invisible ON ITS OWN. The loop runs them
+    # in the order `;`, `||`, `|`, `&&`, so a mutation must leave every EARLIER
+    # separator working or the message names that one instead — which is
+    # exactly what the message check would then report.
+    ("T5  last_command: `;` not a separator",
+     "reached by ';'",
+     _testlib_swap(_SEP_SCAN,
+                   '        if ch in "|" or code[i:i + 2] == "&&":\n',
+                   "last_command's separator scan")),
+    ("T6  last_command: `||` not a separator",
+     "reached by '||'",
+     _testlib_swap(_SEP_SCAN,
+                   '        if ch == ";" or code[i:i + 2] == "&&" or (\n'
+                   '                ch == "|" and code[i-1:i] != "|"\n'
+                   '                and code[i+1:i+2] != "|"):\n',
+                   "last_command's separator scan")),
+    ("T7  last_command: a lone `|` not a separator",
+     "reached by '|'",
+     _testlib_swap(_SEP_SCAN,
+                   '        if ch == ";" or code[i:i + 2] in ("||", "&&"):\n',
+                   "last_command's separator scan")),
+    ("T8  last_command: `&&` not a separator",
+     "reached by '&&'",
+     _testlib_swap(_SEP_SCAN, '        if ch in ";|":\n',
+                   "last_command's separator scan")),
+    # 🔴 T9 IS THE HARNESS'S NEGATIVE CONTROL, and it is the row that makes the
+    # eight above readable. Without it, a sub-battery wired to nothing — a
+    # mutation that never lands, a pytest that never selects the test — reports
+    # nine KILLEDs and is indistinguishable from nine real ones. This mutates a
+    # branch of `shell_code` that NO control fixture and no line of the emitted
+    # block reaches (a backslash escape inside double quotes), so it MUST
+    # survive. A red here means the rows above are reacting to the EDIT rather
+    # than to the semantics, and every verdict beside it is uninterpretable.
+    ("T9  (control) an unreached shell_code branch",
+     SURVIVES,
+     _testlib_swap(_SHELL_ESCAPE, '            if False:\n',
+                   "shell_code's backslash-in-double-quotes branch")),
+]
+
+
+def failing(root: Path, tb: str = "no"):
+    """-> (killer test names, raw output). Reads the CONTENT, never an exit code.
+
+    🔴 `tb` IS NOT COSMETIC — it decides what the caller can DISCRIMINATE.
+    `--tb=no` yields test NAMES only, which is all `ROWS` needs and all it can
+    use. `TESTLIB_ROWS` below mutates parsers whose eight controls live inside
+    ONE test, so a killer SET cannot tell them apart: every row would report
+    the same single name and eight rows would read as coverage while measuring
+    one. Those rows ask for `--tb=short` and match the failing assertion's own
+    MESSAGE instead.
+    """
     env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
     p = subprocess.run(
         [sys.executable, "-m", "pytest", str(root / TEST_REL),
-         "-q", "--no-header", "--tb=no", "-p", "no:cacheprovider"],
+         "-q", "--no-header", f"--tb={tb}", "-p", "no:cacheprovider"],
         capture_output=True, text=True, env=env, cwd=str(root), check=False,
     )
     # stderr is CAPTURED, not discarded: the commonest way to get "0 tests ran"
@@ -3309,11 +3425,70 @@ def main() -> int:
             print(f"  ok {label:44s} killed by exactly {len(got)}: "
                   + ", ".join(sorted(got)))
 
+        # ------------------------------------------------------------------ #
+        # The suite's own parser controls. Different target file, different
+        # discrimination — see the TESTLIB_ROWS banner.
+        # ------------------------------------------------------------------ #
         print()
+        print("TESTLIB (mutating scripts/tests/test_audit_dispatch.py itself)")
+        original_test = (root / TEST_REL).read_text(encoding="utf-8")
+        all_msgs = [m for _, m, _ in TESTLIB_ROWS if m is not SURVIVES]
+        for label, want, mutate in TESTLIB_ROWS:
+            try:
+                mutated = mutate(original_test)
+            except AssertionError as e:
+                print(f"  🔴 {label:44s} MUTATION DID NOT APPLY — {e}")
+                bad += 1
+                continue
+            if mutated == original_test:
+                print(f"  🔴 {label:44s} MUTATION DID NOT APPLY (no change)")
+                bad += 1
+                continue
+            (root / TEST_REL).write_text(mutated, encoding="utf-8")
+            got, raw2 = failing(root, tb="short")
+            (root / TEST_REL).write_text(original_test, encoding="utf-8")
+
+            if got is None:
+                print(f"  🔴 {label:44s} HARNESS BROKE — {raw2}")
+                bad += 1
+                continue
+            if want is SURVIVES:
+                if got:
+                    print(f"  🔴 {label:44s} KILLED by {sorted(got)} — this row "
+                          "must SURVIVE. The rows above are then reacting to "
+                          "the EDIT, not the semantics, and none of their "
+                          "verdicts can be read.")
+                    bad += 1
+                else:
+                    print(f"  ok {label:44s} SURVIVED as required (control)")
+                continue
+            if not got:
+                print(f"  🔴 {label:44s} SURVIVED — the control it targets is "
+                      "UNREACHABLE or vacuous")
+                bad += 1
+                continue
+            # 🔴 THE MESSAGE, NOT THE TEST NAME. All eight controls share one
+            # test, so a name proves only that SOMETHING in it fired.
+            others = [m for m in all_msgs if m != want and m in raw2]
+            if want not in raw2:
+                print(f"  🔴 {label:44s} KILLED FOR THE WRONG REASON: the "
+                      f"failure does not carry {want!r}"
+                      + (f"; it carries {others!r}" if others else ""))
+                bad += 1
+                continue
+            if others:
+                print(f"  🔴 {label:44s} EXTRA-KILLER: {others!r} also fired — "
+                      "the row no longer isolates the control it names")
+                bad += 1
+                continue
+            print(f"  ok {label:44s} killed by its OWN control ({want!r})")
+
+        print()
+        total = len(ROWS) + len(TESTLIB_ROWS)
         if bad:
-            print(f"🔴 {bad} of {len(ROWS)} row(s) not as expected")
+            print(f"🔴 {bad} of {total} row(s) not as expected")
             return 1
-        print(f"✅ {len(ROWS)} row(s), all as expected")
+        print(f"✅ {total} row(s), all as expected")
         return 0
     finally:
         shutil.rmtree(tmp, ignore_errors=True)

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -9273,13 +9273,21 @@ def _known_mutant_ids():
 
     Imported, not restated: a ledger of mutant ids kept here by hand would go
     stale in exactly the direction that makes a false claim pass.
+
+    🔴 BOTH TABLES, AND THE SECOND ONE WAS ADDED WITH THIS SENTENCE. The
+    harness grew `TESTLIB_ROWS` — mutants of THIS module's own parsers, which
+    a killer-set expectation cannot discriminate — and reading `ROWS` alone
+    would have made every `T…` id "a mutant the harness does not carry", i.e.
+    a false RED on a row citing evidence that exists. `known_mutants` is a
+    membership set only, so widening it can never turn a passing row red.
     """
     spec = importlib.util.spec_from_file_location(
         "mutants_audit_dispatch", MUTANT_HARNESS
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return {label.split()[0] for label, _want, _mutate in mod.ROWS}
+    return {label.split()[0]
+            for label, _want, _mutate in (*mod.ROWS, *mod.TESTLIB_ROWS)}
 
 
 KNOWN_MUTANT_IDS = _known_mutant_ids()


### PR DESCRIPTION
Rank 11 of `claudedocs/handoff-audit-pr-ladder.md`. #1342 merged eight control
assertions that **nobody had shown were reachable** — the item rank 6 deliberately
left open.

## The live risk

The controls sit inside `_assert_the_cached_build_fallback_carries_its_guards`,
which runs only after **two** earlier gates in
`test_the_cached_build_fallback_is_emitted_with_its_guards`: an early `return`
when the brief fences no sandbox tier, and a `len(blocks) == 1` assert. Either
would have made all eight vacuous while the suite stayed green.

## Measured, at `39c31521`

**Reachability first.** `run_main(["900"])` → rc 0, the precondition string IS
present, exactly one `nix log` fenced block is emitted. The block executes.

**Own-reason, per control.** Each was isolated by mutating the **parser** — never
the assertion, which would only prove the assertion exists and that pytest ran the
file — so that exactly one control's claim breaks *and is the first to fail*.

| control | mutation | verdict |
|---|---|---|
| `shell_code` eats a `#` in a flake ref | comment opens anywhere, not at a word start | KILLED, own message |
| `shell_code` eats a `#` inside quotes | quote tracking disabled | KILLED, own message |
| `last_command` splits inside quotes | quote tracking disabled | KILLED, own message |
| `last_command` splits on `2>&1`'s `&` | bare `&` made a separator | KILLED, own message |
| separator `;` | `;` removed from the scan | KILLED, names `';'` |
| separator `\|\|` | `\|\|` made invisible, lone `\|` kept | KILLED, names `'\|\|'` |
| separator `\|` | lone `\|` made invisible, `\|\|` kept | KILLED, names `'\|'` |
| separator `&&` | `&&` removed from the scan | KILLED, names `'&&'` |

Nothing vacuous, nothing needed fixing.

## The count in the item was wrong — and it was the SPEC of the verification

The item and the investigation block both said **six**. The block is **5 `assert`
statements carrying 8 distinct claims** (a 4-iteration loop is four controls, not
one). Six reconciles with neither reading. A session verifying "six" stops two
controls short and reports the item closed.

## Why a second table

`ROWS` grades a mutant by the **set of test names** that must kill it. All eight
controls live in the body of **one** test, so eight rows would each report
`killed by exactly 1: test_the_cached_build_fallback_…` — indistinguishable from
one another *and* from any other assertion in that test firing. The battery's own
docstring already names that hazard; it just could not express the finer unit.

`TESTLIB_ROWS` mutates `scripts/tests/test_audit_dispatch.py` (not
`audit-dispatch.py`), runs pytest with `--tb=short`, and matches the failing
assertion's own **message** — failing a row when *another* row's message appears,
which is the in-test spelling of EXTRA-KILLER.

## T9 is what makes the other eight readable

Nine KILLEDs is also what a battery wired to nothing prints. `T9` mutates a
`shell_code` branch no fixture and no line of the emitted block reaches and **must
survive**. It does. Positive control in the same batch: `shell_code` stubbed to
`return ""` is killed, so a stale `.pyc` scoring SURVIVED would show. Everything
runs under `PYTHONDONTWRITEBYTECODE=1` with `-p no:cacheprovider`, each mutation
asserted to have landed on disk before its run.

## Also

`_known_mutant_ids()` read `mod.ROWS` alone, so a future fix-matrix row citing
`T5` would have been rejected as a mutant the harness does not carry. Widened to
both tables — it is a membership set, so widening cannot turn a passing row red,
and deleting `TESTLIB_ROWS` now breaks the suite at import rather than silently.

The handoff's `Open investigations` block was **edited in place, not appended to**.
That section is append-only under `handoff_doc.py`, and this doc already records an
incident where a correction appended elsewhere left the original still making its
claim 140 lines above. The old entry is kept, marked historical, and points at the
resolution.

---

## Gate — four legs, on the MERGED tree

Integration branch `integ/r7-r11` off **`65d8bfba`**, merging this PR and
`docs/audit-pr-testlib-classification` (RULES: disjoint files are not safety).
`nix` derivations built **one at a time**.

| tier | result |
|---|---|
| dev-host pytest | `collected=20968 passed=20966 skipped=2 failed=0` (floor 20235) |
| dev-host node | `tests=1449 pass=1449 fail=0` (floor 1367) |
| `nix` `checks.x86_64-linux.pytests` | same totals, `RESULT: PASS (exit=0)`, **0** `panic: test timed out`, **0** target FAIL rows |
| `nix` `checks.x86_64-linux.nodetests` | `1449/1449`, `RESULT: PASS (exit=0)`, 0 panics |

⚠ An earlier run at base `57319960` showed `failed=7`. Those were **not this
diff**: a pristine detached worktree at unmodified `57319960` failed the same
seven test ids, and #1389 documents the same `failed=7` in CI with a
main-without-my-commit control. `94f82796` fixed them (nixpkgs drift — the
opencode pin and an age 1.3.2 tamper verdict). Recorded because the number is in
this session's history and would otherwise read as unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mDnzCxetU3NskAepKgHu9
