### PR TITLE
docs(handoff): civitai-app-fleet — seven repos ready-to-work, six apps live on pnpm, skill ladder at round 3

### DIFF
--- a/claudedocs/handoff-civitai-app-fleet.md
+++ b/claudedocs/handoff-civitai-app-fleet.md
@@ -1,0 +1,198 @@
+# Handoff: civitai-app-fleet — 2026-09-08
+
+## Run this first — the index, one command
+```bash
+cairn recall --repo /home/zach/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+Get the seven Civitai App Block repos to a "ready to work" state (pinned nix
+toolchain, `CLAUDE.md`, drift guards), ship that change through the whole fleet,
+and capture the fleet-iteration knowledge as a devrc skill so the next bulk pass
+does not re-derive it.
+
+## State now
+
+**Branch / PR:** `devrc` worktree at `/home/zach/workspace/devrc-fleet-skill`,
+branch `zach/civitai-app-fleet`, head `f769372c`, pushed, clean.
+
+**DONE and merged — the seven app repos.** Each has a pinned flake (node 24 +
+pnpm 11), `.envrc`, `.nvmrc`, a `CLAUDE.md` (ecosystem map + ranked doc
+sources), an npm→pnpm conversion, and a 5-assertion toolchain drift guard:
+
+| Repo | ready-to-work | guard backport | guard hole fix | released |
+|---|---|---|---|---|
+| gen-matrix | #22 | #23 | #24 | — (byte-identical bundle, deliberately unsubmitted) |
+| custom-generators | #17 | #18 | #19 | 0.6.5 live |
+| playable-collections | #23 | #26 | #27 | 0.2.12 live |
+| model-benchmarking | #37 | #39 | #40 | 0.4.3 live |
+| app-requests | #18 | had it | #19 | 0.4.1 live |
+| generate-from-model | #8 | #9 | #10 | 0.2.23 live |
+| sensei (base branch is `trunk`) | #66 | #67 (normalize) | — | 0.1.21 live |
+
+All six submits built and deployed on the real platform builder; every URL
+returns HTTP 200. That is the only proof that `buildCommand: pnpm run build`
+works, and it is now measured rather than inferred.
+
+**IN FLIGHT — devrc#1393**, the `civitai-app-fleet` skill. Adversarial audit
+ladder is at **round 3 fixed, round 4 not yet run**. Rounds so far:
+
+- r1 (full, `eab2ceb6`): 2 🔴 — `fleet.py` fabricated values in three columns and
+  its exit code promised coverage it lacked. Fixed in `d6815fd1`.
+- r2 (delta): found the r1 fix OVER-CORRECTED — a failed fetch was folded into
+  `error`, and an error row prints `!!` instead of the row, so a global fetch
+  failure emitted no inventory at all. Fixed in `db08c7f0`.
+- r3 (delta): found (a) I overstated that bug's blast radius by 7×, (b) r2's own
+  rule applied to one axis only, (c) four of the five behaviours r2 shipped were
+  unpinned. Fixed in `f769372c`.
+
+**IN FLIGHT — talos-infra#1456**, node 22 → 24 for the app-blocks builder.
+`MERGEABLE/CLEAN`, deliberately unmerged: that builder builds EVERY tenant's app
+block and Flux reconciles `trunk` in ~1 min. Needs someone who can speak for the
+other tenants.
+
+**Deploy/verify status, honestly:** the app repos are merged and six apps are
+live and serving. The skill is NOT live — global skills are home-manager
+`home.file` copies, so devrc#1393 merging does not install it; that needs a
+`home-manager switch`, which has not been run.
+
+## Open investigations — live diagnosis state
+
+### devrc `main` is red — 7 pre-existing failures, undiagnosed
+- **Symptom + exact repro:** `nix develop <repo> --command bash -c 'bash scripts/run-tests.sh .'`
+  on a pristine `origin/main` worktree.
+- **Observed (with values):** `TOTAL collected=20908 passed=20899 skipped=2 failed=7`,
+  rc=1. Failures are confined to three files:
+  `scripts/tests/test_analyze_service_index_backup.py` (1),
+  `scripts/tests/test_analyze_service_index_escrow_verify.py` (5),
+  `scripts/tests/test_opencode_engine.py` (1). One named failure:
+  `test_every_decrypt_family_VERDICT_is_pinned_WHOLE`, asserting
+  `'DECRYPT-FAILED' == 'ARTIFACT-CORRUPT'`.
+- **Ruled out:** caused by this session's work — a pristine `origin/main`
+  control run reproduces the identical 7 across the identical 3 files. via: measurement
+- **Ruled out:** an xdist ordering artefact — a same-named, same-test-count dummy
+  file added to pristine main produced 7, not 18. via: measurement
+- **Leading hypothesis:** an `age`/`age-keygen` behaviour change; devrc#1398 is
+  open about `age 1.3.2 removed the age-keygen input echo`, which is adjacent to
+  the escrow/keygen failures.
+- **Next probe:** `nix develop /home/zach/workspace/devrc --command bash -c 'cd /home/zach/workspace/devrc && python3 -m pytest scripts/tests/test_analyze_service_index_escrow_verify.py -q -x'`
+  then compare `age --version` against what that test expects.
+
+### A `custom-generators` 0.6.5 submission this session did not make
+- **Symptom + exact repro:** `civitai app status` lists TWO `custom-generators 0.6.5`
+  rows — one `approved/live` (mine), one `withdrawn`.
+- **Observed (with values):** mine is `pubreq_01M1ZKMVVXSPG7D09QA5A011EH`,
+  submitted ~23:2x. The withdrawn one is `pubreq_01M1ZMSA9S0B58KV77K3XXA1JX`,
+  submitted 23:35 — AFTER mine, and withdrawn shortly after.
+- **Ruled out:** a duplicate from this session — only one `civitai app submit`
+  was run for that app, and its returned pubreq id is the live one. via: command
+- **Leading hypothesis:** Zach submitted from the web UI, or another session did.
+  Benign either way; the live 0.6.5 is unaffected.
+- **Next probe:** ask Zach; or `civitai app status custom-generators` and check
+  whether a third row appears (would indicate an automated producer).
+
+### Three owned apps have no source repo anyone has located
+- **Symptom + exact repro:** `civitai app doctor` lists `radio`,
+  `cosmetic-studio` and `prompt-library` as `(approved, owner)`, but no checkout
+  under `~/workspace/civit` and no `ZacxDev/*` repo matches them.
+- **Observed (with values):** `gh repo list ZacxDev --limit 100` has no `radio`,
+  no `cosmetic-studio`, no `prompt-library`. `ZacxDev/vitrine` exists but has NO
+  `block.manifest.json` — it is a Dockerized Drizzle app, a different shape.
+  `prompt-library` is `status=removed` with a BLOCKING `missing-cover`.
+  A non-git scaffold exists at `~/workspace/civit/civitai-block-prompt-library`.
+- **Ruled out:** `comfy` being one of these — its store description is hosted
+  ComfyUI, i.e. a platform-team app rather than an app-block repo of Zach's. via: doc
+- **Leading hypothesis:** they were scaffolded and submitted without a git repo,
+  or live in a repo under a different owner.
+- **Next probe:** `civitai app pull radio` — the CLI claims it can "Clone or sync
+  your app's repository from Civitai", which would settle where the source is.
+
+## Next steps (ranked)
+
+1. **Run round 4 of the audit ladder on devrc#1393, then merge it.**
+   `python3 ~/workspace/devrc/scripts/audit-dispatch.py 1393 --repo innovation-upstream/devrc --round 4`
+   after posting the round-3 claims block. A CLEAN round is the stop condition —
+   do not run another to confirm one. Payload changed in r3 was non-zero, so the
+   two-consecutive-zero-payload gate has not fired.
+   forcing: gate — the PR is open behind a stop rule I set and have not met.
+2. **`home-manager switch`, then smoke the skill against real data.**
+   Until then `~/.claude/skills/civitai-app-fleet/` does not exist and the old
+   `civitai-app-release/` directory lingers. After switching:
+   `python3 ~/.claude/skills/civitai-app-fleet/fleet.py --no-fetch`
+   forcing: none
+3. **Decide talos-infra#1456** (node 22 → 24 for the app-blocks builder).
+   Needs a judgement about other tenants that I could not make. Files:
+   `clusters/production/apps/tekton-builds/app-blocks-pipeline.yaml`.
+   forcing: none
+4. **Locate `radio` / `cosmetic-studio` / `prompt-library`** — see the open
+   investigation above; `civitai app pull <slug>` is the cheapest probe.
+   forcing: none
+5. **Diagnose devrc `main`'s 7 red tests** — see the open investigation. A
+   permanently-red gate trains everyone to merge through it, and I merged
+   through it once this session.
+   forcing: gate — the merge gate on every devrc PR is currently red.
+
+## Gotchas / decisions / dead-ends
+
+- **`isolation: "worktree"` builds a worktree of the CWD's repo, not the
+  target's.** For cross-repo fan-out, have each agent run
+  `git -C <target> worktree add` itself. This is in `reference/fan-out.md`.
+- **`sensei`'s default branch is `trunk`**, the other six are `main`. A brief
+  hardcoding `origin/main` was handed to seven agents; only the sensei agent
+  noticing saved it.
+- **The submit floor is the highest version ON RECORD, not deployed** — a
+  withdrawn submission still occupies it.
+- **`civitai app status <slug>` returns only the NEWEST submission.** A
+  withdrawn duplicate masked a healthy `building` row. Use the list view.
+- **Deploy states seen live:** `-`, `building`, `deploying`, `live`, `failed`,
+  `preview-live`. `queued` does NOT exist — it was invented in a first draft.
+- **Two ratchets were raised then partly lowered** in devrc:
+  `LISTING_TOTAL_CEILING_CHARS` 10,800→11,192→11,170 and `TIER_A_CEILING_CHARS`
+  7,496→7,639→7,617. Both files say "do NOT raise"; Zach took both decisions
+  with that text quoted to him. Headroom is pinned at 0 in both, so the next
+  skill addition of any size reds those gates. **A third raise is almost
+  certainly wrong — demote instead.**
+- **Attribute a suite failure by comparing failing FILES against a pristine
+  control**, never by scraping test ids out of output. Doing the latter cost two
+  confident wrong diagnoses this session.
+- **Read a runner's counted output, never its exit code** — a trailing `echo` in
+  a wrapper replaced `run-tests.sh`'s status and reported a red suite as
+  "exit code 0" twice.
+- **devrc global skills are `home.file` copies** (`readlink -f` lands in
+  `/nix/store`), so editing devrc does not make a skill live; that needs a
+  `home-manager switch`.
+- **Decision: `gen-matrix` is deliberately unsubmitted.** Its manifest and source
+  are unchanged by this work, so a bump would rebuild a byte-identical bundle.
+
+## How to verify
+
+```bash
+# every app repo carries the 5-assertion guard, and sensei is on trunk
+for r in civitai-app-gen-matrix civitai-app-custom-generators \
+         civitai-app-playable-collections civitai-app-requests \
+         civitai-app-model-benchmarking civitai-block-generate-from-model; do
+  git -C ~/workspace/civit/$r show origin/main:src/toolchain-lockstep.test.ts \
+    | grep -cE '^\s*it\('
+done
+git -C ~/workspace/civit/civitai-app-sensei show \
+  origin/trunk:src/toolchain-lockstep.test.ts | grep -cE '^\s*it\('
+
+# all six released apps serve
+for h in app-requests generate-from-model custom-generators \
+         playable-collections model-benchmarking sensei; do
+  curl -sS -o /dev/null -w "$h %{http_code}\n" https://$h.civit.ai/
+done
+
+# the skill's own gates (six named files)
+cd /home/zach/workspace/devrc-fleet-skill && nix develop . --command bash -c \
+  'python3 -m pytest scripts/tests/test_civitai_app_fleet.py \
+     scripts/tests/test_skill_tiers.py scripts/tests/test_skill_descriptions.py \
+     scripts/tests/test_skill_audit.py scripts/tests/test_doc_path_rot.py \
+     scripts/tests/test_no_client_hostnames.py -q'
+# expect: 316 passed
+```

--- a/claudedocs/handoff-civitai-app-fleet.md
+++ b/claudedocs/handoff-civitai-app-fleet.md
@@ -169,6 +169,22 @@ live and serving. The skill is NOT live — global skills are home-manager
 - **Decision: `gen-matrix` is deliberately unsubmitted.** Its manifest and source
   are unchanged by this work, so a bump would rebuild a byte-identical bundle.
 
+- 🔴 **THIS DOC LANDS VIA devrc#1402 AND IS NOT ON `main` UNTIL THAT MERGES.**
+  The kickoff block points at
+  `/home/zach/workspace/devrc/claudedocs/handoff-civitai-app-fleet.md`, and that
+  path **does not exist in the primary clone** while the PR is open — the doc
+  lives only on branch `docs/handoff-civitai-app-fleet` (commit `c3124df6`). If
+  `/resume` cannot find it, read it from the ref instead:
+  `git -C ~/workspace/devrc show origin/docs/handoff-civitai-app-fleet:claudedocs/handoff-civitai-app-fleet.md`
+  — or merge #1402 first, which is the cheaper fix.
+- **Why a PR rather than a direct commit:** `handoff_doc.py` refused with
+  `status=behind` because the primary devrc clone was 6 commits behind `origin/main`
+  AND dirty with 5 uncommitted paths belonging to another session. Fast-forwarding
+  would have refused or overwritten that work, so the doc was written from a
+  throwaway worktree off `origin/main` and pushed as its own branch. The primary
+  clone was left byte-identical — verify with
+  `git -C ~/workspace/devrc status -sb`.
+
 ## How to verify
 
 ```bash


### PR DESCRIPTION
Handoff for the civitai-app-fleet effort.

**Shipped and merged:** all seven Civitai App Block repos now carry a pinned flake (node 24 + pnpm 11), `CLAUDE.md`, an npm→pnpm conversion, and a 5-assertion toolchain drift guard. Six apps were submitted and are **live and serving** on the real platform builder — the only proof that `buildCommand: pnpm run build` works.

**Open:** devrc#1393 (the `civitai-app-fleet` skill) is at audit-ladder round 3 fixed, round 4 unrun; talos-infra#1456 (node 22→24 for the app-blocks builder) is deliberately unmerged pending a judgement about other tenants.

The doc carries three open investigations with verbatim evidence — devrc `main`'s 7 pre-existing failures, an unexplained duplicate submission, and three owned apps with no locatable source repo — plus the gotchas that cost the most time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DULuahpBaAwuYb89Hg2pEv