### PR TITLE
docs(audit-pr): the shared-test-library call — scaffolding, decided once, by the revert test

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -201,6 +201,21 @@ file type reads every round of those as zero and stops a ladder that is working.
 directions on ordinary names (reference file). A round's fix touches a handful of files — read the list and name each one
 payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and the ladder continues.
 
+🔴 **DECIDE ONCE, AT ROUND 1, AND WRITE IT IN THE CLAIMS BLOCK.** A class that can be re-decided
+each round disarms the gate without anyone choosing to — measured on devrc #1132, where a shared
+test library was named scaffolding early and payload later, in a ladder whose summary claimed it
+stopped on this gate. The tie-breaker for a shared helper is the **REVERT TEST**: if this file's
+diff were reverted, would the PR's stated deliverable still ship? Yes ⇒ scaffolding — however big
+and however reusable the helper is. No ⇒ payload — however deep under `tests/` it sits. Standing
+call for devrc: **`scripts/testlib/**` is SCAFFOLDING**, except a scanner that IS a repo gate on a
+PR whose deliverable is that gate. Reasons and the worked case: reference file.
+
+🔴 **ONE NUMBER, ONE NAME.** Report exactly one payload count per round and call it the same thing
+every time. #1132's ledger carried *"payload lines"* and *"executable payload"* on the same line
+with different values, so its rounds could be read as zero or non-zero at will and the stop needed
+no reclassification to become unfalsifiable. A second count is fine — under a different name, and
+the summary must say which one the stop was taken on.
+
 🔴 **Per-round, and every commit the round actually made.** Anchored at round 1 the count stays
 non-zero forever once an early round touched payload — on #498 that prints the same number for
 rounds 4 through 10 and never fires. Every flag earns its place, measured across four ladder shapes

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -150,6 +150,67 @@ directions, on directory names any repo might have. `':!*_test.*'` is entirely s
 
 ---
 
+## 2026-09-08 · THE CALL ON A SHARED TEST LIBRARY — devrc `scripts/testlib/**`
+
+The classifier above says the unit is a JUDGEMENT and tells you to name each file. This section
+makes the standing call for the one directory that has been named both ways inside a single
+ladder, and gives the procedure that decides the next one.
+
+🔴 **THE CALL: `scripts/testlib/**` is SCAFFOLDING. It is PAYLOAD only when the PR's own stated
+deliverable is that module's behaviour — and the call is made ONCE, at round 1, written into the
+claims block, and does not move for the rest of the ladder.**
+
+**The procedure, because "read the list and name each one" needs a tie-breaker for a shared
+library — the REVERT TEST.** Ask: *if this file's diff were reverted, would the PR's stated
+deliverable still ship?* Yes ⇒ scaffolding. No ⇒ payload. It is the same question the gate turns
+on ("what does the PR exist to ship"), asked per file, and it survives the two shapes a pathspec
+gets wrong: a new 200-line helper written only so a new test can run is scaffolding however big
+and however reusable, and a scanner that IS the repo's content gate is payload however deep under
+`tests/` it sits.
+
+**The worked case, from devrc #1132** (*"the store HAS an off-machine backup — 15 places said it
+did not"*, 19 files). `scripts/testlib/nix_units.py` was **+225 new lines** — a nix parser created
+so `test_index_store_backup_claim.py` could assert something about `flake.nix`. Revert it and all
+15 corrected claims still ship; only the new test stops running. **Scaffolding.** That ratifies
+what the PR's own round-2 ledger said in as many words — *"63 payload lines, the rest scaffolding
+(`nix_units.py` +94, six test files)"* — and it is the reading a later round moved away from.
+
+**Why the DEFAULT falls this way, and it is an argument about which error is worse, not about
+what a testlib file "really is".** The documented failure mode of the ladder is that it does not
+terminate: #498 ran ten rounds with zero clean, devrc #958 twelve with zero clean, and in both the
+rounds after the last source change were spent auditing guards the ladder itself had written.
+Classifying shared test infrastructure as payload makes every one of those rounds read as *"the
+ladder is on the PR"* — the gate never fires, in exactly the regime it exists to detect. The
+opposite error costs a round the operator can still choose to run: the gate is a **signal to a
+human**, not an automatic merge, and the skill's own stop rule is a stated criterion, not this
+count alone. **A gate that cannot fire in its own target regime is worse than one that fires a
+round early.**
+
+**The named exception, so the rule is not read wider than it is.** `scripts/testlib/` holds two
+different kinds of thing. Fixtures and plugins (`mockbin.py`, `hermetic_git.py`, `runner_patch.py`,
+the `*_plugin.py` files) are apparatus, always scaffolding. The **scanners that ARE repo gates**
+(`captured_text_scan.py`, `public_ip_scan.py`, `client_host_scan.py`, `shebang_scan.py`) enforce
+policy that devrc's `CLAUDE.md` treats as load-bearing — for a PR whose stated deliverable is
+*"close this leak class"*, that scanner is the payload, and the revert test says so directly.
+
+🔴 **AND THE DEEPER FINDING, WHICH IS NOT ABOUT `testlib` AT ALL: #1132's ledger reported TWO
+DIFFERENTLY-NAMED NUMBERS AND THE STOP WAS TAKEN ON ONE OF THEM.** Verbatim from the PR's own
+comments — round 5: *"31 payload lines, **zero executable** (166 since round 1)"*; round 6: *"19
+payload lines (391 since round 1), **~4 executable**"*; and the closing summary: *"Stopped on the
+payload-attribution gate… Rounds 6 and 7 both changed zero payload lines."* Two units share one
+word. A ladder that prints both can be read as having stopped correctly *or* as having stopped
+with payload still moving, and nobody has to decide which — the classification never needs to
+flip for the gate to be disarmed. **One number, one name.** If a ladder wants an "executable
+payload" count, it is a SECOND, differently-named line, and the summary must say which one the
+stop was taken on.
+
+⚠ **Residual, stated rather than papered over:** the churn for #1132's rounds 6 and 7 was **not
+recomputed here**, so this section does not claim the stop was wrong. It claims the ledger cannot
+be checked as written — and note the documented off-by-one, that round N's ledger reports round
+N−1's range, which is exactly what makes reconciling those three sentences by eye unsafe.
+
+---
+
 ## 2026-08-26 · which range form counts a ROUND's payload — measured across four shapes
 
 The measurement behind the gate's command. Each shape is a throwaway repo (git 2.55.0); the numbers


### PR DESCRIPTION
Rank 7 of `claudedocs/handoff-audit-pr-ladder.md`. `scripts/testlib/**` had been
named **both ways inside a single ladder** (devrc #1132), and the classifier the
skill carries says only *"read the list and name each one"* — which has no
tie-breaker for a shared library.

## The call

**`scripts/testlib/**` is SCAFFOLDING.** It is PAYLOAD only when the PR's own
stated deliverable is that module's behaviour, and the call is made **once, at
round 1**, written into the claims block, and does not move for the rest of the
ladder.

## The procedure — the REVERT TEST

*If this file's diff were reverted, would the PR's stated deliverable still ship?*
Yes ⇒ scaffolding, however big and however reusable the helper. No ⇒ payload,
however deep under `tests/` it sits.

It is the gate's own question ("what does this PR exist to ship") asked per file,
and it gets right the two shapes a pathspec gets wrong: a new 200-line helper
written only so a new test can run, and a scanner that IS the repo's content gate.

## Worked case, from #1132 itself

`scripts/testlib/nix_units.py` was **+225 new lines** — a nix parser created so
`test_index_store_backup_claim.py` could assert something about `flake.nix`.
Revert it and all 15 corrected claims still ship; only the new test stops running.
**Scaffolding** — which ratifies that PR's own round-2 ledger (*"63 payload lines,
the rest scaffolding (`nix_units.py` +94, six test files)"*) and identifies the
later reading as the drift.

## Why the default falls this way

An argument about **which error is worse**, not about what a testlib file "really
is". The ladder's documented failure mode is that it does not **terminate** —
#498 ten rounds zero clean, #958 twelve rounds zero clean, both spent after the
last source change on guards the ladder itself wrote. Classifying shared test
infrastructure as payload makes every such round read as *"the ladder is on the
PR"*, so the gate cannot fire in the regime it exists to detect. The opposite
error costs a round the operator can still choose to run: the gate is a **signal
to a human**, not an automatic merge.

**Named exception** so the rule is not read wider than it is: the scanners under
testlib that ARE repo gates (`captured_text_scan.py`, `public_ip_scan.py`,
`client_host_scan.py`, `shebang_scan.py`) are payload for a PR whose deliverable
is that gate. The revert test says so directly.

## And a finding that is not about testlib at all

#1132's ledger reported **two differently-named numbers** — *"31 payload lines,
zero executable"* and *"19 payload lines … ~4 executable"* — so its rounds could be
read as zero or non-zero at will, and the stop needed no reclassification to become
unfalsifiable. **One number, one name**; a second count is fine under a different
name, and the summary must say which one the stop was taken on.

⚠ The churn for #1132's rounds 6 and 7 was **not** recomputed, so nothing here
claims that stop was wrong — only that the ledger cannot be checked as written. The
documented off-by-one (round N's ledger reports round N−1's range) is exactly what
makes reconciling those sentences by eye unsafe.

## Coexistence with #1050, test-merged not reasoned about

Open PR #1050 edits the same file. Test-merged: clean, and I read the merged
region rather than trusting that. #1050 inserts its premise block at ~line 182 in
the framing section; this lands at 218–231 inside ATTRIBUTION. The two arguments
are complementary. Whoever merges second should not need to re-derive this.

## Gate — four legs, on the MERGED tree

Integration branch `integ/r7-r11` off **`65d8bfba`**, merging this PR and
`test/audit-dispatch-control-reachability` (RULES: disjoint files are not safety).
`nix` derivations built **one at a time**.

| tier | result |
|---|---|
| dev-host pytest | `collected=20968 passed=20966 skipped=2 failed=0` (floor 20235) |
| dev-host node | `tests=1449 pass=1449 fail=0` (floor 1367) |
| `nix` `checks.x86_64-linux.pytests` | same totals, `RESULT: PASS (exit=0)`, **0** `panic: test timed out`, **0** target FAIL rows |
| `nix` `checks.x86_64-linux.nodetests` | `1449/1449`, `RESULT: PASS (exit=0)`, 0 panics |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mDnzCxetU3NskAepKgHu9
