### PR TITLE
fix(nebula): run the relay verifier through this shell, not /usr/bin/env — main is RED on the sandbox tier

### DIFF
--- a/nix/system/apply-nebula-relay.sh
+++ b/nix/system/apply-nebula-relay.sh
@@ -72,6 +72,33 @@ IFACE="nebula.${NET}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK="${HERE}/check-nebula-relays.sh"
 
+# 🔴 RUN THE VERIFIER THROUGH THIS SHELL, NEVER BY EXECUTING IT DIRECTLY.
+#
+# `"$CHECK" …` dispatches on the verifier's `#!/usr/bin/env bash` shebang, which
+# makes /usr/bin/env a hard runtime dependency of this script. That path does not
+# exist everywhere this repo's tests run: the `nix build .#checks…pytests` sandbox
+# has no /usr/bin, so every direct execution died with
+#
+#     /usr/bin/env: bad interpreter: No such file or directory
+#
+# surfacing as `ABORT: the verifier could not read the current config (rc=126)`.
+# rc 126 is "found but not executable" — it is NOT one of the verifier's own codes,
+# so the abort message blamed the config for an interpreter fault. That failed all
+# 20 tests in test_nebula_relay_apply.py on the sandbox tier while the dev-host tier
+# stayed green, because the dev host does have /usr/bin/env. A suite that runs in
+# two tiers has to be green in both; this is the shape where one tier is
+# structurally unable to see the bug.
+#
+# `$BASH` is the absolute path of the interpreter already running this script, so
+# the verifier runs under exactly the same shell with no PATH lookup and no
+# /usr/bin/env. Both scripts keep their shebangs — they are still run directly by
+# the operator, where /usr/bin/env exists.
+#
+# One helper rather than three call sites: the invocation was open-coded three
+# times (preflight, post-test verify, post-restart retry), and a fix applied to
+# some-but-not-all of them regrows the bug at whichever site was missed.
+run_check() { "$BASH" "$CHECK" "$@"; }
+
 die() { echo "ABORT: $*" >&2; exit 1; }
 
 # Scratch dir for everything this script writes outside $CFG.
@@ -119,7 +146,7 @@ echo "  unit      : $UNIT loaded"
 # loaded, so a stale edit that was never switched does not read as satisfied.
 PRE="$SCRATCH/pre.out"
 set +e
-"$CHECK" "$RELAY" >"$PRE" 2>&1
+run_check "$RELAY" >"$PRE" 2>&1
 pre_rc=$?
 set -e
 case "$pre_rc" in
@@ -434,7 +461,7 @@ verify_now() {   # dies on failure; retries exactly once, on ONE narrow conditio
   echo "  unit      : active"
 
   out="$SCRATCH/check.out"
-  set +e; "$CHECK" "$RELAY" >"$out" 2>&1; rc=$?; set -e
+  set +e; run_check "$RELAY" >"$out" 2>&1; rc=$?; set -e
   sed 's/^/    | /' "$out"
 
   # 🔴 THE RETRY IS NARROWER THAN rc 2. The verifier returns 2 for seven different
@@ -448,7 +475,7 @@ verify_now() {   # dies on failure; retries exactly once, on ONE narrow conditio
   if [ "$rc" = "2" ] && grep -qx 'REASON: unit-process-disagree' "$out"; then
     echo "  retry     : the running process has not picked up the new config; restarting $UNIT once"
     systemctl restart "$UNIT"
-    set +e; "$CHECK" "$RELAY" >"$out" 2>&1; rc=$?; set -e
+    set +e; run_check "$RELAY" >"$out" 2>&1; rc=$?; set -e
     sed 's/^/    | /' "$out"
   fi
   [ "$rc" = "0" ] || die "the verifier does not see $RELAY advertised by the running unit (rc=$rc)"


### PR DESCRIPTION
## `main` is red, and this is why

All **20** tests in `scripts/tests/test_nebula_relay_apply.py` fail on the `nix build .#checks.x86_64-linux.pytests` tier — the one **Tekton gates on** — while `scripts/gate.sh` (dev-host) is green. #1272 landed on that split.

`apply-nebula-relay.sh` executed the verifier directly:

```sh
"$CHECK" "$RELAY" >"$PRE" 2>&1
```

which dispatches on `check-nebula-relays.sh`'s `#!/usr/bin/env bash` shebang, making `/usr/bin/env` a hard runtime dependency. **The nix build sandbox has no `/usr/bin`**, so every exec died with:

```
/usr/bin/env: bad interpreter: No such file or directory
```

surfacing as:

```
ABORT: the verifier could not read the current config (rc=126)
```

🔴 **rc 126 is "found but not executable" — not one of the verifier's own exit codes.** So the abort blamed the *config* for an interpreter fault, which is why this did not read as a shebang problem. The dev host *has* `/usr/bin/env`, so that tier is structurally unable to see it.

## Fix

Invoke the verifier through **`$BASH`** — the absolute path of the interpreter already running the script. No PATH lookup, no `/usr/bin/env`, and the verifier provably runs under the same shell.

Both scripts **keep their shebangs**: they are still executed directly by the operator, where `/usr/bin/env` exists. That path is unchanged.

Consolidated into one `run_check` helper rather than patched at each of the three call sites (preflight, post-test verify, post-restart retry) — a predicate open-coded at N sites regrows the bug at whichever site a later fix misses.

## Verification — red→green, control watched failing

Base and fix built **one at a time**, control = `origin/main` @ `14126d94`:

| | collected | passed | failed | `bad interpreter` lines | verdict |
|---|---|---|---|---|---|
| **CONTROL** (`main`, unmodified) | 21127 | 21105 | **20** | **11** | `RESULT: FAIL (exit=1)` |
| **FIXED** | 21127 | 21125 | **0** | **0** | `RESULT: PASS (exit=0)` |

`collected` is **identical** on both — the 20 were fixed, not skipped or removed. `passed` rose by exactly 20.

Second tier, fixed tree: `nodetests` → `RESULT: PASS`, `tests=1449 pass=1449 fail=0`, floor 1367.

⚠ **The dev-host tier is deliberately not offered as evidence.** It was already green *before* this change (30 passed), because the dev host has `/usr/bin/env` — so it cannot distinguish the fix from the bug. Only the sandbox pair is load-bearing.

## Notes

- Claimed via `claim-work` before starting (`claim/nebula-relay-sandbox-shebang`) — four sessions collided on the previous `main`-red investigation.
- `main` moved four times during this work; rebased and re-pointed the control each time rather than reusing a stale measurement.
