### PR TITLE
docs(secrets): age 1.3.2 removed the age-keygen input echo — say so, and say why the redaction STAYS

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -283,10 +283,39 @@ no commit; this flag is it, upstreamed. What remains unexercised is only a
 unchanged.** `age-keygen -y` prints only the `age1…` recipient (measured, age
 v1.3.1: exactly 63 bytes, `age1…` + one `\n`), which is why the pin above is
 committed in a public repo. The secret half is never printed, never hashed into a
-message, and never passed in argv. ⚠ **age-keygen's stderr is NOT safe** — a file
-it cannot parse comes back as `unknown identity type: "<the offending line>"`,
-i.e. it echoes its input, which on a mangled identity is the secret key. The tool
-quotes no stream at all on that path.
+message, and never passed in argv. ⚠ **age-keygen's stderr is NOT safe** — on
+**age ≤ 1.3.1** a file it cannot parse comes back as
+`unknown identity type: "<the offending line>"`, i.e. it echoes its input, which
+on a mangled identity is the secret key. The tool quotes no stream at all on that
+path.
+
+🔴 **age 1.3.2 removed that echo — and the redaction STAYS. Do not delete it as
+dead code.** Upstream dropped the offending argument from the error deliberately
+(`parse.go`: *"Don't include arg in the error: it may contain private key
+material, and callers print these errors"*). Measured 2026-09-08 on this host,
+same fixtures against both binaries — 8 realistic manglings (leading/trailing
+space, case-folded, CRLF, prefix typo, quoted, truncated, trailing NUL):
+
+| binary | manglings echoing secret material into stderr |
+|---|---|
+| `age-1.3.1` (positive control — the sweep CAN see a leak) | **4 / 8** |
+| `age-1.3.2` (currently on PATH) | **0 / 8** |
+
+The `0` is reportable only because the same sweep scored `4` against 1.3.1; a
+bare zero here would be indistinguishable from a sweep wired to nothing.
+
+The guard is kept regardless, for two independent reasons: `age-keygen` is
+**whatever is on PATH** and this repo does not pin the operator's binary, so a
+defence that is only correct on the newest release is not a defence; and a
+recovery is exactly the situation where someone reaches for an older `age` on a
+machine that is not this one. Its non-vacuity no longer depends on upstream
+keeping the bug. Two tests in
+`scripts/tests/test_analyze_service_index_escrow_verify.py` hold it up:
+`test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1` puts a
+stub on PATH that echoes the way 1.3.1 did, so the guard is exercised whatever
+age is installed, and
+`test_which_age_keygen_ECHO_REGIME_is_installed_is_OBSERVED_not_assumed` reads
+the installed regime rather than assuming one.
 
 ##### Verifying a hand-pasted note (the browser-clipboard leg)
 


### PR DESCRIPTION
## The gap

#1392 re-keyed the tamper discriminator for age 1.3.2 and updated `SECRETS.md`'s *file presence* paragraph. It left the age-keygen **stderr echo** paragraph describing 1.3.1 behaviour as current:

> ⚠ **age-keygen's stderr is NOT safe** — a file it cannot parse comes back as `unknown identity type: "<the offending line>"`, i.e. it echoes its input, which on a mangled identity is the secret key.

That is false on the age actually installed here. Upstream removed the echo deliberately in `parse.go` — *"Don't include arg in the error: it may contain private key material, and callers print these errors"*.

## Measurement

2026-09-08 on the workbench, the **same 8 manglings against both binaries** (leading/trailing space, case-folded, CRLF, prefix typo, quoted, truncated, trailing NUL):

| binary | manglings echoing secret material into stderr |
|---|---|
| `age-1.3.1` (`/nix/store/13gh7y9l…-age-1.3.1`) | **4 / 8** |
| `age-1.3.2` (`~/.nix-profile`, on PATH) | **0 / 8** |

The `4` is the **positive control**. The `0` is reportable only because the same sweep scored non-zero against 1.3.1 — a bare zero is indistinguishable from a sweep wired to nothing, so the doc states both numbers together.

(Independently reproduced: a separate sweep over 23 manglings gave 9/23 on 1.3.1 and 0/23 on 1.3.2. Different fixtures, same conclusion.)

## Why this is worth a PR rather than a shrug

The hazard is not the stale fact, it's what the stale fact invites. A reader who checks the claim against age 1.3.2, finds no echo, and concludes the redaction guards nothing is one step from deleting it — the exact failure mode `CLAUDE.md` names: *"a safety comment whose falsity would have led a maintainer to delete the guard it described."*

So the paragraph now states the two reasons the redaction is kept:
- `age-keygen` is **whatever is on PATH**, and this repo does not pin the operator's binary — a defence correct only on the newest release is not a defence.
- A recovery is precisely the situation where someone reaches for an older `age` on a machine that is not this one.

It also names the two tests that hold the guard up — **verified present in the code, not assumed**:
- `test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1` — puts a 1.3.1-style echoing stub on PATH, so the guard is exercised whatever age is installed. Its non-vacuity no longer depends on upstream keeping the bug.
- `test_which_age_keygen_ECHO_REGIME_is_installed_is_OBSERVED_not_assumed`

## Gate

Docs only, no code change. Ran the four suites that read `SECRETS.md` — `test_doc_path_rot`, `test_no_captured_markup`, `test_analyze_service_index_backup`, `test_analyze_service_index_escrow_verify`: **563 passed, 0 failed**. Full two-tier verification of current `main` is running separately.
