### PR TITLE
docs(toolchain): three claims #1392 left in the tree were false or stale — measured, retracted, re-verified

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2216,11 +2216,21 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   **The workbench runs 1.18.29** — verified at the consumer 2026-09-08,
   `readlink -f $(command -v opencode)` in a login shell resolving to the store
   path `flake.lock` pins, so the pin and the deploy agree there.
-  🔴 **The LAPTOP is UNVERIFIED at this pin.** It was unreachable when the pin
-  moved (ssh to its nebula address refused), so it was last checked at the
-  consumer on 2026-08-29, at the version this pin superseded. "Both hosts run
-  the same opencode" is therefore a claim nobody has re-checked — do not repeat
-  it until you have.
+  ✅ **The LAPTOP is now verified at this pin too** (2026-09-08), by the same
+  method: `readlink -f $(command -v opencode)` in a **login shell** resolves to
+  `/nix/store/6pw7n475…-opencode-1.18.29/bin/opencode` — byte-identical to the
+  workbench's. So "both hosts run the same opencode" is a re-checked claim, not
+  a repeated one.
+  ⚠ It was UNVERIFIED when the pin moved, and the reason is worth keeping: the
+  laptop was unreachable at its **LAN** address, and the note recorded that as
+  "unreachable" full stop. It answers on **nebula** (`zach@10.42.0.100`), which
+  is how this check was run. A host being off-LAN is not a host being down —
+  `ship.sh` has the same blind spot (`LAPTOP_SSH_DEFAULT` is the LAN address,
+  overridable with `LAPTOP_SSH`).
+  🔴 **The browser-only RESOLUTION on the laptop is STILL UNVERIFIED** — that is
+  a separate claim from the version, and closing the easy half must not be read
+  as closing both. It needs `opencode debug agent` run on the laptop; only the
+  workbench's resolution has been re-derived at this pin.
   ✅ **The browser-only RESOLUTION *was* re-derived at the pin** (2026-09-08),
   which the two bumps before this one had declined: the gate's scratch project
   rebuilt exactly as the wrapper builds it and run against the REAL pinned

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -31,8 +31,11 @@ been measured identical at every version this repo has pinned, including the
 current one (re-derived 2026-09-08 against the real binary, on the workbench),
 and on 1.18.4, 1.18.16 and 1.18.18 in the passes before that. That is why the
 version hypothesis stays closed. Do not re-open it.
-(The DEPLOY is a separate claim: the workbench consumer was verified at the pin
-on 2026-09-08, the laptop was unreachable and is unverified.)
+(The DEPLOY is a separate claim: BOTH consumers are verified at the pin as of
+2026-09-08 — a login-shell `readlink -f $(command -v opencode)` resolves to the
+identical store path on each. The laptop's earlier "unreachable" was its LAN
+address only; it answers on nebula. ⚠ Its browser-only RESOLUTION is still
+unverified — that is a different claim from the version.)
 
 ✅ **The `browser agent`-first default IS shipped** (SKILL.md → `## FIRST DECISION`).
 It was held back until capability was measured rather than argued from token
@@ -252,9 +255,11 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **The workbench consumer runs the pinned version**
-  (verified 2026-09-08); the LAPTOP was unreachable and is unverified at this
-  pin. The browser-only resolution itself WAS re-derived at the pin on
+  gate failure leaks no tab. **Both consumers run the pinned version**
+  (verified 2026-09-08 — login-shell `readlink -f` resolves to the identical
+  store path on workbench and laptop; the laptop's earlier "unreachable" was
+  its LAN address, and it answers on nebula). ⚠ The laptop's browser-only
+  RESOLUTION remains unverified — a separate claim from the version. The browser-only resolution itself WAS re-derived at the pin on
   2026-09-08 — on the workbench, by hand, against the real binary and against
   the superseded one — and resolved identically on 1.18.4, 1.18.16 and 1.18.18
   in the passes before those. Nothing in CI observes it, so it is evidence and

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -1191,14 +1191,29 @@ def test_resolve_recipient_NEVER_quotes_age_keygens_INPUT_ECHOING_stderr(
     test's positive control impossible: the guard would have gone green while
     proving nothing about our redaction.
 
-    🔴 THE RISK IS LIVE, NOT HISTORICAL. Both versions are installed on this host
-    right now (login shell v1.3.1, dev shell v1.3.2) and the deployed backup unit
-    takes whatever its PATH provides, so a message that quoted stderr would still
-    print a key today. A guard whose sensitivity depends on which of two
-    installed binaries answers is not a guard — so the leak is supplied
-    deterministically instead. `backup.py` invokes `age-keygen` as a bare literal
-    (see `age_public_key_bytes`), so PATH is the whole injection surface and
-    nothing in production changes.
+    THE UPSTREAM FIX, NAMED: age v1.3.2, commit `c45ccfd2` ("avoid echoing
+    private keys in errors", reported by Trail of Bits), released 2026-08-29.
+    ⚠ The `error at line N` prefix is NOT new — only the echo was removed.
+
+    🔴 THE RISK IS LIVE, NOT HISTORICAL — BUT THE REASON GIVEN HERE WAS FALSE
+    AND IS RETRACTED. It read "Both versions are installed on this host right
+    now (login shell v1.3.1, dev shell v1.3.2)". They are not. MEASURED
+    2026-09-08: non-interactive zsh, login zsh, login bash and the flake
+    devShell all resolve v1.3.2 on the workbench, and the laptop does too — no
+    shell on either host resolves v1.3.1. (v1.3.1 derivations remain in the
+    store; nothing puts one on a PATH.) A claim about which binary answers rots
+    the moment a pin moves, and this one did.
+
+    The real reason, which is stronger: **v1.3.2 did not close every echo
+    path.** MEASURED 2026-09-08 with a synthetic key — `age -r
+    "<AGE-SECRET-KEY-1…>"` still prints the whole key, because
+    `cmd/age/parse.go` keeps `unknown recipient type: %q`. A message that quoted
+    stderr would still print a key today, against the CURRENT pin.
+
+    A guard whose sensitivity depends on which binary answers is not a guard —
+    so the leak is supplied deterministically instead. `backup.py` invokes
+    `age-keygen` as a bare literal (see `age_public_key_bytes`), so PATH is the
+    whole injection surface and nothing in production changes.
 
     ⚠ CASE-INSENSITIVE, against the FIXTURE'S OWN secret: a case-sensitive check
     reads clean on the lowercased-prefix case while the whole key body is in the

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -4854,10 +4854,31 @@ def test_the_redaction_is_pinned_against_a_STUB_that_echoes_like_age_v1_3_1(
     message" now survives against v1.3.2 for a reason that says NOTHING about
     whether our code redacts.
 
-    🔴 AND THE RISK IS LIVE, not historical. Both versions are installed on this
-    host today (login shell v1.3.1, dev shell v1.3.2) and the deployed backup
-    unit takes whatever its PATH provides. A guard whose sensitivity depends on
-    which of two installed binaries answers is not a guard.
+    THE UPSTREAM FIX, NAMED so this is an attributable fact rather than a
+    measurement someone has to re-derive: age v1.3.2, commit `c45ccfd2`
+    ("avoid echoing private keys in errors", reported by Trail of Bits),
+    released 2026-08-29. It dropped the `%q` from `unknown identity type: %q`
+    in `age-keygen`'s parse path. ⚠ The `error at line N` prefix is NOT new —
+    only the echo was removed, so do not read the line number as the fix.
+
+    🔴 AND THE RISK IS LIVE, not historical — BUT NOT FOR THE REASON THIS
+    PARAGRAPH USED TO GIVE, WHICH WAS FALSE. It read "Both versions are
+    installed on this host today (login shell v1.3.1, dev shell v1.3.2)". They
+    are not. MEASURED 2026-09-08 on the workbench: non-interactive zsh, login
+    zsh, login bash and the flake devShell ALL resolve v1.3.2, and the laptop
+    does too — no shell on either host resolves v1.3.1. (v1.3.1 derivations do
+    still sit in the store; nothing puts them on a PATH.) A claim about which
+    binary answers is exactly the kind that rots when a pin moves, which is what
+    happened here.
+
+    The real reason the risk is live, and it is a stronger one: **v1.3.2 did not
+    close every echo path.** MEASURED 2026-09-08 with a synthetic key —
+    `age -r "<AGE-SECRET-KEY-1…>"` still prints the whole key back, because
+    `cmd/age/parse.go` keeps `unknown recipient type: %q`. So a redaction guard
+    is still needed against the CURRENT pinned age, not merely against a version
+    somebody might still have. That is why the leak below is supplied by a STUB
+    rather than by whichever age is installed: the guard's sensitivity must not
+    depend on the toolchain at all.
 
     So the leak is supplied by a STUB on PATH that reproduces v1.3.1's stderr
     byte for byte. `backup.py` invokes `age-keygen` as a bare literal (see

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -230,16 +230,26 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 #     incoming binary rather than the harness being green by default.
 #
 # 🔴 NOT COVERED by this pass, named so nobody reads it as more than it is:
-#   * THE LAPTOP. Every "both hosts run <v>" line was re-verified AT THE CONSUMER
-#     on the workbench only (`readlink -f $(command -v opencode)` in a login
-#     shell -> the incoming store path). The laptop was UNREACHABLE at the time
-#     (ssh to its nebula address refused), so those sentences are now split: the
-#     workbench half carries the pin and is dated, the laptop half says
-#     explicitly that it is unverified. Do not re-conjoin them.
-#   * The DEV SHELL is not the interactive shell. `nix develop` and the login
-#     shell happened to agree on opencode here (both resolve the same store
-#     path), but they did NOT agree on `age` in the same session — so "the
-#     version on PATH" is a claim about ONE shell until you say which.
+#   * THE LAPTOP — ✅ NOW COVERED, 2026-09-08. This entry read "the laptop was
+#     UNREACHABLE at the time (ssh to its nebula address refused), so those
+#     sentences are now split". It answers on nebula now, and by the same method
+#     (`readlink -f $(command -v opencode)` in a LOGIN shell) it resolves to the
+#     identical store path as the workbench: `6pw7n475…-opencode-1.18.29`. The
+#     split sentences elsewhere have been re-conjoined ON THAT EVIDENCE — which
+#     is the only thing that licenses re-conjoining them.
+#     ⚠ Still NOT covered on the laptop: the browser-only RESOLUTION
+#     (`opencode debug agent`). The version and the resolution are two claims;
+#     closing the cheap one does not close the other.
+#   * The DEV SHELL is not the interactive shell — the PRINCIPLE STANDS, its
+#     EXAMPLE WAS FALSE and is retracted. It read that the two "did NOT agree on
+#     `age` in the same session". MEASURED 2026-09-08: non-interactive zsh,
+#     login zsh, login bash and the devShell ALL resolve age v1.3.2, on both
+#     hosts — nothing resolves v1.3.1 anywhere, though v1.3.1 derivations do
+#     remain in the store. The claim was true when written or was never
+#     re-checked; either way it is not true now, and an example that has rotted
+#     argues for the principle less well than no example. "The version on PATH"
+#     is still a claim about ONE shell until you say which — that part needed no
+#     example to be true.
 PINNED_VERSION = "1.18.29"
 
 # MEASURED via `opencode debug agent nav --pure` at 1.18.29, on BOTH the incoming


### PR DESCRIPTION
#1392 correctly unbroke the 7 gate failures. Three of its supporting claims did not
survive being checked. A comment is a claim like any other, and two of these are
load-bearing for guards about **key material**.

## 1. FALSE — and in three places, not the one reported

> "Both versions are installed on this host right now (login shell v1.3.1, dev shell v1.3.2)"

plus the same idea in `test_opencode_engine.py` as *"they did NOT agree on `age` in the
same session"*. Found by re-greping the corrected claim at **every** site rather than
trusting the report's count.

**MEASURED 2026-09-08:** non-interactive zsh, login zsh, login bash **and** the flake
devShell all resolve age **v1.3.2** — on *both* hosts. Nothing resolves v1.3.1 anywhere.
(v1.3.1 derivations do remain in the store; nothing puts one on a PATH — stated
precisely, because "there is no v1.3.1 on the box" would be its own overclaim.)

**The conclusion those paragraphs draw is still right, for a stronger reason** — now
written down instead:

🔴 **v1.3.2 did not close every echo path.** Measured with a synthetic key:
```
$ age -r "AGE-SECRET-KEY-1SYNTHETIC…"
age: error: unknown recipient type: "AGE-SECRET-KEY-1SYNTHETIC…"
```
`cmd/age/parse.go` keeps `unknown recipient type: %q`. The identity path
(`age-keygen -y`) does **not** echo, matching the fix. So a message that quoted stderr
would still print a key today, against the **current** pin — a reason that cannot rot
when a pin moves.

## 2. STALE — the laptop is verified now

"The LAPTOP is UNVERIFIED at this pin" (browser-bridge README, `reference/agent.md` ×2,
`test_opencode_engine.py`). True when written. It answers now, and by the **same method
the notes name** — `readlink -f $(command -v opencode)` in a **login shell** — resolves
to `6pw7n475…-opencode-1.18.29`, byte-identical to the workbench.

⚠ Its earlier "unreachable" was its **LAN** address; it answers on **nebula**. A host
being off-LAN is not a host being down — and `ship.sh` shares that blind spot
(`LAPTOP_SSH_DEFAULT` is the LAN address, `LAPTOP_SSH` overrides). Recorded beside the
note, because it silently converged one host earlier today.

🔴 **Only the VERSION half is closed.** The laptop's browser-only RESOLUTION
(`opencode debug agent`) is still unverified and now says so explicitly — closing the
cheap half of a split claim must not read as closing both.

## 3. MISSING — the upstream fix is now attributable

Described only as measurement. Now cited: age **v1.3.2**, commit **`c45ccfd2`**
("avoid echoing private keys in errors", **reported by Trail of Bits**), released
2026-08-29, which dropped the `%q` from `unknown identity type: %q`.
⚠ The `error at line N` prefix is **not** new — only the echo was removed, so nobody
reads the line number as the fix.

## Not changed, deliberately

Two other `laptop unreachable` matches are **not** this claim and were left alone:
`scripts/README.md` (a drift-check rc-13 *policy* statement, still true) and
`test_cairn_who.py` (synthetic fixture text). Fixing a claim without verifying it is
the exact error this PR corrects.

## Verification

Every retraction quotes the sentence it replaces, so a reader can see it was a
correction rather than a reword.

Both tiers on the merged tree `0859f7a0` (`origin/main` confirmed an ancestor):
dev-host `gate.sh --tier both` **PASS** (21,020 pytest + 1,449 node, 0 failed, all 28
floors met); sandbox built one derivation at a time from a `git archive` extract —
`pytests` **PASS**, `nodetests` **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FENxxrZztNTsrKgChnGT1X
