### PR TITLE
feat(transcript): stream deltas on the reply agent existing poll, and lift the coverage cap

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3739,6 +3739,19 @@ in
         # triggers, which is what makes the omission an asymmetry rather than a
         # policy.
         "${../scripts/lib/host_label.py}"
+        # 🔴 THE BUILDER'S OWN IMPORT, MISSED FOR THE WHOLE ARC. The resident
+        # agent's list gained transcript_search.py when the tailer started
+        # loading it; this timer's did not, even though build_transcript_push.py
+        # imports it directly and cannot run without it:
+        #
+        #   builder without transcript_search.py -> rc 1
+        #   ModuleNotFoundError: No module named 'transcript_search'
+        #
+        # The asymmetry mattered twice over: a comment three lines below asserted
+        # this unit "names every module it depends on", and the test it named
+        # pinned a hand-written 3-set — so the gap was not merely unnoticed, it
+        # was locked in by the guard meant to prevent it.
+        "${../scripts/lib/transcript_search.py}"
       ];
     };
   };

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3845,6 +3845,10 @@ in
       #
       # tmux_text_policy.py — the text allowlist. TIGHTENING it is a security
       #   change, and this is the one process it has to reach.
+      # host_label.py — the ONE rule for "which box is this". It decides which
+      #   host's writes this agent claims AND which host the transcript stream
+      #   files its deltas under; a stale copy would either deliver another
+      #   machine's commands or reseed every session for ever.
       # transcript_stream.py — the transcript delta tailer, and transcript_search
       #   .py which it loads in turn. A splice bug in either is a CORRECTNESS bug
       #   in what the operator reads about a session; both were added after the
@@ -3858,6 +3862,7 @@ in
       X-Restart-Triggers = [
         "${../scripts/tmux-reply-agent}"
         "${../scripts/lib/tmux_text_policy.py}"
+        "${../scripts/lib/host_label.py}"
         "${../scripts/lib/transcript_stream.py}"
         "${../scripts/lib/transcript_search.py}"
       ];

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3732,6 +3732,13 @@ in
         # change there is a change to what this unit delivers, with no edit to
         # the shell at all.
         "${../scripts/lib/build_transcript_push.py}"
+        # 🔴 A THIRD HARD DEPENDENCY, ADDED THE DAY THE HOST LABEL WAS
+        # CONSOLIDATED AND NOT LISTED WITH IT. This unit now EXITS 3 when
+        # host_label.py cannot be resolved, so it is as load-bearing as the
+        # builder beside it — and the same commit did add it to the reply agent's
+        # triggers, which is what makes the omission an asymmetry rather than a
+        # policy.
+        "${../scripts/lib/host_label.py}"
       ];
     };
   };

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3863,9 +3863,12 @@ in
       #
       # ⚠ THE COVERAGE USED TO SIT WHERE IT MATTERED LEAST. The transcript-push
       # TIMER — where a stale copy costs at most five minutes, because the next
-      # tick runs fresh code — names both its halves and is pinned by
-      # `test_the_unit_restart_triggers_name_BOTH_halves`. This RESIDENT unit,
-      # where a stale copy lasts until somebody notices, named two of four.
+      # tick runs fresh code — names every module it depends on and is pinned by
+      # `test_the_unit_restart_triggers_name_EVERY_half`. This RESIDENT unit,
+      # where a stale copy lasts until somebody notices, named two while loading
+      # four. Both units and both tests were widened in the same arc; the numbers
+      # are deliberately not restated here, because they moved three times while
+      # this comment sat still.
       X-Restart-Triggers = [
         "${../scripts/tmux-reply-agent}"
         "${../scripts/lib/tmux_text_policy.py}"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3837,14 +3837,29 @@ in
         "TMUX_TMPDIR=%t"
       ];
       ExecStart = "${pkgs.python3}/bin/python3 %h/workspace/devrc/scripts/tmux-reply-agent";
-      # 🔴 THE POLICY MODULE IS A TRIGGER TOO. This is a RESIDENT service, not a
-      # timer: it imports scripts/lib/tmux_text_policy.py once at startup and then
-      # runs for weeks. Without this line, TIGHTENING the text allowlist would
-      # leave the running agent on the OLD predicate indefinitely -- a security
-      # change that appears deployed and is not, on the process that executes.
+      # 🔴 EVERY MODULE THIS UNIT IMPORTS AT STARTUP IS A TRIGGER. This is a
+      # RESIDENT service, not a timer: it loads each of these ONCE and then runs
+      # for weeks. Without a line here, a fix to one of them lands on disk and the
+      # running agent keeps executing the OLD code indefinitely — a change that
+      # appears deployed and is not, on the process that executes.
+      #
+      # tmux_text_policy.py — the text allowlist. TIGHTENING it is a security
+      #   change, and this is the one process it has to reach.
+      # transcript_stream.py — the transcript delta tailer, and transcript_search
+      #   .py which it loads in turn. A splice bug in either is a CORRECTNESS bug
+      #   in what the operator reads about a session; both were added after the
+      #   two lines above and neither inherited the rule.
+      #
+      # ⚠ THE COVERAGE USED TO SIT WHERE IT MATTERED LEAST. The transcript-push
+      # TIMER — where a stale copy costs at most five minutes, because the next
+      # tick runs fresh code — names both its halves and is pinned by
+      # `test_the_unit_restart_triggers_name_BOTH_halves`. This RESIDENT unit,
+      # where a stale copy lasts until somebody notices, named two of four.
       X-Restart-Triggers = [
         "${../scripts/tmux-reply-agent}"
         "${../scripts/lib/tmux_text_policy.py}"
+        "${../scripts/lib/transcript_stream.py}"
+        "${../scripts/lib/transcript_search.py}"
       ];
     };
     Install = {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3739,18 +3739,30 @@ in
         # triggers, which is what makes the omission an asymmetry rather than a
         # policy.
         "${../scripts/lib/host_label.py}"
-        # 🔴 THE BUILDER'S OWN IMPORT, MISSED FOR THE WHOLE ARC. The resident
-        # agent's list gained transcript_search.py when the tailer started
-        # loading it; this timer's did not, even though build_transcript_push.py
-        # imports it directly and cannot run without it:
+        # The builder's own import, and the oldest omission in this list:
+        # build_transcript_push.py has imported transcript_search since the
+        # feeder shipped, and cannot run without it —
         #
         #   builder without transcript_search.py -> rc 1
         #   ModuleNotFoundError: No module named 'transcript_search'
         #
-        # The asymmetry mattered twice over: a comment three lines below asserted
-        # this unit "names every module it depends on", and the test it named
-        # pinned a hand-written 3-set — so the gap was not merely unnoticed, it
-        # was locked in by the guard meant to prevent it.
+        # ⚠ WHAT IT COSTS IS ONE TICK, NOT A STALE DEPLOY, AND THE COMMIT THAT
+        # ADDED THIS ENTRY SAID OTHERWISE. This is a `Type=oneshot` fired by a
+        # 5-minute timer, and ExecStart above names the WORKING-TREE path, not a
+        # store path; transcript-push.sh then resolves the builder through
+        # `readlink -f "$0"`, so the next tick execs whatever is on disk with or
+        # without a trigger. Measured on the live unit:
+        #
+        #   ExecStart=…/bash %h/workspace/devrc/scripts/transcript-push.sh
+        #   Type=oneshot   timer: last run 19s ago, next in 4min 40s
+        #
+        # So a missing trigger here buys back at most one 5-minute tick — the
+        # bound the reply-agent block states for exactly this contrast (search
+        # for "where a stale copy costs at most five minutes"). It is listed
+        # because the other three are, and because a hard dependency that can
+        # exit the unit belongs in its own declaration; NOT because omitting it
+        # runs old code indefinitely. That consequence is the resident agent's,
+        # and this arc has now made the same overstatement twice.
         "${../scripts/lib/transcript_search.py}"
       ];
     };
@@ -3877,7 +3889,8 @@ in
       # ⚠ THE COVERAGE USED TO SIT WHERE IT MATTERED LEAST. The transcript-push
       # TIMER — where a stale copy costs at most five minutes, because the next
       # tick runs fresh code — names every module it depends on and is pinned by
-      # `test_the_unit_restart_triggers_name_EVERY_half`. This RESIDENT unit,
+      # `test_the_unit_restart_triggers_name_EVERY_hard_dependency` (and now by a
+      # source-derived sibling, the way this unit already was). This RESIDENT unit,
       # where a stale copy lasts until somebody notices, named two while loading
       # four. Both units and both tests were widened in the same arc; the numbers
       # are deliberately not restated here, because they moved three times while

--- a/scripts/lib/build_transcript_push.py
+++ b/scripts/lib/build_transcript_push.py
@@ -64,8 +64,28 @@ def hash_tail(tail: bytes) -> str:
     return hashlib.sha256(tail).hexdigest()
 
 
-def read_tail(path: Path, max_bytes: int) -> tuple[str, bool] | None:
-    """Return (tail_text, truncated) for one transcript, or None if unreadable.
+def read_tail(path: Path, max_bytes: int) -> tuple[str, bool, int] | None:
+    """Return (tail_text, truncated, file_bytes) for one transcript, or None.
+
+    🔴 `file_bytes` IS WHERE THIS TAIL ENDS IN THE FILE, AND IT IS THE DELTA
+    STREAM'S RESUME CURSOR. The server stores it as the position its stored tail
+    corresponds to. Without it a bulk push REPLACES the tail while leaving the
+    cursor describing the tail it replaced, and the next delta appends onto a base
+    that no longer matches its offset — a splice, stored, with nothing to indicate
+    it. See migration 0034 on the clawgate side.
+
+    🔴 IT IS DERIVED FROM WHAT WAS ACTUALLY READ, NOT FROM `size`, BECAUSE THE
+    FILE IS BEING APPENDED TO. `size` is a stat taken before the read; the bytes
+    that came back can end past it. `start + len(raw)` is exact either way.
+
+    🔴 AND IT IS RETURNED AS 0 — MEANING *UNKNOWN* — WHENEVER THE DECODED TAIL
+    RE-ENCODES LONGER THAN THE BYTES IT CAME FROM. `errors="replace"` turns one
+    bad byte into a three-byte U+FFFD, so a corrupt transcript can produce a tail
+    LARGER than its own file. The server rejects a fileBytes smaller than the tail
+    beside it (a cursor pointing before the start of the stored tail is a splice
+    waiting to happen), so claiming the honest number there would fail the WHOLE
+    atomic push and take every other session in the request with it. Unknown makes
+    the stream reseed that one session and costs nothing else.
 
     🔴 THE LEADING PARTIAL RECORD IS DROPPED, NOT SHIPPED. Seeking to
     `size - max_bytes` lands in the middle of a JSON line essentially every time.
@@ -89,15 +109,19 @@ def read_tail(path: Path, max_bytes: int) -> tuple[str, bool] | None:
     """
     try:
         size = path.stat().st_size
+        start = 0
         with path.open("rb") as fh:
             if size > max_bytes:
-                fh.seek(size - max_bytes)
+                start = size - max_bytes
+                fh.seek(start)
                 truncated = True
             else:
                 truncated = False
             raw = fh.read(max_bytes)
     except OSError:
         return None
+
+    file_end = start + len(raw)
 
     if truncated:
         nl = raw.find(b"\n")
@@ -108,7 +132,10 @@ def read_tail(path: Path, max_bytes: int) -> tuple[str, bool] | None:
             return None
         raw = raw[nl + 1 :]
 
-    return raw.decode("utf-8", errors="replace"), truncated
+    text = raw.decode("utf-8", errors="replace")
+    if len(text.encode("utf-8")) > file_end:
+        file_end = 0  # UNKNOWN — see the docstring.
+    return text, truncated, file_end
 
 
 def project_of(transcript: Path) -> str:
@@ -192,8 +219,18 @@ def build(args: argparse.Namespace) -> dict:
     known = load_digest(Path(args.digest))
 
     sessions = []
+    # 🔴 THE AGGREGATE, WHICH THE SESSION COUNT DOES NOT IMPLY. The server bounds
+    # the total tail bytes in one push (MaxPushTailBytes) as well as the count, and
+    # a rejection changes nothing server-side — so a builder that only counted
+    # sessions would, once the count rose from 6 to 48, start producing pushes that
+    # are refused on EVERY tick while looking correctly configured. Stopping here
+    # means a very busy host catches up over several ticks instead.
+    max_push_bytes = getattr(args, "max_push_bytes", 0) or 0
+    total_bytes = 0
     for path in candidates(projects_dir, args.max_age_hours, args.max_candidates):
         if len(sessions) >= args.max_sessions:
+            break
+        if max_push_bytes and total_bytes >= max_push_bytes:
             break
         # The session id IS the filename stem — that is how Claude Code writes
         # them, and it is the same id the attention queue and session-manager's
@@ -205,11 +242,19 @@ def build(args: argparse.Namespace) -> dict:
         result = read_tail(path, args.tail_bytes)
         if result is None:
             continue
-        text, truncated = result
+        text, truncated, file_bytes = result
         if not text.strip():
             continue
 
-        digest = hash_tail(text.encode("utf-8"))
+        encoded = text.encode("utf-8")
+        # 🔴 CHECKED BEFORE THE SKIP, NOT AFTER, so a single oversized session
+        # cannot be admitted by arriving first. A session that alone exceeds the
+        # remaining budget is deferred to the next tick rather than dropped for
+        # ever — the loop is re-run every five minutes and the candidate list is
+        # ordered by recency, so it is first next time.
+        if max_push_bytes and sessions and total_bytes + len(encoded) > max_push_bytes:
+            break
+        digest = hash_tail(encoded)
         # 🔴 THE SKIP. This single comparison is the whole reason the steady-state
         # push is kilobytes rather than megabytes.
         if known.get(session_id) == digest:
@@ -231,8 +276,15 @@ def build(args: argparse.Namespace) -> dict:
                 "tail": text,
                 "truncated": truncated,
                 "contentHash": digest,
+                # 🔴 THE SEAM WITH THE DELTA STREAM. See read_tail. The server
+                # rejects a fileBytes SMALLER than the tail it accompanies, which
+                # is why this is `size` and not, say, len(text) — the tail is a
+                # decoded string and `errors="replace"` can make it a different
+                # length from the bytes it came from.
+                "fileBytes": file_bytes,
             }
         )
+        total_bytes += len(encoded)
 
     return {"host": args.host, "sessions": sessions}
 
@@ -244,6 +296,9 @@ def main() -> int:
     ap.add_argument("--host", required=True)
     ap.add_argument("--tail-bytes", type=int, required=True)
     ap.add_argument("--max-sessions", type=int, required=True)
+    # Optional so an older caller keeps working: 0 means "no aggregate bound",
+    # which is exactly the behaviour before this flag existed.
+    ap.add_argument("--max-push-bytes", type=int, default=0)
     ap.add_argument("--max-age-hours", type=float, required=True)
     ap.add_argument("--max-candidates", type=int, required=True)
     args = ap.parse_args()

--- a/scripts/lib/build_transcript_push.py
+++ b/scripts/lib/build_transcript_push.py
@@ -227,6 +227,7 @@ def build(args: argparse.Namespace) -> dict:
     # means a very busy host catches up over several ticks instead.
     max_push_bytes = getattr(args, "max_push_bytes", 0) or 0
     total_bytes = 0
+    claimed: set[str] = set()
     for path in candidates(projects_dir, args.max_age_hours, args.max_candidates):
         if len(sessions) >= args.max_sessions:
             break
@@ -235,9 +236,31 @@ def build(args: argparse.Namespace) -> dict:
         # The session id IS the filename stem — that is how Claude Code writes
         # them, and it is the same id the attention queue and session-manager's
         # `claude_session_id` carry, which is what makes the join work at all.
-        session_id = path.stem
-        if not session_id:
+        #
+        # 🔴 STRIPPED AND DE-DUPLICATED, AND THE BLAST RADIUS HERE IS THE WHOLE
+        # HOST — WHICH IS THE OPPOSITE OF WHAT THE PROSE ELSEWHERE ASSUMED. The
+        # delta stream grew this guard first, and there a duplicate costs ONE
+        # session. Here `NormalizePush` rejects THE ENTIRE PUSH on a duplicate or
+        # an empty id, a rejection stores nothing, so the digest never matches,
+        # so the same poisoned batch is re-sent on every tick — permanently, for
+        # every session on this host. And this is the feed the whole streaming
+        # design designates as the RECONCILER.
+        #
+        # Two ways two files produce one id, both closed here as they are there:
+        # the same <uuid>.jsonl under two project directories, and — because the
+        # server TrimSpaces the id and this side did not — "abc.jsonl" beside
+        # "abc .jsonl".
+        #
+        # ⚠ RAISING `MAX_PER_PUSH` FROM 6 TO 48 WIDENED THIS. Six candidates
+        # rarely collide; forty-eight over a 24h window is a different exposure,
+        # and the change that widened it is the one that had to close it.
+        # Measured over the live corpus: 962 files, 0 duplicates after TrimSpace
+        # — so this is not live, and the cost of it becoming live is total.
+        # Candidates arrive newest-first, so the survivor is the freshest file.
+        session_id = path.stem.strip()
+        if not session_id or session_id in claimed:
             continue
+        claimed.add(session_id)
 
         result = read_tail(path, args.tail_bytes)
         if result is None:
@@ -247,11 +270,26 @@ def build(args: argparse.Namespace) -> dict:
             continue
 
         encoded = text.encode("utf-8")
-        # 🔴 CHECKED BEFORE THE SKIP, NOT AFTER, so a single oversized session
-        # cannot be admitted by arriving first. A session that alone exceeds the
-        # remaining budget is deferred to the next tick rather than dropped for
-        # ever — the loop is re-run every five minutes and the candidate list is
-        # ordered by recency, so it is first next time.
+        # 🔴 THE `and sessions` CONJUNCT IS AN EXEMPTION, AND AN EARLIER COMMENT
+        # HERE CLAIMED THE OPPOSITE — "a single oversized session cannot be
+        # admitted by arriving first". It can, deliberately: when the push is
+        # otherwise EMPTY, a session larger than the whole budget is sent anyway,
+        # because it is also the newest and would otherwise be dropped first on
+        # every tick, for ever. `test_ONE_oversized_session_alone_is_still_sent_
+        # rather_than_dropped_for_ever` exists to guarantee exactly that.
+        #
+        # What the ordering does buy is the OTHER case: once something is in the
+        # push, a session that would overflow the budget is deferred to the next
+        # tick rather than truncated.
+        #
+        # ⚠ AND THE BUDGET IS CHARGED BEFORE THE DEDUPE SKIP BELOW, so a large
+        # UNCHANGED session — which contributes nothing to the payload — can end
+        # the loop and defer sessions behind it by one tick. Measured and
+        # deliberate: moving the check after the skip would mean hashing every
+        # candidate before knowing whether there is room, and one tick of
+        # deferral on a recency-ordered list is cheaper than that. With the
+        # shipped values (192 KiB tail against a 3 MiB budget) it needs 16
+        # unchanged sessions in one window to bite at all.
         if max_push_bytes and sessions and total_bytes + len(encoded) > max_push_bytes:
             break
         digest = hash_tail(encoded)
@@ -276,11 +314,17 @@ def build(args: argparse.Namespace) -> dict:
                 "tail": text,
                 "truncated": truncated,
                 "contentHash": digest,
-                # 🔴 THE SEAM WITH THE DELTA STREAM. See read_tail. The server
-                # rejects a fileBytes SMALLER than the tail it accompanies, which
-                # is why this is `size` and not, say, len(text) — the tail is a
-                # decoded string and `errors="replace"` can make it a different
-                # length from the bytes it came from.
+                # 🔴 THE SEAM WITH THE DELTA STREAM. See read_tail.
+                #
+                # ⚠ AN EARLIER VERSION OF THIS COMMENT SAID "this is `size`", and
+                # read_tail's own 🔴 docstring says the opposite in capitals: it
+                # is derived from what was actually READ, not from the stat,
+                # because the file is being appended to while it is read. `size`
+                # is not even in scope here. The reason it is not len(text) is
+                # right, though: the tail is a decoded string and
+                # `errors="replace"` can make it a different length from the
+                # bytes it came from — which is also why read_tail reports 0 =
+                # UNKNOWN when that inflation happens.
                 "fileBytes": file_bytes,
             }
         )

--- a/scripts/lib/build_transcript_push.py
+++ b/scripts/lib/build_transcript_push.py
@@ -282,14 +282,23 @@ def build(args: argparse.Namespace) -> dict:
         # push, a session that would overflow the budget is deferred to the next
         # tick rather than truncated.
         #
-        # ⚠ AND THE BUDGET IS CHARGED BEFORE THE DEDUPE SKIP BELOW, so a large
-        # UNCHANGED session — which contributes nothing to the payload — can end
-        # the loop and defer sessions behind it by one tick. Measured and
-        # deliberate: moving the check after the skip would mean hashing every
-        # candidate before knowing whether there is room, and one tick of
-        # deferral on a recency-ordered list is cheaper than that. With the
-        # shipped values (192 KiB tail against a 3 MiB budget) it needs 16
-        # unchanged sessions in one window to bite at all.
+        # ⚠ AND THE CHECK RUNS BEFORE THE DEDUPE SKIP BELOW, so a large UNCHANGED
+        # session can END the loop and defer sessions behind it by one tick.
+        # Deliberate: moving it after the skip would mean hashing every candidate
+        # before knowing whether there is room.
+        #
+        # 🔴 AN EARLIER VERSION SAID THE BUDGET IS "CHARGED" BY SUCH A SESSION AND
+        # QUANTIFIED IT AT "16 unchanged sessions". Both wrong: `total_bytes` is
+        # only incremented on APPEND, so an unchanged session is never charged,
+        # and the `and sessions` conjunct means an unchanged-ONLY window can never
+        # break at all. Measured with the shipped values:
+        #
+        #   18 large UNCHANGED sessions -> pushed 3, all 3 smalls reached
+        #   17 large CHANGED   sessions -> pushed 16, 0 of 3 smalls reached
+        #
+        # The mechanism is real — an unchanged session CAN end the loop once
+        # something is already in the push and the budget is nearly spent — but it
+        # is the CHANGED ones that fill the budget, and the number was invented.
         if max_push_bytes and sessions and total_bytes + len(encoded) > max_push_bytes:
             break
         digest = hash_tail(encoded)

--- a/scripts/lib/host_label.py
+++ b/scripts/lib/host_label.py
@@ -1,0 +1,82 @@
+"""host_label — THE one rule for "which box is this".
+
+🔴 IT EXISTS BECAUSE THE RULE WAS OPEN-CODED TWICE AND THE TWO COPIES DISAGREED,
+AND BECAUSE A LATER CHANGE MADE THAT DISAGREEMENT LOAD-BEARING.
+
+Both halves of the transcript feed write the SAME row's `host` column:
+
+  * `transcript-push.sh` had `HOST_NAME="${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}"`.
+    Its own comment said ACTIVITY_HOST is "the fleet's existing per-host handle …
+    so reusing it keeps one answer to 'which box is this' rather than minting a
+    second" — but ACTIVITY_HOST lives in a FILE that the unit does not source and
+    the shell never reads, so it fell through to `uname -n`, which is **"nixos"
+    on BOTH machines**. Measured on the deployed server: every stored transcript
+    row said `host: nixos`, i.e. the column was useless.
+  * `tmux-reply-agent` read that file, lowercased, validated against the two real
+    names, and produced "workbench" / "laptop".
+
+That mismatch cost nothing while `host` was display-only. Then the delta stream
+made it a CORRECTNESS predicate (an append whose host differs from the stored
+row's is refused, because the stored offset is a position in the other machine's
+file) — and the two feeders' disagreement turned into a permanent refusal: every
+5-minute bulk tick stamped `nixos` back onto every row, and every 5-second stream
+poll then reseeded up to 48 KiB per session because "the host changed". Caught by
+an adversarial audit BEFORE deploy, with both values measured side by side.
+
+So the rule lives here now, in one module, and both feeders read it.
+"""
+from __future__ import annotations
+
+import os
+
+#: The host vocabulary the read model, the termwrite queue and the activity
+#: collector all use. `hostname` is "nixos" on BOTH machines, which is precisely
+#: why it cannot be the source of truth.
+HOST_NAMES = ("workbench", "laptop")
+DEFAULT_LOCAL_HOST = "workbench"
+
+#: Where the collector records this machine's label.
+#:
+#: `HOST_LABEL_ENV_FILE` redirects it. That override exists so a test can point
+#: BOTH feeders at one fixture and assert they agree — which is the only way to
+#: pin the property that matters here; pinning each side to a literal separately
+#: is exactly what let them drift.
+ACTIVITY_ENV = os.environ.get("HOST_LABEL_ENV_FILE") or os.path.expanduser(
+    "~/.config/activity-collector/env")
+
+
+def local_host_label(env=None, env_file: str = ACTIVITY_ENV) -> str:
+    """This machine's ACTIVITY_HOST label.
+
+    The ENVIRONMENT wins over the file, then the file, then the default. A value
+    that is not one of HOST_NAMES is ignored rather than passed through: a typo
+    would otherwise mint a third host that nothing else in the fleet knows about,
+    and — since the termwrite queue is keyed on this label — an agent computing
+    one would poll for a host nobody enqueues to and deliver nothing, silently.
+    """
+    e = os.environ if env is None else env
+    v = (e.get("ACTIVITY_HOST") or "").strip().lower()
+    if v in HOST_NAMES:
+        return v
+    try:
+        with open(env_file, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        text = ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("ACTIVITY_HOST="):
+            val = line[len("ACTIVITY_HOST="):].strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                val = val[1:-1]
+            val = val.strip().lower()
+            if val in HOST_NAMES:
+                return val
+    return DEFAULT_LOCAL_HOST
+
+
+if __name__ == "__main__":
+    # 🔴 THE SHELL ENTRY POINT. transcript-push.sh calls `python3 host_label.py`
+    # rather than re-deriving the rule in shell — which is what it used to do, and
+    # what got the two feeders out of step. Prints nothing but the label.
+    print(local_host_label())

--- a/scripts/lib/transcript_stream.py
+++ b/scripts/lib/transcript_stream.py
@@ -233,7 +233,7 @@ def _decode_exact(raw: bytes) -> str | None:
         return None
 
 
-def _read_append(path: str, offset: int, budget: int, at_eof: bool = False):
+def _read_append(path: str, offset: int, budget: int, *, at_eof: bool):
     """Whole records starting at `offset`, at most `budget` bytes.
 
     Returns (start, byte_length, text) on success, or a SKIP_* reason string.

--- a/scripts/lib/transcript_stream.py
+++ b/scripts/lib/transcript_stream.py
@@ -135,6 +135,7 @@ MAX_CANDIDATES = 200
 # every real event in the journal.
 SKIP_UNCHANGED = "unchanged"
 SKIP_DUPLICATE_ID = "duplicate-session-id"
+SKIP_NO_SESSION_ID = "no-session-id"
 SKIP_NO_BOUNDARY = "no-record-boundary"
 SKIP_UNDECODABLE = "undecodable"
 SKIP_UNREADABLE = "unreadable"
@@ -172,7 +173,15 @@ class StreamState:
         self.hydrated = False
 
     def note_inode(self, session_id: str, inode: int) -> None:
-        """Record a file identity, bounded."""
+        """Record a file identity, bounded, LEAST-RECENTLY-SEEN first.
+
+        🔴 THE POP-THEN-SET IS THE EVICTION ORDER, NOT A NO-OP. A plain
+        assignment leaves an existing key at its ORIGINAL insertion position, so
+        eviction would drop the longest-LIVED session — typically the most active
+        one — rather than the least recently seen. Unreachable at the current
+        limit, and wrong for free if it ever is not.
+        """
+        self.inodes.pop(session_id, None)
         self.inodes[session_id] = inode
         while len(self.inodes) > self.INODE_LIMIT:
             # dicts preserve insertion order, so this evicts the oldest.
@@ -224,7 +233,7 @@ def _decode_exact(raw: bytes) -> str | None:
         return None
 
 
-def _read_append(path: str, offset: int, budget: int):
+def _read_append(path: str, offset: int, budget: int, at_eof: bool = False):
     """Whole records starting at `offset`, at most `budget` bytes.
 
     Returns (start, byte_length, text) on success, or a SKIP_* reason string.
@@ -246,10 +255,17 @@ def _read_append(path: str, offset: int, budget: int):
     nl = raw.rfind(b"\n")
     if nl >= 0:
         raw = raw[: nl + 1]
-    elif len(raw) < budget:
+    elif at_eof:
         # The read reached EOF without a newline: this is just a line still being
         # written. Sending it would put a fragment in the stored tail; it costs
         # one poll to wait.
+        #
+        # 🔴 `at_eof` COMES FROM THE CALLER'S stat, NOT FROM `len(raw) < budget`.
+        # The length test is wrong at exactly one point — a file that ends
+        # precisely `budget` bytes past the cursor reads a FULL window that is
+        # also the end of the file, and the length test then calls it an
+        # over-window record and ships the fragment. One chance in 49,152 per
+        # poll, and the caller already knows the answer exactly.
         return SKIP_NO_BOUNDARY
     else:
         # 🔴 THE WINDOW IS FULL AND HOLDS NO BOUNDARY, SO THIS RECORD IS LONGER
@@ -331,6 +347,17 @@ def _read_reseed(path: str, size: int, window: int):
     nl = raw.rfind(b"\n")
     if nl >= 0:
         raw = raw[: nl + 1]
+    elif start == 0:
+        # 🔴 THE WHOLE FILE IS SHORTER THAN THE WINDOW AND HOLDS NO RECORD
+        # BOUNDARY AT ALL, so this is a FIRST LINE STILL BEING WRITTEN — the one
+        # case where the "a record bigger than the window can never complete"
+        # justification provably does not apply. Waiting costs one poll.
+        #
+        # The append path has had this discriminator since the stall fix and a
+        # test to go with it; the reseed path did not, so it shipped a fragment
+        # here where the previous revision had waited. `start == 0` is exact and
+        # free — it is already in hand.
+        return SKIP_NO_BOUNDARY
     else:
         raw = _cut_at_rune_boundary(raw)
     if not raw:
@@ -367,10 +394,19 @@ def _cut_at_rune_boundary(raw: bytes) -> bytes:
     bytes are half a character — and, downstream, what keeps the two sides' byte
     counts equal, since a lossy decode would diverge them for ever.
 
-    ⚠ IT REMOVES AT MOST 3 BYTES, and it removes them only when the final
-    sequence is genuinely incomplete. A complete trailing rune is left alone; an
-    invalid lead byte is left alone too, so `_decode_exact` still rejects real
-    corruption rather than having it silently trimmed away.
+    ⚠ TWO THINGS THIS DOES NOT DO, both of which an earlier version of this
+    docstring claimed and neither of which was true:
+      * it does not remove "at most 3 bytes" — an incomplete FOUR-byte sequence
+        costs 4. At most 3 is the bound for a valid UTF-8 prefix only.
+      * it does not leave every invalid byte alone. A run of stray CONTINUATION
+        bytes at the end is walked past and dropped, so `_decode_exact` never
+        sees them. Byte accounting stays exact (the result is always a prefix of
+        the input, so `offset + len(sent)` is still the true file position), but
+        the effect is to convert a REPORTABLE corruption into an unreported one —
+        the next poll then stalls on `undecodable` instead, which is where it
+        surfaces.
+    A complete trailing rune is left alone, and an invalid LEAD byte is left
+    alone, so ordinary corruption still reaches `_decode_exact`.
     """
     n = len(raw)
     for back in range(1, 5):
@@ -494,8 +530,13 @@ def plan_frame(
         # is not live; the cost of it becoming live is total, and the fix is
         # this branch. Candidates arrive newest-first, so the survivor is the
         # freshest file.
+        # A name that strips to nothing is not a duplicate of anything — counting
+        # it as one would report the wrong mechanism for a file called " .jsonl".
         sid = sid.strip()
-        if not sid or sid in claimed:
+        if not sid:
+            skip(SKIP_NO_SESSION_ID)
+            continue
+        if sid in claimed:
             skip(SKIP_DUPLICATE_ID)
             continue
         claimed.add(sid)
@@ -541,7 +582,8 @@ def plan_frame(
             skip(SKIP_UNCHANGED)
             continue
 
-        got = _read_append(path, offset, per_session)
+        got = _read_append(path, offset, per_session,
+                           at_eof=(st.st_size - offset) <= per_session)
         if isinstance(got, str):
             skip(got)
             continue

--- a/scripts/lib/transcript_stream.py
+++ b/scripts/lib/transcript_stream.py
@@ -1,0 +1,481 @@
+"""transcript_stream — the host half of clawgate's transcript DELTA STREAM.
+
+WHAT THIS IS
+------------
+`transcript-push.sh` feeds clawgate's transcript read model by REPLACING each
+session's stored tail every five minutes. This module feeds the same read model
+by APPENDING, on the poll the host agent already runs, so a line written into a
+`.jsonl` shows on `/session/<id>` in seconds rather than minutes.
+
+🔴 IT IS THE FAST PATH, NEVER THE ONLY PATH. The five-minute bulk push stays
+exactly as it was and remains the RECONCILER: it is what repairs anything this
+missed while the agent was down, the laptop asleep, or the clawgate pod
+mid-redeploy. A stream-only design loses every line written during a deploy
+window and has no mechanism that could ever notice. Do not delete the timer
+because "the stream covers it".
+
+🔴 NO NEW CONNECTION AND NO NEW PORT. This runs inside `tmux-reply-agent`, which
+already holds an OUTBOUND poll to clawgate every ~5s. Nothing listens on either
+host, and no credential for either host lives in the pod. What it adds is one
+more request per existing poll cycle — not a second long-lived connection, and
+not a second unit.
+
+🔴 THE CURSOR IS THE SERVER'S, NOT OURS. Every response carries the authoritative
+offset for every session in the frame, accepted or refused, and this module
+ADOPTS it rather than computing its own by adding len(data). That is the whole
+resume protocol: a clawgate redeploy, a lost response, or a bulk push landing
+between two deltas all leave the host one poll out of step, and one poll later it
+is back in step having neither duplicated nor skipped a line. Computing the
+cursor locally would be right until the one time it was not, and then the two
+sides would be permanently spliced with nothing saying so.
+
+🔴 A DELTA IS ALWAYS WHOLE RECORDS. Every read is cut at a NEWLINE, which does
+two jobs at once: the server never stores a leading JSON fragment, and a
+multi-byte rune can never be split across two frames (a newline is ASCII, so a
+cut there is always a rune boundary). The trailing partial line waits for the
+next poll.
+
+🔴 THE BYTE COUNTS ON BOTH SIDES MUST AGREE EXACTLY, so this decodes STRICTLY.
+The server advances its cursor by the byte length of the text it received; this
+advances the file position by the bytes it read. `errors="replace"` would turn
+one bad byte into a three-byte U+FFFD, the two counts would diverge, and — because
+the host re-reads from the server's offset — the SAME bad byte would be re-sent
+and re-refused on every poll for ever. A session whose bytes will not decode is
+therefore SKIPPED by the stream entirely and left to the bulk reconciler, which
+does use `errors="replace"` and replaces the whole tail. Cutting on newlines
+makes this reachable only by real corruption, not by a cut point.
+
+Scope: this is the operator's own clawgate feed. It is deliberately NOT the team
+Cairn / handoff session-shipping path, which is opt-in and must stay so.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_transcript_search(path: str = None):
+    """Load `scripts/lib/transcript_search.py` by EXPLICIT PATH.
+
+    🔴 THE SHARED ENUMERATOR, NOT A HAND-ROLLED WALK, AND BY PATH BECAUSE THIS
+    MODULE IS ITSELF LOADED BY PATH. `tmux-reply-agent` imports this file with a
+    SourceFileLoader, so `scripts/lib` is not on sys.path and a plain
+    `from transcript_search import ...` would fail at runtime while working
+    perfectly under pytest — the worst possible split.
+
+    🔴 AND IT IS A CORRECTNESS FIX, NOT ONLY LEDGER HYGIENE. `is_corpus_member`
+    excludes `subagents/`, which holds transcripts that are NOT resumable
+    sessions: measured on this host 2026-09-04, 4,884 of 5,788 `.jsonl` files —
+    84% — live there. A hand-rolled `os.walk` for `*.jsonl` would stream thousands
+    of rows that no attention entry and no tmux window can ever join to, at the
+    fastest cadence in the system.
+    """
+    path = path or os.path.join(_HERE, "transcript_search.py")
+    loader = importlib.machinery.SourceFileLoader("_ts_transcript_search", path)
+    spec = importlib.util.spec_from_loader("_ts_transcript_search", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+_SEARCH = _load_transcript_search()
+
+# ── the bounds, mirrored from the server ─────────────────────────────────────
+# 🔴 THESE MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The server enforces
+# MaxDeltaBytes=65536, MaxFrameBytes=524288 and MaxDeltaSessionsPerFrame=64 and
+# REJECTS a frame that exceeds any of them; a rejection changes nothing
+# server-side, so a client tuned exactly to a limit turns any rounding
+# disagreement into a stream that fails every poll while looking correctly
+# configured. Same rule, and the same reason, as transcript-push.sh's header.
+MAX_DELTA_BYTES = 48 * 1024        # server cap 64 KiB
+MAX_FRAME_BYTES = 384 * 1024       # server cap 512 KiB
+MAX_SESSIONS_PER_FRAME = 48        # server cap 64
+
+# 🔴 THE BACKPRESSURE BOUND, AND THE ONLY PLACE UNBOUNDED LAG IS ANSWERED. A
+# session can outrun the stream: MAX_DELTA_BYTES per poll is ~9.6 KB/s at the
+# agent's 5s cadence, and a burst of tool output beats that. Replaying an
+# arbitrarily long backlog would make the stream slower the further behind it
+# got — the shape where a queue never drains. Past this much lag the host SKIPS
+# FORWARD with a reset instead, which is lossy by construction and repaired by
+# the bulk reconciler on its next tick.
+MAX_LAG_BYTES = 1024 * 1024
+
+# How much of a file a reseed carries.
+#
+# 🔴 IT IS THE PER-DELTA CAP, NOT THE SERVER'S 256 KiB TAIL CAP, AND THE FIRST
+# DRAFT OF THIS FILE HAD IT WRONG. A reseed IS a delta — it travels in the same
+# `data` field and is measured by the same MaxDeltaBytes guard — so a 192 KiB
+# reseed would be REJECTED by the server, and the rejection would present as "the
+# stream never recovers from a rotation". The consequence of the correct value is
+# real and accepted: immediately after a reseed the view holds ~48 KiB of tail
+# rather than the full 256 KiB, until the bulk reconciler's next tick restores
+# the wider window. That is the reconciler earning its keep, not a gap.
+RESEED_TAIL_BYTES = MAX_DELTA_BYTES
+
+# How far back a transcript is considered at all, and how many files are stat'd.
+# Mirrors transcript-push.sh's own window so the two feeders agree about which
+# sessions exist.
+MAX_AGE_HOURS = 24.0
+MAX_CANDIDATES = 200
+
+# The reasons a session is not in a frame. Returned as counters rather than
+# logged per session: this runs every 5 seconds and a per-session line would bury
+# every real event in the journal.
+SKIP_UNCHANGED = "unchanged"
+SKIP_NO_BOUNDARY = "no-record-boundary"
+SKIP_UNDECODABLE = "undecodable"
+SKIP_UNREADABLE = "unreadable"
+
+
+class StreamState:
+    """The host's memory between polls: a cursor and an inode per session.
+
+    🔴 THE INODE IS NOT REDUNDANT WITH THE SIZE. A rotated or recreated file can
+    be LARGER than the old one at the moment it is checked, so a size comparison
+    alone reports "grew" and the next delta appends the head of a new file onto
+    the tail of an old one. The inode is the only thing that distinguishes "this
+    file grew" from "this is a different file at the same path".
+
+    🔴 CURSORS ARE HYDRATED FROM THE SERVER, ONCE, AND NEVER PERSISTED TO DISK. A
+    host-side cache of "what I sent last time" is wrong whenever the two sides
+    disagree, and they disagree in both directions — a database restore leaves
+    the server empty while the host believes everything is delivered. Asking the
+    server is correct in both directions and needs no state on this machine.
+    """
+
+    def __init__(self) -> None:
+        self.cursors: dict[str, int | None] = {}
+        self.inodes: dict[str, int] = {}
+        self.hydrated = False
+
+    def forget(self, session_id: str) -> None:
+        self.cursors.pop(session_id, None)
+        self.inodes.pop(session_id, None)
+
+
+def iter_candidates(projects_dir, max_age_hours=MAX_AGE_HOURS, limit=MAX_CANDIDATES, now=None):
+    """Recently-modified transcripts, newest first, bounded.
+
+    Recency is the only selector, for the reason build_transcript_push.py gives:
+    asking which sessions have a live tmux window would couple this to a
+    collector that runs on one host, and would stop feeding a session the moment
+    its window closed — which is exactly when someone wants to read what it did.
+
+    The WALK is `transcript_search.iter_transcripts`, never a local glob — see
+    `_load_transcript_search` for the ledger that enforces that and for the
+    84%-of-files correctness reason.
+    """
+    import time as _time
+
+    if now is None:
+        now = _time.time()
+    cutoff = now - max_age_hours * 3600
+    found: list[tuple[float, str]] = []
+    for p in _SEARCH.iter_transcripts(projects_dir):
+        path = str(p)
+        try:
+            st = os.stat(path)
+        except OSError:
+            # A transcript can vanish between the walk and the stat. Skipping
+            # one file must never fail the round.
+            continue
+        if st.st_mtime < cutoff:
+            continue
+        found.append((st.st_mtime, path))
+    found.sort(key=lambda pair: pair[0], reverse=True)
+    return [p for _, p in found[:limit]]
+
+
+def _decode_exact(raw: bytes) -> str | None:
+    """Decode `raw` so the result re-encodes to exactly `raw`, or None.
+
+    See the module header: a lossy decode makes the two sides' byte counts
+    diverge and the same bytes are then re-sent and re-refused for ever.
+    """
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _read_append(path: str, offset: int, budget: int):
+    """Whole records starting at `offset`, at most `budget` bytes.
+
+    Returns (start, byte_length, text) on success, or a SKIP_* reason string.
+
+    🔴 IT RETURNS THE REASON RATHER THAN None, because the three ways this can
+    decline are three different facts about the host and one of them is a real
+    defect signal. "Only a partial line has landed" is the ordinary steady state;
+    "these bytes will not decode" means a transcript is corrupt and the stream is
+    permanently deferring that session to the reconciler. Counting them as one
+    number would hide the second inside the first, which happens every few
+    seconds.
+    """
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(offset)
+            raw = fh.read(budget)
+    except OSError:
+        return SKIP_UNREADABLE
+    nl = raw.rfind(b"\n")
+    if nl < 0:
+        # Only a partial line so far. Sending it would put a fragment in the
+        # stored tail AND risk splitting a rune; it costs one poll to wait.
+        return SKIP_NO_BOUNDARY
+    raw = raw[: nl + 1]
+    text = _decode_exact(raw)
+    if text is None:
+        return SKIP_UNDECODABLE
+    return offset, len(raw), text
+
+
+def _read_reseed(path: str, size: int, window: int):
+    """The tail of a file as a reseed: (start_offset, byte_length, text), or a
+    SKIP_* reason string.
+
+    The leading partial record is DROPPED and the trailing one is left for the
+    next poll, so a reseed is whole records exactly like an append is.
+    """
+    start = max(0, size - window)
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(start)
+            raw = fh.read(window)
+    except OSError:
+        return SKIP_UNREADABLE
+    if start > 0:
+        nl = raw.find(b"\n")
+        if nl < 0:
+            # One record longer than the whole window: there is no boundary to
+            # cut on. The bulk reconciler makes the same call for the same reason.
+            return SKIP_NO_BOUNDARY
+        start += nl + 1
+        raw = raw[nl + 1 :]
+    nl = raw.rfind(b"\n")
+    if nl < 0:
+        return SKIP_NO_BOUNDARY
+    raw = raw[: nl + 1]
+    text = _decode_exact(raw)
+    if text is None:
+        return SKIP_UNDECODABLE
+    return start, len(raw), text
+
+
+def session_id_of(path: str) -> str:
+    """The Claude Code session id IS the filename stem."""
+    return os.path.basename(path)[: -len(".jsonl")] if path.endswith(".jsonl") else ""
+
+
+def project_of(path: str) -> str:
+    """The project LABEL, spelled exactly as the bulk feeder spells it.
+
+    ⚠ A LABEL, NOT AN IDENTIFIER. Claude Code names the directory after a
+    slugified cwd, and the slug is lossy — a literal `-` is indistinguishable
+    from a `/` — so reconstructing a path from it would ship a confidently wrong
+    answer. `cwd` is left to the server, which reads it out of the records.
+    """
+    parent = os.path.basename(os.path.dirname(path))
+    return parent.lstrip("-").split("-")[-1] or parent
+
+
+def plan_frame(
+    projects_dir,
+    state: StreamState,
+    *,
+    max_delta_bytes: int = MAX_DELTA_BYTES,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
+    max_sessions: int = MAX_SESSIONS_PER_FRAME,
+    max_lag_bytes: int = MAX_LAG_BYTES,
+    reseed_tail_bytes: int = RESEED_TAIL_BYTES,
+    max_age_hours: float = MAX_AGE_HOURS,
+    max_candidates: int = MAX_CANDIDATES,
+    now=None,
+) -> tuple[list[dict], dict[str, int]]:
+    """Build the deltas this host would send now, plus a counter of what it skipped.
+
+    🔴 IT MUTATES `state.inodes` BUT NEVER `state.cursors`. The cursor is the
+    SERVER's answer and is only ever adopted from a response — see the module
+    header. Advancing it here would be the local computation this design exists
+    to avoid, and it would advance even for a delta the server refused.
+    """
+    deltas: list[dict] = []
+    skipped: dict[str, int] = {}
+
+    def skip(reason: str) -> None:
+        skipped[reason] = skipped.get(reason, 0) + 1
+
+    budget = max_frame_bytes
+    for path in iter_candidates(projects_dir, max_age_hours, max_candidates, now=now):
+        # 🔴 ONE EXPRESSION COMPUTES THE REMAINING ALLOWANCE AND BOTH THE BREAK
+        # AND THE READ USE IT. An earlier revision had `budget <= 0` in the break
+        # AND `min(max_delta_bytes, budget)` at the read — two spellings of one
+        # rule, and the redundancy made the aggregate bound UNTESTABLE: deleting
+        # the break left the clamp holding it, so a mutation of either survived
+        # while the other silently covered. (The clamp covered it by accident, at
+        # that: a negative budget made `min` negative, which made the file read
+        # return nothing, which skipped the session — a bound enforced by a
+        # seek-past-EOF.) With one expression there is one thing to break.
+        per_session = min(max_delta_bytes, budget)
+        if len(deltas) >= max_sessions or per_session <= 0:
+            break
+        sid = session_id_of(path)
+        if not sid:
+            continue
+        try:
+            st = os.stat(path)
+        except OSError:
+            skip(SKIP_UNREADABLE)
+            continue
+
+        offset = state.cursors.get(sid)
+        known_inode = state.inodes.get(sid)
+        # 🔴 A FILE THIS PROCESS HAS NEVER STAT'd IS RESEEDED EVEN WHEN THE SERVER
+        # GAVE US AN OFFSET FOR IT. The inode is what distinguishes "this file
+        # grew" from "this is a different file at the same path", and on the first
+        # sighting there is no inode to compare against — so an append would be
+        # taking the server's word about a file that could have been rotated while
+        # this agent was down. The cost is exactly one reseed per session per
+        # agent lifetime; the alternative is a splice that nothing detects.
+        first_sighting = known_inode is None
+        rotated = known_inode is not None and known_inode != st.st_ino
+        truncated = offset is not None and st.st_size < offset
+        lagging = offset is not None and (st.st_size - offset) > max_lag_bytes
+
+        if offset is None or first_sighting or rotated or truncated or lagging:
+            # 🔴 EVERY ONE OF THESE FIVE IS A RESEED, AND THEY ARE NOT THE SAME
+            # EVENT. Unknown cursor = a fresh server or a session it has never
+            # seen. First sighting = this process cannot yet vouch for the file's
+            # identity. Rotated = a different file at the same path. Truncated =
+            # the file shrank. Lagging = the host cannot catch up by replaying.
+            # They share a REMEDY, not a cause, and collapsing them in the code is
+            # fine only because the remedy is genuinely identical: send the end of
+            # the file and let the server replace what it has.
+            got = _read_reseed(path, st.st_size, min(reseed_tail_bytes, per_session))
+            state.inodes[sid] = st.st_ino
+            if isinstance(got, str):
+                skip(got)
+                continue
+            start, nbytes, text = got
+            deltas.append({
+                "sessionId": sid,
+                "project": project_of(path),
+                "updatedAt": _rfc3339(st.st_mtime),
+                "offset": start,
+                "data": text,
+                "reset": True,
+            })
+            budget -= nbytes
+            continue
+
+        state.inodes[sid] = st.st_ino
+        if st.st_size == offset:
+            skip(SKIP_UNCHANGED)
+            continue
+
+        got = _read_append(path, offset, per_session)
+        if isinstance(got, str):
+            skip(got)
+            continue
+        start, nbytes, text = got
+        deltas.append({
+            "sessionId": sid,
+            "project": project_of(path),
+            "updatedAt": _rfc3339(st.st_mtime),
+            "offset": start,
+            "data": text,
+            "reset": False,
+        })
+        budget -= nbytes
+
+    return deltas, skipped
+
+
+def _rfc3339(epoch: float) -> str:
+    import time as _time
+
+    return _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime(epoch))
+
+
+def adopt_cursors(state: StreamState, cursors) -> int:
+    """Take the server's authoritative offsets. Returns how many were adopted.
+
+    🔴 A `null` OFFSET IS ADOPTED AS None, NOT IGNORED. It means the server holds
+    a tail whose file position it cannot state, and the correct next action is a
+    RESEED — which `plan_frame` does exactly when the cursor is None. Skipping the
+    null would leave the host's stale offset in place and every subsequent delta
+    would be refused, for ever, with nothing saying why.
+    """
+    n = 0
+    if not isinstance(cursors, list):
+        return 0
+    for c in cursors:
+        if not isinstance(c, dict):
+            continue
+        sid = c.get("sessionId")
+        if not isinstance(sid, str) or not sid:
+            continue
+        off = c.get("offset")
+        if off is None:
+            state.cursors[sid] = None
+        elif isinstance(off, int) and not isinstance(off, bool) and off >= 0:
+            state.cursors[sid] = off
+        else:
+            # A malformed offset is worse than none: adopting a wrong number
+            # would splice. Treat it as unknown and reseed.
+            state.cursors[sid] = None
+        n += 1
+    return n
+
+
+def run_round(post, get, host: str, state: StreamState, projects_dir, **kw) -> dict:
+    """One streaming round. Returns counters; raises nothing the caller must catch
+    beyond what `post`/`get` raise.
+
+    `post(path, payload) -> dict` and `get(path) -> dict` are supplied by the
+    caller so this module does no HTTP of its own and is testable without a
+    server.
+    """
+    if not state.hydrated:
+        # One hydration per agent lifetime. A failure here leaves `hydrated`
+        # False, so the next poll retries; it must not be swallowed into "the
+        # server has nothing", which would make every session reseed on every
+        # poll — the expensive direction, at exactly the moment the server is
+        # least able to absorb it.
+        doc = get("/api/transcripts/stream/cursors")
+        # 🔴 REPLACE THE MAP, DO NOT MERGE INTO IT. The server is authoritative,
+        # so a session ABSENT from its listing has no server-side cursor — and
+        # merging would leave this host's stale offset in place for exactly that
+        # session. The case is not hypothetical: a database restore, or a wiped
+        # deployment, leaves the server empty while the host believes everything
+        # is delivered. Merging makes that take TWO polls to recover (append,
+        # refused as unknown, then reseed); replacing makes it take one, and more
+        # importantly makes the host's map a copy of the server's rather than a
+        # union of the server's and its own history.
+        state.cursors = {}
+        adopt_cursors(state, (doc or {}).get("sessions"))
+        state.hydrated = True
+
+    deltas, skipped = plan_frame(projects_dir, state, **kw)
+    if not deltas:
+        # 🔴 SEND NOTHING RATHER THAN AN EMPTY FRAME. The server REJECTS a frame
+        # with no sessions (correctly — it is not a delta frame), so posting one
+        # would turn the ordinary steady state into an HTTP 400 on every poll,
+        # i.e. a stream that reports failure precisely when it is working.
+        return {"sent": 0, "applied": 0, "refused": 0, "skipped": skipped}
+
+    doc = post("/api/transcripts/stream", {"host": host, "sessions": deltas}) or {}
+    adopt_cursors(state, doc.get("cursors"))
+
+    applied = 0
+    for c in doc.get("cursors") or []:
+        if isinstance(c, dict) and c.get("reason") == "accepted":
+            applied += 1
+    return {
+        "sent": len(deltas),
+        "applied": applied,
+        "refused": len(deltas) - applied,
+        "skipped": skipped,
+    }

--- a/scripts/lib/transcript_stream.py
+++ b/scripts/lib/transcript_stream.py
@@ -29,11 +29,20 @@ is back in step having neither duplicated nor skipped a line. Computing the
 cursor locally would be right until the one time it was not, and then the two
 sides would be permanently spliced with nothing saying so.
 
-🔴 A DELTA IS ALWAYS WHOLE RECORDS. Every read is cut at a NEWLINE, which does
-two jobs at once: the server never stores a leading JSON fragment, and a
-multi-byte rune can never be split across two frames (a newline is ASCII, so a
-cut there is always a rune boundary). The trailing partial line waits for the
-next poll.
+🔴 A DELTA IS WHOLE RECORDS WHEREVER THERE IS A RECORD BOUNDARY TO CUT ON. Every
+read is cut at a NEWLINE, which does two jobs at once: the server never stores a
+leading JSON fragment, and a multi-byte rune can never be split across two frames
+(a newline is ASCII, so a cut there is always a rune boundary). The trailing
+partial line waits for the next poll.
+
+⚠ AND WHERE THERE IS NO BOUNDARY IN THE WINDOW, IT CUTS ON A RUNE BOUNDARY
+INSTEAD RATHER THAN DECLINING. A single tool-result record on this fleet has been
+measured well past 256 KiB — far beyond one delta — so "wait for a newline" is not
+a delay there, it is a PERMANENT STALL: every poll re-reads the same window, finds
+no newline, and declines. That is what an earlier revision did, on both the append
+and the reseed path, and it silently confined the biggest sessions to the
+five-minute feed. Streaming such a record in pieces leaves the stored tail ending
+mid-record for a few seconds, which the parser already tolerates.
 
 🔴 THE BYTE COUNTS ON BOTH SIDES MUST AGREE EXACTLY, so this decodes STRICTLY.
 The server advances its cursor by the byte length of the text it received; this
@@ -125,6 +134,7 @@ MAX_CANDIDATES = 200
 # logged per session: this runs every 5 seconds and a per-session line would bury
 # every real event in the journal.
 SKIP_UNCHANGED = "unchanged"
+SKIP_DUPLICATE_ID = "duplicate-session-id"
 SKIP_NO_BOUNDARY = "no-record-boundary"
 SKIP_UNDECODABLE = "undecodable"
 SKIP_UNREADABLE = "unreadable"
@@ -146,14 +156,27 @@ class StreamState:
     server is correct in both directions and needs no state on this machine.
     """
 
+    #: Bounds `inodes`, which — unlike `cursors` — is never wholesale-replaced by
+    #: a re-hydration, so in a process that runs for weeks it would otherwise grow
+    #: one entry per session ever seen. Eviction is oldest-first and costs the
+    #: evicted session exactly one reseed, because a missing inode is a first
+    #: sighting. The bound is generous against the measured rate (~1,465 sessions
+    #: a week fleet-wide) and against the 24h candidate window, so in practice
+    #: nothing is ever evicted; it exists so that "in practice" is not the only
+    #: thing standing between this and a slow leak.
+    INODE_LIMIT = 8192
+
     def __init__(self) -> None:
         self.cursors: dict[str, int | None] = {}
         self.inodes: dict[str, int] = {}
         self.hydrated = False
 
-    def forget(self, session_id: str) -> None:
-        self.cursors.pop(session_id, None)
-        self.inodes.pop(session_id, None)
+    def note_inode(self, session_id: str, inode: int) -> None:
+        """Record a file identity, bounded."""
+        self.inodes[session_id] = inode
+        while len(self.inodes) > self.INODE_LIMIT:
+            # dicts preserve insertion order, so this evicts the oldest.
+            self.inodes.pop(next(iter(self.inodes)))
 
 
 def iter_candidates(projects_dir, max_age_hours=MAX_AGE_HOURS, limit=MAX_CANDIDATES, now=None):
@@ -221,11 +244,36 @@ def _read_append(path: str, offset: int, budget: int):
     except OSError:
         return SKIP_UNREADABLE
     nl = raw.rfind(b"\n")
-    if nl < 0:
-        # Only a partial line so far. Sending it would put a fragment in the
-        # stored tail AND risk splitting a rune; it costs one poll to wait.
+    if nl >= 0:
+        raw = raw[: nl + 1]
+    elif len(raw) < budget:
+        # The read reached EOF without a newline: this is just a line still being
+        # written. Sending it would put a fragment in the stored tail; it costs
+        # one poll to wait.
         return SKIP_NO_BOUNDARY
-    raw = raw[: nl + 1]
+    else:
+        # 🔴 THE WINDOW IS FULL AND HOLDS NO BOUNDARY, SO THIS RECORD IS LONGER
+        # THAN ONE DELTA AND WAITING CAN NEVER HELP. An earlier revision returned
+        # SKIP_NO_BOUNDARY here, which STALLED that session's append path FOR
+        # EVER: every poll re-read the same 48 KiB, found no newline, and declined
+        # — silently, at ~830 MB/day of wasted reads, with the bulk reconciler as
+        # the only feed. The lag escape could not save it either, because a record
+        # between MAX_DELTA_BYTES and MAX_LAG_BYTES never reaches that threshold.
+        #
+        # 🔴 AND IT IS NOT AN EDGE CASE ON THIS FLEET. stream.go's own trimToTail
+        # records the measurement: "a single tool-result record on this fleet has
+        # been measured well past 256 KiB". So the sessions with the biggest tool
+        # output — the ones an operator most wants seconds-fresh — were exactly
+        # the ones that fell back to the five-minute path.
+        #
+        # Cutting on a RUNE boundary instead streams the record in pieces. The
+        # stored tail then ends mid-record for a few seconds, which the parser
+        # already tolerates (it counts a partial record rather than failing), and
+        # the next delta completes it. A transient partial record beats a
+        # permanent stall.
+        raw = _cut_at_rune_boundary(raw)
+        if not raw:
+            return SKIP_NO_BOUNDARY
     text = _decode_exact(raw)
     if text is None:
         return SKIP_UNDECODABLE
@@ -236,8 +284,22 @@ def _read_reseed(path: str, size: int, window: int):
     """The tail of a file as a reseed: (start_offset, byte_length, text), or a
     SKIP_* reason string.
 
-    The leading partial record is DROPPED and the trailing one is left for the
-    next poll, so a reseed is whole records exactly like an append is.
+    The leading partial record is DROPPED where there is one to drop to, and the
+    trailing one is left for the next poll, so a reseed is normally whole records
+    exactly like an append is.
+
+    🔴 "NORMALLY". WHERE THE WINDOW HOLDS NO BOUNDARY AT ALL IT SENDS THE BYTES
+    ANYWAY, cut on a rune boundary. Returning SKIP here — which an earlier
+    revision did, on both the leading and the trailing cut — made a file whose
+    last record exceeds the window a PERMANENT RESEED LOOP: plan_frame only
+    leaves the reseed branch once a cursor is adopted, and no cursor can be
+    adopted while the reseed declines. Measured: three identical rounds, zero
+    deltas, forever.
+
+    ⚠ Note the asymmetry it created with the reconciler, which is why the bug was
+    invisible: build_transcript_push.read_tail uses a 192 KiB window against this
+    48 KiB one, so for last-records between those two sizes the five-minute push
+    worked perfectly while the stream looped.
     """
     start = max(0, size - window)
     try:
@@ -248,20 +310,91 @@ def _read_reseed(path: str, size: int, window: int):
         return SKIP_UNREADABLE
     if start > 0:
         nl = raw.find(b"\n")
-        if nl < 0:
-            # One record longer than the whole window: there is no boundary to
-            # cut on. The bulk reconciler makes the same call for the same reason.
-            return SKIP_NO_BOUNDARY
-        start += nl + 1
-        raw = raw[nl + 1 :]
+        if 0 <= nl < len(raw) - 1:
+            start += nl + 1
+            raw = raw[nl + 1 :]
+        else:
+            # 🔴 EITHER THERE IS NO BOUNDARY IN THE WINDOW, OR THE ONLY ONE IS ITS
+            # LAST BYTE — AND DROPPING TO THAT WOULD LEAVE NOTHING. Both happen
+            # for the same fleet-real reason: a record larger than the window,
+            # whose terminating newline is the file's last byte. An earlier
+            # revision dropped unconditionally, produced an EMPTY reseed, returned
+            # SKIP, and looped for ever.
+            #
+            # So the reseed starts MID-RECORD. The server marks the tail truncated
+            # and the parser counts a leading partial, which is exactly what both
+            # are for — but the start must still be a RUNE boundary, or
+            # _decode_exact rejects the whole window and the loop comes back by
+            # another door.
+            skipped_bytes, raw = _align_to_rune_start(raw)
+            start += skipped_bytes
     nl = raw.rfind(b"\n")
-    if nl < 0:
+    if nl >= 0:
+        raw = raw[: nl + 1]
+    else:
+        raw = _cut_at_rune_boundary(raw)
+    if not raw:
         return SKIP_NO_BOUNDARY
-    raw = raw[: nl + 1]
     text = _decode_exact(raw)
     if text is None:
         return SKIP_UNDECODABLE
     return start, len(raw), text
+
+
+def _align_to_rune_start(raw: bytes) -> tuple[int, bytes]:
+    """Drop LEADING UTF-8 continuation bytes; return (how many, the rest).
+
+    The mirror of `_cut_at_rune_boundary`, for the one place a read can begin at
+    an arbitrary byte offset: a reseed seeks to `size - window`, which lands
+    inside a rune two times in three on CJK text. The count is returned because
+    the caller must move its `offset` by exactly the bytes it dropped — the
+    cursor is a FILE position, and an offset that does not match the data sent is
+    the splice this whole protocol exists to prevent.
+    """
+    i = 0
+    while i < len(raw) and raw[i] & 0xC0 == 0x80:
+        i += 1
+    return i, raw[i:]
+
+
+def _cut_at_rune_boundary(raw: bytes) -> bytes:
+    """Drop a trailing INCOMPLETE UTF-8 sequence, and nothing else.
+
+    🔴 THE CUT POINT IS A BYTE OFFSET, SO IT CAN LAND INSIDE A MULTI-BYTE RUNE.
+    That is the whole reason the normal path cuts on a newline (an ASCII byte is
+    always a rune boundary). Where there is no newline to cut on, this is what
+    keeps `_decode_exact` from failing on a perfectly good chunk whose last three
+    bytes are half a character — and, downstream, what keeps the two sides' byte
+    counts equal, since a lossy decode would diverge them for ever.
+
+    ⚠ IT REMOVES AT MOST 3 BYTES, and it removes them only when the final
+    sequence is genuinely incomplete. A complete trailing rune is left alone; an
+    invalid lead byte is left alone too, so `_decode_exact` still rejects real
+    corruption rather than having it silently trimmed away.
+    """
+    n = len(raw)
+    for back in range(1, 5):
+        if back > n:
+            return raw
+        b = raw[n - back]
+        if b & 0xC0 == 0x80:
+            continue  # a continuation byte; keep walking back to the lead
+        if b < 0x80:
+            need = 1
+        elif b & 0xE0 == 0xC0:
+            need = 2
+        elif b & 0xF0 == 0xE0:
+            need = 3
+        elif b & 0xF8 == 0xF0:
+            need = 4
+        else:
+            # Not a legal lead byte. Leave it: this is corruption, and
+            # _decode_exact must be the thing that says so.
+            return raw
+        if back == need:
+            return raw  # the last sequence is complete
+        return raw[: n - back]
+    return raw
 
 
 def session_id_of(path: str) -> str:
@@ -303,9 +436,30 @@ def plan_frame(
     """
     deltas: list[dict] = []
     skipped: dict[str, int] = {}
+    claimed: set[str] = set()
 
     def skip(reason: str) -> None:
         skipped[reason] = skipped.get(reason, 0) + 1
+
+    # 🔴 ONE PLACE APPENDS A DELTA AND SPENDS THE BUDGET, because the accumulator
+    # used to be written out in BOTH arms and only one of them was reachable by a
+    # test. Deleting `budget -= nbytes` from the APPEND arm survived the whole
+    # suite: the aggregate test exercises reseeds, so the reseed copy was pinned
+    # and the append copy was not. With the append arm unbounded, 48 appending
+    # sessions could build a 2.25 MiB frame against a 512 KiB server bound — a
+    # 413 on every poll, permanently. The single-expression `per_session` below
+    # closed half of this class; this closes the other half.
+    def emit(sid, path, st, start, nbytes, text, reset):
+        nonlocal budget
+        deltas.append({
+            "sessionId": sid,
+            "project": project_of(path),
+            "updatedAt": _rfc3339(st.st_mtime),
+            "offset": start,
+            "data": text,
+            "reset": reset,
+        })
+        budget -= nbytes
 
     budget = max_frame_bytes
     for path in iter_candidates(projects_dir, max_age_hours, max_candidates, now=now):
@@ -324,6 +478,27 @@ def plan_frame(
         sid = session_id_of(path)
         if not sid:
             continue
+        # 🔴 ONE DUPLICATE ID WOULD KILL THIS HOST'S STREAM PERMANENTLY. The
+        # server REJECTS THE WHOLE FRAME with a 400 when a session appears twice
+        # (NormalizeDeltas, and rightly — the deltas would have to be applied in
+        # an order nobody declared, on a protocol whose correctness rests on
+        # offsets matching exactly). The agent then logs once, clears `hydrated`,
+        # and sends THE SAME FRAME on the next poll: nothing in the loop removes
+        # the offending session, so the stream is dead for this host until
+        # somebody deletes a file.
+        #
+        # Two ways two files produce one id, and neither is exotic: the same
+        # <uuid>.jsonl under two project directories, and — because the server
+        # TrimSpaces the id and this side did not — "abc.jsonl" beside
+        # "abc .jsonl". Measured on this host: 0 duplicates in 949 files, so it
+        # is not live; the cost of it becoming live is total, and the fix is
+        # this branch. Candidates arrive newest-first, so the survivor is the
+        # freshest file.
+        sid = sid.strip()
+        if not sid or sid in claimed:
+            skip(SKIP_DUPLICATE_ID)
+            continue
+        claimed.add(sid)
         try:
             st = os.stat(path)
         except OSError:
@@ -354,23 +529,14 @@ def plan_frame(
             # fine only because the remedy is genuinely identical: send the end of
             # the file and let the server replace what it has.
             got = _read_reseed(path, st.st_size, min(reseed_tail_bytes, per_session))
-            state.inodes[sid] = st.st_ino
+            state.note_inode(sid, st.st_ino)
             if isinstance(got, str):
                 skip(got)
                 continue
-            start, nbytes, text = got
-            deltas.append({
-                "sessionId": sid,
-                "project": project_of(path),
-                "updatedAt": _rfc3339(st.st_mtime),
-                "offset": start,
-                "data": text,
-                "reset": True,
-            })
-            budget -= nbytes
+            emit(sid, path, st, *got, reset=True)
             continue
 
-        state.inodes[sid] = st.st_ino
+        state.note_inode(sid, st.st_ino)
         if st.st_size == offset:
             skip(SKIP_UNCHANGED)
             continue
@@ -379,16 +545,7 @@ def plan_frame(
         if isinstance(got, str):
             skip(got)
             continue
-        start, nbytes, text = got
-        deltas.append({
-            "sessionId": sid,
-            "project": project_of(path),
-            "updatedAt": _rfc3339(st.st_mtime),
-            "offset": start,
-            "data": text,
-            "reset": False,
-        })
-        budget -= nbytes
+        emit(sid, path, st, *got, reset=False)
 
     return deltas, skipped
 

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -2589,12 +2589,6 @@ def test_TWO_skip_reasons_are_each_logged_ONCE_through_the_REAL_loop(server, tmu
     })
 
     lines = [l for l in out.splitlines() if "skipped some sessions" in l]
-    # 🔴 A BOUND, NOT AN EXACT COUNT, AND ONLY HERE. Which poll each reason first
-    # appears on is timing-dependent (the undecodable file may be seen on the
-    # same poll as the partial one, or the next), so 1 or 2 lines are both
-    # correct. What is NOT correct is a line per poll — that is the regression,
-    # and it is orders of magnitude away from this bound rather than adjacent to
-    # it. The sibling test below asserts the exact count where it IS deterministic.
     # 🔴 EXACTLY TWO, NOT "AT MOST TWO", NOW THAT THE STAGGER IS DETERMINISTIC.
     # `1 <= len(lines)` was the arm that admitted the degenerate run: one line
     # means both reasons arrived together, which is precisely the configuration

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -146,6 +146,10 @@ class _Recorder(HTTPServer):
         # seam tests below is that one surface failing must not disturb the other.
         self.stream_status = 200
         self.cursor_status = 200
+        #: How many times the agent has polled (claim requests), and an optional
+        #: callback fired with that count — see the hook in do_POST.
+        self.polls = 0
+        self.on_poll = None
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -158,6 +162,22 @@ class _Handler(BaseHTTPRequestHandler):
             "auth": self.headers.get("Authorization"),
         })
         if self.path.endswith("/claim"):
+            # 🔴 A DETERMINISTIC HOOK FOR STAGGERING A FIXTURE, replacing a
+            # wall-clock timer — and it is on the CLAIM, which is the agent's ONE
+            # guaranteed request per poll. The obvious hook (the delta POST) does
+            # not fire at all when the only thing to report is a SKIP: run_round
+            # returns early with sent=0 and posts nothing, so a counter there
+            # never advances and the staggered file is never written.
+            #
+            # Why not a timer: measured, under this box's normal load a
+            # `threading.Timer(0.5, …)` fired before the agent's first poll in 3
+            # of 12 runs. Both reasons were then present at poll 1 — the exact
+            # configuration in which the mutant this fixture exists to kill
+            # SURVIVES — and the test passed anyway, so a green run was
+            # indistinguishable from one that proved nothing.
+            self.server.polls += 1
+            if self.server.on_poll:
+                self.server.on_poll(self.server.polls)
             status = self.server.claim_status
             if status != 200:
                 self._reply(status, b'{"error":"no"}')
@@ -2547,23 +2567,26 @@ def test_TWO_skip_reasons_are_each_logged_ONCE_through_the_REAL_loop(server, tmu
 
     # 🔴 REASON 2 ARRIVES **LATER**, AND THE STAGGER IS THE WHOLE FIXTURE. With
     # both files present from poll 1 the rebind mutant SURVIVES: the first poll
-    # reports {A,B} and every later poll has fresh=∅, so `stream_skips = fresh`
-    # never executes again and the two formulations are indistinguishable. The
-    # ping-pong needs A to be reported BEFORE B appears — measured, this fixture
-    # scored 1 line shipped / many with the mutant only after the delay was added.
-    def _late_second_reason():
-        (d / "skip-b.jsonl").write_bytes(b'{"type":"user","t":"\xff\xfe"}\n')
+    # reports {A,B}, every later poll has fresh=∅, so `stream_skips = fresh` never
+    # executes again and the two formulations are indistinguishable.
+    #
+    # 🔴 SO THE STAGGER MUST BE DETERMINISTIC, AND A `threading.Timer` IS NOT.
+    # Measured with the timer: under this box's normal load it fired before the
+    # agent's first poll in 3 of 12 runs — the degenerate configuration — and the
+    # test PASSED anyway, so the mutant survived 4 of 14 loaded runs while the
+    # battery reported 6/6 at ambient load. The file is now written from the stub
+    # server's own handler on the agent's THIRD POLL, so "after A has been
+    # reported" is a fact about the traffic rather than about the clock.
+    def _second_reason_after_third_poll(n):
+        if n == 3:
+            (d / "skip-b.jsonl").write_bytes(b'{"type":"user","t":"\xff\xfe"}\n')
 
-    timer = threading.Timer(0.5, _late_second_reason)
-    timer.start()
-    try:
-        server.claim_batches = [[], [], [], []]
-        rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=24, env_extra={
-            "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
-            "CLAUDE_PROJECTS_DIR": str(projects),
-        })
-    finally:
-        timer.cancel()
+    server.on_poll = _second_reason_after_third_poll
+    server.claim_batches = [[], [], [], []]
+    rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=30, env_extra={
+        "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
 
     lines = [l for l in out.splitlines() if "skipped some sessions" in l]
     # 🔴 A BOUND, NOT AN EXACT COUNT, AND ONLY HERE. Which poll each reason first
@@ -2572,10 +2595,15 @@ def test_TWO_skip_reasons_are_each_logged_ONCE_through_the_REAL_loop(server, tmu
     # correct. What is NOT correct is a line per poll — that is the regression,
     # and it is orders of magnitude away from this bound rather than adjacent to
     # it. The sibling test below asserts the exact count where it IS deterministic.
-    assert 1 <= len(lines) <= 2, (
-        f"two skip reasons with STAGGERED onsets produced {len(lines)} log lines. 0 means the "
-        f"signal is gone; more than 2 means the memo is not ACCUMULATING — the two reasons are "
-        f"ping-ponging and this loop polls 17,280 times a day:\n"
+    # 🔴 EXACTLY TWO, NOT "AT MOST TWO", NOW THAT THE STAGGER IS DETERMINISTIC.
+    # `1 <= len(lines)` was the arm that admitted the degenerate run: one line
+    # means both reasons arrived together, which is precisely the configuration
+    # the mutant survives, so a pass there proved nothing.
+    assert len(lines) == 2, (
+        f"two skip reasons with STAGGERED onsets produced {len(lines)} log lines, want exactly "
+        f"2. 1 means the stagger did not happen and this run proved NOTHING; more than 2 means "
+        f"the memo is not ACCUMULATING — the two reasons are ping-ponging and this loop polls "
+        f"17,280 times a day:\n"
         + "\n".join(lines[:6]) + "\n---\n" + out[-1500:])
     reported = " ".join(lines)
     assert "no-record-boundary" in reported, reported
@@ -2678,14 +2706,22 @@ def test_the_skip_memo_key_ignores_COUNTS_and_tracks_REASONS():
 
 
 def test_the_reported_reason_bound_matches_the_TAILERS_OWN_set():
-    """🔴 THE BOUND IS A RELATIONSHIP, NOT A NUMBER IN PROSE. `skip_reasons_to_report`
-    logs at most one line per distinct reason per agent lifetime, so the bound IS
-    the tailer's reason vocabulary — and an earlier docstring wrote it out as
-    "four, since there are four reasons" when there were five.
+    """🔴 A LEDGER, NOT A RECOMPUTATION. `skip_reasons_to_report` logs at most one
+    line per distinct reason per agent lifetime, so the bound IS the tailer's
+    reason vocabulary — and the prose used to write it out as "four, since there
+    are four reasons" when there were five.
 
-    Derived from the DEFINING surface (`transcript_stream`'s SKIP_* constants),
-    not from a list restated here, so a sixth reason added tomorrow moves this
-    test rather than silently invalidating a sentence.
+    🔴 THE FIRST VERSION OF THIS TEST WAS A TAUTOLOGY. It built `reportable` as
+    `{r for r in reasons if r != "unchanged"}` and compared it against
+    `skip_memo_key`, whose body is the identical predicate — so both sides
+    recomputed from the same input and the equality held for ANY constant set.
+    Measured: adding a sixth reason to the tailer PASSED, while this test's own
+    docstring claimed such a change "moves this test".
+
+    So the expected set is written out ONCE, by hand, and checked BOTH ways
+    against the module: a reason added upstream fails here (GROWTH), and a reason
+    removed fails here too (SHRINK). That is a ledger — the only kind worth
+    having, and the same shape this repo's other two-way ledgers use.
     """
     import importlib.util
 
@@ -2694,13 +2730,28 @@ def test_the_reported_reason_bound_matches_the_TAILERS_OWN_set():
     ts = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(ts)
 
-    reasons = {v for k, v in vars(ts).items() if k.startswith("SKIP_") and isinstance(v, str)}
-    assert len(reasons) >= 4, f"the SKIP_* scan found {reasons} — it is measuring nothing"
-    assert "unchanged" in reasons, "the steady-state reason is not named SKIP_UNCHANGED any more"
+    # The ledger. Every entry is a reason a skip line may name; `unchanged` is
+    # deliberately absent because it IS the steady state and must never be logged.
+    WANT_REPORTABLE = {
+        "no-record-boundary",
+        "undecodable",
+        "unreadable",
+        "duplicate-session-id",
+        "no-session-id",
+    }
 
-    reportable = {r for r in reasons if r != "unchanged"}
-    # The key must drop `unchanged` and keep every other reason — that IS the bound.
-    assert AGENT.skip_memo_key({r: 1 for r in reasons}) == frozenset(reportable), (
-        "the memo key does not admit exactly the tailer's reportable reasons; the "
-        "per-lifetime line bound is therefore not what the docstring describes"
-    )
+    declared = {v for k, v in vars(ts).items() if k.startswith("SKIP_") and isinstance(v, str)}
+    assert declared, "the SKIP_* scan found nothing — it is measuring nothing"
+    assert "unchanged" in declared, (
+        f"the steady-state reason is not among the tailer's SKIP_* values: {sorted(declared)}")
+
+    assert declared - {"unchanged"} == WANT_REPORTABLE, (
+        f"the tailer's reportable reasons are {sorted(declared - {'unchanged'})} but this "
+        f"ledger says {sorted(WANT_REPORTABLE)}. A reason added upstream widens the "
+        f"per-lifetime line bound the sticky memo promises; one removed narrows it. Update "
+        f"the ledger deliberately — that IS the accounting.")
+
+    # And the memo key must admit exactly the ledger, no more and no less.
+    assert AGENT.skip_memo_key({r: 1 for r in declared}) == frozenset(WANT_REPORTABLE), (
+        "the memo key does not admit exactly the tailer's reportable reasons, so the bound "
+        "the docstring describes is not the one the code enforces")

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -141,6 +141,11 @@ class _Recorder(HTTPServer):
         self.claim_batches = []      # popped one per claim; [] when exhausted
         self.claim_status = 200
         self.result_status = 200
+        # The transcript DELTA STREAM rides the same poll, on the hook tier.
+        # Separate status knobs from the claim's, because the whole point of the
+        # seam tests below is that one surface failing must not disturb the other.
+        self.stream_status = 200
+        self.cursor_status = 200
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -160,7 +165,40 @@ class _Handler(BaseHTTPRequestHandler):
             batch = self.server.claim_batches.pop(0) if self.server.claim_batches else []
             self._reply(200, json.dumps({"writes": batch}).encode())
             return
+        if self.path == "/api/transcripts/stream":
+            if self.server.stream_status != 200:
+                self._reply(self.server.stream_status, b'{"error":"no"}')
+                return
+            # 🔴 THE CURSOR IS THE SERVER'S ANSWER, so this stub must actually
+            # answer one — a fake that returned only `{"ok":true}` would leave the
+            # host with no cursor to adopt and the next poll would reseed for ever,
+            # which is not the behaviour under test.
+            frame = json.loads(raw.decode() or "{}")
+            cursors = [
+                {"sessionId": s["sessionId"],
+                 "offset": s.get("offset", 0) + len(s.get("data", "").encode()),
+                 "reason": "accepted"}
+                for s in frame.get("sessions", [])
+            ]
+            self._reply(200, json.dumps(
+                {"ok": True, "applied": len(cursors), "cursors": cursors}).encode())
+            return
         self._reply(self.server.result_status, b'{"ok":true}')
+
+    def do_GET(self):  # noqa: N802 — name fixed by BaseHTTPRequestHandler
+        """The transcript stream's one READ: where the server's cursors are.
+
+        🔴 IT EXISTS SO A MISSING do_GET CANNOT BE MISTAKEN FOR A DEFECT IN THE
+        AGENT. Without it BaseHTTPRequestHandler answers 501, the stream backs
+        off, and every streaming test below would be measuring the stub.
+        """
+        self.server.requests.append({
+            "path": self.path, "body": b"", "auth": self.headers.get("Authorization"),
+        })
+        if self.server.cursor_status != 200:
+            self._reply(self.server.cursor_status, b'{"error":"no"}')
+            return
+        self._reply(200, b'{"sessions":[]}')
 
     def _reply(self, status, body):
         self.send_response(status)
@@ -2355,3 +2393,127 @@ def test_the_launch_env_KEEPS_tmux_reachable_when_the_server_PATH_lacks_it(monke
         subprocess.run([tmux_exe, "-L", sock, "kill-server"], capture_output=True,
                        env=server_env, timeout=30)
         shutil.rmtree(sockdir, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# The transcript DELTA STREAM seam.
+#
+# 🔴 THE MODULE AND THE AGENT ARE EACH TESTED IN ISOLATION ELSEWHERE, AND THAT IS
+# EXACTLY WHY THESE EXIST. `test_transcript_stream.py` drives the protocol against
+# a simulated server; the tests above drive the write path against a stub. Neither
+# ever builds the combined state, and the defect this feature can produce lives in
+# the seam nobody owns: a stream failure reaching the WRITE loop's handler, which
+# would put the agent into its 60-second backoff and delay somebody's typed reply
+# by a minute.
+# --------------------------------------------------------------------------- #
+
+
+def _projects_tree(tmp_path, session_id="stream-sess", body=None):
+    """A synthetic ~/.claude/projects tree with one session."""
+    root = tmp_path / "projects" / "-home-zach-workspace-devrc"
+    root.mkdir(parents=True, exist_ok=True)
+    f = root / f"{session_id}.jsonl"
+    f.write_text(body or (
+        '{"type":"user","sessionId":"%s","message":{"role":"user","content":"hello"}}\n'
+        % session_id), encoding="utf-8")
+    return tmp_path / "projects", f
+
+
+def _stream_posts(server):
+    return [r for r in server.requests if r["path"] == "/api/transcripts/stream"]
+
+
+def test_the_agent_streams_transcript_deltas_on_the_SAME_poll(server, tmux_stub, tmp_path):
+    """🔴 THE WHOLE CLAIM OF THIS FEATURE'S TRANSPORT: no new port, no new
+    connection, no new unit — the deltas ride the poll the write agent already
+    holds. Asserted by seeing BOTH surfaces' traffic from ONE process."""
+    projects, _ = _projects_tree(tmp_path)
+    server.claim_batches = [[write()]]
+    rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=4, env_extra={
+        "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
+
+    posts = _stream_posts(server)
+    assert posts, f"the agent never streamed a delta frame; requests={[r['path'] for r in server.requests]}\n{out}"
+    frame = json.loads(posts[0]["body"])
+    assert frame["host"] == "workbench", frame
+    assert [s["sessionId"] for s in frame["sessions"]] == ["stream-sess"], frame
+    assert frame["sessions"][0]["reset"] is True, "the first frame for an unseen file must reseed"
+
+    # 🔴 THE HOOK TOKEN, NOT THE TERMINAL ONE. Fusing the tiers would mean
+    # disarming the write surface silently takes the operator's session view with
+    # it — see transcript_round's docstring.
+    assert posts[0]["auth"] == "Bearer hook-token-for-the-stream", posts[0]["auth"]
+    claims = [r for r in server.requests if r["path"].endswith("/claim")]
+    assert claims, "the write path stopped working once streaming was added"
+    assert claims[0]["auth"] == "Bearer not-a-real-terminal-token-not-a-real-token"
+
+    # And the write itself still happened.
+    assert len(tmux_stub.send_keys_calls()) == 2, tmux_stub.send_keys_calls()
+
+
+def test_a_FAILING_transcript_stream_does_not_disturb_the_write_path(server, tmux_stub, tmp_path):
+    """🔴 THE SEAM DEFECT THIS GUARDS. Everything the stream can raise is caught
+    at the stream's own call site, NOT by the loop's handler — that handler puts
+    the agent into a 60-second backoff, so a transcript hiccup would delay a
+    typed reply by a minute. The write surface is the capability with a person
+    waiting on it."""
+    projects, _ = _projects_tree(tmp_path)
+    server.stream_status = 500
+    server.claim_batches = [[write()]]
+    rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=4, env_extra={
+        "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
+
+    assert _stream_posts(server), "the stream never even tried — this test is measuring nothing"
+    sends = tmux_stub.send_keys_calls()
+    assert len(sends) == 2, (
+        f"a FAILING transcript stream stopped the write from being delivered: {sends}\n{out}")
+    results = [r for r in server.requests if r["path"].endswith("/result")]
+    assert results and json.loads(results[0]["body"])["state"] == "delivered", out
+    assert "transcript streaming failed this poll" in out, (
+        f"the stream failure was swallowed silently: {out}")
+
+
+def test_no_hook_token_turns_streaming_OFF_and_says_so_without_touching_the_write_path(
+    server, tmux_stub, tmp_path
+):
+    """🔴 NOT FATAL, AND NOT SILENT. The transcript routes are on the hook tier;
+    a host with a terminal token but no hook token must still deliver writes, and
+    the 5-minute bulk push keeps feeding the read model. Exiting here would take
+    the write surface down over a read model's missing key."""
+    projects, _ = _projects_tree(tmp_path)
+    server.claim_batches = [[write()]]
+    rc, out = run_agent(server, tmux_stub, tmp_path, env_extra={
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
+
+    assert not _stream_posts(server), "a frame was streamed with no hook token"
+    assert "transcript streaming is OFF" in out, out
+    assert "bulk push" in out, "the log does not say what still covers the feed: " + out
+    assert len(tmux_stub.send_keys_calls()) == 2, (
+        f"the write path broke when streaming was unconfigured\n{out}")
+
+
+def test_a_transcript_stream_failure_forces_a_RE_HYDRATION_on_the_next_poll(
+    server, tmux_stub, tmp_path
+):
+    """🔴 THE MOST LIKELY CAUSE OF A STREAM FAILURE IS A REDEPLOY, which is
+    exactly when this host's cursors may no longer describe what the server
+    holds. Adopting them again is what makes the gap bounded rather than
+    permanent — so a failure must cost a cursor read, not just a retry."""
+    projects, _ = _projects_tree(tmp_path)
+    server.stream_status = 500
+    server.claim_batches = [[write()], []]
+    rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=8, env_extra={
+        "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
+
+    cursor_reads = [r for r in server.requests if r["path"] == "/api/transcripts/stream/cursors"]
+    assert len(cursor_reads) >= 2, (
+        f"the cursors were read {len(cursor_reads)} time(s) across repeated stream failures — "
+        f"hydration happens once per agent lifetime, so a failure that does not clear it leaves "
+        f"the host resending against cursors the server may no longer hold\n{out}")

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -2517,3 +2517,62 @@ def test_a_transcript_stream_failure_forces_a_RE_HYDRATION_on_the_next_poll(
         f"the cursors were read {len(cursor_reads)} time(s) across repeated stream failures — "
         f"hydration happens once per agent lifetime, so a failure that does not clear it leaves "
         f"the host resending against cursors the server may no longer hold\n{out}")
+
+
+def test_a_REPEATING_skip_condition_is_logged_ONCE_not_on_every_poll(server, tmux_stub, tmp_path):
+    """🔴 THE MEMO WAS KEYED ON COUNTS AND THEREFORE DEFEATED ITSELF. A count
+    moves whenever a different NUMBER of sessions is mid-record this poll than
+    last — and `no-record-boundary` fires whenever an append window ends without
+    a newline, which the tailer's own docstring calls the ordinary steady state.
+    So the same condition re-logged every few seconds, on a loop that runs 17,280
+    times a day. That is the journal-flooding the memo exists to prevent, and it
+    is the failure mode that trains an operator to ignore the one channel this
+    unit has.
+
+    The fixture makes the COUNT move while the REASON stays the same: one session
+    whose in-flight line is present on every poll, and a second that appears
+    later. One line, not two.
+    """
+    projects, first = _projects_tree(tmp_path, "skip-a")
+    # Two sessions, both permanently mid-record: the reason is constant, the
+    # count goes 1 -> 2.
+    (projects / "-home-zach-workspace-devrc" / "skip-a.jsonl").write_text(
+        '{"type":"user","partial":tr', encoding="utf-8")
+
+    server.claim_batches = [[], [], [], []]
+    rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=10, env_extra={
+        "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+        "CLAUDE_PROJECTS_DIR": str(projects),
+    })
+
+    lines = [l for l in out.splitlines() if "skipped some sessions" in l]
+    assert len(lines) <= 1, (
+        f"the skip condition was logged {len(lines)} times across one run — the memo is not "
+        f"holding, and this loop polls 17,280 times a day:\n" + "\n".join(lines[:5]))
+    if lines:
+        assert "no-record-boundary" in lines[0], lines[0]
+
+
+def test_the_skip_memo_key_ignores_COUNTS_and_tracks_REASONS():
+    """🔴 THE SUBPROCESS TEST ABOVE COULD NOT SEE THIS, AND THE MUTANT SURVIVED
+    IT. Its fixture has one skipping session throughout, so no count ever moves —
+    the count-keyed and set-keyed memos behave identically under it. The rule has
+    to be asserted at the point it can be wrong.
+
+    A count moves whenever a different NUMBER of sessions is mid-record this poll
+    than last, and `no-record-boundary` is the ordinary steady state — so a
+    count-keyed memo re-logs the same condition on a loop that runs 17,280 times
+    a day.
+    """
+    k = AGENT.skip_memo_key
+
+    # The COUNT moving must NOT move the key.
+    assert k({"no-record-boundary": 1}) == k({"no-record-boundary": 2}) == k({"no-record-boundary": 97})
+
+    # A new REASON must.
+    assert k({"no-record-boundary": 1}) != k({"no-record-boundary": 1, "undecodable": 1})
+
+    # `unchanged` is the steady state and must not register at all — otherwise
+    # every poll of a quiet fleet logs.
+    assert k({"unchanged": 3}) == k({}) == k(None) == frozenset()
+    assert k({"unchanged": 3, "undecodable": 1}) == k({"undecodable": 9}) == frozenset({"undecodable"})

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -2519,23 +2519,86 @@ def test_a_transcript_stream_failure_forces_a_RE_HYDRATION_on_the_next_poll(
         f"the host resending against cursors the server may no longer hold\n{out}")
 
 
-def test_a_REPEATING_skip_condition_is_logged_ONCE_not_on_every_poll(server, tmux_stub, tmp_path):
-    """🔴 THE MEMO WAS KEYED ON COUNTS AND THEREFORE DEFEATED ITSELF. A count
-    moves whenever a different NUMBER of sessions is mid-record this poll than
-    last — and `no-record-boundary` fires whenever an append window ends without
-    a newline, which the tailer's own docstring calls the ordinary steady state.
-    So the same condition re-logged every few seconds, on a loop that runs 17,280
-    times a day. That is the journal-flooding the memo exists to prevent, and it
-    is the failure mode that trains an operator to ignore the one channel this
-    unit has.
+def test_TWO_skip_reasons_are_each_logged_ONCE_through_the_REAL_loop(server, tmux_stub, tmp_path):
+    """🔴 THE STICKY MEMO'S UNION IS ONLY OBSERVABLE WITH **TWO** REASONS, AND
+    EVERY EARLIER TEST HAD ONE.
 
-    The fixture makes the COUNT move while the REASON stays the same: one session
-    whose in-flight line is present on every poll, and a second that appears
-    later. One line, not two.
+    `stream_skips |= fresh` accumulates; mutating it to a REBIND
+    (`stream_skips = fresh`) passed all 208 tests — and it restores exactly the
+    flood round 7 removed. With `= fresh`, `seen` is REPLACED by whatever was
+    fresh, so two simultaneously-present reasons ping-pong forever:
+
+        {A,B} - {A} = {B}   -> seen={B}
+        {A,B} - {B} = {A}   -> seen={A}   -> one line per poll, for ever
+
+    Measured against the real agent as a subprocess: shipped = 2 skip lines,
+    the rebind mutant = 69.
+
+    A single-reason flap does NOT distinguish them (both score 1), and the unit
+    test for `skip_reasons_to_report` cannot either — it does its own `seen |=
+    fresh`, so it is structurally blind to a mutation of the LOOP. This drives
+    the loop, with two reasons whose onsets are STAGGERED so the union is what
+    has to hold.
     """
-    projects, first = _projects_tree(tmp_path, "skip-a")
-    # Two sessions, both permanently mid-record: the reason is constant, the
-    # count goes 1 -> 2.
+    projects, _first = _projects_tree(tmp_path, "skip-a")
+    d = projects / "-home-zach-workspace-devrc"
+    # Reason 1, present from the first poll: a line still being written.
+    (d / "skip-a.jsonl").write_text('{"type":"user","partial":tr', encoding="utf-8")
+
+    # 🔴 REASON 2 ARRIVES **LATER**, AND THE STAGGER IS THE WHOLE FIXTURE. With
+    # both files present from poll 1 the rebind mutant SURVIVES: the first poll
+    # reports {A,B} and every later poll has fresh=∅, so `stream_skips = fresh`
+    # never executes again and the two formulations are indistinguishable. The
+    # ping-pong needs A to be reported BEFORE B appears — measured, this fixture
+    # scored 1 line shipped / many with the mutant only after the delay was added.
+    def _late_second_reason():
+        (d / "skip-b.jsonl").write_bytes(b'{"type":"user","t":"\xff\xfe"}\n')
+
+    timer = threading.Timer(0.5, _late_second_reason)
+    timer.start()
+    try:
+        server.claim_batches = [[], [], [], []]
+        rc, out = run_agent(server, tmux_stub, tmp_path, expect_requests=24, env_extra={
+            "CLAWGATE_HOOK_TOKEN": "hook-token-for-the-stream",
+            "CLAUDE_PROJECTS_DIR": str(projects),
+        })
+    finally:
+        timer.cancel()
+
+    lines = [l for l in out.splitlines() if "skipped some sessions" in l]
+    # 🔴 A BOUND, NOT AN EXACT COUNT, AND ONLY HERE. Which poll each reason first
+    # appears on is timing-dependent (the undecodable file may be seen on the
+    # same poll as the partial one, or the next), so 1 or 2 lines are both
+    # correct. What is NOT correct is a line per poll — that is the regression,
+    # and it is orders of magnitude away from this bound rather than adjacent to
+    # it. The sibling test below asserts the exact count where it IS deterministic.
+    assert 1 <= len(lines) <= 2, (
+        f"two skip reasons with STAGGERED onsets produced {len(lines)} log lines. 0 means the "
+        f"signal is gone; more than 2 means the memo is not ACCUMULATING — the two reasons are "
+        f"ping-ponging and this loop polls 17,280 times a day:\n"
+        + "\n".join(lines[:6]) + "\n---\n" + out[-1500:])
+    reported = " ".join(lines)
+    assert "no-record-boundary" in reported, reported
+    assert "undecodable" in reported, (
+        "the SECOND reason was never reported — with a rebinding memo the two reasons "
+        f"ping-pong and neither ever settles:\n{reported}")
+
+
+def test_a_REPEATING_skip_condition_is_logged_ONCE_not_on_every_poll(server, tmux_stub, tmp_path):
+    """🔴 THE ONE-REASON CASE, WHERE THE COUNT IS DETERMINISTIC.
+
+    One session, one reason, present on every poll: a correct memo logs it
+    exactly once. An upper bound would not do here — `<= 1` is satisfied by ZERO,
+    i.e. by the skip line never being emitted at all, which is the regression
+    this whole arc is about. Measured: with the emit forced off, the `<= 1`
+    version SURVIVED.
+
+    ⚠ THE FIXTURE IS ONE SESSION, AND AN EARLIER COMMENT HERE CLAIMED TWO. It
+    wrote `skip-a.jsonl` — the same path `_projects_tree` had just created — so
+    "the count goes 1 -> 2" never happened and the unused `first` was the tell.
+    The two-reason case it was reaching for is the test above.
+    """
+    projects, _first = _projects_tree(tmp_path, "skip-a")
     (projects / "-home-zach-workspace-devrc" / "skip-a.jsonl").write_text(
         '{"type":"user","partial":tr', encoding="utf-8")
 
@@ -2545,11 +2608,6 @@ def test_a_REPEATING_skip_condition_is_logged_ONCE_not_on_every_poll(server, tmu
         "CLAUDE_PROJECTS_DIR": str(projects),
     })
 
-    # 🔴 EXACTLY ONE, NOT "AT MOST ONE". An upper bound is satisfied by ZERO —
-    # i.e. by the skip line never being emitted at all, which is the regression
-    # this whole memo arc is about. Measured: with `if fresh:` forced false the
-    # `<= 1` version SURVIVED. The fixture provably emits one line on the shipped
-    # code, so the exact count is available and is what must be asserted.
     lines = [l for l in out.splitlines() if "skipped some sessions" in l]
     assert len(lines) == 1, (
         f"the skip condition was logged {len(lines)} times across one run, want exactly 1 — "
@@ -2617,3 +2675,32 @@ def test_the_skip_memo_key_ignores_COUNTS_and_tracks_REASONS():
     # every poll of a quiet fleet logs.
     assert k({"unchanged": 3}) == k({}) == k(None) == frozenset()
     assert k({"unchanged": 3, "undecodable": 1}) == k({"undecodable": 9}) == frozenset({"undecodable"})
+
+
+def test_the_reported_reason_bound_matches_the_TAILERS_OWN_set():
+    """🔴 THE BOUND IS A RELATIONSHIP, NOT A NUMBER IN PROSE. `skip_reasons_to_report`
+    logs at most one line per distinct reason per agent lifetime, so the bound IS
+    the tailer's reason vocabulary — and an earlier docstring wrote it out as
+    "four, since there are four reasons" when there were five.
+
+    Derived from the DEFINING surface (`transcript_stream`'s SKIP_* constants),
+    not from a list restated here, so a sixth reason added tomorrow moves this
+    test rather than silently invalidating a sentence.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "ts_for_bound", REPO_ROOT / "scripts" / "lib" / "transcript_stream.py")
+    ts = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ts)
+
+    reasons = {v for k, v in vars(ts).items() if k.startswith("SKIP_") and isinstance(v, str)}
+    assert len(reasons) >= 4, f"the SKIP_* scan found {reasons} — it is measuring nothing"
+    assert "unchanged" in reasons, "the steady-state reason is not named SKIP_UNCHANGED any more"
+
+    reportable = {r for r in reasons if r != "unchanged"}
+    # The key must drop `unchanged` and keep every other reason — that IS the bound.
+    assert AGENT.skip_memo_key({r: 1 for r in reasons}) == frozenset(reportable), (
+        "the memo key does not admit exactly the tailer's reportable reasons; the "
+        "per-lifetime line bound is therefore not what the docstring describes"
+    )

--- a/scripts/tests/test_tmux_reply_agent.py
+++ b/scripts/tests/test_tmux_reply_agent.py
@@ -2545,12 +2545,53 @@ def test_a_REPEATING_skip_condition_is_logged_ONCE_not_on_every_poll(server, tmu
         "CLAUDE_PROJECTS_DIR": str(projects),
     })
 
+    # 🔴 EXACTLY ONE, NOT "AT MOST ONE". An upper bound is satisfied by ZERO —
+    # i.e. by the skip line never being emitted at all, which is the regression
+    # this whole memo arc is about. Measured: with `if fresh:` forced false the
+    # `<= 1` version SURVIVED. The fixture provably emits one line on the shipped
+    # code, so the exact count is available and is what must be asserted.
     lines = [l for l in out.splitlines() if "skipped some sessions" in l]
-    assert len(lines) <= 1, (
-        f"the skip condition was logged {len(lines)} times across one run — the memo is not "
-        f"holding, and this loop polls 17,280 times a day:\n" + "\n".join(lines[:5]))
-    if lines:
-        assert "no-record-boundary" in lines[0], lines[0]
+    assert len(lines) == 1, (
+        f"the skip condition was logged {len(lines)} times across one run, want exactly 1 — "
+        f"0 means the signal is gone, >1 means the memo is not holding and this loop polls "
+        f"17,280 times a day:\n" + "\n".join(lines[:5]) + "\n---\n" + out[-1500:])
+    assert "no-record-boundary" in lines[0], lines[0]
+
+
+def test_a_FLAPPING_skip_reason_is_reported_ONCE_not_on_every_appearance():
+    """🔴 THE SET-COMPARISON MEMO STILL FLOODED, AND ITS OWN DOCSTRING CLAIMED IT
+    DID NOT. Comparing the current reason set against the previous one logs on
+    every change in EITHER direction, so a reason that appears and disappears
+    costs TWO lines per cycle — and `no-record-boundary` is exactly that shape: a
+    session is mid-record on one poll and complete on the next, which the tailer's
+    own docstring calls the ordinary steady state.
+
+    Measured against a transcription of the loop before this fix: 39 log lines
+    over 40 polls when the reason flaps; 8 when it appears 1 poll in 10, which is
+    3,456 a day at the real cadence.
+
+    Driven against the REAL decision function, because a rule inside main()'s loop
+    cannot be tested where it can be wrong — the lesson the previous fix in this
+    same arc had to learn.
+    """
+    report = AGENT.skip_reasons_to_report
+    seen = frozenset()
+    lines = 0
+    # 40 polls, the reason flapping on every other one.
+    for i in range(40):
+        skipped = {"no-record-boundary": 1} if i % 2 == 0 else {"unchanged": 3}
+        fresh = report(seen, skipped)
+        if fresh:
+            lines += 1
+            seen |= fresh
+    assert lines == 1, (
+        f"a FLAPPING reason produced {lines} log lines over 40 polls. At 17,280 polls a day "
+        f"that is a channel nobody reads.")
+
+    # 🔴 THE POSITIVE CONTROL: a genuinely NEW reason must still be reported, or
+    # the bound above is achieved by saying nothing.
+    fresh = report(seen, {"undecodable": 1})
+    assert fresh == frozenset({"undecodable"}), fresh
 
 
 def test_the_skip_memo_key_ignores_COUNTS_and_tracks_REASONS():

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1070,3 +1070,200 @@ def test_a_SUBAGENT_transcript_is_never_pushed(projects, tmp_path):
     # POSITIVE CONTROL: the walk found the real one, so the absence above is not a
     # fact about a walk that enumerated nothing.
     assert ids == ["sess-main"], f"the main session was not picked up either: {ids}"
+
+
+def _reply_agent_unit_block() -> str:
+    """The tmux-reply-agent SERVICE block from nix/home.nix."""
+    text = HOME_NIX.read_text()
+    idx = text.index("systemd.user.services.tmux-reply-agent")
+    end = text.index("systemd.user.services", idx + 10)
+    return text[idx:end]
+
+
+def test_the_RESIDENT_agent_restart_triggers_name_EVERY_module_it_imports():
+    """🔴 THE COVERAGE USED TO SIT WHERE IT MATTERED LEAST. This file already pins
+    that the transcript-push TIMER names both its halves — where a stale copy
+    costs at most five minutes, because the next tick execs fresh code.
+
+    `tmux-reply-agent` is a RESIDENT service: it imports each module ONCE and then
+    runs for weeks. A fix to `transcript_stream.py` (or to `transcript_search.py`,
+    which it loads in turn) would land on disk and the running agent would keep
+    executing the old code indefinitely — a correctness change to what the
+    operator reads about a session that appears deployed and is not. The unit's
+    own comment states the rule for `tmux_text_policy.py`; the two transcript
+    modules were added afterwards and did not inherit it.
+
+    ⚠ ASSERTED AS A SET, NOT AS A LIST OF `in` CHECKS. A membership test grows
+    silently: the next module loaded at startup passes without anyone noticing,
+    which is exactly how this gap opened.
+    """
+    import re
+
+    block = _reply_agent_unit_block()
+    m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)
+    assert m, "the reply-agent unit declares no X-Restart-Triggers at all"
+    declared = set(re.findall(r"\$\{\.\./([^}]+)\}", m.group(1)))
+
+    want = {
+        "scripts/tmux-reply-agent",
+        "scripts/lib/tmux_text_policy.py",
+        "scripts/lib/transcript_stream.py",
+        "scripts/lib/transcript_search.py",
+    }
+    assert declared == want, (
+        f"the reply-agent's restart triggers are {sorted(declared)}, want {sorted(want)}. "
+        "A module this RESIDENT unit imports at startup but does not trigger on stays on "
+        "the OLD code until something else restarts the process."
+    )
+
+
+def test_every_module_the_agent_loads_by_path_IS_a_restart_trigger():
+    """🔴 THE RELATIONSHIP, NOT THE LIST. The test above pins a set someone typed;
+    this one derives the set from the AGENT'S OWN SOURCE, so a module added to the
+    agent tomorrow fails here rather than passing unseen.
+
+    It scans for the loader idiom the agent actually uses — `os.path.join(_HERE,
+    "lib", "<name>")` — plus the one transitive hop `transcript_stream` makes.
+    """
+    import re
+
+    agent = (REPO_ROOT / "scripts" / "tmux-reply-agent").read_text()
+    loaded = set(re.findall(r'os\.path\.join\(_HERE,\s*"lib",\s*"([^"]+)"\)', agent))
+    assert loaded, "the scanner found no path-loaded modules — it is measuring nothing"
+
+    stream = (REPO_ROOT / "scripts" / "lib" / "transcript_stream.py").read_text()
+    loaded |= set(re.findall(r'os\.path\.join\(_HERE,\s*"([^"]+\.py)"\)', stream))
+
+    block = _reply_agent_unit_block()
+    m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)
+    declared = set(re.findall(r"\$\{\.\./scripts/lib/([^}]+)\}", m.group(1)))
+    missing = loaded - declared
+    assert not missing, (
+        f"the agent loads {sorted(missing)} at startup but the unit does not trigger on "
+        "them — a resident service would keep running the old copy indefinitely"
+    )
+
+
+def test_an_UNDECODABLE_byte_makes_fileBytes_UNKNOWN_instead_of_400ing_the_WHOLE_push(
+    server, projects, tmp_path
+):
+    """🔴 ONE BAD BYTE IN ONE SMALL TRANSCRIPT WOULD 400 THE ENTIRE HOST'S FEED.
+
+    `read_tail` decodes with `errors="replace"`, which turns one bad byte into a
+    three-byte U+FFFD — so a small corrupt file produces a TAIL LARGER THAN THE
+    FILE IT CAME FROM. The server rejects a `fileBytes` smaller than the tail
+    beside it (a cursor pointing before the start of the stored tail is a splice
+    waiting to happen) and a rejection is atomic, so that one session would take
+    every other session in the request down with it — on every tick, for the whole
+    24-hour candidate window.
+
+    Reporting UNKNOWN instead costs that session a stream reseed and nothing else.
+
+    Measured on the guard and its absence:
+        shipped   file=29 tail_bytes=31 fileBytes=0   -> push accepted
+        no guard  file=29 tail_bytes=31 fileBytes=29  -> whole push REJECTED
+    """
+    d = projects.root / "-home-zach-workspace-devrc"
+    d.mkdir(exist_ok=True)
+    (d / "corrupt.jsonl").write_bytes(b'{"type":"user","t":"\xff"}\n')
+    projects("healthy", transcript("healthy", human_turn("fine", "healthy")))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sent = {s["sessionId"]: s for s in json.loads(pushes(server)[0]["body"])["sessions"]}
+    assert "healthy" in sent, "the innocent session was lost"
+    bad = sent.get("corrupt")
+    assert bad is not None, "the corrupt session was dropped entirely"
+    assert len(bad["tail"].encode("utf-8")) > bad["fileBytes"] or bad["fileBytes"] == 0
+    assert bad["fileBytes"] == 0, (
+        f"fileBytes={bad['fileBytes']} for a {len(bad['tail'].encode())}-byte tail taken from a "
+        "smaller file — the server rejects that, atomically, taking every other session with it"
+    )
+
+
+def test_fileBytes_is_derived_from_what_was_READ_not_from_the_stat(tmp_path):
+    """🔴 THE FILE IS BEING APPENDED TO WHILE IT IS READ — that is the normal case
+    here, not an edge one, because the sessions worth feeding are the live ones.
+    `size` is a stat taken BEFORE the read, so bytes that arrive in between come
+    back in `raw` and the tail ends past `size`. Reporting `size` would put the
+    cursor BEHIND the stored tail's true end, and the next delta would duplicate
+    the bytes in between.
+
+    Driven directly rather than through the script: reproducing the race with a
+    real concurrent writer would be a timing test for a property that is decidable
+    by construction. The fixture instead makes `stat` under-report by patching it,
+    which is exactly the observable the race produces.
+    """
+    import importlib.util
+
+    # The builder imports `transcript_search` as a bare name, which works because
+    # it is normally RUN as a script from scripts/lib. Loading it as a module here
+    # needs that directory on the path — the same arrangement, spelled out.
+    sys.path.insert(0, str(BUILDER.parent))
+    try:
+        spec = importlib.util.spec_from_file_location("btp_under_test", BUILDER)
+        btp = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(btp)
+    finally:
+        sys.path.remove(str(BUILDER.parent))
+
+    body = transcript("s", *[human_turn(f"turn {i}", "s") for i in range(20)])
+    f = tmp_path / "s.jsonl"
+    f.write_text(body)
+    real_size = f.stat().st_size
+
+    class _Stat:
+        st_size = real_size - 40  # the stat that a concurrent append raced
+
+    class _Path(type(f)):
+        def stat(self, *a, **kw):
+            return _Stat()
+
+    text, truncated, file_bytes = btp.read_tail(_Path(f), 1 << 20)
+    assert not truncated
+    assert file_bytes == real_size, (
+        f"fileBytes={file_bytes} but the read returned {real_size} bytes — the cursor would "
+        "sit BEHIND the end of the stored tail and the next delta would duplicate"
+    )
+
+
+def test_ONE_oversized_session_alone_is_still_sent_rather_than_dropped_for_ever(
+    server, projects, tmp_path
+):
+    """🔴 THE `and sessions` EXEMPTION, whose comment promises "deferred to the
+    next tick rather than dropped for ever". Without it, a session whose tail
+    alone exceeds the aggregate budget is skipped on EVERY tick — and since it is
+    also the newest, it is skipped first, every time. The exemption admits it when
+    the push is otherwise empty.
+    """
+    body = transcript("big", *[human_turn("y" * 400, "big") for _ in range(40)])
+    projects("big", body)
+    per = len(body.encode())
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_MAX_BYTES": str(per // 4),  # far under one session
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # 🔴 THE ABSENCE IS THE DEFECT, SO NAME IT. Without the exemption the builder
+    # produces an EMPTY payload and exits 10 ("nothing to push") — the script then
+    # exits 0 having POSTed nothing, and a test that indexed straight into the
+    # request list would die with an IndexError that names no mechanism at all.
+    assert pushes(server), (
+        "a session larger than the whole budget was dropped rather than sent alone: NOTHING "
+        "was pushed. It is the newest file, so it would be dropped first on every tick, for "
+        f"ever. Script said: {proc.stdout.strip()[:200]}")
+    sent = json.loads(pushes(server)[0]["body"])["sessions"]
+    assert [s["sessionId"] for s in sent] == ["big"], (
+        "a session larger than the whole budget was dropped rather than sent alone — it is "
+        "the newest file, so it would be dropped first on every tick, for ever"
+    )

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1191,11 +1191,18 @@ def _lib_modules_a_python_file_imports(path, libdir):
 
     🔴 A REGEX OVER IMPORT LINES IS IDIOM-SHAPED, AND THIS REPO USES THE OTHER
     IDIOMS. The first version of this scanner was `^(?:from|import)\s+(\w+)`,
-    which is blind to an import that is indented, wrapped in `try:`, or shares a
-    line (`import base64, json, sys`) — all three of which appear in
-    `scripts/lib/transcript_search.py` itself, i.e. inside this unit's own
-    dependency chain. Measured against the old scanner, five realistic "fifth
-    dependency" shapes were added and all five passed GREEN.
+    which is blind to an import that is indented or wrapped in `try:` — both of
+    which appear in `scripts/lib/transcript_search.py` itself, i.e. inside this
+    unit's own dependency chain. Measured against the old scanner, five realistic
+    "fifth dependency" shapes were added and all five passed GREEN.
+
+    ⚠ A THIRD EXAMPLE WAS CITED AND WAS WRONG, IN THE DIRECTION THAT MATTERS.
+    `import base64, json, sys` does appear in that file — inside a triple-quoted
+    raw-string literal (`_REMOTE_SCAN`), as the source of a script run on a PEER. It is not an
+    import of that module, and an AST walk correctly does not report it, while
+    the old regex DID. So on that one shape the rewrite is NARROWER, deliberately
+    and correctly. A multi-name import line is still handled — `ast.Import`
+    carries every alias — it simply was not the example it was quoted as.
 
     An AST walk sees every `import`/`from` at any depth, in one rule. It also
     picks up the `os.path.join(_HERE, "<name>.py")` loader idiom, because that is
@@ -1220,29 +1227,76 @@ def _lib_modules_a_python_file_imports(path, libdir):
 
 
 def _strip_shell_comments(src):
-    """Shell source with comments removed, so a scanner over it sees CODE.
+    """Shell source with comments removed, quote-aware, so a scanner sees CODE.
 
-    🔴 THE COMMENT-BLIND VERSION HAD BOTH FAILURE DIRECTIONS AT ONCE, MEASURED:
+    🔴 THE FIRST VERSION WAS A PAIR OF REGEXES AND WAS WRONG IN BOTH DIRECTIONS.
+    It stripped a full-line `#` and `\\s#.*$`, which is neither necessary nor
+    sufficient, and its docstring claimed the error was one-directional and safe.
+    Measured, both directions produce a wrong verdict:
 
-        a comment-only mention of scripts/lib/agent_ledger.py
-            -> ['agent_ledger.py'] appears in `needed`  (a PHANTOM requirement:
-               the test demands a trigger for a file the script never opens)
+      OVER-strip (the dangerous one — it PASSES). A real executable line that
+      resolves `scripts/lib/host-role.sh` and also carries a quoted `#`:
 
-        deleting line 99, the ONLY line that actually resolves host_label.py
-            -> 'host_label.py' still in `needed`, because line 79 mentions it in
-               prose — so the positive control below stayed GREEN over a scanner
-               that had stopped seeing executable code entirely
+          printf "fmt: a #b\\n"; ROLE="$(... /lib/host-role.sh)"
 
-    Approximate by design: a `#` inside a quoted string would be cut too. That
-    direction is safe here — it can only make the scanner see LESS, which the
-    per-arm controls below turn into a failure rather than a silent pass.
+      was truncated at the quoted `#`, so an UNDECLARED dependency vanished and
+      the guard went green. The same line without the quoted `#` fails correctly.
+      The claim that the per-arm controls turn this into a failure is false: they
+      pin two named modules, and ANY OTHER module lost this way is a silent pass.
+
+      UNDER-strip (loud, but it is the very defect round 12 reported fixed).
+      Confirmed against bash itself — `echo A;# x` and `echo B |# x` both comment
+      out — but `\\s#` matches neither, so:
+
+          echo A;#  see scripts/lib/agent_ledger.py     -> minted a PHANTOM
+          echo B |# scripts/lib/agent_ledger.py            requirement for a file
+          true &&#  scripts/lib/agent_ledger.py            the script never opens
+
+    So this walks the line: `#` opens a comment only OUTSIDE quotes and only at
+    the start of a word — start of line, or after whitespace or one of `;|&()`.
+    `X=y#foo` is left alone, because bash does not treat that as a comment either.
+
+    ⚠ WHAT IT STILL DOES NOT MODEL: a here-document body. A `#` line inside a
+    `<<EOF` block is content, not a comment, and would be stripped; a `/lib/x.py`
+    mentioned in prose inside one would not be. `transcript-push.sh` contains no
+    heredoc today (`grep -nE '<<|;#|\\|#|&&#'` finds nothing), which is why this
+    is recorded as a limit rather than implemented — but it IS a limit, and the
+    previous version of this docstring is the reason to write it down.
     """
     out = []
     for line in src.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("#"):
-            continue
-        out.append(re.sub(r"\s#.*$", "", line))
+        res = []
+        in_single = in_double = False
+        i = 0
+        while i < len(line):
+            c = line[i]
+            prev = line[i - 1] if i else None
+            if in_single:
+                res.append(c)
+                in_single = c != "'"
+            elif in_double:
+                res.append(c)
+                if c == "\\" and i + 1 < len(line):
+                    i += 1
+                    res.append(line[i])
+                elif c == '"':
+                    in_double = False
+            elif c == "'":
+                in_single = True
+                res.append(c)
+            elif c == '"':
+                in_double = True
+                res.append(c)
+            elif c == "\\" and i + 1 < len(line):
+                res.append(c)
+                i += 1
+                res.append(line[i])
+            elif c == "#" and (prev is None or prev in " \t;|&()"):
+                break
+            else:
+                res.append(c)
+            i += 1
+        out.append("".join(res))
     return "\n".join(out)
 
 
@@ -1263,14 +1317,52 @@ def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():
       (c) `host_label.py` — the unit's THIRD runnable file (`transcript-push.sh`
           execs it directly), whose own imports were previously never read.
 
-    It does NOT see a dependency reached through a shell variable holding a
-    computed path, or one loaded by a mechanism none of the three use. That is a
-    real limit, written down rather than implied by silence.
+    🔴 WHAT IT DOES NOT SEE, ENUMERATED BY RUNNING IT — an earlier version of
+    this paragraph gestured at "a mechanism none of the three use", which names
+    nothing checkable. Each of these was driven with a real undeclared
+    `scripts/lib` module injected into the builder, and each ESCAPED:
 
-    🔴 THREE ARMS, THREE SEPARATE POSITIVE CONTROLS. A control over the UNION
-    cannot tell "all arms work" from "one arm works and covers for a dead one" —
-    measured: with the shell arm reading prose, deleting the only executable
+        importlib.import_module("x") / __import__("x")
+        os.path.join(_HERE, f"{n}.py")            (an f-string, not a literal)
+        os.path.join(_HERE, os.path.basename(p), "x.py")   (the regex cannot
+                                                    cross the inner `)`)
+        Path(__file__).parent / "x.py"
+        a module imported by a module we scan     (ZERO transitive hops — the
+                                                   sibling above follows one)
+        an import inside a string that is executed elsewhere (the `_REMOTE_SCAN`
+                                                   idiom in transcript_search.py)
+
+    None is used by the three scanned files today, so nothing is invisible NOW —
+    but `importlib.import_module` and `Path(__file__).parent` both occur
+    elsewhere under `scripts/`, so these are repo idioms, not hypotheticals.
+    A relative import (`from .x import y`) is deliberately skipped: these modules
+    load as top-level, so that form would fail at runtime anyway.
+
+    🔴 TWO ARM-EXCLUSIVE CONTROLS AND ONE SHARED PROBE — NOT "three controls",
+    which is what this docstring claimed for one revision. Arms (a) and (b) each
+    have a sentinel only that arm can produce, so blinding either fails HERE
+    rather than hiding behind the other's hit. A control over the UNION cannot do
+    that: measured, with the shell arm reading prose, deleting the only executable
     `host_label.py` reference left a union control fully green.
+
+    ⚠ ARM (c) HAS NO ARM-EXCLUSIVE SENTINEL AND CANNOT BE GIVEN ONE HONESTLY —
+    its subject, `host_label.py`, imports only stdlib, so its correct result is
+    the empty set, and `assert from_host_label == set()` is satisfied identically
+    by "the arm ran" and "the arm is wired to nothing". Measured: blinding arm
+    (c) alone left the whole guard GREEN. What replaces it is a synthetic probe
+    of the SHARED helper and this call site's `libdir`. Stated precisely, because
+    the failure this whole round is about is a guard described more widely than
+    it works:
+
+      COVERED    the helper is live; the `libdir` passed here resolves
+      NOT COVERED a defect confined to arm (c)'s own call site (wrong path
+                 constant) while the helper stays healthy
+
+    And the probe is not independently demonstrable: a mutation that breaks the
+    shared helper is caught by arm (a)'s control FIRST, so the probe never runs.
+    That is a real limit on what its presence proves, not a reason to delete it —
+    it is what makes arm (c)'s empty result mean "read and empty" rather than
+    "never read".
 
     ⚠ WHAT THIS GUARDS IS A DECLARATION, NOT AN OUTAGE — this unit is oneshot on a
     timer with a working-tree ExecStart, so a missing trigger costs one tick. The
@@ -1306,13 +1398,27 @@ def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():
     assert "host_label.py" in from_shell, (
         f"the SHELL arm found {sorted(from_shell)} — it is not reading executable "
         "shell code (the builder never imports host_label, so no other arm covers it)")
-    # (c) has no dependency to sentinel today: host_label.py imports only stdlib.
-    # Asserting a name here would be asserting a fixture, so instead pin the
-    # PROPERTY that makes its emptiness meaningful — the file parsed at all.
+    # 🔴 A SYNTHETIC PROBE, NOT AN ARM-EXCLUSIVE CONTROL — see the docstring for
+    # exactly what it does and does not cover. It runs the same helper, with the
+    # same `libdir` this call site passes, over a file that provably imports a lib
+    # module, so arm (c)'s empty result means "read and empty" rather than "never
+    # read". A shared-helper mutation dies to arm (a)'s control before reaching
+    # here; that is measured, and it is why this is not counted as a third arm.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as _d:
+        _probe = Path(_d) / "probe.py"
+        _probe.write_text("from transcript_search import iter_transcripts\n")
+        _probe_found = _lib_modules_a_python_file_imports(_probe, libdir)
+    assert _probe_found == {"transcript_search.py"}, (
+        f"arm (c)'s scanner returned {sorted(_probe_found)} for a file that plainly "
+        "imports transcript_search — the helper or the `libdir` this call site passes "
+        "is wrong, and arm (c)'s own empty result would be meaningless either way")
+
     assert from_host_label == set(), (
         f"host_label.py now imports {sorted(from_host_label)} from scripts/lib. That is "
-        "fine, but it must be declared as a trigger and this assertion updated — the "
-        "point is that its imports are READ, not that they are empty")
+        "fine — declare them as triggers and update this assertion. It is a ledger of a "
+        "known-stdlib-only file, NOT the control; the control is the probe above")
 
     needed = from_builder | from_shell | from_host_label
 

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1448,3 +1448,48 @@ def test_the_agent_reads_the_env_file_the_SHARED_MODULE_names(tmp_path):
         f"reading the file the shared module names, so the two feeders can be pointed at "
         f"different files and the reseed loop comes back invisibly"
     )
+
+
+def test_the_BULK_push_dedupes_and_strips_session_ids_TOO(server, projects, tmp_path):
+    """🔴 THE GUARD WENT ON THE PATH WHERE THE BLAST RADIUS IS SMALLER FIRST.
+    The delta stream grew it, and there a duplicate costs ONE session. Here
+    `NormalizePush` rejects THE WHOLE PUSH on a duplicate or an empty id, a
+    rejection stores nothing, so the digest never matches, so the same poisoned
+    batch is re-sent every tick — permanently, for every session on this host.
+    And this is the feed the streaming design designates as the RECONCILER.
+
+    Measured before the fix, straight out of the builder:
+
+        emitted sessionIds: ['abc ', 'abc', 'same-uuid', 'same-uuid']
+        after the server's TrimSpace: ['abc', 'abc', 'same-uuid', 'same-uuid']
+        duplicates the server rejects the WHOLE push on: ['abc', 'same-uuid']
+
+    ⚠ RAISING MAX_PER_PUSH 6 -> 48 WIDENED THIS, which is why the change that
+    widened it is the one that had to close it.
+    """
+    body = transcript("x", human_turn("hi", "x"))
+    # Same <uuid> under two project directories.
+    projects("same-uuid", body, project="-home-zach-projA")
+    projects("same-uuid", transcript("y", human_turn("hi there", "y")), project="-home-zach-projB")
+    # "abc.jsonl" beside "abc .jsonl" — distinct on disk, one id after TrimSpace.
+    projects("abc", body, project="-home-zach-projA")
+    projects("abc ", transcript("z", human_turn("hello", "z")), project="-home-zach-projA")
+    projects("healthy", transcript("healthy", human_turn("fine", "healthy")))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert pushes(server), "nothing was pushed at all: " + proc.stdout
+
+    ids = [s["sessionId"] for s in json.loads(pushes(server)[0]["body"])["sessions"]]
+    # The server TrimSpaces before checking, so that is the comparison that matters.
+    trimmed = [i.strip() for i in ids]
+    assert len(trimmed) == len(set(trimmed)), (
+        f"the bulk push carries ids that collide after the server's TrimSpace: {ids}. "
+        "NormalizePush rejects the WHOLE push on that, nothing is stored, the digest never "
+        "matches, and the same batch is re-sent on every tick for ever.")
+    assert "" not in trimmed, f"an id that strips to empty was pushed: {ids}"
+    assert "healthy" in trimmed, "the innocent session was dropped along with the duplicates"

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -482,6 +482,117 @@ def test_the_newest_sessions_win_when_the_cap_bites(server, projects, tmp_path):
     assert ids == ["sess-4", "sess-5"], f"the cap kept the wrong sessions: {ids}"
 
 
+def test_every_pushed_session_carries_fileBytes_equal_to_its_file_size(server, projects, tmp_path):
+    """🔴 THE SEAM WITH THE DELTA STREAM, AND ITS ABSENCE IS SILENT. `fileBytes`
+    is where this tail ENDS in the file, which the server stores as the delta
+    stream's resume cursor. Without it a bulk push REPLACES the tail while leaving
+    the cursor describing the tail it replaced, and the next delta appends onto a
+    base that no longer matches its offset — a splice, stored, with nothing to
+    indicate it. Nothing about the tail itself looks wrong when this is missing.
+    """
+    f = projects("sess-a", transcript("sess-a", human_turn("do the thing")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"]
+    assert len(sent) == 1
+    assert sent[0]["fileBytes"] == f.stat().st_size, (
+        "fileBytes does not equal the transcript's size, so the cursor the server stores "
+        "will not match where the stream reads from"
+    )
+    # 🔴 AND IT MUST BE >= THE TAIL IT ACCOMPANIES, which is what the server
+    # enforces: a cursor pointing BEFORE the start of the stored tail is a splice
+    # waiting to happen, and the server rejects the whole atomic push over it.
+    assert sent[0]["fileBytes"] >= len(sent[0]["tail"].encode("utf-8"))
+
+
+def test_a_truncated_tail_reports_the_WHOLE_file_size_not_the_tail_length(server, projects, tmp_path):
+    """The cursor is a FILE position. Reporting the tail's length instead would
+    put it 250 KiB behind on every long session — and the stream would then be
+    refused for ever while looking correctly configured."""
+    big = transcript("sess-big", *[human_turn(f"turn {i} " + "x" * 400, "sess-big") for i in range(900)])
+    f = projects("sess-big", big)
+    assert f.stat().st_size > 196608, "the fixture is not big enough to be truncated"
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"][0]
+    assert sent["truncated"] is True
+    assert sent["fileBytes"] == f.stat().st_size
+    assert sent["fileBytes"] > len(sent["tail"].encode("utf-8")), (
+        "a TRUNCATED tail reported a fileBytes equal to its own length — the cursor would "
+        "point at the start of the stored tail rather than its end"
+    )
+
+
+def test_coverage_is_not_capped_at_eight_sessions(server, projects, tmp_path):
+    """🔴 RED ON PRE-CHANGE CODE. The default was MAX_PER_PUSH=6 against a server
+    cap of 8, so a host with 21 changed sessions carried SIX of them per
+    five-minute tick — which is why most session cards had no conversation to
+    show at all (~93 live windows, measured 2026-09-07).
+
+    21 is deliberately NOT a multiple of 8 or 6: a fixture of 8, 16 or 12 could be
+    passed by a mutant restoring the old cap by landing exactly on a boundary.
+    """
+    n = 21
+    assert n % 8 != 0 and n % 6 != 0
+    for i in range(n):
+        projects(f"sess-{i:02d}", transcript(f"sess-{i:02d}", human_turn(f"turn {i}", f"sess-{i:02d}")))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"]
+    assert len(sent) == n, f"one push carried {len(sent)} of {n} changed sessions"
+    assert len({s["sessionId"] for s in sent}) == n
+
+
+def test_the_aggregate_byte_bound_stops_the_push_before_the_session_count_does(
+    server, projects, tmp_path
+):
+    """🔴 THIS IS THE BOUND THE SESSION COUNT USED TO STAND IN FOR. Raising the
+    count from 6 to 48 is only safe because the TOTAL is bounded directly; without
+    it, 48 sessions of 192 KiB would be a 9 MiB body the server refuses on every
+    tick.
+
+    The fixture keeps every session well under the per-session tail cap, so this
+    can only fail on the aggregate — a fixture that also breached the tail bound
+    would die to the other guard and this check would be unreachable.
+    """
+    body = transcript("x", *[human_turn("y" * 400, "x") for _ in range(40)])
+    per = len(body.encode())
+    assert per < 196608, "the fixture breaches the per-session tail cap and would test that instead"
+    n = 12
+    for i in range(n):
+        projects(f"sess-{i:02d}", body)
+
+    budget = per * 4  # room for ~4 sessions
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_MAX_BYTES": str(budget),
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"]
+    assert 0 < len(sent) < n, f"the aggregate bound did not bite: {len(sent)} of {n} sessions"
+    total = sum(len(s["tail"].encode()) for s in sent)
+    assert total <= budget + per, f"the push carried {total} bytes against a {budget}-byte budget"
+
+
 def test_the_client_bounds_sit_UNDER_the_servers_not_at_them(server, projects, tmp_path):
     """🔴 A CLIENT TUNED EXACTLY TO THE SERVER'S CAP TURNS ANY ROUNDING
     DISAGREEMENT INTO A FEEDER THAT FAILS EVERY TICK while looking correctly
@@ -490,17 +601,32 @@ def test_the_client_bounds_sit_UNDER_the_servers_not_at_them(server, projects, t
     changes one.
     """
     server_max_tail_bytes = 256 * 1024  # transcript.MaxTailBytes
-    server_max_sessions = 8  # transcript.MaxSessionsPerPush
+    # 🔴 RAISED FROM 8 TO 128 WITH THE SERVER, AND THE PAIR MOVED FOR A REASON,
+    # NOT TO MAKE A TEST PASS. 8 was a COVERAGE cap wearing a safety cap's
+    # clothes: measured 2026-09-07 against ~93 live windows, at most 8 sessions
+    # could carry a transcript per push, so most session cards had no conversation
+    # to show at all. The ceiling the count was standing in for is the AGGREGATE
+    # tail bytes, which the server now bounds directly (transcript.MaxPushTailBytes)
+    # — so the count is free to rise and the third assertion below is the one now
+    # doing the work the second used to pretend to do.
+    server_max_sessions = 128  # transcript.MaxSessionsPerPush
+    server_max_push_bytes = 4 * 1024 * 1024  # transcript.MaxPushTailBytes
 
     text = SCRIPT.read_text()
     tail_default = _shell_default(text, "TAIL_BYTES", "TRANSCRIPT_PUSH_TAIL_BYTES")
     sess_default = _shell_default(text, "MAX_PER_PUSH", "TRANSCRIPT_PUSH_MAX_SESSIONS")
+    bytes_default = _shell_default(text, "MAX_PUSH_BYTES", "TRANSCRIPT_PUSH_MAX_BYTES")
 
     assert tail_default < server_max_tail_bytes, (
         f"the default tail ({tail_default}) is not UNDER the server's cap ({server_max_tail_bytes})"
     )
     assert sess_default < server_max_sessions, (
         f"the default session count ({sess_default}) is not UNDER the server's cap ({server_max_sessions})"
+    )
+    assert bytes_default < server_max_push_bytes, (
+        f"the default aggregate ({bytes_default}) is not UNDER the server's cap "
+        f"({server_max_push_bytes}) — this is the bound that actually holds now that the "
+        f"session count is {sess_default}"
     )
 
 

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1015,14 +1015,33 @@ def test_the_unit_PATH_carries_the_binaries_the_script_needs():
         assert pkg in block, f"the transcript feeder's PATH is missing {pkg}"
 
 
-def test_the_unit_restart_triggers_name_BOTH_halves():
-    """The builder decides WHICH sessions are sent and HOW MUCH of each. A change
-    there changes what this unit delivers with no edit to the shell at all, so a
-    trigger on the shell alone would leave a deployed unit running the old rule.
+def test_the_unit_restart_triggers_name_EVERY_half():
+    """The builder decides WHICH sessions are sent and HOW MUCH of each, and
+    host_label.py decides WHAT HOST they are filed under — a change to either
+    changes what this unit delivers with no edit to the shell at all, so a trigger
+    on the shell alone would leave a deployed unit running the old rule.
+
+    🔴 THE NAME SAID "BOTH HALVES" WHILE THE UNIT GREW A THIRD, and the same
+    commit that added it wired it into the AGENT's triggers — so the omission was
+    an asymmetry, not a policy. Asserted as a SET, because a list of `in` checks
+    is exactly what grows silently: `host_label.py` is now FATAL for this unit
+    (exit 3) and was not listed.
     """
+    import re
+
     block = _unit_block()
-    assert "../scripts/transcript-push.sh" in block
-    assert "../scripts/lib/build_transcript_push.py" in block
+    m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)
+    assert m, "the transcript-push unit declares no X-Restart-Triggers at all"
+    declared = set(re.findall(r"\$\{\.\./([^}]+)\}", m.group(1)))
+    want = {
+        "scripts/transcript-push.sh",
+        "scripts/lib/build_transcript_push.py",
+        "scripts/lib/host_label.py",
+    }
+    assert declared == want, (
+        f"the transcript-push unit's restart triggers are {sorted(declared)}, want "
+        f"{sorted(want)} — every file this unit hard-depends on must be one, or a fix to it "
+        "ships while the timer keeps running the old copy")
 
 
 def test_the_script_and_builder_are_executable():
@@ -1388,3 +1407,44 @@ def test_the_push_REFUSES_rather_than_guessing_when_the_label_cannot_be_resolved
     assert proc.returncode == 3, f"rc={proc.returncode}: {proc.stdout}{proc.stderr}"
     assert "refusing to push under a guessed name" in proc.stdout
     assert not pushes(server), "a push went out under a guessed host name"
+
+
+def test_the_agent_reads_the_env_file_the_SHARED_MODULE_names(tmp_path):
+    """🔴 THE PATH IS THE THIRD LITERAL, AND RE-EXPORTING THE OTHER TWO IS NOT
+    ENOUGH. The consolidation re-exported HOST_NAMES and DEFAULT_LOCAL_HOST
+    "rather than restating two literals" and left the env-file PATH restated in
+    the agent — and because `local_host_label` passes it as the DEFAULT
+    `env_file`, host_label.ACTIVITY_ENV was dead there. Measured: pointing the
+    agent's copy at /nonexistent changed nothing, 203/203 still passed.
+
+    That is the exact axis that produced the earlier blocker: two feeders reading
+    two files. `test_BOTH_feeders_resolve_the_SAME_host_label` cannot see it — it
+    passes `env_file=` explicitly, so it exercises the module's PARSING and never
+    the agent's own path.
+
+    🔴 IT RUNS IN A SUBPROCESS BECAUSE THE BINDING IS AT IMPORT TIME. Setting the
+    variable after importing would prove nothing about what a real agent does.
+    """
+    env_file = tmp_path / "activity-env"
+    env_file.write_text("ACTIVITY_HOST=laptop\n")
+
+    snippet = (
+        "import importlib.machinery, importlib.util, sys\n"
+        "loader = importlib.machinery.SourceFileLoader('a', sys.argv[1])\n"
+        "spec = importlib.util.spec_from_file_location('a', sys.argv[1], loader=loader)\n"
+        "m = importlib.util.module_from_spec(spec); loader.exec_module(m)\n"
+        # no env_file= argument: the DEFAULT is what is under test
+        "print(m.local_host_label(env={}))\n"
+    )
+    env = dict(os.environ, HOST_LABEL_ENV_FILE=str(env_file))
+    env.pop("ACTIVITY_HOST", None)
+    out = subprocess.run(
+        [sys.executable, "-c", snippet, str(REPO_ROOT / "scripts" / "tmux-reply-agent")],
+        capture_output=True, text=True, env=env, timeout=120)
+    assert out.returncode == 0, out.stdout + out.stderr
+    got = out.stdout.strip()
+    assert got == "laptop", (
+        f"the agent resolved {got!r} from its DEFAULT env-file path, want 'laptop' — it is not "
+        f"reading the file the shared module names, so the two feeders can be pointed at "
+        f"different files and the reseed loop comes back invisibly"
+    )

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1226,200 +1226,297 @@ def _lib_modules_a_python_file_imports(path, libdir):
     return found
 
 
-def _join_line_continuations(src):
-    r"""Join backslash-newline continuations, which bash joins BEFORE lexing.
-
-    Round 15 found this as an OVER-strip: `echo abc\` + a next line starting `#`
-    is ONE WORD to bash (`abc#...`), not a comment, and the per-line walk deleted
-    the second line outright. Latent — 21 continuations exist in
-    `transcript-push.sh` and none is followed by a `#` line — but it is the
-    false-PASS direction, so it is closed rather than documented.
-
-    An ODD number of trailing backslashes continues; an even number is escaped
-    backslashes and does not.
-    """
-    out, buf = [], ""
-    for line in src.splitlines():
-        trailing = len(line) - len(line.rstrip("\\"))
-        if trailing % 2 == 1:
-            buf += line[:-1]
-            continue
-        out.append(buf + line)
-        buf = ""
-    if buf:
-        out.append(buf)
-    return out
-
-
 def _strip_shell_comments(src):
-    r"""Shell source with comments removed, quote-aware, so a scanner sees CODE.
+    r"""Shell source with comments removed, so a scanner over it sees CODE.
 
-    🔴 A REGEX PAIR WAS WRONG IN BOTH DIRECTIONS AND ITS DOCSTRING CALLED THE
-    ERROR ONE-DIRECTIONAL AND SAFE. Measured against bash, a real executable line
-    resolving `scripts/lib/host-role.sh` that also carried a quoted `#` was
-    truncated at that `#` — an UNDECLARED dependency vanished and the guard went
-    GREEN (false PASS); and `echo A;# x`, `|#`, `&&#`, `)#` are all comments to
-    bash, so keeping them minted PHANTOM requirements (false FAIL).
+    🔴 READ THE DIRECTIONS BEFORE CHANGING ANYTHING HERE. An OVER-strip deletes
+    text bash would execute, so a `scripts/lib/<x>.py` inside it disappears and
+    the ledger PASSES over an undeclared dependency — silent, and the exact
+    failure the ledger exists to prevent. An UNDER-strip keeps a comment, minting
+    a requirement for a file the script never opens — LOUD, a human sees it.
+    Every judgement call below resolves toward under-stripping.
 
-    So: `#` opens a comment only OUTSIDE quotes and only at the start of a word.
-    `X=y#foo` is left alone, because bash does not treat that as a comment either.
+    🔴 ONE PASS OVER THE WHOLE SOURCE, NOT LINE BY LINE. Three separate defects
+    were all the per-line architecture, and each was an over-strip:
 
-    🔴 QUOTE STATE CARRIES ACROSS LINES. Round 15's finding, and the one that
-    mattered most: a bash string can span newlines, so re-initialising per line
-    made a `#`-leading line INSIDE a multi-line string look like a comment — the
-    false-PASS direction again — while the line AFTER a closing quote read that
-    quote as an opening one and kept a real trailing comment (false FAIL). Both
-    are gone now that the walk threads its state.
+      * a `#`-leading line INSIDE a multi-line string was read as a comment;
+      * `sub_depth` reset per line, so a `$( … )` spanning a real newline left
+        its `)` looking like a word start (`X=$(echo a\ntrue)#x` is one word);
+      * a pre-pass that JOINED backslash-newline continuations swallowed the
+        next line when the first was a COMMENT — bash ends a comment at the
+        newline whatever the backslash does. That one was INTRODUCED by the fix
+        for the third over-strip, which is why the join now lives inside the
+        walk, where comment state is known.
 
-    ⚠ I EXPECTED THIS FIX TO POISON THE REAL FILE AND IT DOES NOT — measured, not
-    assumed. `transcript-push.sh` has two lines with an odd `"` count and fifteen
-    with an odd `'`, which looks like it would leave the walk permanently "inside
-    a string"; every one of them is a FULL-LINE `#` comment, where the walk breaks
-    at column 0 before any quote is read. Real-tree output is unchanged.
+    WORD-START SET, each character measured against bash in a realistic shape.
+    Two entries were REMOVED after their justifications were refuted:
 
-    ⚠ WHAT IT STILL DOES NOT MODEL — enumerated by running each shape against
-    bash, and every one is LATENT (absent from `transcript-push.sh` today):
+        ; | & and whitespace      -> comment start          (in)
+        bare `(`                  -> comment start          (in)
+        `)` closing $( or $((     -> NOT a word start       (tracked, not listed)
+        `}`                       -> REMOVED. `{ echo a; }#` is a SYNTAX ERROR,
+                                     not a comment; `${V}#x` and `{a,b}#x` both
+                                     keep the text. The shape that justified it
+                                     does not parse.
+        ` (backtick)              -> REMOVED from the flat set and TRACKED: an
+                                     OPENING backtick starts a comment context,
+                                     a CLOSING one is mid-word (`echo `true`#x`
+                                     keeps `#x`) — the same asymmetry as `(`/`)`.
+        < >                       -> left OUT. bash DOES comment after them, so
+                                     this is a deliberate under-strip; see the
+                                     divergence test.
 
-      a here-document body            `#` line inside `<<EOF` is content, not a
-                                      comment  (0 heredocs in the file)
-      `$'…'` ANSI-C quoting           `\'` is an escape there but not in plain
-                                      `'…'`, so the walk mis-pairs  (0 occurrences)
-      `#` inside `$(…)`/backticks
-      that sit inside double quotes   bash resets the quoting context; the walk
-                                      treats `"` as suppressing comments outright
+    HEREDOC BODIES ARE CONTENT AND ARE KEPT VERBATIM. A `#` line inside `<<EOF`
+    is data, not a comment, and stripping it was an over-strip. Keeping it can
+    only over-report a dependency, which is the loud direction — and a heredoc
+    carrying a python script is exactly where a real `scripts/lib` import hides.
 
-    All three of those remaining are the false-FAIL direction (a phantom
-    requirement), which is LOUD. The false-PASS shapes round 15 found — the
-    multi-line string, an escaped word-separator, a `)` closing a substitution,
-    and a line continuation — are fixed above and below, because a silent pass is
-    exactly what this guard exists to prevent.
+    `$'…'` IS ITS OWN QUOTE STATE, because backslash escapes there and does not
+    in plain `'…'`. Treating them alike mis-paired the quotes and over-stripped.
+
+    ⚠ STILL NOT MODELLED, and both are the LOUD direction: a `#` inside `$(…)`
+    or backticks nested within double quotes (bash resets the quoting context
+    there; this walk does not), and `splitlines()`-only separators such as \x0c
+    which bash treats as ordinary characters.
     """
     out = []
-    in_single = in_double = False
-    for line in _join_line_continuations(src):
-        res = []
-        i = 0
-        sub_depth = 0
-        prev_was_escape = False
-        prev_closed_sub = False
-        while i < len(line):
-            c = line[i]
-            # 🔴 `prev` MUST NOT BE THE RAW PREVIOUS CHARACTER. Round 15: in
-            # `echo a\\ #x` the `\\ ` is consumed as an escaped SPACE, so re-reading
-            # line[i-1] saw a space and called the `#` a word start — to bash it is
-            # one word. Same for a `)` that closed a `$(…)`: `$(true)#x` is one
-            # word, while a subshell `(true)#x` really is a comment. Both are
-            # tracked as flags rather than re-read from the raw line.
-            prev = None if i == 0 else line[i - 1]
-            at_word_start = (
-                i == 0
-                # 🔴 THE SET IS CHOSEN BY A SAFETY ASYMMETRY, NOT BY COMPLETENESS.
-                # Omitting a character that bash WOULD treat as a comment start
-                # mints a phantom requirement — loud, and a human sees it. Adding
-                # one bash does NOT hides a real dependency — silent, and it is
-                # the exact failure this guard exists to prevent. So a character
-                # goes in only once measured as a comment start in a REALISTIC
-                # shape. Probed individually against bash:
-                #     ; | & ` and whitespace -> comment      (in)
-                #     < >                    -> NOT a comment (OUT: including
-                #                               them was a measured over-strip)
-                #     ) }                    -> context-dependent; the realistic
-                #                               shapes `(true)#` and `{ …; }#`
-                #                               ARE comments, so they stay in
-                or (prev in " \t;|&()}`" and not prev_was_escape and not prev_closed_sub)
-            )
-            prev_was_escape = False
-            prev_closed_sub = False
-            if in_single:
-                res.append(c)
-                in_single = c != "'"
-            elif in_double:
-                res.append(c)
-                if c == "\\" and i + 1 < len(line):
-                    i += 1
-                    res.append(line[i])
-                    prev_was_escape = True
-                elif c == '"':
-                    in_double = False
-            elif c == "'":
-                in_single = True
-                res.append(c)
-            elif c == '"':
-                in_double = True
-                res.append(c)
-            elif c == "\\" and i + 1 < len(line):
-                res.append(c)
-                i += 1
-                res.append(line[i])
-                prev_was_escape = True
-            elif c == "(" and (prev == "$" or (prev == "(" and sub_depth)):
-                # Only `$(` opens a substitution — a bare `(` is a SUBSHELL, whose
-                # `)` IS a word start (`(true)# x` is a comment to bash). `$((`
-                # pushes twice so both of `))` are consumed as closers.
-                sub_depth += 1
-                res.append(c)
-            elif c == ")" and sub_depth:
-                sub_depth -= 1
-                prev_closed_sub = True
-                res.append(c)
-            elif c == "#" and at_word_start:
-                break
-            else:
-                res.append(c)
+    i, n = 0, len(src)
+    in_single = in_double = in_ansi = False
+    in_comment = False
+    sub_depth = 0
+    tick_depth = 0
+    heredoc_term = None      # set at `<<WORD`, consumed at the next newline
+    heredoc_active = None
+    prev_closed_group = False   # a `)` or backtick that CLOSED — mid-word
+    prev_was_escape = False
+    after_join = False          # a backslash-newline was just consumed
+
+    while i < n:
+        c = src[i]
+
+        # --- inside a heredoc body: copy verbatim until the terminator line ---
+        if heredoc_active is not None:
+            j = src.find("\n", i)
+            if j == -1:
+                j = n
+            line = src[i:j]
+            out.append(line)
+            if line.strip() == heredoc_active:
+                heredoc_active = None
+            if j < n:
+                out.append("\n")
+            i = j + 1
+            continue
+
+        if c == "\n":
+            # A comment ENDS at the newline no matter what preceded it.
+            in_comment = False
+            if heredoc_term is not None:
+                heredoc_active, heredoc_term = heredoc_term, None
+            out.append(c)
+            prev_closed_group = prev_was_escape = False
             i += 1
-        out.append("".join(res))
-    return "\n".join(out)
+            continue
+
+        if in_comment:
+            i += 1
+            continue
+
+        # --- backslash-newline continuation, OUTSIDE a comment: bash joins ---
+        if c == "\\" and i + 1 < n and src[i + 1] == "\n" and not in_single:
+            i += 2
+            prev_was_escape = True
+            prev_closed_group = False
+            # 🔴 THE JOIN MUST NOT LOOK LIKE A LINE START. `prev` is read from the
+            # RAW source, where the character before is the newline we just
+            # consumed — so without this flag `echo abc\<nl>#x` saw a line start
+            # and stripped a word bash keeps joined. Measured as an over-strip.
+            after_join = True
+            continue
+
+        if in_single:
+            out.append(c)
+            if c == "'":
+                in_single = False
+            i += 1
+            continue
+
+        if in_ansi:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if c == "'":
+                in_ansi = False
+            i += 1
+            continue
+
+        if in_double:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_double = False
+            i += 1
+            continue
+
+        prev = src[i - 1] if i else None
+        at_word_start = not after_join and (
+            i == 0
+            or prev == "\n"
+            # `)` is included but gated on prev_closed_group below: a SUBSHELL's
+            # `)` is a word start (`(true)# x` is a comment), while a `)` that
+            # closed `$(`/`$((` is mid-word (`$(true)#x` is one word).
+            or (prev in " \t;|&()" and not prev_was_escape)
+            or (prev == "`" and not prev_closed_group)
+        )
+        was_escape, closed_group = prev_was_escape, prev_closed_group
+        prev_was_escape = prev_closed_group = after_join = False
+
+        if c == "$" and i + 1 < n and src[i + 1] == "'":
+            in_ansi = True
+            out.append(c)
+            out.append(src[i + 1])
+            i += 2
+            continue
+        if c == "'":
+            in_single = True
+            out.append(c)
+        elif c == '"':
+            in_double = True
+            out.append(c)
+        elif c == "\\" and i + 1 < n:
+            out.append(c)
+            out.append(src[i + 1])
+            i += 2
+            prev_was_escape = True
+            continue
+        elif c == "<" and src[i : i + 2] == "<<" and heredoc_term is None:
+            m = re.match(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", src[i:])
+            out.append(c)
+            if m:
+                heredoc_term = m.group(2)
+        elif c == "`":
+            tick_depth ^= 1
+            if tick_depth == 0:
+                prev_closed_group = True
+            out.append(c)
+        elif c == "(" and (prev == "$" or (prev == "(" and sub_depth)):
+            sub_depth += 1
+            out.append(c)
+        elif c == ")" and sub_depth:
+            sub_depth -= 1
+            prev_closed_group = True
+            out.append(c)
+        elif c == "#" and at_word_start and not closed_group:
+            in_comment = True
+        else:
+            out.append(c)
+        i += 1
+
+    return "".join(out)
 
 
 @pytest.mark.parametrize(
     "name,text,marker_survives",
     [
-        # 🔴 EVERY ROW'S EXPECTATION WAS TAKEN FROM BASH, NOT FROM READING THE
-        # WALK. The probe was `<line-with-MARKER>; echo SAW` on ONE line: if bash
-        # swallows the same-line `; echo SAW` and never prints MARKER, it is a
-        # comment. `; echo SAW` on the NEXT line always runs and measures nothing
-        # — which is exactly how the first version of that harness was wrong.
+        # --- bash COMMENTS these out, so the stripper must remove the marker ---
         ("a full-line comment", "# /lib/MARK.py", False),
         ("a trailing comment", "echo hi   # /lib/MARK.py", False),
         ("`;#` with no space", "echo A;# /lib/MARK.py", False),
         ("`|#` with no space", "echo B |# /lib/MARK.py", False),
         ("`&&#` with no space", "true &&# /lib/MARK.py", False),
-        ("a subshell's `)#`", "(true)# /lib/MARK.py", False),
-        ("`}` closing a group", "{ echo a; }# /lib/MARK.py", False),
-        # --- the false-PASS shapes: bash keeps these, so the walk must too ---
+        ("a SUBSHELL's `)#`", "(true)# /lib/MARK.py", False),
+        ("a comment after a multi-line string closes",
+         'echo "one\ntwo" # /lib/MARK.py', False),
+        # --- bash KEEPS these as executable text: removing the marker would be
+        #     an OVER-strip, which hides a dependency and passes the ledger ---
         ("`X=y#foo` is one word", "F=/lib/MARK.py#tag", True),
+        # 🔴 THE MIRROR OF THE ROW ABOVE, AND THE ROW ABOVE IS VACUOUS WITHOUT IT.
+        # There the marker sits BEFORE the `#`, and the walk keeps everything
+        # accumulated before it breaks — so that row passes even under a mutant
+        # where EVERY `#` starts a comment. Here the marker sits after.
+        ("`X=#tag/lib/x` — marker AFTER the hash", "F=#tag/lib/MARK.py", True),
         ("a QUOTED # then real code", 'printf "a #b\\n"; R=/lib/MARK.py', True),
         ("an ESCAPED word-separator", "echo a\\ #/lib/MARK.py", True),
         ("`)` closing a $(...)", "echo $(true)#/lib/MARK.py", True),
         ("`)` closing a $((...))", "echo $((1+2))#/lib/MARK.py", True),
-        ("`>` is NOT a comment start", "echo hi ># /lib/MARK.py", True),
+        ("`}` of ${V} — NOT a comment start", "V=1; echo ${V}#/lib/MARK.py", True),
+        ("`}` of a brace expansion", "echo {a,b}#/lib/MARK.py", True),
+        ("a CLOSING backtick", "echo `true`#/lib/MARK.py", True),
+        ("a HEREDOC body is content", "cat <<EOF\n# /lib/MARK.py\nEOF", True),
+        ("$'...' escapes its own quote", "echo $'a\\'b #/lib/MARK.py'", True),
+        ("a COMMENT ending in a backslash does NOT continue",
+         "# c \\\necho /lib/MARK.py", True),
+        ("a $( ) spanning a real newline", "X=$(echo a\ntrue)#/lib/MARK.py", True),
         ("inside a multi-line \"...\"", 'echo "one\n# /lib/MARK.py\nthree"', True),
         ("inside a multi-line '...'", "echo 'one\n# /lib/MARK.py\nthree'", True),
-        ("a backslash-newline continuation", "echo abc\\\n#/lib/MARK.py", True),
-        # --- and one the other way, after a string CLOSES ---
-        ("a comment after a multi-line string closes",
-         'echo "one\ntwo" # /lib/MARK.py', False),
+        ("a backslash-newline continuation joins", "echo abc\\\n#/lib/MARK.py", True),
     ],
 )
 def test_the_shell_comment_stripper_AGREES_WITH_BASH(name, text, marker_survives):
     """🔴 THE STRIPPER IS A NO-OP ON THE REAL SCRIPT TODAY, SO NOTHING EXERCISED
     IT. `transcript-push.sh` yields the same module set stripped, unstripped, and
-    under the old regex version — so every defect it has ever had was found by a
-    throwaway harness and then had no permanent guard. Its worth is entirely
-    prospective, which is precisely the code that rots unwatched.
+    under every previous version — so its worth is entirely prospective, which is
+    precisely the code that rots unwatched. Three rewrites and three audit rounds
+    produced these rows; each is a shape where some version disagreed with bash.
 
-    Two rewrites and two audit rounds produced these rows. Each is a shape where
-    a previous version disagreed with bash; roughly half are the OVER-strip
-    direction, where a real `scripts/lib` dependency silently vanished and the
-    ledger passed GREEN — the failure this whole guard exists to prevent.
+    🔴 EVERY EXPECTATION CAME FROM BASH, AND THE ORACLE THAT PRODUCED THEM WAS
+    ITSELF WRONG TWICE BEFORE IT WAS TRUSTED. Probe: `<line-with-MARK>; echo SAW`
+    on ONE line — if bash swallows the same-line `; echo SAW` and never prints
+    the marker, it is a comment. Putting `; echo SAW` on the NEXT line measures
+    nothing (it always runs), and `declare -f` is unreliable for backtick CONTENT
+    because bash stores those verbatim. The harness asserts a known-comment and a
+    known-code control before any row's expectation is read.
+
+    Two rows were REMOVED as refuted rather than kept and re-explained: `{ …; }#`
+    (a syntax error, so bash has no verdict) and `>#` (bash DOES comment there —
+    see the divergence test below).
     """
     kept = "MARK.py" in _strip_shell_comments(text)
     assert kept is marker_survives, (
         f"{name}: bash {'keeps' if marker_survives else 'comments out'} the marker, "
         f"but the stripper {'kept' if kept else 'removed'} it. "
-        + ("An OVER-strip hides a real dependency and the ledger passes green."
+        + ("An OVER-strip hides a real dependency and the ledger passes GREEN."
            if marker_survives else
            "An UNDER-strip mints a requirement for a file the script never opens."))
+
+
+@pytest.mark.parametrize("name,text", [
+    ("`>` before a comment", "echo hi ># /lib/MARK.py"),
+    ("`<` before a comment", ": <# /lib/MARK.py"),
+    # 🔴 A BACKTICK SUBSTITUTION NESTED INSIDE DOUBLE QUOTES. bash resets the
+    # quoting context inside `…`, so the `#` there IS a comment — measured, the
+    # script prints `[]`. This walk treats `"` as suppressing comments outright
+    # and keeps it. Same loud direction, same trade, and it is the one shape
+    # whose verdict the `; echo SAW` probe gets WRONG: that `echo` sits OUTSIDE
+    # the substitution, so it runs either way. Read stdout for this family.
+    ("a backtick substitution inside double quotes", 'echo "[`#/lib/MARK.py`]"'),
+])
+def test_the_stripper_DELIBERATELY_UNDER_STRIPS_after_a_redirect(name, text):
+    """🔴 A KNOWN DIVERGENCE FROM BASH, PINNED SO IT STAYS DELIBERATE.
+
+    bash DOES start a comment after `<` or `>` — `echo hi > a#foo` creates the
+    file `a#foo`, so `#` is legal mid-word, while `echo hi >#foo` is a syntax
+    error and creates NO file: the redirect lost its target because `#foo` was
+    eaten as a comment. An earlier version of this suite asserted the opposite
+    and called it measured.
+
+    They are still left OUT of the word-start set, because the two directions
+    are not symmetric. Omitting them UNDER-strips: a `/lib/<x>.py` in such a
+    comment mints a requirement for a file the script never opens — wrong, but
+    LOUD, and a human sees the failure. Including them would OVER-strip any
+    executable text after a redirect, which hides a real dependency and passes
+    the ledger GREEN. When the shapes are this rare (0 in `transcript-push.sh`),
+    take the loud error.
+    """
+    assert "MARK.py" in _strip_shell_comments(text), (
+        f"{name}: the stripper now removes text after a redirect. That is the "
+        "SILENT direction — a real dependency there would vanish and the ledger "
+        "would pass. If this was deliberate, the reasoning above must be rewritten.")
 
 
 def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1037,6 +1037,14 @@ def test_the_unit_restart_triggers_name_EVERY_half():
         "scripts/transcript-push.sh",
         "scripts/lib/build_transcript_push.py",
         "scripts/lib/host_label.py",
+        # 🔴 THE BUILDER IMPORTS IT AND CANNOT RUN WITHOUT IT (ModuleNotFoundError,
+        # rc 1). It was missing for the whole arc — and this ledger, whose own
+        # failure message says "every file this unit hard-depends on must be one",
+        # was pinning the 3-set that omitted it. A hand-written want-set is a
+        # ledger only while somebody checks it against the thing it describes;
+        # the sibling test derives its set from the agent's SOURCE, and that is
+        # the one that caught the equivalent gap on the other unit.
+        "scripts/lib/transcript_search.py",
     }
     assert declared == want, (
         f"the transcript-push unit's restart triggers are {sorted(declared)}, want "

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1015,17 +1015,21 @@ def test_the_unit_PATH_carries_the_binaries_the_script_needs():
         assert pkg in block, f"the transcript feeder's PATH is missing {pkg}"
 
 
-def test_the_unit_restart_triggers_name_EVERY_half():
-    """The builder decides WHICH sessions are sent and HOW MUCH of each, and
-    host_label.py decides WHAT HOST they are filed under — a change to either
-    changes what this unit delivers with no edit to the shell at all, so a trigger
-    on the shell alone would leave a deployed unit running the old rule.
+def test_the_unit_restart_triggers_name_EVERY_hard_dependency():
+    """Every file this unit cannot run without is declared as a trigger.
 
-    🔴 THE NAME SAID "BOTH HALVES" WHILE THE UNIT GREW A THIRD, and the same
-    commit that added it wired it into the AGENT's triggers — so the omission was
-    an asymmetry, not a policy. Asserted as a SET, because a list of `in` checks
-    is exactly what grows silently: `host_label.py` is now FATAL for this unit
-    (exit 3) and was not listed.
+    Asserted as a SET, not a list of `in` checks, because a membership test grows
+    silently — which is how this list reached four entries having been described
+    as "both halves" through three of them.
+
+    ⚠ WHAT A MISSING TRIGGER COSTS HERE IS ONE TICK, AND THE PROSE IN THIS FILE
+    SAID OTHERWISE THROUGH TWO REVISIONS. This unit is `Type=oneshot` on a
+    5-minute timer whose ExecStart names the WORKING-TREE path, so the next tick
+    execs current code regardless. The indefinitely-stale consequence belongs to
+    the RESIDENT reply agent, which imports once and runs for weeks — see the
+    two tests below, which are the ones where that reasoning applies. The
+    declaration is still worth pinning (a dependency that can exit the unit
+    should be visible in the unit), but this test is not guarding an outage.
     """
     import re
 
@@ -1038,18 +1042,19 @@ def test_the_unit_restart_triggers_name_EVERY_half():
         "scripts/lib/build_transcript_push.py",
         "scripts/lib/host_label.py",
         # 🔴 THE BUILDER IMPORTS IT AND CANNOT RUN WITHOUT IT (ModuleNotFoundError,
-        # rc 1). It was missing for the whole arc — and this ledger, whose own
-        # failure message says "every file this unit hard-depends on must be one",
-        # was pinning the 3-set that omitted it. A hand-written want-set is a
-        # ledger only while somebody checks it against the thing it describes;
-        # the sibling test derives its set from the agent's SOURCE, and that is
-        # the one that caught the equivalent gap on the other unit.
+        # rc 1), and it was the OLDEST omission here — the builder has imported it
+        # since the feeder shipped, before the delta tailer existed. A hand-written
+        # want-set is a ledger only while somebody checks it against the thing it
+        # describes: this one was pinning the 3-set that omitted it, so the gap was
+        # not merely unnoticed, it was locked in by its own guard. That is why the
+        # test below derives the set from SOURCE instead.
         "scripts/lib/transcript_search.py",
     }
     assert declared == want, (
         f"the transcript-push unit's restart triggers are {sorted(declared)}, want "
-        f"{sorted(want)} — every file this unit hard-depends on must be one, or a fix to it "
-        "ships while the timer keeps running the old copy")
+        f"{sorted(want)} — every file this unit hard-depends on must be one. A missing "
+        "one costs at most one 5-minute tick here (oneshot + working-tree ExecStart), "
+        "but an undeclared hard dependency is invisible to anyone reading the unit")
 
 
 def test_the_script_and_builder_are_executable():
@@ -1178,6 +1183,64 @@ def test_every_module_the_agent_loads_by_path_IS_a_restart_trigger():
         f"the agent loads {sorted(missing)} at startup but the unit does not trigger on "
         "them — a resident service would keep running the old copy indefinitely"
     )
+
+
+def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():
+    """🔴 THE HALF THE HAND-WRITTEN LEDGER LEFT OPEN. `transcript_search.py` was
+    absent from the timer's triggers from the day the feeder shipped, and the
+    test that grades those triggers is a set somebody typed — so it graded the
+    omission as correct. The agent unit already had a source-derived counterpart;
+    the timer had none, which is precisely why the gap survived on this side.
+
+    So: derive the timer's expected set from the two files the unit actually
+    runs. A fifth dependency added to either tomorrow fails here rather than
+    waiting for someone to notice the `want` set is one short.
+
+    🔴 BOTH SOURCES, BECAUSE THE UNIT HAS TWO. The first draft of this test
+    scanned only the builder's imports and its own positive control caught that:
+    `host_label.py` is resolved by the SHELL (`transcript-push.sh:99`, fatal at
+    exit 3), never imported by the builder, so a builder-only scanner would have
+    declared the ledger complete while being blind to the dependency that
+    actually kills the unit.
+
+    ⚠ WHAT THIS GUARDS IS A DECLARATION, NOT AN OUTAGE — this unit is oneshot on a
+    timer with a working-tree ExecStart, so a missing trigger costs one tick. The
+    resident-agent sibling above is the one where staleness is unbounded, and
+    conflating the two is the error this arc made twice.
+    """
+    import re
+
+    libdir = REPO_ROOT / "scripts" / "lib"
+
+    # (a) what the BUILDER imports — plain sibling imports off its own sys.path.
+    builder = (REPO_ROOT / "scripts" / "lib" / "build_transcript_push.py").read_text()
+    names = set(re.findall(r"^(?:from|import)\s+([a-z_][a-z0-9_]*)", builder, re.M))
+    needed = {f"{n}.py" for n in names if (libdir / f"{n}.py").exists()}
+
+    # (b) what the SHELL resolves out of lib/ — a different mechanism, same
+    #     consequence when it is missing.
+    shell = (REPO_ROOT / "scripts" / "transcript-push.sh").read_text()
+    needed |= {m for m in re.findall(r'/lib/([a-z_][a-z0-9_]*\.py)', shell)
+               if (libdir / m).exists()}
+
+    # 🔴 POSITIVE CONTROL, AND IT EARNED ITS KEEP IMMEDIATELY. A scanner that
+    # matches nothing yields an empty `missing` and PASSES — the same reassuring
+    # zero this arc has been bitten by repeatedly. Both names below are known to
+    # be real dependencies, one per mechanism, so this fails if either scanner
+    # stops measuring.
+    assert {"transcript_search.py", "host_label.py"} <= needed, (
+        f"the dependency scanner found {sorted(needed)} — it is not measuring the "
+        "unit's real dependencies, so its verdict is about the regex")
+
+    block = _unit_block()
+    m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)
+    assert m, "the transcript-push unit declares no X-Restart-Triggers at all"
+    declared = set(re.findall(r"\$\{\.\./scripts/lib/([^}]+)\}", m.group(1)))
+    missing = needed - declared
+    assert not missing, (
+        f"the transcript-push unit hard-depends on {sorted(missing)} from scripts/lib "
+        "but does not declare them as restart triggers — the unit's hard dependencies "
+        "must be readable from the unit")
 
 
 def test_an_UNDECODABLE_byte_makes_fileBytes_UNKNOWN_instead_of_400ing_the_WHOLE_push(

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -45,6 +45,7 @@ not the happy path:
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -1185,6 +1186,66 @@ def test_every_module_the_agent_loads_by_path_IS_a_restart_trigger():
     )
 
 
+def _lib_modules_a_python_file_imports(path, libdir):
+    r"""Every `scripts/lib` module `path` pulls in, by AST — not by regex.
+
+    🔴 A REGEX OVER IMPORT LINES IS IDIOM-SHAPED, AND THIS REPO USES THE OTHER
+    IDIOMS. The first version of this scanner was `^(?:from|import)\s+(\w+)`,
+    which is blind to an import that is indented, wrapped in `try:`, or shares a
+    line (`import base64, json, sys`) — all three of which appear in
+    `scripts/lib/transcript_search.py` itself, i.e. inside this unit's own
+    dependency chain. Measured against the old scanner, five realistic "fifth
+    dependency" shapes were added and all five passed GREEN.
+
+    An AST walk sees every `import`/`from` at any depth, in one rule. It also
+    picks up the `os.path.join(_HERE, "<name>.py")` loader idiom, because that is
+    how this repo loads siblings when a plain import will not do — and it is the
+    idiom the resident-agent sibling test scans for, so a scanner here that could
+    not see it would be narrower than the test it was modelled on.
+    """
+    import ast
+
+    src = path.read_text()
+    names = set()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Import):
+            names |= {a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    found = {f"{n}.py" for n in names if (libdir / f"{n}.py").exists()}
+    # The SourceFileLoader idiom: os.path.join(_HERE, "x.py") / (_HERE, "lib", "x.py").
+    found |= {m for m in re.findall(r'os\.path\.join\(\s*_HERE\s*,[^)]*?"([^"]+\.py)"', src)
+              if (libdir / m).exists()}
+    return found
+
+
+def _strip_shell_comments(src):
+    """Shell source with comments removed, so a scanner over it sees CODE.
+
+    🔴 THE COMMENT-BLIND VERSION HAD BOTH FAILURE DIRECTIONS AT ONCE, MEASURED:
+
+        a comment-only mention of scripts/lib/agent_ledger.py
+            -> ['agent_ledger.py'] appears in `needed`  (a PHANTOM requirement:
+               the test demands a trigger for a file the script never opens)
+
+        deleting line 99, the ONLY line that actually resolves host_label.py
+            -> 'host_label.py' still in `needed`, because line 79 mentions it in
+               prose — so the positive control below stayed GREEN over a scanner
+               that had stopped seeing executable code entirely
+
+    Approximate by design: a `#` inside a quoted string would be cut too. That
+    direction is safe here — it can only make the scanner see LESS, which the
+    per-arm controls below turn into a failure rather than a silent pass.
+    """
+    out = []
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append(re.sub(r"\s#.*$", "", line))
+    return "\n".join(out)
+
+
 def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():
     """🔴 THE HALF THE HAND-WRITTEN LEDGER LEFT OPEN. `transcript_search.py` was
     absent from the timer's triggers from the day the feeder shipped, and the
@@ -1192,45 +1253,68 @@ def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():
     omission as correct. The agent unit already had a source-derived counterpart;
     the timer had none, which is precisely why the gap survived on this side.
 
-    So: derive the timer's expected set from the two files the unit actually
-    runs. A fifth dependency added to either tomorrow fails here rather than
-    waiting for someone to notice the `want` set is one short.
+    WHAT THIS SCANS, stated as narrowly as it is implemented — an earlier
+    docstring said "the two files the unit actually runs", which was both wider
+    than the body and one file short:
 
-    🔴 BOTH SOURCES, BECAUSE THE UNIT HAS TWO. The first draft of this test
-    scanned only the builder's imports and its own positive control caught that:
-    `host_label.py` is resolved by the SHELL (`transcript-push.sh:99`, fatal at
-    exit 3), never imported by the builder, so a builder-only scanner would have
-    declared the ledger complete while being blind to the dependency that
-    actually kills the unit.
+      (a) `build_transcript_push.py` — every import, by AST, at any depth;
+      (b) `transcript-push.sh` — literal `lib/<name>.{py,sh}` references, with
+          COMMENTS STRIPPED first;
+      (c) `host_label.py` — the unit's THIRD runnable file (`transcript-push.sh`
+          execs it directly), whose own imports were previously never read.
+
+    It does NOT see a dependency reached through a shell variable holding a
+    computed path, or one loaded by a mechanism none of the three use. That is a
+    real limit, written down rather than implied by silence.
+
+    🔴 THREE ARMS, THREE SEPARATE POSITIVE CONTROLS. A control over the UNION
+    cannot tell "all arms work" from "one arm works and covers for a dead one" —
+    measured: with the shell arm reading prose, deleting the only executable
+    `host_label.py` reference left a union control fully green.
 
     ⚠ WHAT THIS GUARDS IS A DECLARATION, NOT AN OUTAGE — this unit is oneshot on a
     timer with a working-tree ExecStart, so a missing trigger costs one tick. The
     resident-agent sibling above is the one where staleness is unbounded, and
     conflating the two is the error this arc made twice.
     """
-    import re
-
     libdir = REPO_ROOT / "scripts" / "lib"
 
-    # (a) what the BUILDER imports — plain sibling imports off its own sys.path.
-    builder = (REPO_ROOT / "scripts" / "lib" / "build_transcript_push.py").read_text()
-    names = set(re.findall(r"^(?:from|import)\s+([a-z_][a-z0-9_]*)", builder, re.M))
-    needed = {f"{n}.py" for n in names if (libdir / f"{n}.py").exists()}
+    # (a) the builder's imports.
+    from_builder = _lib_modules_a_python_file_imports(
+        libdir / "build_transcript_push.py", libdir)
 
-    # (b) what the SHELL resolves out of lib/ — a different mechanism, same
-    #     consequence when it is missing.
-    shell = (REPO_ROOT / "scripts" / "transcript-push.sh").read_text()
-    needed |= {m for m in re.findall(r'/lib/([a-z_][a-z0-9_]*\.py)', shell)
-               if (libdir / m).exists()}
+    # (b) what the SHELL resolves out of lib/, comments removed. `.sh` too:
+    #     scripts/lib holds shell helpers, and the old `\.py`-only pattern could
+    #     never have matched one.
+    shell = _strip_shell_comments((REPO_ROOT / "scripts" / "transcript-push.sh").read_text())
+    # 🔴 HYPHENS. `scripts/lib` really holds `host-role.sh`, and the first version
+    # of this pattern was `[a-z_][a-z0-9_]*`, which cannot match one — a mutant
+    # adding exactly that dependency SURVIVED. A filename character class is a
+    # place to be generous: the `.exists()` filter below is what makes a match
+    # real, so widening it costs nothing and narrowing it loses whole files.
+    from_shell = {m for m in re.findall(r"/lib/([A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh))", shell)
+                  if (libdir / m).exists()}
 
-    # 🔴 POSITIVE CONTROL, AND IT EARNED ITS KEEP IMMEDIATELY. A scanner that
-    # matches nothing yields an empty `missing` and PASSES — the same reassuring
-    # zero this arc has been bitten by repeatedly. Both names below are known to
-    # be real dependencies, one per mechanism, so this fails if either scanner
-    # stops measuring.
-    assert {"transcript_search.py", "host_label.py"} <= needed, (
-        f"the dependency scanner found {sorted(needed)} — it is not measuring the "
-        "unit's real dependencies, so its verdict is about the regex")
+    # (c) the third runnable file's own imports.
+    from_host_label = _lib_modules_a_python_file_imports(libdir / "host_label.py", libdir)
+
+    # 🔴 ONE CONTROL PER ARM. Each names a dependency only THAT arm can see, so a
+    # single dead scanner fails here instead of hiding behind another's hit.
+    assert "transcript_search.py" in from_builder, (
+        f"the BUILDER arm found {sorted(from_builder)} — it is not reading the "
+        "builder's imports, so its verdict is about the parser")
+    assert "host_label.py" in from_shell, (
+        f"the SHELL arm found {sorted(from_shell)} — it is not reading executable "
+        "shell code (the builder never imports host_label, so no other arm covers it)")
+    # (c) has no dependency to sentinel today: host_label.py imports only stdlib.
+    # Asserting a name here would be asserting a fixture, so instead pin the
+    # PROPERTY that makes its emptiness meaningful — the file parsed at all.
+    assert from_host_label == set(), (
+        f"host_label.py now imports {sorted(from_host_label)} from scripts/lib. That is "
+        "fine, but it must be declared as a trigger and this assertion updated — the "
+        "point is that its imports are READ, not that they are empty")
+
+    needed = from_builder | from_shell | from_host_label
 
     block = _unit_block()
     m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1285,9 +1285,12 @@ def _strip_shell_comments(src):
     in_comment = False
     sub_depth = 0
     tick_depth = 0
-    heredoc_term = None      # set at `<<WORD`, consumed at the next newline
+    heredoc_terms = []       # set at `<<WORD`, consumed at the next newline
     heredoc_active = None
+    heredoc_dash = False
+    unmodelled = False       # a construct this walk cannot lex -> refuse to strip
     prev_closed_group = False   # a `)` or backtick that CLOSED — mid-word
+    saw_subst = False           # a substitution opened on this line (see below)
     prev_was_escape = False
     after_join = False          # a backslash-newline was just consumed
 
@@ -1301,8 +1304,15 @@ def _strip_shell_comments(src):
                 j = n
             line = src[i:j]
             out.append(line)
-            if line.strip() == heredoc_active:
-                heredoc_active = None
+            # 🔴 EXACT MATCH, not `.strip()`. bash allows leading whitespace on the
+            # terminator ONLY under `<<-`, and then only TABS. `.strip()` ended a
+            # heredoc early on a space-indented `  EOF`, after which the remaining
+            # BODY was lexed as shell and its `#` lines removed — an over-strip.
+            if (line.lstrip("\t") if heredoc_dash else line) == heredoc_active:
+                # `cmd <<A <<B` runs the bodies BACK TO BACK, with no intervening
+                # newline for the main loop to pop the queue at — so the second
+                # body was lexed as shell. Pull the next terminator right here.
+                heredoc_active = heredoc_terms.pop(0) if heredoc_terms else None
             if j < n:
                 out.append("\n")
             i = j + 1
@@ -1311,10 +1321,11 @@ def _strip_shell_comments(src):
         if c == "\n":
             # A comment ENDS at the newline no matter what preceded it.
             in_comment = False
-            if heredoc_term is not None:
-                heredoc_active, heredoc_term = heredoc_term, None
+            if heredoc_terms:
+                heredoc_active = heredoc_terms.pop(0)
             out.append(c)
-            prev_closed_group = prev_was_escape = False
+            prev_closed_group = prev_was_escape = after_join = False
+            saw_subst = False
             i += 1
             continue
 
@@ -1371,7 +1382,7 @@ def _strip_shell_comments(src):
             # `)` is a word start (`(true)# x` is a comment), while a `)` that
             # closed `$(`/`$((` is mid-word (`$(true)#x` is one word).
             or (prev in " \t;|&()" and not prev_was_escape)
-            or (prev == "`" and not prev_closed_group)
+            or (prev == "`" and not prev_closed_group and not prev_was_escape)
         )
         was_escape, closed_group = prev_was_escape, prev_closed_group
         prev_was_escape = prev_closed_group = after_join = False
@@ -1394,21 +1405,41 @@ def _strip_shell_comments(src):
             i += 2
             prev_was_escape = True
             continue
-        elif c == "<" and src[i : i + 2] == "<<" and heredoc_term is None:
-            m = re.match(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", src[i:])
+        elif c == "<" and src[i : i + 2] == "<<" and src[i : i + 3] != "<<<":
+            # 🔴 A QUEUE, BECAUSE `cmd <<A <<B` IS TWO HEREDOCS. The single-slot
+            # version armed only the first, and the SECOND body was lexed as
+            # shell — an over-strip on data.
+            m = re.match(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2", src[i:])
             out.append(c)
             if m:
-                heredoc_term = m.group(2)
+                heredoc_dash = bool(m.group(1))
+                heredoc_terms.append(m.group(3))
+            else:
+                # `<<\EOF`, `<<$VAR`, `<< "a b"` … forms this walk cannot resolve.
+                # Refusing to strip the WHOLE source is the loud direction; lexing
+                # a body we failed to arm is the silent one.
+                unmodelled = True
         elif c == "`":
             tick_depth ^= 1
             if tick_depth == 0:
                 prev_closed_group = True
             out.append(c)
-        elif c == "(" and (prev == "$" or (prev == "(" and sub_depth)):
+        elif c == "(" and (prev == "$" or sub_depth or (prev is not None and prev in "<>")):
+            # Every `(` inside a substitution counts, and `<(`/`>(` open one too.
+            # Counting only `$(`/`((` left a plain subshell `$( (cd /) )` and a
+            # process substitution `<(echo z)` with an UNPAIRED closer.
             sub_depth += 1
+            saw_subst = True
             out.append(c)
-        elif c == ")" and sub_depth:
-            sub_depth -= 1
+        elif c == ")" and (sub_depth or saw_subst):
+            # 🔴 `saw_subst` IS THE FAIL-SAFE, AND IT IS DELIBERATELY ONE-WAY. A
+            # `case` pattern's `)` inside `$( … )` is genuinely unbalanced, so no
+            # counter can pair it. Once a substitution has opened on this line,
+            # EVERY later `)` is treated as mid-word — which KEEPS a following
+            # `#`. That is the loud direction; the alternative was a silent
+            # over-strip on ordinary shell.
+            if sub_depth:
+                sub_depth -= 1
             prev_closed_group = True
             out.append(c)
         elif c == "#" and at_word_start and not closed_group:
@@ -1417,6 +1448,11 @@ def _strip_shell_comments(src):
             out.append(c)
         i += 1
 
+    if unmodelled:
+        # Every unmodelled construct becomes an UNDER-strip (a phantom
+        # requirement — loud) instead of a silent over-strip. Structural, so it
+        # covers shapes nobody enumerated.
+        return src
     return "".join(out)
 
 
@@ -1432,6 +1468,14 @@ def _strip_shell_comments(src):
         ("a SUBSHELL's `)#`", "(true)# /lib/MARK.py", False),
         ("a comment after a multi-line string closes",
          'echo "one\ntwo" # /lib/MARK.py', False),
+        # 🔴 THREE MECHANISMS THE DOCSTRING ASSERTED AS MEASURED AND NO ROW
+        # COVERED. Each was found by mutating the walk and watching every row
+        # stay green: deleting `(` from the word-start set, deleting the opening-
+        # backtick clause, and replacing `prev == "\n"` with `or False` — the
+        # last of which does almost all the real work on the actual script.
+        ("a full-line comment on line >= 2", "echo one\n# /lib/MARK.py", False),
+        ("a bare `(` is a word start", "echo a (# /lib/MARK.py", False),
+        ("an unquoted OPENING backtick", "echo `#/lib/MARK.py`", False),
         # --- bash KEEPS these as executable text: removing the marker would be
         #     an OVER-strip, which hides a dependency and passes the ledger ---
         ("`X=y#foo` is one word", "F=/lib/MARK.py#tag", True),
@@ -1455,6 +1499,21 @@ def _strip_shell_comments(src):
         ("inside a multi-line \"...\"", 'echo "one\n# /lib/MARK.py\nthree"', True),
         ("inside a multi-line '...'", "echo 'one\n# /lib/MARK.py\nthree'", True),
         ("a backslash-newline continuation joins", "echo abc\\\n#/lib/MARK.py", True),
+        # 🔴 SEVEN MEASURED OVER-STRIPS FROM ONE AUDIT ROUND, EVERY ONE A GROUP
+        # DELIMITER THE COUNTER COULD NOT PAIR. They are the reason the walk now
+        # fails SAFE (see `saw_subst` and `unmodelled`) instead of enumerating.
+        ("a plain subshell inside $( )", "V=$( (cd / && pwd) )#/lib/MARK.py", True),
+        ("a case pattern's ) inside $( )",
+         "V=$(case a in b) echo Z;; esac)#/lib/MARK.py", True),
+        ("a nested ( inside $(( ))", "echo $(( (1+2)*3 ))#/lib/MARK.py", True),
+        ("a process substitution <( )", "wc -l <(echo z)#/lib/MARK.py", True),
+        ("an ESCAPED backtick is not an opening one", "echo x\\`#/lib/MARK.py", True),
+        ("TWO heredocs on one line", "cat <<A <<B\nx\nA\n# /lib/MARK.py\nB", True),
+        ("a backslash-quoted heredoc terminator",
+         "cat <<\\EOF\n# /lib/MARK.py\nEOF", True),
+        ("a variable heredoc terminator", "T=EOF; cat <<$T\n# /lib/MARK.py\nEOF", True),
+        ("a space-indented terminator does NOT end <<EOF",
+         "cat <<EOF\nbody\n  EOF\n# /lib/MARK.py\nEOF", True),
     ],
 )
 def test_the_shell_comment_stripper_AGREES_WITH_BASH(name, text, marker_survives):

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1107,6 +1107,7 @@ def test_the_RESIDENT_agent_restart_triggers_name_EVERY_module_it_imports():
     want = {
         "scripts/tmux-reply-agent",
         "scripts/lib/tmux_text_policy.py",
+        "scripts/lib/host_label.py",
         "scripts/lib/transcript_stream.py",
         "scripts/lib/transcript_search.py",
     }
@@ -1132,7 +1133,15 @@ def test_every_module_the_agent_loads_by_path_IS_a_restart_trigger():
     assert loaded, "the scanner found no path-loaded modules — it is measuring nothing"
 
     stream = (REPO_ROOT / "scripts" / "lib" / "transcript_stream.py").read_text()
-    loaded |= set(re.findall(r'os\.path\.join\(_HERE,\s*"([^"]+\.py)"\)', stream))
+    transitive = set(re.findall(r'os\.path\.join\(_HERE,\s*"([^"]+\.py)"\)', stream))
+    # 🔴 A POSITIVE CONTROL ON THE TRANSITIVE HOP TOO. The agent scan above has
+    # one; this one did not, so if its regex ever stopped matching,
+    # transcript_search.py would silently drop out of `loaded`, `missing` would be
+    # empty, and this test would PASS while the exact gap it exists to close
+    # reopened.
+    assert transitive, ("the transitive scanner found no path-loaded modules in "
+                        "transcript_stream.py — it is measuring nothing")
+    loaded |= transitive
 
     block = _reply_agent_unit_block()
     m = re.search(r"X-Restart-Triggers = \[(.*?)\]", block, re.S)
@@ -1267,3 +1276,115 @@ def test_ONE_oversized_session_alone_is_still_sent_rather_than_dropped_for_ever(
         "a session larger than the whole budget was dropped rather than sent alone — it is "
         "the newest file, so it would be dropped first on every tick, for ever"
     )
+
+
+# ---------------------------------------------------------------------------
+# THE CROSS-FEEDER HOST SEAM.
+#
+# 🔴 THE TWO FEEDERS WRITE THE SAME ROW'S `host` COLUMN, AND NOTHING PINNED THEM
+# TOGETHER. This push derived it in shell (falling through to `uname -n`, which is
+# "nixos" on BOTH machines); tmux-reply-agent read the collector's env file and
+# said "workbench". The disagreement was free while `host` was display-only — the
+# stored rows just said "nixos", uselessly — and became a PERMANENT REFUSAL the
+# moment the delta stream made `host` a correctness predicate: every 5-minute
+# push stamping `nixos` back, every 5-second poll reseeding because "the host
+# changed". Caught before deploy, with both values measured side by side.
+# ---------------------------------------------------------------------------
+
+
+def _host_label_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "host_label_under_test", REPO_ROOT / "scripts" / "lib" / "host_label.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _agent_module():
+    import importlib.machinery
+    import importlib.util
+
+    path = str(REPO_ROOT / "scripts" / "tmux-reply-agent")
+    loader = importlib.machinery.SourceFileLoader("tmux_reply_agent_hostseam", path)
+    spec = importlib.util.spec_from_file_location("tmux_reply_agent_hostseam", path, loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("env_body,want", [
+    ('ACTIVITY_HOST=laptop\n', "laptop"),
+    ('ACTIVITY_HOST="workbench"\n', "workbench"),
+    ('ACTIVITY_HOST=not-a-real-host\n', "workbench"),   # invalid -> default
+    ('', "workbench"),                                    # absent -> default
+])
+def test_BOTH_feeders_resolve_the_SAME_host_label(server, projects, tmp_path, env_body, want):
+    """🔴 THE ASSERTION IS THAT THE TWO AGREE, NOT THAT EITHER IS RIGHT. Pinning
+    each side to a literal separately is what let them drift: both tests would
+    stay green while the two values differed.
+
+    The push is driven end to end (so the SHELL's resolution is what is measured,
+    not a Python restatement of it) and compared with what the agent computes from
+    the same file.
+    """
+    env_file = tmp_path / "activity-env"
+    env_file.write_text(env_body)
+
+    agent = _agent_module()
+    agent_label = agent.local_host_label(env={}, env_file=str(env_file))
+
+    # The shell half, through the real script. TRANSCRIPT_PUSH_HOST is deliberately
+    # NOT set — that override is what the other tests use, and using it here would
+    # bypass the very resolution under test.
+    projects("host-seam", transcript("host-seam", human_turn("hi", "host-seam")))
+    conf = tmp_path / "clawgate.env"
+    conf.write_text("")
+    env = dict(os.environ)
+    for k in ("CLAWGATE_API_URL", "CLAWGATE_HOOK_TOKEN", "ACTIVITY_HOST", "TRANSCRIPT_PUSH_HOST"):
+        env.pop(k, None)
+    env.update({
+        "CLAWGATE_CONF_FILE": str(conf),
+        "CLAUDE_PROJECTS_DIR": str(projects.root),
+        "HOME": str(tmp_path),
+        "CLAWGATE_API_URL": base_url(server),
+        "CLAWGATE_HOOK_TOKEN": "t",
+        # Point the shared module at the fixture's env file.
+        "HOST_LABEL_ENV_FILE": str(env_file),
+    })
+    proc = subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True,
+                          env=env, timeout=180)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    pushed = json.loads(pushes(server)[0]["body"])["host"]
+
+    assert agent_label == want, f"the agent resolved {agent_label!r}, want {want!r}"
+    assert pushed == agent_label, (
+        f"the two feeders that write the SAME row disagree about this host: the bulk push says "
+        f"{pushed!r}, the stream agent says {agent_label!r}. Since `host` became a correctness "
+        f"predicate, that difference is a permanent reseed loop — the push stamping one value "
+        f"back every 5 minutes and the stream refusing every append 5 seconds later."
+    )
+
+
+def test_the_push_REFUSES_rather_than_guessing_when_the_label_cannot_be_resolved(
+    server, projects, tmp_path
+):
+    """🔴 A FALLBACK IS WHAT PRODUCED THE DEFECT. `uname -n` returns a plausible
+    name on both machines, so the old fallback failed silently and looked correct.
+    Exiting is loud and cannot be mistaken for a working feed.
+    """
+    projects("s", transcript("s", human_turn("hi")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_HOST": "",  # the override is empty, so resolution runs
+            "TRANSCRIPT_PUSH_HOST_LABEL": str(tmp_path / "no-such-module.py"),
+        },
+    )
+    assert proc.returncode == 3, f"rc={proc.returncode}: {proc.stdout}{proc.stderr}"
+    assert "refusing to push under a guessed name" in proc.stdout
+    assert not pushes(server), "a push went out under a guessed host name"

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1226,51 +1226,110 @@ def _lib_modules_a_python_file_imports(path, libdir):
     return found
 
 
+def _join_line_continuations(src):
+    r"""Join backslash-newline continuations, which bash joins BEFORE lexing.
+
+    Round 15 found this as an OVER-strip: `echo abc\` + a next line starting `#`
+    is ONE WORD to bash (`abc#...`), not a comment, and the per-line walk deleted
+    the second line outright. Latent — 21 continuations exist in
+    `transcript-push.sh` and none is followed by a `#` line — but it is the
+    false-PASS direction, so it is closed rather than documented.
+
+    An ODD number of trailing backslashes continues; an even number is escaped
+    backslashes and does not.
+    """
+    out, buf = [], ""
+    for line in src.splitlines():
+        trailing = len(line) - len(line.rstrip("\\"))
+        if trailing % 2 == 1:
+            buf += line[:-1]
+            continue
+        out.append(buf + line)
+        buf = ""
+    if buf:
+        out.append(buf)
+    return out
+
+
 def _strip_shell_comments(src):
-    """Shell source with comments removed, quote-aware, so a scanner sees CODE.
+    r"""Shell source with comments removed, quote-aware, so a scanner sees CODE.
 
-    🔴 THE FIRST VERSION WAS A PAIR OF REGEXES AND WAS WRONG IN BOTH DIRECTIONS.
-    It stripped a full-line `#` and `\\s#.*$`, which is neither necessary nor
-    sufficient, and its docstring claimed the error was one-directional and safe.
-    Measured, both directions produce a wrong verdict:
+    🔴 A REGEX PAIR WAS WRONG IN BOTH DIRECTIONS AND ITS DOCSTRING CALLED THE
+    ERROR ONE-DIRECTIONAL AND SAFE. Measured against bash, a real executable line
+    resolving `scripts/lib/host-role.sh` that also carried a quoted `#` was
+    truncated at that `#` — an UNDECLARED dependency vanished and the guard went
+    GREEN (false PASS); and `echo A;# x`, `|#`, `&&#`, `)#` are all comments to
+    bash, so keeping them minted PHANTOM requirements (false FAIL).
 
-      OVER-strip (the dangerous one — it PASSES). A real executable line that
-      resolves `scripts/lib/host-role.sh` and also carries a quoted `#`:
-
-          printf "fmt: a #b\\n"; ROLE="$(... /lib/host-role.sh)"
-
-      was truncated at the quoted `#`, so an UNDECLARED dependency vanished and
-      the guard went green. The same line without the quoted `#` fails correctly.
-      The claim that the per-arm controls turn this into a failure is false: they
-      pin two named modules, and ANY OTHER module lost this way is a silent pass.
-
-      UNDER-strip (loud, but it is the very defect round 12 reported fixed).
-      Confirmed against bash itself — `echo A;# x` and `echo B |# x` both comment
-      out — but `\\s#` matches neither, so:
-
-          echo A;#  see scripts/lib/agent_ledger.py     -> minted a PHANTOM
-          echo B |# scripts/lib/agent_ledger.py            requirement for a file
-          true &&#  scripts/lib/agent_ledger.py            the script never opens
-
-    So this walks the line: `#` opens a comment only OUTSIDE quotes and only at
-    the start of a word — start of line, or after whitespace or one of `;|&()`.
+    So: `#` opens a comment only OUTSIDE quotes and only at the start of a word.
     `X=y#foo` is left alone, because bash does not treat that as a comment either.
 
-    ⚠ WHAT IT STILL DOES NOT MODEL: a here-document body. A `#` line inside a
-    `<<EOF` block is content, not a comment, and would be stripped; a `/lib/x.py`
-    mentioned in prose inside one would not be. `transcript-push.sh` contains no
-    heredoc today (`grep -nE '<<|;#|\\|#|&&#'` finds nothing), which is why this
-    is recorded as a limit rather than implemented — but it IS a limit, and the
-    previous version of this docstring is the reason to write it down.
+    🔴 QUOTE STATE CARRIES ACROSS LINES. Round 15's finding, and the one that
+    mattered most: a bash string can span newlines, so re-initialising per line
+    made a `#`-leading line INSIDE a multi-line string look like a comment — the
+    false-PASS direction again — while the line AFTER a closing quote read that
+    quote as an opening one and kept a real trailing comment (false FAIL). Both
+    are gone now that the walk threads its state.
+
+    ⚠ I EXPECTED THIS FIX TO POISON THE REAL FILE AND IT DOES NOT — measured, not
+    assumed. `transcript-push.sh` has two lines with an odd `"` count and fifteen
+    with an odd `'`, which looks like it would leave the walk permanently "inside
+    a string"; every one of them is a FULL-LINE `#` comment, where the walk breaks
+    at column 0 before any quote is read. Real-tree output is unchanged.
+
+    ⚠ WHAT IT STILL DOES NOT MODEL — enumerated by running each shape against
+    bash, and every one is LATENT (absent from `transcript-push.sh` today):
+
+      a here-document body            `#` line inside `<<EOF` is content, not a
+                                      comment  (0 heredocs in the file)
+      `$'…'` ANSI-C quoting           `\'` is an escape there but not in plain
+                                      `'…'`, so the walk mis-pairs  (0 occurrences)
+      `#` inside `$(…)`/backticks
+      that sit inside double quotes   bash resets the quoting context; the walk
+                                      treats `"` as suppressing comments outright
+
+    All three of those remaining are the false-FAIL direction (a phantom
+    requirement), which is LOUD. The false-PASS shapes round 15 found — the
+    multi-line string, an escaped word-separator, a `)` closing a substitution,
+    and a line continuation — are fixed above and below, because a silent pass is
+    exactly what this guard exists to prevent.
     """
     out = []
-    for line in src.splitlines():
+    in_single = in_double = False
+    for line in _join_line_continuations(src):
         res = []
-        in_single = in_double = False
         i = 0
+        sub_depth = 0
+        prev_was_escape = False
+        prev_closed_sub = False
         while i < len(line):
             c = line[i]
-            prev = line[i - 1] if i else None
+            # 🔴 `prev` MUST NOT BE THE RAW PREVIOUS CHARACTER. Round 15: in
+            # `echo a\\ #x` the `\\ ` is consumed as an escaped SPACE, so re-reading
+            # line[i-1] saw a space and called the `#` a word start — to bash it is
+            # one word. Same for a `)` that closed a `$(…)`: `$(true)#x` is one
+            # word, while a subshell `(true)#x` really is a comment. Both are
+            # tracked as flags rather than re-read from the raw line.
+            prev = None if i == 0 else line[i - 1]
+            at_word_start = (
+                i == 0
+                # 🔴 THE SET IS CHOSEN BY A SAFETY ASYMMETRY, NOT BY COMPLETENESS.
+                # Omitting a character that bash WOULD treat as a comment start
+                # mints a phantom requirement — loud, and a human sees it. Adding
+                # one bash does NOT hides a real dependency — silent, and it is
+                # the exact failure this guard exists to prevent. So a character
+                # goes in only once measured as a comment start in a REALISTIC
+                # shape. Probed individually against bash:
+                #     ; | & ` and whitespace -> comment      (in)
+                #     < >                    -> NOT a comment (OUT: including
+                #                               them was a measured over-strip)
+                #     ) }                    -> context-dependent; the realistic
+                #                               shapes `(true)#` and `{ …; }#`
+                #                               ARE comments, so they stay in
+                or (prev in " \t;|&()}`" and not prev_was_escape and not prev_closed_sub)
+            )
+            prev_was_escape = False
+            prev_closed_sub = False
             if in_single:
                 res.append(c)
                 in_single = c != "'"
@@ -1279,6 +1338,7 @@ def _strip_shell_comments(src):
                 if c == "\\" and i + 1 < len(line):
                     i += 1
                     res.append(line[i])
+                    prev_was_escape = True
                 elif c == '"':
                     in_double = False
             elif c == "'":
@@ -1291,13 +1351,75 @@ def _strip_shell_comments(src):
                 res.append(c)
                 i += 1
                 res.append(line[i])
-            elif c == "#" and (prev is None or prev in " \t;|&()"):
+                prev_was_escape = True
+            elif c == "(" and (prev == "$" or (prev == "(" and sub_depth)):
+                # Only `$(` opens a substitution — a bare `(` is a SUBSHELL, whose
+                # `)` IS a word start (`(true)# x` is a comment to bash). `$((`
+                # pushes twice so both of `))` are consumed as closers.
+                sub_depth += 1
+                res.append(c)
+            elif c == ")" and sub_depth:
+                sub_depth -= 1
+                prev_closed_sub = True
+                res.append(c)
+            elif c == "#" and at_word_start:
                 break
             else:
                 res.append(c)
             i += 1
         out.append("".join(res))
     return "\n".join(out)
+
+
+@pytest.mark.parametrize(
+    "name,text,marker_survives",
+    [
+        # 🔴 EVERY ROW'S EXPECTATION WAS TAKEN FROM BASH, NOT FROM READING THE
+        # WALK. The probe was `<line-with-MARKER>; echo SAW` on ONE line: if bash
+        # swallows the same-line `; echo SAW` and never prints MARKER, it is a
+        # comment. `; echo SAW` on the NEXT line always runs and measures nothing
+        # — which is exactly how the first version of that harness was wrong.
+        ("a full-line comment", "# /lib/MARK.py", False),
+        ("a trailing comment", "echo hi   # /lib/MARK.py", False),
+        ("`;#` with no space", "echo A;# /lib/MARK.py", False),
+        ("`|#` with no space", "echo B |# /lib/MARK.py", False),
+        ("`&&#` with no space", "true &&# /lib/MARK.py", False),
+        ("a subshell's `)#`", "(true)# /lib/MARK.py", False),
+        ("`}` closing a group", "{ echo a; }# /lib/MARK.py", False),
+        # --- the false-PASS shapes: bash keeps these, so the walk must too ---
+        ("`X=y#foo` is one word", "F=/lib/MARK.py#tag", True),
+        ("a QUOTED # then real code", 'printf "a #b\\n"; R=/lib/MARK.py', True),
+        ("an ESCAPED word-separator", "echo a\\ #/lib/MARK.py", True),
+        ("`)` closing a $(...)", "echo $(true)#/lib/MARK.py", True),
+        ("`)` closing a $((...))", "echo $((1+2))#/lib/MARK.py", True),
+        ("`>` is NOT a comment start", "echo hi ># /lib/MARK.py", True),
+        ("inside a multi-line \"...\"", 'echo "one\n# /lib/MARK.py\nthree"', True),
+        ("inside a multi-line '...'", "echo 'one\n# /lib/MARK.py\nthree'", True),
+        ("a backslash-newline continuation", "echo abc\\\n#/lib/MARK.py", True),
+        # --- and one the other way, after a string CLOSES ---
+        ("a comment after a multi-line string closes",
+         'echo "one\ntwo" # /lib/MARK.py', False),
+    ],
+)
+def test_the_shell_comment_stripper_AGREES_WITH_BASH(name, text, marker_survives):
+    """🔴 THE STRIPPER IS A NO-OP ON THE REAL SCRIPT TODAY, SO NOTHING EXERCISED
+    IT. `transcript-push.sh` yields the same module set stripped, unstripped, and
+    under the old regex version — so every defect it has ever had was found by a
+    throwaway harness and then had no permanent guard. Its worth is entirely
+    prospective, which is precisely the code that rots unwatched.
+
+    Two rewrites and two audit rounds produced these rows. Each is a shape where
+    a previous version disagreed with bash; roughly half are the OVER-strip
+    direction, where a real `scripts/lib` dependency silently vanished and the
+    ledger passed GREEN — the failure this whole guard exists to prevent.
+    """
+    kept = "MARK.py" in _strip_shell_comments(text)
+    assert kept is marker_survives, (
+        f"{name}: bash {'keeps' if marker_survives else 'comments out'} the marker, "
+        f"but the stripper {'kept' if kept else 'removed'} it. "
+        + ("An OVER-strip hides a real dependency and the ledger passes green."
+           if marker_survives else
+           "An UNDER-strip mints a requirement for a file the script never opens."))
 
 
 def test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger():

--- a/scripts/tests/test_transcript_stream.py
+++ b/scripts/tests/test_transcript_stream.py
@@ -862,6 +862,33 @@ def test_at_least_one_reseed_padding_actually_lands_MID_RUNE(tmp_path):
         "reached and its test is vacuous")
 
 
+def test_a_reseed_of_an_UNTERMINATED_OVER_WINDOW_record_still_streams(tmp_path):
+    """🔴 THE OTHER SIDE OF `start == 0`, AND IT WAS UNPINNED. Narrowing the wait
+    to `start == 0` is what stops a fragment being shipped where no stall is
+    possible; WIDENING it back to every no-newline window reintroduces the
+    permanent reseed loop, and the existing loop test could not see that because
+    its 100 KiB fixture record is newline-TERMINATED, so `rfind` succeeds and the
+    branch is never reached.
+
+    Measured with the widened branch: `deltas=0 skipped={'no-record-boundary': 1}`
+    on every poll — and `plan_frame` cannot leave the reseed branch until a cursor
+    is adopted, so that is the loop.
+    """
+    d = tmp_path / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    # An over-window record with NO terminating newline: still being written.
+    body = '{"type":"user","t":"' + ("y" * (3 * ts.RESEED_TAIL_BYTES))
+    (d / "sess-1.jsonl").write_text(body, encoding="utf-8")
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    assert len(deltas) == 1, (
+        f"an UNTERMINATED record larger than the window produced no reseed — this is the "
+        f"permanent loop, and the newline-terminated fixture cannot see it: {skipped}")
+    assert deltas[0]["reset"] is True
+    assert deltas[0]["offset"] > 0, "the reseed did not start inside the record"
+
+
 def test_a_reseed_of_an_IN_FLIGHT_FIRST_LINE_waits_rather_than_shipping_a_fragment(tmp_path):
     """🔴 THE CONTROL THE RESEED PATH DID NOT HAVE. The append path distinguishes
     "this record is bigger than the window" (stream it) from "this line is still

--- a/scripts/tests/test_transcript_stream.py
+++ b/scripts/tests/test_transcript_stream.py
@@ -381,6 +381,22 @@ def test_a_null_offset_is_adopted_as_unknown_rather_than_ignored():
     assert state.cursors["s"] is None
 
 
+def test_any_refusal_carrying_a_NULL_offset_makes_the_host_reseed():
+    """🔴 THE HOST BRANCHES ON THE OFFSET, NOT ON THE REASON STRING, AND THAT IS
+    WHAT MAKES A NEW SERVER-SIDE REASON SAFE. The server grew `host-changed` (a
+    session that moved between machines: its stored offset is a position in the
+    OTHER machine's file). This side needs no new branch — a null offset already
+    means "reseed" — but that has to be ASSERTED, or the next reason added on the
+    server passes unhandled and the host retries against a number that means
+    nothing here.
+    """
+    for reason in ("unknown-offset", "host-changed", "some-reason-invented-later"):
+        state = ts.StreamState()
+        state.cursors["s"] = 500
+        ts.adopt_cursors(state, [{"sessionId": "s", "offset": None, "reason": reason}])
+        assert state.cursors["s"] is None, f"a null offset with reason {reason!r} was not adopted"
+
+
 @pytest.mark.parametrize("bad", [-1, "12", 1.5, True, {"a": 1}])
 def test_a_malformed_offset_is_treated_as_unknown_not_adopted(bad):
     """Adopting a wrong number would splice. Unknown reseeds, which is correct."""
@@ -533,3 +549,289 @@ def test_the_client_bounds_stay_under_the_servers(tmp_path):
     # of the module had RESEED_TAIL_BYTES at 192 KiB, which the server would have
     # rejected on every rotation.
     assert ts.RESEED_TAIL_BYTES <= ts.MAX_DELTA_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Records larger than one delta — the two liveness stalls an adversarial audit
+# proved on the first revision of this module. Both were SILENT: the suite was
+# green, the agent logged nothing, and the affected sessions simply fell back to
+# the 5-minute feed for ever.
+# ---------------------------------------------------------------------------
+
+
+def _huge_record(nbytes: int, tag: str = "big") -> str:
+    """One JSONL record whose payload alone exceeds `nbytes`."""
+    return '{"type":"user","tag":"%s","message":{"role":"user","content":"%s"}}\n' % (
+        tag, "x" * nbytes)
+
+
+def test_a_record_LARGER_than_one_delta_streams_in_pieces_rather_than_stalling(tmp_path):
+    """🔴 PROVED STALL, FIXED. `_read_append` used to require a newline inside the
+    48 KiB window; a record longer than that never has one, so the append path
+    declined EVERY POLL, FOR EVER — re-reading 48 KiB every 5s (~830 MB/day) with
+    nothing logged. The lag escape could not save it either: a record between
+    MAX_DELTA_BYTES and MAX_LAG_BYTES never reaches that threshold.
+
+    It is not an edge case. The server's own trimToTail records the fleet
+    measurement: a single tool-result record here has been measured well past
+    256 KiB. So the sessions with the biggest tool output — the ones most worth
+    streaming — were exactly the ones that silently did not.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    big = _huge_record(100 * 1024)
+    assert len(big.encode()) > ts.MAX_DELTA_BYTES, "the fixture is not bigger than one delta"
+    append(p, big)
+
+    # It must make progress on EVERY poll, and finish.
+    got = b""
+    for i in range(12):
+        deltas, skipped = plan(tmp_path, state)
+        if not deltas:
+            assert got, (
+                f"poll {i}: nothing sent and nothing had been sent — the append path is "
+                f"STALLED on a record larger than one delta; skipped={skipped}")
+            break
+        d = deltas[0]
+        assert d["reset"] is False, "a large record should stream, not reseed"
+        assert d["offset"] == state.cursors["sess-1"], "the piece did not start at the cursor"
+        chunk = d["data"].encode()
+        assert chunk, "an empty delta was produced"
+        got += chunk
+        state.cursors["sess-1"] += len(chunk)
+    assert got.decode() == big, (
+        "the reassembled pieces do not equal the record:\n"
+        f"got {len(got)} bytes, want {len(big.encode())}")
+
+
+def test_every_piece_of_a_split_record_is_valid_UTF8(tmp_path):
+    """🔴 A BYTE CUT INSIDE A MULTI-BYTE RUNE IS THE WHOLE REASON THE NORMAL PATH
+    CUTS ON A NEWLINE. With no newline to cut on, the rune-boundary walk is what
+    keeps `_decode_exact` from rejecting a perfectly good chunk — and, downstream,
+    what keeps the two sides' byte counts equal.
+
+    The fixture is 3-byte runes, so a naive byte cut lands mid-rune 2 times in 3
+    rather than by luck.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    huge = '{"type":"user","t":"' + ("あ" * 60000) + '"}\n'
+    assert len(huge.encode()) > 3 * ts.MAX_DELTA_BYTES, (
+        f"the fixture is {len(huge.encode())} bytes; it must span several deltas "
+        f"({ts.MAX_DELTA_BYTES} each) or the split is never exercised")
+    append(p, huge)
+
+    got = b""
+    for _ in range(20):
+        deltas, _ = plan(tmp_path, state)
+        if not deltas:
+            break
+        d = deltas[0]
+        assert d["reset"] is False, "an APPEND was expected; a reseed means the cursor was lost"
+        piece = d["data"]
+        # A round trip is the claim: had the module cut mid-rune, _decode_exact
+        # would have refused the chunk and the session would be SKIPPED instead.
+        assert piece.encode().decode("utf-8") == piece
+        assert d["offset"] == state.cursors["sess-1"], "a piece did not start at the cursor"
+        got += piece.encode()
+        state.cursors["sess-1"] += len(piece.encode())
+    assert got == huge.encode(), f"reassembled {len(got)} of {len(huge.encode())} bytes"
+
+
+def test_a_file_whose_LAST_record_exceeds_the_window_can_still_reseed(tmp_path):
+    """🔴 THE SECOND PROVED STALL, AND THE WORSE ONE. `_read_reseed` required a
+    newline both before and after its cut, so a file ending in a record bigger
+    than the 48 KiB window returned SKIP — and because `plan_frame` only leaves
+    the reseed branch once a cursor is adopted, and no cursor can be adopted while
+    the reseed declines, it was a PERMANENT RESEED LOOP.
+
+    ⚠ The asymmetry that hid it: `build_transcript_push.read_tail` uses a 192 KiB
+    window, so for last-records between the two sizes the 5-minute push worked
+    perfectly while the stream looped.
+    """
+    body = line(1) + _huge_record(100 * 1024)
+    d = tmp_path / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "sess-1.jsonl").write_text(body, encoding="utf-8")
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    assert len(deltas) == 1, (
+        f"a file ending in an over-window record produced NO reseed — this is the "
+        f"permanent loop: skipped={skipped}")
+    assert deltas[0]["reset"] is True
+    assert deltas[0]["data"], "the reseed carried no data"
+    # The reseed starts inside the record, so it is truncated by construction —
+    # the server marks it and the parser counts a leading partial.
+    assert deltas[0]["offset"] > 0
+
+
+def test_a_partial_line_still_being_WRITTEN_waits_rather_than_being_split(tmp_path):
+    """🔴 THE CONTROL FOR THE TWO TESTS ABOVE, AND IT IS NOT THE SAME CASE. The
+    fix must distinguish "this record is bigger than the window" (stream it) from
+    "this line is still being written" (wait one poll). Reaching EOF inside the
+    window is what tells them apart; without that check, every ordinary in-flight
+    line would be shipped as a fragment.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    append(p, '{"type":"user","partial":tr')  # short, no newline, at EOF
+    deltas, skipped = plan(tmp_path, state)
+    assert deltas == [], "a short in-flight line was shipped as a fragment"
+    assert skipped.get(ts.SKIP_NO_BOUNDARY) == 1
+
+
+def test_two_files_with_ONE_session_id_do_not_kill_the_whole_frame(tmp_path):
+    """🔴 THE SERVER REJECTS THE WHOLE FRAME ON A DUPLICATE ID, AND THE AGENT
+    RESENDS THE SAME FRAME. Nothing in the loop removes the offending session, so
+    one duplicate would kill this host's stream permanently — not degrade it.
+
+    Two routes, both covered: the same `<uuid>.jsonl` under two project
+    directories, and — because the SERVER trims the id and this side must too —
+    a name with trailing whitespace.
+    """
+    write_session(tmp_path, "projA", "dup-sess", line(1))
+    write_session(tmp_path, "projB", "dup-sess", line(2))
+    write_session(tmp_path, "projA", "dup-sess ", line(3))
+    write_session(tmp_path, "projA", "unique", line(4))
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    ids = [d["sessionId"] for d in deltas]
+    assert len(ids) == len(set(ids)), f"a frame carried a duplicate session id: {ids}"
+    assert "unique" in ids, "the innocent session was dropped too"
+    assert skipped.get(ts.SKIP_DUPLICATE_ID, 0) >= 2, (
+        f"the duplicates were not counted under their own reason: {skipped}")
+
+
+def test_the_candidate_limit_bounds_how_many_files_are_stat_ed(tmp_path):
+    """A declared bound with no test is a claim. This one keeps a host with
+    thousands of recent transcripts from stat'ing all of them every 5 seconds."""
+    for i in range(40):
+        write_session(tmp_path, "proj", f"sess-{i:04d}", line(i))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state, max_candidates=7)
+    assert len(deltas) == 7, f"max_candidates=7 produced {len(deltas)} deltas"
+
+
+def test_the_inode_memory_is_BOUNDED(tmp_path):
+    """`cursors` is wholesale-replaced on every re-hydration; `inodes` is not, so
+    in a process that runs for weeks it is the one that leaks. Eviction costs the
+    evicted session exactly one reseed."""
+    state = ts.StreamState()
+    for i in range(state.INODE_LIMIT + 50):
+        state.note_inode(f"s{i}", i)
+    assert len(state.inodes) <= state.INODE_LIMIT
+    # Oldest-first, so the NEWEST is the one that survives.
+    assert f"s{state.INODE_LIMIT + 49}" in state.inodes
+    assert "s0" not in state.inodes
+
+
+def test_a_huge_record_converges_END_TO_END_against_the_protocol(tmp_path):
+    """🔴 THE PIECES MUST REASSEMBLE ON THE SERVER, NOT MERELY LEAVE THIS HOST.
+    Splitting a record mid-way is only safe because the server concatenates by
+    OFFSET; a rune-alignment that moved the data without moving the offset by the
+    same number of bytes would produce a tail that is subtly wrong and reads as
+    fine. This drives the real `run_round` against the protocol and compares the
+    stored tail with the file.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    srv = FakeServer()
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+
+    append(p, '{"type":"user","t":"' + ("あ" * 60000) + '"}\n')
+    for _ in range(20):
+        counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+        if counts["sent"] == 0:
+            break
+    assert srv.tails["sess-1"] == p.read_text(), (
+        "a record split across deltas did not reassemble on the server\n"
+        f"stored {len(srv.tails['sess-1'])} chars, file {len(p.read_text())} chars")
+    assert srv.offsets["sess-1"] == len(p.read_bytes()), (
+        f"cursor {srv.offsets['sess-1']} != file size {len(p.read_bytes())} — the offset and "
+        "the data disagree, so the NEXT delta would splice")
+
+
+def _cjk_body(pad: int) -> str:
+    """One huge CJK record, with `pad` filler bytes AFTER the runes so the rune
+    grid moves relative to the reseed window."""
+    return '{"t":"' + ("あ" * 60000) + '"' + ("z" * pad) + "}\n"
+
+
+@pytest.mark.parametrize("pad", [0, 1, 2])
+def test_a_RESEED_that_starts_mid_rune_moves_its_OFFSET_by_the_bytes_it_dropped(tmp_path, pad):
+    """🔴 A RESEED SEEKS TO `size - window`, WHICH LANDS INSIDE A RUNE TWO TIMES
+    IN THREE ON CJK TEXT — the one place in this module a read begins at an
+    arbitrary byte offset. Aligning forward to a rune boundary is necessary (a
+    strict decode would otherwise reject the whole window and the session would
+    reseed for ever), but aligning the DATA without moving the OFFSET by the same
+    number of bytes is worse than not aligning at all: the cursor would then name
+    a position the data does not start at, and the next append would splice.
+
+    🔴 THE PADDING IS THE POINT AND THE FIRST VERSION OF THIS TEST DID NOT HAVE
+    IT. With a fixed prefix, `size - window` landed EXACTLY on a rune boundary by
+    arithmetic accident (20 ASCII bytes + 3-byte runes, against a window that is a
+    multiple of 3), so the alignment never ran and deleting it SURVIVED. Three
+    paddings guarantee at least two land mid-rune, and the assertion below proves
+    which case each one reached rather than assuming.
+
+    The claim is the RELATIONSHIP, not the alignment: the bytes at the reported
+    offset in the file must BE the bytes that were sent.
+    """
+    # 🔴 THE PADDING GOES AFTER THE RUNES, NOT BEFORE THEM. A prefix pad shifts
+    # the file length AND the rune grid by the same amount, so `size - window`
+    # stays exactly as aligned as it was — which is how the first version of this
+    # test managed three paddings that all landed on a boundary.
+    body = _cjk_body(pad)
+    d = tmp_path / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "sess-1.jsonl"
+    p.write_text(body, encoding="utf-8")
+    raw = p.read_bytes()
+    assert len(raw) > 3 * ts.RESEED_TAIL_BYTES, "the fixture must be far larger than the window"
+
+    naive = len(raw) - ts.RESEED_TAIL_BYTES
+    mid_rune = raw[naive] & 0xC0 == 0x80
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    assert len(deltas) == 1, f"no reseed was produced: {skipped}"
+    d0 = deltas[0]
+    assert d0["reset"] is True
+    sent = d0["data"].encode("utf-8")
+    off = d0["offset"]
+    assert off > 0, "the fixture did not exercise a mid-file reseed"
+    assert raw[off:off + len(sent)] == sent, (
+        f"the reseed says it starts at byte {off}, but the file's bytes there are not the "
+        f"bytes it sent — the cursor and the data disagree, so the next append would splice "
+        f"(pad={pad}, the naive seek landed mid-rune: {mid_rune})")
+    if mid_rune:
+        assert off > naive, (
+            f"the naive seek at {naive} is INSIDE a rune and the reseed still reports {off} — "
+            "the data was aligned but the offset was not moved with it")
+
+
+def test_at_least_one_reseed_padding_actually_lands_MID_RUNE(tmp_path):
+    """🔴 THE POSITIVE CONTROL FOR THE PARAMETRISED TEST ABOVE. If every padding
+    happened to land on a boundary, all three cases would pass while exercising
+    nothing — which is exactly what the unpadded version did.
+    """
+    hits = 0
+    for pad in (0, 1, 2):
+        raw = _cjk_body(pad).encode("utf-8")
+        naive = len(raw) - ts.RESEED_TAIL_BYTES
+        if raw[naive] & 0xC0 == 0x80:
+            hits += 1
+    assert hits >= 1, (
+        "no padding makes the reseed seek land inside a rune, so the alignment path is never "
+        "reached and its test is vacuous")

--- a/scripts/tests/test_transcript_stream.py
+++ b/scripts/tests/test_transcript_stream.py
@@ -65,7 +65,23 @@ class FakeServer:
     def __init__(self):
         self.tails: dict[str, str] = {}
         self.offsets: dict[str, int | None] = {}
+        self.hosts: dict[str, str] = {}
         self.frames: list[dict] = []
+
+    def bulk_push(self, session_id: str, tail: str, file_bytes, host: str = "workbench"):
+        """The 5-minute reconciler's write, modelled.
+
+        🔴 THIS IS THE WRITER THE FAKE DID NOT HAVE, AND ITS ABSENCE HID A
+        BLOCKER. The two feeders write the same row; nothing on this side modelled
+        the other one, so a disagreement between them (the bulk push stamping a
+        different `host`, or a NULL cursor) was invisible to every test here. It
+        took an adversarial audit reading two units' environment blocks to find
+        it. A fake that models only the writer under test is a fake that cannot
+        see a seam.
+        """
+        self.tails[session_id] = tail[-self.MAX_TAIL:]
+        self.offsets[session_id] = file_bytes  # None = UNKNOWN, as the server stores it
+        self.hosts[session_id] = host
 
     # the two callables run_round expects
     def get(self, path):
@@ -93,17 +109,26 @@ class FakeServer:
                 tail = (self.tails.get(sid, "") and "") + data
                 self.tails[sid] = tail[-self.MAX_TAIL :]
                 self.offsets[sid] = d["offset"] + nbytes
+                self.hosts[sid] = payload["host"]
                 cursors.append({"sessionId": sid, "offset": self.offsets[sid], "reason": "accepted"})
                 continue
             stored = self.offsets.get(sid)
             if stored is None:
                 cursors.append({"sessionId": sid, "offset": None, "reason": "unknown-offset"})
                 continue
+            # 🔴 THE HOST RULE, MODELLED. The stored offset is a position in the
+            # host's file; an append from a DIFFERENT host is refused with a NULL
+            # offset, because handing back a number that belongs to another
+            # machine's file invites the client to retry against nonsense.
+            if self.hosts.get(sid) not in (None, payload["host"]):
+                cursors.append({"sessionId": sid, "offset": None, "reason": "host-changed"})
+                continue
             if d["offset"] != stored:
                 cursors.append({"sessionId": sid, "offset": stored, "reason": "offset-mismatch"})
                 continue
             self.tails[sid] = (self.tails.get(sid, "") + data)[-self.MAX_TAIL :]
             self.offsets[sid] = stored + nbytes
+            self.hosts[sid] = payload["host"]
             cursors.append({"sessionId": sid, "offset": self.offsets[sid], "reason": "accepted"})
         applied = sum(1 for c in cursors if c["reason"] == "accepted")
         return {"ok": True, "applied": applied, "cursors": cursors}
@@ -835,3 +860,150 @@ def test_at_least_one_reseed_padding_actually_lands_MID_RUNE(tmp_path):
     assert hits >= 1, (
         "no padding makes the reseed seek land inside a rune, so the alignment path is never "
         "reached and its test is vacuous")
+
+
+def test_a_reseed_of_an_IN_FLIGHT_FIRST_LINE_waits_rather_than_shipping_a_fragment(tmp_path):
+    """🔴 THE CONTROL THE RESEED PATH DID NOT HAVE. The append path distinguishes
+    "this record is bigger than the window" (stream it) from "this line is still
+    being written" (wait). `_read_reseed` had no such discriminator — it always
+    reaches EOF by construction — so it shipped a fragment even where the
+    justification provably cannot apply: a file SMALLER than the window cannot
+    contain a record larger than the window.
+
+    Measured before the fix: a 61-byte file holding half a record produced
+    `(0, 61, '{"type":"user"…half a r')`. The previous revision waited.
+    """
+    d = tmp_path / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "sess-1.jsonl").write_text('{"type":"user","message":{"role":"user","content":"half a r',
+                                    encoding="utf-8")
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    assert deltas == [], f"a first line still being written was shipped as a fragment: {deltas}"
+    assert skipped.get(ts.SKIP_NO_BOUNDARY) == 1
+
+    # And once it is a whole record, it goes.
+    with (d / "sess-1.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write('ecord"}}\n')
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1 and deltas[0]["reset"] is True
+
+
+def test_an_append_ending_EXACTLY_at_the_window_boundary_still_waits(tmp_path):
+    """🔴 THE ONE POINT `len(raw) < budget` GOT WRONG. A file that ends precisely
+    `budget` bytes past the cursor reads a FULL window that is ALSO the end of the
+    file; the length test then calls it an over-window record and ships a
+    fragment. One chance in 49,152 per poll — and the caller has the exact answer
+    in the `stat` it already took.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    cur = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+    state.cursors["sess-1"] = cur
+
+    budget = 64
+    append(p, "Z" * budget)  # exactly `budget` bytes, no newline, at EOF
+    deltas, skipped = plan(tmp_path, state, max_delta_bytes=budget)
+    assert deltas == [], (
+        f"a line still being written that happened to be EXACTLY the window size was shipped "
+        f"as a fragment: {deltas}")
+    assert skipped.get(ts.SKIP_NO_BOUNDARY) == 1
+
+    # One byte MORE and it is genuinely an over-window record, so it streams.
+    append(p, "Z")
+    deltas, _ = plan(tmp_path, state, max_delta_bytes=budget)
+    assert len(deltas) == 1, "a record that IS bigger than the window did not stream"
+
+
+def test_a_name_that_strips_to_nothing_is_not_counted_as_a_DUPLICATE(tmp_path):
+    """A file called " .jsonl" is not a duplicate of anything. Counting it as one
+    reports the wrong mechanism for the one signal these counters exist to give.
+    """
+    write_session(tmp_path, "proj", " ", line(1))
+    write_session(tmp_path, "proj", "real", line(2))
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    assert [d["sessionId"] for d in deltas] == ["real"]
+    assert skipped.get(ts.SKIP_NO_SESSION_ID) == 1, f"counted as: {skipped}"
+    assert ts.SKIP_DUPLICATE_ID not in skipped
+
+
+def test_note_inode_evicts_LEAST_RECENTLY_SEEN_not_longest_lived(tmp_path):
+    """A plain assignment leaves an existing key at its ORIGINAL position, so
+    eviction would drop the longest-LIVED session — typically the most active
+    one. Unreachable at the shipped limit, and wrong for free if it ever is not.
+    """
+    state = ts.StreamState()
+    state.INODE_LIMIT = 3
+    for sid in ("a", "b", "c"):
+        state.note_inode(sid, 1)
+    state.note_inode("a", 2)   # `a` is now the most recently seen
+    state.note_inode("d", 3)   # forces one eviction
+    assert "a" in state.inodes, "the most recently SEEN session was evicted"
+    assert "b" not in state.inodes, "the least recently seen session survived"
+
+
+def test_a_bulk_push_that_stamps_a_DIFFERENT_host_does_not_wedge_the_stream(tmp_path):
+    """🔴 THE SEAM THAT HID A BLOCKER, NOW DRIVEN END TO END. The two feeders
+    write the same row's `host`, and they used to derive it by different rules —
+    the bulk push falling through to `uname -n` ("nixos" on BOTH machines), the
+    stream reading the collector's label ("workbench"). While `host` was
+    display-only that cost nothing. Once the stream made it a correctness
+    predicate it became a PERMANENT reseed loop: the push stamping one value back
+    every 5 minutes, the stream refusing every append 5 seconds later and
+    reseeding up to 48 KiB per session.
+
+    The rule is now single-sourced (`scripts/lib/host_label.py`, pinned across
+    both feeders by `test_BOTH_feeders_resolve_the_SAME_host_label`). This test
+    covers the OTHER half — that if a host change does happen (a session genuinely
+    resumed on the other machine), the stream RECOVERS in one poll instead of
+    looping.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    srv = FakeServer()
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert srv.hosts["sess-1"] == "workbench"
+    # 🔴 THE HOST MUST HOLD A REAL CURSOR AFTER ONE ROUND. It can only have come
+    # from the RESPONSE — hydration ran against an empty server. Without that
+    # adoption every poll reseeds and the two assertions below become unreachable,
+    # so this is the precondition that makes the rest of the test mean anything.
+    assert state.cursors.get("sess-1") is not None, (
+        "the host did not adopt a cursor from the response, so it reseeds on every poll and "
+        "nothing below is being tested")
+    srv.bulk_push("sess-1", p.read_text(), len(p.read_bytes()), host="nixos")
+
+    append(p, line(3))
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["refused"] == 1, "the host change was not detected at all"
+
+    # ONE more poll and it is back — a bounded gap, not a loop.
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["applied"] == 1, (
+        "the stream did not recover on the next poll — this is the permanent reseed loop, and "
+        "it would repeat after every single bulk tick")
+    assert srv.hosts["sess-1"] == "workbench"
+    assert srv.tails["sess-1"].endswith(line(3))
+
+
+def test_a_bulk_push_with_an_UNKNOWN_cursor_is_recovered_in_one_poll(tmp_path):
+    """The other cross-writer state the fake could not previously model: a bulk
+    push that reports no file size at all (which the real builder does whenever a
+    transcript holds one undecodable byte). The server stores NULL, every append
+    is refused as `unknown-offset`, and the host must RESEED — in one poll."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    srv = FakeServer()
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+
+    srv.bulk_push("sess-1", p.read_text(), None)  # fileBytes UNKNOWN
+
+    append(p, line(3))
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["refused"] == 1
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["applied"] == 1, (
+        "the stream did not recover on the next poll from an unknown cursor")
+    assert srv.tails["sess-1"].endswith(line(3))

--- a/scripts/tests/test_transcript_stream.py
+++ b/scripts/tests/test_transcript_stream.py
@@ -1,0 +1,535 @@
+"""Tests for scripts/lib/transcript_stream.py — the host half of clawgate's
+transcript delta stream.
+
+Every fixture is SYNTHETIC. What these tests need is the record shape and the
+byte arithmetic, not captured text.
+
+🔴 THE SERVER IS SIMULATED FROM THE PROTOCOL, NOT MOCKED TO AGREE. `FakeServer`
+below re-implements the clawgate merge rules — exact-offset-or-refuse, reset
+replaces, refusal returns the STORED offset — because a fake that accepted
+everything would make every resume test here vacuous. Where the two sides could
+drift, the drift shows up as one of these tests failing rather than as a stream
+that silently splices in production.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MODULE = REPO / "scripts" / "lib" / "transcript_stream.py"
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ts = _load(MODULE, "transcript_stream_under_test")
+
+
+def line(n: int) -> str:
+    return (
+        '{"type":"assistant","seq":%d,"message":{"role":"assistant",'
+        '"content":[{"type":"text","text":"turn %d"}]}}\n' % (n, n)
+    )
+
+
+def write_session(root: Path, project: str, sid: str, body: str) -> Path:
+    d = root / project
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{sid}.jsonl"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def append(path: Path, body: str) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(body)
+
+
+class FakeServer:
+    """clawgate's delta merge, re-implemented from the protocol.
+
+    Stores (tail, offset) per session and answers with the authoritative cursor
+    for every session in a frame — accepted or refused.
+    """
+
+    MAX_TAIL = 256 * 1024
+
+    def __init__(self):
+        self.tails: dict[str, str] = {}
+        self.offsets: dict[str, int | None] = {}
+        self.frames: list[dict] = []
+
+    # the two callables run_round expects
+    def get(self, path):
+        assert path == "/api/transcripts/stream/cursors", path
+        return {
+            "sessions": [
+                {
+                    "sessionId": sid,
+                    "offset": off,
+                    "reason": "accepted" if off is not None else "unknown-offset",
+                }
+                for sid, off in self.offsets.items()
+            ]
+        }
+
+    def post(self, path, payload):
+        assert path == "/api/transcripts/stream", path
+        self.frames.append(payload)
+        cursors = []
+        for d in payload["sessions"]:
+            sid = d["sessionId"]
+            data = d["data"]
+            nbytes = len(data.encode("utf-8"))
+            if d.get("reset"):
+                tail = (self.tails.get(sid, "") and "") + data
+                self.tails[sid] = tail[-self.MAX_TAIL :]
+                self.offsets[sid] = d["offset"] + nbytes
+                cursors.append({"sessionId": sid, "offset": self.offsets[sid], "reason": "accepted"})
+                continue
+            stored = self.offsets.get(sid)
+            if stored is None:
+                cursors.append({"sessionId": sid, "offset": None, "reason": "unknown-offset"})
+                continue
+            if d["offset"] != stored:
+                cursors.append({"sessionId": sid, "offset": stored, "reason": "offset-mismatch"})
+                continue
+            self.tails[sid] = (self.tails.get(sid, "") + data)[-self.MAX_TAIL :]
+            self.offsets[sid] = stored + nbytes
+            cursors.append({"sessionId": sid, "offset": self.offsets[sid], "reason": "accepted"})
+        applied = sum(1 for c in cursors if c["reason"] == "accepted")
+        return {"ok": True, "applied": applied, "cursors": cursors}
+
+
+# ---------------------------------------------------------------------------
+# planning
+# ---------------------------------------------------------------------------
+
+
+def test_a_first_sighting_is_a_reseed_not_an_append(tmp_path):
+    """🔴 THE INODE IS THE ONLY THING THAT DISTINGUISHES 'this file grew' FROM
+    'this is a different file at the same path', and on the first sighting there
+    is none. Appending on the server's word alone would take an offset for a file
+    that could have been rotated while this agent was down."""
+    write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    state = ts.StreamState()
+    # The server says it has this session at a known offset...
+    state.cursors["sess-1"] = len(line(1))
+
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1
+    assert deltas[0]["reset"] is True, (
+        "a file this process has never stat'd was APPENDED to on the server's word — "
+        "a rotation while the agent was down would splice two different files"
+    )
+
+
+def plan(root, state, **kw):
+    return ts.plan_frame(root, state, **kw)
+
+
+def test_an_append_carries_exactly_the_new_bytes_from_the_cursor(tmp_path):
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)          # first sighting -> reseed
+    assert deltas[0]["reset"] is True
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    append(p, line(2))
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1
+    d = deltas[0]
+    assert d["reset"] is False
+    assert d["offset"] == len(line(1))
+    assert d["data"] == line(2), "the delta carried something other than exactly the new bytes"
+
+
+def test_an_unchanged_file_produces_no_delta(tmp_path):
+    """A frame with no sessions is REJECTED by the server, so the steady state
+    must produce nothing at all rather than an empty delta."""
+    write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    deltas, skipped = plan(tmp_path, state)
+    assert deltas == []
+    assert skipped.get(ts.SKIP_UNCHANGED) == 1
+
+
+def test_a_trailing_partial_line_waits_for_the_next_poll(tmp_path):
+    """🔴 CUTTING ON A NEWLINE DOES TWO JOBS: no leading JSON fragment in the
+    stored tail, and no multi-byte rune split across two frames."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    append(p, '{"type":"assistant","partial":tr')  # no newline yet
+    deltas, skipped = plan(tmp_path, state)
+    assert deltas == [], "a partial record was sent"
+    assert skipped.get(ts.SKIP_NO_BOUNDARY) == 1
+
+    append(p, 'ue}\n')
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1
+    assert deltas[0]["data"].endswith("true}\n")
+    assert deltas[0]["data"].startswith('{"type":"assistant","partial":')
+
+
+def test_a_truncated_file_reseeds_rather_than_appending(tmp_path):
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2) + line(3))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+    state.inodes["sess-1"] = os.stat(p).st_ino
+
+    p.write_text(line(9), encoding="utf-8")  # same inode, much smaller
+    deltas, _ = plan(tmp_path, state)
+    # 🔴 BOTH FAILURE MODES NAMED, because deleting the truncation check does NOT
+    # produce a wrong append — it produces a read past EOF, which yields NOTHING
+    # and silently stops streaming that session until the reconciler resets it.
+    # An assertion that only said "reset is True" would die with an IndexError
+    # whose message names neither.
+    assert len(deltas) == 1, (
+        f"a SHRUNK file produced {len(deltas)} deltas, want 1 reset — a read past the new EOF "
+        "returns nothing, so this session silently stops streaming"
+    )
+    assert deltas[0]["reset"] is True, "a SHRUNK file was appended to — the stored tail would " \
+        "be the old end plus the new start, spliced"
+    assert deltas[0]["data"] == line(9)
+    assert deltas[0]["offset"] == 0
+
+
+def test_a_ROTATED_file_reseeds_even_though_it_GREW(tmp_path):
+    """🔴 THE CASE A SIZE COMPARISON CANNOT SEE. A recreated file can be LARGER
+    than the old one at the moment it is checked, so 'shrank' reports nothing and
+    the next delta appends the head of a new file onto the tail of an old one."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+    old_inode = state.inodes["sess-1"]
+
+    # Replace the file with a BIGGER one at the same path, new inode.
+    #
+    # 🔴 THE REPLACEMENT IS CREATED WHILE THE OLD FILE STILL EXISTS, then renamed
+    # over it. `unlink` then `create` frees the inode first and the filesystem
+    # HANDS IT STRAIGHT BACK — measured on this host's tmpfs — so the "rotated"
+    # fixture had the SAME inode as before and the test was asserting nothing.
+    other = p.with_suffix(".jsonl.new")
+    other.write_text(line(5) + line(6) + line(7), encoding="utf-8")
+    os.replace(other, p)
+    assert os.stat(p).st_ino != old_inode, "the fixture did not actually change the inode, so " \
+        "this test cannot distinguish rotation from growth"
+
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1
+    assert deltas[0]["reset"] is True, "a ROTATED file that happened to be LARGER was appended to"
+
+
+def test_a_session_that_outruns_the_stream_SKIPS_FORWARD_rather_than_queueing(tmp_path):
+    """🔴 THE BACKPRESSURE BOUND. Replaying an arbitrarily long backlog makes the
+    stream slower the further behind it gets — the shape where a queue never
+    drains. Past MAX_LAG_BYTES the host skips forward with a reset and lets the
+    5-minute reconciler repair the gap."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    lag = 4096
+    big = "".join(line(i) for i in range(2, 2 + (lag // len(line(2))) + 4))
+    append(p, big)
+
+    # AT the bound: still an append, catching up piecewise.
+    deltas, _ = plan(tmp_path, state, max_lag_bytes=len(big) + 1, max_delta_bytes=1024)
+    assert deltas[0]["reset"] is False, "at the lag bound the host should still be appending"
+    assert len(deltas[0]["data"].encode()) <= 1024
+
+    # OVER the bound: skip forward.
+    deltas, _ = plan(tmp_path, state, max_lag_bytes=len(big) - 1, max_delta_bytes=1024)
+    assert deltas[0]["reset"] is True, "a session lagging past the bound kept replaying its " \
+        "backlog — the stream gets slower the further behind it falls"
+    assert deltas[0]["offset"] > 0, "the skip-forward reset claims to start at byte 0"
+
+
+def test_one_delta_never_exceeds_the_per_session_bound(tmp_path):
+    """The server REJECTS a delta over MaxDeltaBytes and a rejection changes
+    nothing, so a client at or over the limit fails every poll while looking
+    correctly configured."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1))
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    state.cursors["sess-1"] = deltas[0]["offset"] + len(deltas[0]["data"].encode())
+
+    append(p, "".join(line(i) for i in range(2, 4000)))
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == 1
+    assert len(deltas[0]["data"].encode()) <= ts.MAX_DELTA_BYTES
+
+
+def test_the_frame_SESSION_COUNT_bound_holds(tmp_path):
+    """🔴 CAPPING THE PER-SESSION SIZE WHILE LEAVING THE SESSION COUNT UNBOUNDED
+    IS NOT A BOUND — the same hole the server's own comments record.
+
+    🔴 THE SESSIONS ARE TINY ON PURPOSE, so this can only fail on the COUNT. With
+    fat sessions the aggregate bound bites first and the count is never reached —
+    measured: a fixture of 73 x ~20 KB sessions SURVIVED a mutant that deleted the
+    count cap entirely, because the byte budget stopped the loop at 19.
+    """
+    body = line(1)
+    n = ts.MAX_SESSIONS_PER_FRAME + 25
+    assert n * len(body.encode()) < ts.MAX_FRAME_BYTES, (
+        "the fixture's total exceeds the aggregate bound, so this test would die to the "
+        "OTHER guard and say nothing about the count"
+    )
+    for i in range(n):
+        write_session(tmp_path, "proj", f"sess-{i:04d}", body)
+
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    assert len(deltas) == ts.MAX_SESSIONS_PER_FRAME, (
+        f"a frame carried {len(deltas)} sessions against a cap of {ts.MAX_SESSIONS_PER_FRAME}"
+    )
+
+
+def test_the_frame_AGGREGATE_BYTE_bound_holds(tmp_path):
+    """🔴 THE OTHER HALF, WITH THE COUNT DELIBERATELY OUT OF REACH. Few enough
+    sessions that the count cap cannot be what stops the loop, each big enough
+    that their sum breaches the aggregate."""
+    body = "".join(line(i) for i in range(600))
+    per = len(body.encode())
+    n = (ts.MAX_FRAME_BYTES // min(per, ts.MAX_DELTA_BYTES)) + 3
+    assert n < ts.MAX_SESSIONS_PER_FRAME, (
+        f"the fixture needs {n} sessions but the count cap is {ts.MAX_SESSIONS_PER_FRAME} — "
+        "it would die to the count guard instead"
+    )
+    for i in range(n):
+        write_session(tmp_path, "proj", f"sess-{i:04d}", body)
+
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    # 🔴 THE BYTE TOTAL IS ASSERTED FIRST BECAUSE IT IS THE CLAIM. The count check
+    # below is a fixture-reachability guard — it says the fixture was big enough
+    # to reach the bound at all — and asserting it first would make every failure
+    # report "the bound did not bite" even when the real finding is "the frame
+    # carried 528 KiB".
+    total = sum(len(d["data"].encode()) for d in deltas)
+    assert total <= ts.MAX_FRAME_BYTES, (
+        f"a frame carried {total} bytes against a {ts.MAX_FRAME_BYTES}-byte cap"
+    )
+    assert len(deltas) < n, "the aggregate bound did not bite at all — the fixture is too small"
+
+
+def test_a_transcript_whose_bytes_will_not_decode_is_left_to_the_reconciler(tmp_path):
+    """🔴 A LOSSY DECODE WOULD MAKE THE TWO SIDES' BYTE COUNTS DIVERGE, and
+    because the host re-reads from the SERVER's offset, the same bad bytes would
+    be re-sent and re-refused on every poll for ever. Skipping the session is the
+    bounded failure; the bulk push (which does use errors='replace') repairs it."""
+    d = tmp_path / "proj"
+    d.mkdir(parents=True)
+    (d / "bad.jsonl").write_bytes(b'{"type":"user","t":"\xff\xfe"}\n')
+    write_session(tmp_path, "proj", "good", line(1))
+
+    state = ts.StreamState()
+    deltas, skipped = plan(tmp_path, state)
+    ids = {x["sessionId"] for x in deltas}
+    assert "bad" not in ids, "undecodable bytes were sent; the cursor would drift for ever"
+    assert "good" in ids, "one bad transcript stopped the whole round"
+    assert skipped.get(ts.SKIP_UNDECODABLE) == 1, (
+        "the undecodable session was counted as something else — a real corruption "
+        f"signal hidden inside the ordinary steady state; got {skipped}"
+    )
+
+
+def test_subagent_transcripts_are_not_streamed(tmp_path):
+    """🔴 84% OF `.jsonl` FILES ON THIS HOST LIVE UNDER `subagents/` AND ARE NOT
+    RESUMABLE SESSIONS. Streaming them would push thousands of rows that no
+    attention entry and no tmux window can ever join to, at the fastest cadence in
+    the system. The shared enumerator excludes them; a hand-rolled walk would not."""
+    write_session(tmp_path, "proj", "real", line(1))
+    sub = tmp_path / "proj" / "real" / "subagents"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "agent-decoy.jsonl").write_text(line(2), encoding="utf-8")
+
+    state = ts.StreamState()
+    deltas, _ = plan(tmp_path, state)
+    ids = {d["sessionId"] for d in deltas}
+    assert ids == {"real"}, f"a subagent transcript was streamed: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# cursors
+# ---------------------------------------------------------------------------
+
+
+def test_a_null_offset_is_adopted_as_unknown_rather_than_ignored():
+    """🔴 SKIPPING THE NULL WOULD LEAVE A STALE OFFSET IN PLACE and every
+    subsequent delta would be refused for ever, with nothing saying why."""
+    state = ts.StreamState()
+    state.cursors["s"] = 500
+    ts.adopt_cursors(state, [{"sessionId": "s", "offset": None, "reason": "unknown-offset"}])
+    assert state.cursors["s"] is None
+
+
+@pytest.mark.parametrize("bad", [-1, "12", 1.5, True, {"a": 1}])
+def test_a_malformed_offset_is_treated_as_unknown_not_adopted(bad):
+    """Adopting a wrong number would splice. Unknown reseeds, which is correct."""
+    state = ts.StreamState()
+    state.cursors["s"] = 500
+    ts.adopt_cursors(state, [{"sessionId": "s", "offset": bad}])
+    assert state.cursors["s"] is None, f"offset {bad!r} was adopted"
+
+
+# ---------------------------------------------------------------------------
+# the resume path, end to end against the protocol
+# ---------------------------------------------------------------------------
+
+
+def test_a_lost_response_resumes_without_duplicating_or_skipping_a_line(tmp_path):
+    """🔴 THE FAILURE A CLAWGATE REDEPLOY ACTUALLY PRODUCES, AND THE HARD
+    DIRECTION. Not 'the request never arrived' — that is trivially safe. The
+    dangerous one is a frame the server APPLIED and COMMITTED whose response the
+    host never saw. The host still believes its old cursor; accepting the retry
+    would store those bytes twice.
+
+    The assertion is on the RECONSTRUCTED TAIL, not on a status: after the
+    disconnect and the resume the server's tail must equal the file exactly.
+    """
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    srv = FakeServer()
+    state = ts.StreamState()
+
+    def poll():
+        return ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+
+    poll()                       # reseed
+    append(p, line(3))
+    poll()
+
+    # The pod applies and commits, then dies before the reply is written.
+    stale = dict(state.cursors)
+    append(p, line(4) + line(5))
+    counts = poll()
+    assert counts["applied"] == 1
+    state.cursors = stale        # the reply never arrived
+
+    # It comes back. The host retries from where it thinks it is.
+    append(p, line(6))
+    counts = poll()
+    assert counts["refused"] == 1, (
+        "the retry after a lost response was ACCEPTED — lines 4 and 5 are now stored "
+        "twice and nothing downstream can detect it"
+    )
+
+    # The refusal carried the server's own offset, so the very next poll resumes.
+    counts = poll()
+    assert counts["applied"] == 1, "the host did not resynchronise on the next poll"
+    assert srv.tails["sess-1"] == p.read_text(), (
+        "after the disconnect and resume the server's tail does not equal the file\n"
+        f"server: {srv.tails['sess-1']!r}\nfile:   {p.read_text()!r}"
+    )
+
+
+def test_an_agent_restart_reseeds_and_loses_nothing_after_the_reseed(tmp_path):
+    """The other disconnect shape: the AGENT restarted, so it has no cursors at
+    all. It must hydrate from the server and reseed, not guess."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    srv = FakeServer()
+
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    append(p, line(3))
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert srv.tails["sess-1"] == p.read_text()
+
+    # Restart: brand-new state. It hydrates from the server, then reseeds because
+    # it has never stat'd the file.
+    state2 = ts.StreamState()
+    append(p, line(4))
+    counts = ts.run_round(srv.post, srv.get, "workbench", state2, tmp_path)
+    assert counts["applied"] == 1
+    assert state2.hydrated is True
+    assert srv.tails["sess-1"] == p.read_text(), "the reseed after a restart did not converge"
+
+    # And it keeps streaming from there.
+    append(p, line(5))
+    ts.run_round(srv.post, srv.get, "workbench", state2, tmp_path)
+    assert srv.tails["sess-1"] == p.read_text()
+
+
+def test_a_server_that_forgot_everything_is_reseeded_not_appended_to(tmp_path):
+    """A database restore leaves the server empty while the host believes
+    everything is delivered. Asking the server is what makes this recoverable."""
+    p = write_session(tmp_path, "proj", "sess-1", line(1) + line(2))
+    srv = FakeServer()
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert srv.tails["sess-1"]
+
+    srv.tails.clear()
+    srv.offsets.clear()
+    state.hydrated = False       # what the agent does after any stream failure
+    append(p, line(3))
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["applied"] == 1
+    assert srv.tails["sess-1"] == p.read_text()
+
+
+def test_no_frame_is_posted_when_there_is_nothing_to_send(tmp_path):
+    """🔴 THE SERVER REJECTS A FRAME WITH NO SESSIONS, so posting one would turn
+    the ordinary steady state into an HTTP 400 on every poll — a stream that
+    reports failure precisely when it is working."""
+    write_session(tmp_path, "proj", "sess-1", line(1))
+    srv = FakeServer()
+    state = ts.StreamState()
+    ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert len(srv.frames) == 1
+
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["sent"] == 0
+    assert len(srv.frames) == 1, "an empty frame was posted"
+
+
+def test_coverage_is_not_capped_at_eight_sessions(tmp_path):
+    """🔴 THE CRITERION-3 CLAIM, ON THE PRODUCER SIDE. The old bulk feeder carried
+    at most 6 sessions per 5-minute tick against a server cap of 8; the stream
+    must represent every active session in ONE poll.
+
+    21 is deliberately NOT a multiple of 8: a fixture of 8 or 16 could be passed
+    by a mutant that restored the old cap by landing on a boundary.
+    """
+    n = 21
+    assert n % 8 != 0
+    for i in range(n):
+        write_session(tmp_path, "proj", f"sess-{i:04d}", line(i))
+
+    srv = FakeServer()
+    state = ts.StreamState()
+    counts = ts.run_round(srv.post, srv.get, "workbench", state, tmp_path)
+    assert counts["sent"] == n, f"only {counts['sent']} of {n} sessions were carried"
+    assert counts["applied"] == n
+    assert len(srv.tails) == n, f"the server holds {len(srv.tails)} of {n} sessions"
+
+
+def test_the_client_bounds_stay_under_the_servers(tmp_path):
+    """🔴 A CLIENT TUNED EXACTLY TO A SERVER LIMIT TURNS ANY ROUNDING
+    DISAGREEMENT INTO A STREAM THAT FAILS EVERY POLL WHILE LOOKING CORRECTLY
+    CONFIGURED. The server's numbers are MaxDeltaBytes=65536,
+    MaxFrameBytes=524288, MaxDeltaSessionsPerFrame=64."""
+    assert ts.MAX_DELTA_BYTES < 65536
+    assert ts.MAX_FRAME_BYTES < 524288
+    assert ts.MAX_SESSIONS_PER_FRAME < 64
+    # And a reseed IS a delta, so it must obey the per-delta cap — the first draft
+    # of the module had RESEED_TAIL_BYTES at 192 KiB, which the server would have
+    # rejected on every rotation.
+    assert ts.RESEED_TAIL_BYTES <= ts.MAX_DELTA_BYTES

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -126,6 +126,25 @@ def _load_transcript_stream(path: str = None):
 
 TRANSCRIPT_STREAM = _load_transcript_stream()
 
+
+def _load_host_label(path: str = None):
+    """Load `scripts/lib/host_label.py` by EXPLICIT PATH.
+
+    🔴 IT RAISES RATHER THAN FALLING BACK, like the text policy and unlike the
+    transcript tailer. The label decides which host's writes this agent claims: a
+    fallback that guessed would make it deliver another machine's commands, or
+    none at all. A missing module must stop the agent.
+    """
+    path = path or os.path.join(_HERE, "lib", "host_label.py")
+    loader = importlib.machinery.SourceFileLoader("_tra_host_label", path)
+    spec = importlib.util.spec_from_loader("_tra_host_label", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+HOST_LABEL = _load_host_label()
+
 # Where the transcripts live. Overridable so the tests never touch the real one,
 # and spelled the same way transcript-push.sh spells it so the two feeders agree
 # about which files exist.
@@ -137,8 +156,11 @@ ACTIVITY_ENV = os.path.expanduser("~/.config/activity-collector/env")
 
 # The host vocabulary the read model and the queue both use. `hostname` is
 # "nixos" on BOTH machines, so it cannot be the source of truth; ACTIVITY_HOST is.
-HOST_NAMES = ("workbench", "laptop")
-DEFAULT_LOCAL_HOST = "workbench"
+# 🔴 RE-EXPORTED FROM THE SHARED MODULE, NOT RESTATED. Two literals here and one
+# rule there is the same drift this consolidation exists to end; the tests below
+# read these names, so they must BE the module's values, not equal to them.
+HOST_NAMES = HOST_LABEL.HOST_NAMES
+DEFAULT_LOCAL_HOST = HOST_LABEL.DEFAULT_LOCAL_HOST
 
 # The poll cadence. The server's write TTL is 90s, so this is ~18 polls inside a
 # write's whole deliverable life: a reply typed on a phone lands within seconds,
@@ -230,31 +252,20 @@ def resolve(key: str, conf_file: str, env=None) -> str:
 
 
 def local_host_label(env=None, env_file: str = ACTIVITY_ENV) -> str:
-    """This machine's ACTIVITY_HOST label.
+    """This machine's ACTIVITY_HOST label — DELEGATED, not re-derived.
 
-    Same rule as the collector's, and it has to be: the server's queue is keyed on
-    the host label the read model stores, so an agent that computed a different
-    label would poll for a host nobody enqueues to and deliver nothing, silently.
+    🔴 THIS USED TO BE A SECOND COPY OF THE RULE, AND transcript-push.sh HELD A
+    THIRD (in shell, falling through to `uname -n`, which is "nixos" on BOTH
+    machines). The three agreed while `host` was display-only and stopped agreeing
+    the moment the delta stream made it a correctness predicate. `scripts/lib/
+    host_label.py` carries the rule and the measurement; this wrapper stays only
+    so the name and the tests that use it keep working.
+
+    The server's termwrite queue is keyed on this label, so an agent computing a
+    different one would poll for a host nobody enqueues to and deliver nothing,
+    silently — which is why a wrapper is acceptable here and a fourth copy is not.
     """
-    e = os.environ if env is None else env
-    v = (e.get("ACTIVITY_HOST") or "").strip().lower()
-    if v in HOST_NAMES:
-        return v
-    try:
-        with open(env_file, "r", encoding="utf-8", errors="replace") as fh:
-            text = fh.read()
-    except OSError:
-        text = ""
-    for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("ACTIVITY_HOST="):
-            val = line[len("ACTIVITY_HOST="):].strip()
-            if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-                val = val[1:-1]
-            val = val.strip().lower()
-            if val in HOST_NAMES:
-                return val
-    return DEFAULT_LOCAL_HOST
+    return HOST_LABEL.local_host_label(env=env, env_file=env_file)
 
 
 # ── tmux ─────────────────────────────────────────────────────────────────────

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -264,8 +264,14 @@ def local_host_label(env=None, env_file: str = ACTIVITY_ENV) -> str:
 
     🔴 THIS USED TO BE A SECOND COPY OF THE RULE, AND transcript-push.sh HELD A
     THIRD (in shell, falling through to `uname -n`, which is "nixos" on BOTH
-    machines). The three agreed while `host` was display-only and stopped agreeing
-    the moment the delta stream made it a correctness predicate. `scripts/lib/
+    machines).
+
+    ⚠ THEY NEVER AGREED — an earlier version of this sentence said "the three
+    agreed while `host` was display-only". They did not: every stored transcript
+    row said `host: nixos` while this agent called the same machine `workbench`,
+    measured on the deployed server. What changed when the delta stream made
+    `host` a correctness predicate was the COST of the disagreement, not its
+    existence. host_label.py carries the measurement. `scripts/lib/
     host_label.py` carries the rule and the measurement; this wrapper stays only
     so the name and the tests that use it keep working.
 
@@ -1011,14 +1017,40 @@ def skip_reasons_to_report(seen: frozenset, skipped) -> frozenset:
     So the fix that made the counts stop mattering did not make the LINE stop
     repeating, while its own docstring claimed it had. Reporting each reason the
     FIRST time this process sees it gives a bound that is provable rather than
-    hoped for: at most one line per distinct reason per agent lifetime — four,
-    since there are four reasons.
+    hoped for: at most one line per distinct reason per agent lifetime, and the
+    reasons are the SKIP_* constants in `transcript_stream` minus `unchanged`.
+
+    ⚠ NO NUMBER IS WRITTEN HERE, AND ONE WAS — "four, since there are four
+    reasons", when there were five. Worse, a later commit's message claimed to
+    have removed it and had not: the edit landed on the emit-site comment and not
+    on this docstring, so the false number survived a round whose whole subject
+    was that number. A count restated in prose beside the list that defines it is
+    the rot the repo's own doc gate exists for.
+    `test_the_reported_reason_bound_matches_the_TAILERS_OWN_set` checks the
+    relationship against that module instead.
 
     ⚠ THE COST, STATED: a reason that goes away and comes back is not re-reported.
-    That is deliberate. The counts are still printed when a reason is first seen,
-    and the condition is diagnostic rather than urgent — the bulk push covers
-    every skipped session either way. A signal that fires 3,456 times a day is
-    not a louder version of this one; it is a channel nobody reads.
+    That is deliberate — a signal that fires 3,456 times a day is not a louder
+    version of this one, it is a channel nobody reads — and the counts are still
+    printed when a reason is first seen.
+
+    🔴 BUT NOT BECAUSE "the bulk push covers every skipped session either way",
+    WHICH IS WHAT THIS PARAGRAPH USED TO SAY AND IS FALSE. Measured, both feeders
+    over one fixture with a mode-000 file beside a healthy one:
+
+        STREAM emitted ['good'], skipped {'unreadable': 1}
+        BULK   emitted ['good']
+        -> covered by the bulk push? False
+
+    `read_tail` catches OSError and skips, so an `unreadable` session reaches
+    NEITHER feed. So the honest statement is narrower: `no-record-boundary` and
+    `undecodable` are covered by the reconciler; `unreadable` is covered by
+    nothing, and `duplicate-session-id` / `no-session-id` are conditions the
+    reconciler now guards against itself rather than repairs.
+
+    The consequence to accept with this design: a session stalled under a reason
+    whose one-shot budget was already spent on a benign earlier occurrence is not
+    announced again. `no-record-boundary` is the likeliest to be spent that way.
     """
     return skip_memo_key(skipped) - seen
 

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -1027,7 +1027,12 @@ def main(argv: list[str]) -> int:
 
     # 🔴 LOG A REPEATING STREAM CONDITION ONCE, NOT EVERY POLL, for the same
     # reason the write loop does: 17,280 polls a day would bury every real event.
+    # Two conditions, two memories: a stream FAILURE (the request did not
+    # complete) and a stream SKIP (the request was fine, some session could not be
+    # read). They are different facts and a single variable would let one mask the
+    # other.
     stream_problem = ""
+    stream_skips: dict = {}
 
     backoff_reason = ""
     while not _STOP:
@@ -1038,18 +1043,33 @@ def main(argv: list[str]) -> int:
         # The write surface is the capability with a person waiting on it.
         if stream_state is not None:
             try:
-                # 🔴 THE RESULT IS DELIBERATELY NOT INSPECTED FOR REFUSALS. A
-                # refusal is the NORMAL way a host that fell out of step learns
-                # where the server got to — it happens on every redeploy and after
-                # every bulk push — so logging or counting it as a fault would fire
-                # the one signal this loop has at exactly the moments the design
-                # is working. An earlier revision had a `if counts["refused"]:`
-                # branch here that assigned the empty string it had just been
-                # assigned: dead code that read as a decision.
-                transcript_round(api, hook_token, host, stream_state)
+                # 🔴 REFUSALS ARE DELIBERATELY NOT REPORTED. A refusal is the
+                # NORMAL way a host that fell out of step learns where the server
+                # got to — it happens on every redeploy and after every bulk push
+                # — so logging one as a fault would fire the one signal this loop
+                # has at exactly the moments the design is working.
+                #
+                # 🔴 BUT THE `skipped` COUNTERS ARE, AND AN EARLIER REVISION THREW
+                # THEM AWAY. `unchanged` is the steady state and says nothing; the
+                # others are the only observable a stalled or corrupt session
+                # has. Two liveness bugs in the tailer were found by reading the
+                # code rather than by reading a log, because nothing printed
+                # these — and one of them re-read 48 KiB every five seconds, for
+                # ever, in silence. Rate-limited exactly like the failure line
+                # below: this runs 17,280 times a day.
+                counts = transcript_round(api, hook_token, host, stream_state)
                 if stream_problem:
                     log("transcript streaming is working again")
                     stream_problem = ""
+                notable = {k: v for k, v in (counts.get("skipped") or {}).items()
+                           if k != "unchanged"}
+                if notable != stream_skips:
+                    if notable:
+                        log("transcript streaming skipped some sessions "
+                            f"(the 5-minute bulk push still covers them): {notable}")
+                    elif stream_skips:
+                        log("transcript streaming is no longer skipping any session")
+                    stream_skips = notable
             except Exception as exc:  # noqa: BLE001 — must never affect the write path
                 reason = f"{exc!r}"
                 if reason != stream_problem:

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -101,6 +101,36 @@ def _load_tmux_text_policy(path: str = None):
 
 TEXT_POLICY = _load_tmux_text_policy()
 
+
+def _load_transcript_stream(path: str = None):
+    """Load `scripts/lib/transcript_stream.py` by EXPLICIT PATH.
+
+    🔴 IT RETURNS None RATHER THAN RAISING, WHICH IS THE OPPOSITE OF THE POLICY
+    LOADER ABOVE, AND THE ASYMMETRY IS THE POINT. The text policy is a SAFETY
+    rule on the path that executes commands; a missing copy must stop the agent,
+    because the alternative is running with a weaker check. Transcript streaming
+    is a READ-MODEL nicety: it types nothing, runs nothing, and its absence costs
+    freshness that the five-minute bulk push restores anyway. Letting it stop the
+    write agent would trade a real capability for a cosmetic one.
+    """
+    path = path or os.path.join(_HERE, "lib", "transcript_stream.py")
+    try:
+        loader = importlib.machinery.SourceFileLoader("_tra_transcript_stream", path)
+        spec = importlib.util.spec_from_loader("_tra_transcript_stream", loader)
+        mod = importlib.util.module_from_spec(spec)
+        loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 — see the docstring: never fatal
+        return None
+
+
+TRANSCRIPT_STREAM = _load_transcript_stream()
+
+# Where the transcripts live. Overridable so the tests never touch the real one,
+# and spelled the same way transcript-push.sh spells it so the two feeders agree
+# about which files exist.
+PROJECTS_DIR = os.environ.get("CLAUDE_PROJECTS_DIR") or os.path.expanduser("~/.claude/projects")
+
 API_DEFAULT = "http://192.168.50.250:30302"
 CONF_FILE = os.environ.get("CLAWGATE_CONF_FILE") or os.path.expanduser("~/.claude/clawgate.env")
 ACTIVITY_ENV = os.path.expanduser("~/.config/activity-collector/env")
@@ -344,6 +374,32 @@ def post_json(url: str, token: str, payload: dict) -> dict:
             raise Refused("the server has no terminal write route (HTTP 404) — it "
                           "predates the write surface, or has no database wired") from exc
         raise Refused(f"the server answered HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise Refused(f"could not reach the server: {exc.reason}") from exc
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise Refused(f"the server's answer was not JSON: {exc}") from exc
+
+
+def get_json(url: str, token: str) -> dict:
+    """A bounded, bearer-authenticated GET.
+
+    🔴 IT IS A SEPARATE FUNCTION RATHER THAN A `method=` ARGUMENT TO post_json,
+    because post_json's HTTPError branches are written about the TERMINAL write
+    surface — its 503 text asserts that the pod's terminal secret was removed.
+    Reusing it for a read on the HOOK tier would make an ordinary hook-token
+    problem report a disarmed write surface, which is the one message in this file
+    that must never fire wrongly.
+    """
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", "Bearer " + token)
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            raw = resp.read(MAX_RESPONSE_BYTES)
+    except urllib.error.HTTPError as exc:
+        raise Refused(f"the server answered HTTP {exc.code} to a read") from exc
     except urllib.error.URLError as exc:
         raise Refused(f"could not reach the server: {exc.reason}") from exc
     try:
@@ -890,6 +946,36 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
     return len(writes)
 
 
+def transcript_round(api: str, hook_token: str, host: str, state) -> dict:
+    """One transcript-streaming round, over the connection this agent already has.
+
+    🔴 IT RIDES THIS POLL AND OPENS NOTHING NEW. No inbound port on either host,
+    no second long-lived connection, no second unit — one more request per
+    existing ~5s cycle, which is why the session view goes from five-minutes-fresh
+    to seconds-fresh for the cost of a route rather than a transport.
+
+    🔴 IT IS ON THE HOOK TIER, NOT THE TERMINAL ONE, AND THAT SEPARATION IS
+    DELIBERATE. The transcript ingest executes nothing; the write surface executes
+    arbitrary commands as the operator. Fusing them into one request would put a
+    read-model feed behind the credential whose whole purpose is to gate command
+    execution, so disarming the write surface — a security act — would silently
+    take the operator's session view with it.
+
+    ⚠ THE ONE COUPLING THAT REMAINS, STATED RATHER THAN HIDDEN: this runs inside
+    the reply agent's loop, and the reply agent exits 2 without
+    CLAWGATE_TERMINAL_TOKEN. So on a host where the write surface is disarmed,
+    streaming does not run either — the five-minute bulk push is the whole feed
+    there, exactly as it was before this change.
+    """
+    return TRANSCRIPT_STREAM.run_round(
+        lambda path, payload: post_json(api + path, hook_token, payload),
+        lambda path: get_json(api + path, hook_token),
+        host,
+        state,
+        PROJECTS_DIR,
+    )
+
+
 def main(argv: list[str]) -> int:
     signal.signal(signal.SIGTERM, _on_signal)
     signal.signal(signal.SIGINT, _on_signal)
@@ -921,8 +1007,57 @@ def main(argv: list[str]) -> int:
     agent = f"{host}:{os.getpid()}"
     log(f"polling {api} every {POLL_SECONDS:g}s for writes addressed to `{host}` as `{agent}`")
 
+    # ── transcript streaming, on this same poll ──────────────────────────────
+    # 🔴 A SEPARATE CREDENTIAL, AND ITS ABSENCE IS NOT FATAL. The transcript
+    # routes are on the HOOK tier; a host with a terminal token but no hook token
+    # can still deliver writes, and the five-minute bulk push keeps feeding the
+    # read model. Exiting here would take the write surface down over a read
+    # model's missing key.
+    hook_token = resolve("CLAWGATE_HOOK_TOKEN", CONF_FILE)
+    stream_state = None
+    if TRANSCRIPT_STREAM is None:
+        log("transcript streaming is OFF: scripts/lib/transcript_stream.py could not be "
+            "loaded — the 5-minute bulk push is the whole transcript feed on this host")
+    elif not hook_token:
+        log(f"transcript streaming is OFF: no CLAWGATE_HOOK_TOKEN in the environment or "
+            f"{CONF_FILE} — the 5-minute bulk push is the whole transcript feed on this host")
+    else:
+        stream_state = TRANSCRIPT_STREAM.StreamState()
+        log("transcript streaming is ON, riding this poll")
+
+    # 🔴 LOG A REPEATING STREAM CONDITION ONCE, NOT EVERY POLL, for the same
+    # reason the write loop does: 17,280 polls a day would bury every real event.
+    stream_problem = ""
+
     backoff_reason = ""
     while not _STOP:
+        # 🔴 THE STREAM RUNS FIRST AND ITS FAILURES NEVER REACH THE WRITE PATH.
+        # Everything it can raise is caught HERE rather than by the loop's own
+        # handler, because that handler puts the agent into a 60-second backoff —
+        # so a transcript hiccup would delay somebody's typed reply by a minute.
+        # The write surface is the capability with a person waiting on it.
+        if stream_state is not None:
+            try:
+                counts = transcript_round(api, hook_token, host, stream_state)
+                if stream_problem:
+                    log("transcript streaming is working again")
+                    stream_problem = ""
+                if counts.get("refused"):
+                    # A refusal is NORMAL — it is how a host that fell out of step
+                    # learns where the server got to — so it is not an error, but a
+                    # SUSTAINED refusal is worth seeing.
+                    stream_problem = ""
+            except Exception as exc:  # noqa: BLE001 — must never affect the write path
+                reason = f"{exc!r}"
+                if reason != stream_problem:
+                    log(f"transcript streaming failed this poll (the 5-minute bulk push still "
+                        f"covers it): {reason}")
+                    stream_problem = reason
+                # 🔴 RE-HYDRATE ON THE NEXT POLL. The most likely cause is that
+                # clawgate was redeployed, which is exactly when this host's
+                # cursors may no longer describe what the server holds.
+                stream_state.hydrated = False
+
         try:
             one_round(api, token, host, agent)
             if backoff_reason:

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -1038,14 +1038,17 @@ def main(argv: list[str]) -> int:
         # The write surface is the capability with a person waiting on it.
         if stream_state is not None:
             try:
-                counts = transcript_round(api, hook_token, host, stream_state)
+                # 🔴 THE RESULT IS DELIBERATELY NOT INSPECTED FOR REFUSALS. A
+                # refusal is the NORMAL way a host that fell out of step learns
+                # where the server got to — it happens on every redeploy and after
+                # every bulk push — so logging or counting it as a fault would fire
+                # the one signal this loop has at exactly the moments the design
+                # is working. An earlier revision had a `if counts["refused"]:`
+                # branch here that assigned the empty string it had just been
+                # assigned: dead code that read as a decision.
+                transcript_round(api, hook_token, host, stream_state)
                 if stream_problem:
                     log("transcript streaming is working again")
-                    stream_problem = ""
-                if counts.get("refused"):
-                    # A refusal is NORMAL — it is how a host that fell out of step
-                    # learns where the server got to — so it is not an error, but a
-                    # SUSTAINED refusal is worth seeing.
                     stream_problem = ""
             except Exception as exc:  # noqa: BLE001 — must never affect the write path
                 reason = f"{exc!r}"

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -152,7 +152,15 @@ PROJECTS_DIR = os.environ.get("CLAUDE_PROJECTS_DIR") or os.path.expanduser("~/.c
 
 API_DEFAULT = "http://192.168.50.250:30302"
 CONF_FILE = os.environ.get("CLAWGATE_CONF_FILE") or os.path.expanduser("~/.claude/clawgate.env")
-ACTIVITY_ENV = os.path.expanduser("~/.config/activity-collector/env")
+# 🔴 THE PATH COMES FROM THE SHARED MODULE TOO, NOT JUST THE VOCABULARY. The
+# consolidation re-exported HOST_NAMES and DEFAULT_LOCAL_HOST "rather than
+# restating two literals" and left the THIRD literal — this path — restated. The
+# consequence was measured: because local_host_label passes it as the default
+# `env_file`, host_label.ACTIVITY_ENV (and HOST_LABEL_ENV_FILE with it) was DEAD
+# for the agent, and pointing the module at a different file changed nothing here
+# — 203/203 still passed. That is the exact axis that produced the round-2
+# blocker: two feeders reading two files.
+ACTIVITY_ENV = HOST_LABEL.ACTIVITY_ENV
 
 # The host vocabulary the read model and the queue both use. `hostname` is
 # "nixos" on BOTH machines, so it cannot be the source of truth; ACTIVITY_HOST is.

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -989,6 +989,40 @@ def skip_memo_key(skipped) -> frozenset:
     return frozenset(k for k in (skipped or {}) if k != "unchanged")
 
 
+def skip_reasons_to_report(seen: frozenset, skipped) -> frozenset:
+    """The reasons worth logging THIS poll, given the ones already reported.
+
+    🔴 THE MEMO IS STICKY, AND A SET-COMPARISON MEMO WAS NOT ENOUGH. Comparing
+    the current reason set against the previous one logs on every change in
+    EITHER direction — so a reason that appears and disappears costs TWO lines
+    per cycle, and `no-record-boundary` is exactly that shape: a session is
+    mid-record on one poll and complete on the next, which _read_append's own
+    docstring calls the ordinary steady state. A condition that is ordinary is
+    also ordinarily ABSENT, which is what makes it flap rather than persist.
+
+    Measured against a verbatim transcription of the loop, 40 polls:
+
+        constant reason, constant counts              1 log line
+        constant reason, MOVING counts                1 log line   (the count fix)
+        reason FLAPS present/absent                  39 log lines  <- this
+        reason present 1 poll in 10                   8 log lines
+                                                     = 3,456/day at 17,280 polls
+
+    So the fix that made the counts stop mattering did not make the LINE stop
+    repeating, while its own docstring claimed it had. Reporting each reason the
+    FIRST time this process sees it gives a bound that is provable rather than
+    hoped for: at most one line per distinct reason per agent lifetime — four,
+    since there are four reasons.
+
+    ⚠ THE COST, STATED: a reason that goes away and comes back is not re-reported.
+    That is deliberate. The counts are still printed when a reason is first seen,
+    and the condition is diagnostic rather than urgent — the bulk push covers
+    every skipped session either way. A signal that fires 3,456 times a day is
+    not a louder version of this one; it is a channel nobody reads.
+    """
+    return skip_memo_key(skipped) - seen
+
+
 def transcript_round(api: str, hook_token: str, host: str, state) -> dict:
     """One transcript-streaming round, over the connection this agent already has.
 
@@ -1074,6 +1108,10 @@ def main(argv: list[str]) -> int:
     # complete) and a stream SKIP (the request was fine, some session could not be
     # read). They are different facts and a single variable would let one mask the
     # other.
+    #
+    # `stream_skips` is STICKY — the reasons already reported, never cleared. See
+    # skip_reasons_to_report for why a set that tracks the CURRENT reasons still
+    # floods when a reason flaps.
     stream_problem = ""
     stream_skips: frozenset = frozenset()
 
@@ -1114,16 +1152,13 @@ def main(argv: list[str]) -> int:
                 # the journal-flooding this memo exists to prevent (17,280 polls a
                 # day). The REASONS are the condition; the counts are noise, and
                 # they are still printed in the line so nothing is lost.
-                notable = {k: v for k, v in (counts.get("skipped") or {}).items()
-                           if k != "unchanged"}
-                reasons = skip_memo_key(counts.get("skipped"))
-                if reasons != stream_skips:
-                    if reasons:
-                        log("transcript streaming skipped some sessions "
-                            f"(the 5-minute bulk push still covers them): {notable}")
-                    elif stream_skips:
-                        log("transcript streaming is no longer skipping any session")
-                    stream_skips = reasons
+                fresh = skip_reasons_to_report(stream_skips, counts.get("skipped"))
+                if fresh:
+                    notable = {k: v for k, v in (counts.get("skipped") or {}).items()
+                               if k != "unchanged"}
+                    log("transcript streaming skipped some sessions "
+                        f"(the 5-minute bulk push still covers them): {notable}")
+                    stream_skips |= fresh
             except Exception as exc:  # noqa: BLE001 — must never affect the write path
                 reason = f"{exc!r}"
                 if reason != stream_problem:

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -1135,9 +1135,17 @@ def main(argv: list[str]) -> int:
                 # others are the only observable a stalled or corrupt session
                 # has. Two liveness bugs in the tailer were found by reading the
                 # code rather than by reading a log, because nothing printed
-                # these — and one of them re-read 48 KiB every five seconds, for
-                # ever, in silence. Rate-limited exactly like the failure line
-                # below: this runs 17,280 times a day.
+                # these.
+                #
+                # ⚠ IT IS **NOT** RATE-LIMITED "exactly like the failure line
+                # below", WHICH IS WHAT THIS COMMENT USED TO SAY. The two are
+                # structurally different and the difference matters to whoever
+                # reads the journal: the failure memo is a change-detector that is
+                # CLEARED on success and has a recovery line, so a repeating
+                # failure re-fires after each recovery; this one is STICKY and
+                # one-shot per reason per process, and its recovery line was
+                # removed on purpose. See skip_reasons_to_report for why, and for
+                # what that costs.
                 counts = transcript_round(api, hook_token, host, stream_state)
                 if stream_problem:
                     log("transcript streaming is working again")

--- a/scripts/tmux-reply-agent
+++ b/scripts/tmux-reply-agent
@@ -965,6 +965,30 @@ def one_round(api: str, token: str, host: str, agent: str) -> int:
     return len(writes)
 
 
+def skip_memo_key(skipped) -> frozenset:
+    """The rate-limit key for the transcript stream's skip line.
+
+    🔴 THE KEY IS THE SET OF REASONS, NOT THEIR COUNTS, AND THE COUNT VERSION
+    DEFEATED THE RATE LIMIT IT WAS WRITTEN AS. A count moves whenever a different
+    NUMBER of sessions is mid-record this poll than last — and `no-record-boundary`
+    fires whenever an append window ends without a newline, which the tailer's own
+    docstring calls the ordinary steady state. So the same condition re-logged
+    every few seconds, on a loop that runs 17,280 times a day. That is the
+    journal-flooding the memo exists to prevent, and it is what trains an operator
+    to ignore the one channel this unit has.
+
+    🔴 IT IS A FUNCTION RATHER THAN AN EXPRESSION INSIDE THE LOOP BECAUSE A RULE
+    THAT LIVES IN `main()` CANNOT BE TESTED AT THE POINT IT CAN BE WRONG. The
+    first attempt at this fix was pinned only through a whole-agent subprocess
+    run, and the count-keyed mutant SURVIVED it: the fixture had one skipping
+    session throughout, so no count ever moved and the distinction the test
+    claimed to make was never exercised.
+
+    `unchanged` is dropped: it IS the steady state and says nothing.
+    """
+    return frozenset(k for k in (skipped or {}) if k != "unchanged")
+
+
 def transcript_round(api: str, hook_token: str, host: str, state) -> dict:
     """One transcript-streaming round, over the connection this agent already has.
 
@@ -1051,7 +1075,7 @@ def main(argv: list[str]) -> int:
     # read). They are different facts and a single variable would let one mask the
     # other.
     stream_problem = ""
-    stream_skips: dict = {}
+    stream_skips: frozenset = frozenset()
 
     backoff_reason = ""
     while not _STOP:
@@ -1080,15 +1104,26 @@ def main(argv: list[str]) -> int:
                 if stream_problem:
                     log("transcript streaming is working again")
                     stream_problem = ""
+                # 🔴 THE MEMO IS THE SET OF REASONS, NOT THEIR COUNTS, AND THE
+                # COUNT VERSION DEFEATED THE RATE LIMIT IT WAS WRITTEN AS. A count
+                # moves whenever a different NUMBER of sessions is mid-record this
+                # poll than last — and `no-record-boundary` fires whenever an
+                # append window ends without a newline, which _read_append's own
+                # docstring calls the ordinary steady state. So a busy fleet
+                # re-logged the same condition every few seconds, which is exactly
+                # the journal-flooding this memo exists to prevent (17,280 polls a
+                # day). The REASONS are the condition; the counts are noise, and
+                # they are still printed in the line so nothing is lost.
                 notable = {k: v for k, v in (counts.get("skipped") or {}).items()
                            if k != "unchanged"}
-                if notable != stream_skips:
-                    if notable:
+                reasons = skip_memo_key(counts.get("skipped"))
+                if reasons != stream_skips:
+                    if reasons:
                         log("transcript streaming skipped some sessions "
                             f"(the 5-minute bulk push still covers them): {notable}")
                     elif stream_skips:
                         log("transcript streaming is no longer skipping any session")
-                    stream_skips = notable
+                    stream_skips = reasons
             except Exception as exc:  # noqa: BLE001 — must never affect the write path
                 reason = f"{exc!r}"
                 if reason != stream_problem:

--- a/scripts/transcript-push.sh
+++ b/scripts/transcript-push.sh
@@ -61,6 +61,11 @@
 
 set -euo pipefail
 
+# Defined FIRST: the host-label resolution below is the earliest thing that can
+# exit, and it reports through log(). A definition further down would make that
+# branch die with "log: command not found" instead of its own message.
+log() { printf 'transcript-push: %s\n' "$*"; }
+
 API_DEFAULT="http://192.168.50.250:30302"
 CONF_FILE="${CLAWGATE_CONF_FILE:-$HOME/.claude/clawgate.env}"
 CURL_TIMEOUT="${TRANSCRIPT_PUSH_CURL_TIMEOUT:-30}"
@@ -69,11 +74,39 @@ BUILD_TIMEOUT="${TRANSCRIPT_PUSH_BUILD_TIMEOUT:-120}"
 # Where the transcripts live. Overridable so the tests never touch the real one.
 PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 
-# This host's name as the read model will record it. `ACTIVITY_HOST` is the
-# fleet's existing per-host handle (the activity collector sets it on both
-# machines), so reusing it keeps one answer to "which box is this" rather than
-# minting a second.
-HOST_NAME="${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}"
+# This host's name as the read model will record it.
+#
+# 🔴 THE RULE IS `scripts/lib/host_label.py`, NOT A SHELL EXPANSION, AND THE
+# DIFFERENCE WAS A LIVE DEFECT. This line used to be
+#
+#     HOST_NAME="${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}"
+#
+# whose comment claimed it reused the fleet's per-host handle "rather than
+# minting a second". It did not: ACTIVITY_HOST lives in a FILE the unit does not
+# source and this script never read, so it fell through to `uname -n` — which is
+# **"nixos" on BOTH machines**. Measured on the deployed server: every stored
+# transcript row said `host: nixos`, so the column was useless, while the reply
+# agent (which does read the file) called the same machine "workbench".
+#
+# That cost nothing while `host` was display-only. The delta stream makes it a
+# CORRECTNESS predicate — an append whose host differs from the stored row's is
+# refused, because the stored offset is a position in the other machine's file —
+# so the disagreement would have become a permanent reseed loop: this push
+# stamping `nixos` back onto every row every 5 minutes, the stream reseeding
+# every session every 5 seconds because "the host changed".
+#
+# `TRANSCRIPT_PUSH_HOST` still wins, for the tests and for a deliberate override.
+HOST_LABEL_PY="${TRANSCRIPT_PUSH_HOST_LABEL:-$(dirname "$(readlink -f "$0")")/lib/host_label.py}"
+if [ -n "${TRANSCRIPT_PUSH_HOST:-}" ]; then
+  HOST_NAME="$TRANSCRIPT_PUSH_HOST"
+else
+  # 🔴 A FAILURE HERE IS FATAL, NOT A FALLBACK TO `uname -n`. Falling back is what
+  # produced the defect above, and it would produce it again silently.
+  if ! HOST_NAME="$(python3 "$HOST_LABEL_PY" 2>/dev/null)" || [ -z "$HOST_NAME" ]; then
+    log "could not resolve this host's label via $HOST_LABEL_PY — refusing to push under a guessed name"
+    exit 3
+  fi
+fi
 
 # 🔴 THESE BOUNDS MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The server
 # enforces MaxTailBytes=262144, MaxSessionsPerPush=128 and MaxPushTailBytes=4 MiB
@@ -100,7 +133,6 @@ MAX_AGE_HOURS="${TRANSCRIPT_PUSH_MAX_AGE_HOURS:-24}"
 # in the steady state and it is bounded by TAIL_BYTES, so this is generous.
 MAX_CANDIDATES="${TRANSCRIPT_PUSH_MAX_CANDIDATES:-200}"
 
-log() { printf 'transcript-push: %s\n' "$*"; }
 
 # ── credentials ──────────────────────────────────────────────────────────────
 # 🔴 THE ENVIRONMENT WINS OVER THE FILE, and that direction is load-bearing —

--- a/scripts/transcript-push.sh
+++ b/scripts/transcript-push.sh
@@ -75,13 +75,24 @@ PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 # minting a second.
 HOST_NAME="${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}"
 
-# 🔴 THESE THREE BOUNDS MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The
-# server enforces MaxTailBytes=262144 and MaxSessionsPerPush=8 and REJECTS a push
-# that exceeds either — a rejection changes nothing server-side, so a client tuned
-# exactly to the limit turns any rounding disagreement into a feeder that fails
-# every single tick while looking correctly configured.
+# 🔴 THESE BOUNDS MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The server
+# enforces MaxTailBytes=262144, MaxSessionsPerPush=128 and MaxPushTailBytes=4 MiB
+# and REJECTS a push that exceeds any of them — a rejection changes nothing
+# server-side, so a client tuned exactly to a limit turns any rounding
+# disagreement into a feeder that fails every single tick while looking correctly
+# configured.
+#
+# 🔴 MAX_PER_PUSH WAS 6 AGAINST A SERVER CAP OF 8, AND THAT PAIR WAS A COVERAGE
+# CAP, NOT A SAFETY BOUND. Measured 2026-09-07 against ~93 live windows: at most
+# six sessions could carry a transcript per tick, so most session cards had no
+# conversation to show at all. The server now bounds the AGGREGATE tail bytes
+# directly — which is the ceiling the count was only ever approximating — so the
+# count is free to rise to what coverage needs. 48 sessions x 192 KiB is 9 MiB in
+# the worst case, so MAX_PUSH_BYTES below is what actually holds, and the builder
+# stops adding sessions when it is reached.
 TAIL_BYTES="${TRANSCRIPT_PUSH_TAIL_BYTES:-196608}"     # 192 KiB; server cap 256 KiB
-MAX_PER_PUSH="${TRANSCRIPT_PUSH_MAX_SESSIONS:-6}"      # server cap 8
+MAX_PER_PUSH="${TRANSCRIPT_PUSH_MAX_SESSIONS:-48}"     # server cap 128
+MAX_PUSH_BYTES="${TRANSCRIPT_PUSH_MAX_BYTES:-3145728}" # 3 MiB; server cap 4 MiB
 # How far back to consider a transcript at all. 24h keeps a session readable the
 # morning after; older ones are past the server's retention anyway.
 MAX_AGE_HOURS="${TRANSCRIPT_PUSH_MAX_AGE_HOURS:-24}"
@@ -209,6 +220,7 @@ timeout "$BUILD_TIMEOUT" python3 "$BUILDER" \
   --host "$HOST_NAME" \
   --tail-bytes "$TAIL_BYTES" \
   --max-sessions "$MAX_PER_PUSH" \
+  --max-push-bytes "$MAX_PUSH_BYTES" \
   --max-age-hours "$MAX_AGE_HOURS" \
   --max-candidates "$MAX_CANDIDATES" \
   >"$PAYLOAD" 2>"$WORK/build.err"


### PR DESCRIPTION
Producer half of clawgate task **519**. Consumer half: **ZacxDev/homelab-infra#771**. **Not stacked** — based directly on `main`, and independently green.

## What it does

The session view was five-minutes-fresh because the only feed was `transcript-push.sh`, a timer that **replaces** each session's stored tail. This adds `scripts/lib/transcript_stream.py`, an **append** path that rides the outbound poll `tmux-reply-agent` already holds.

**No inbound port on either host, no second long-lived connection, no second unit** — one more request per existing ~5s cycle.

⚠️ **One honest caveat on "the existing connection".** It is one additional HTTP request inside the same poll cycle, not literally the same request. Fusing it into the termwrite claim would have put a read-model feed behind `CLAWGATE_TERMINAL_TOKEN` — so disarming the write surface, a security act, would silently take the operator's session view with it. The tiers stay separate; the reason is written at `transcript_round`.

## Measured

Driving this module against a real clawgate binary on a real Postgres, at **two poll intervals** because the claim depends on that dimension:

| poll interval | n | min | median | max | mean |
|---|---|---|---|---|---|
| **5s** (the agent's real cadence) | 14 | 0.232s | 2.687s | 4.638s | 2.710s |
| 1s | 12 | 0.043s | 0.599s | 1.176s | 0.612s |

⚠️ The first run reported `min 4.383 / max 4.871` at 5s — a fixed 0.7s inter-trial sleep **aliased** against the fixed poll and sampled one phase of the window. The numbers above use a random phase. The aliased numbers looked perfectly plausible.

**Coverage:** 21 of 21 sessions carried in **one** round (`sent 21, applied 21, refused 0`).

**The reconciler still reconciles:** stream stopped, 40 lines appended, `transcript-push.sh` run **unchanged** → 40/40 gap lines missing before, **0/40 after**; the stream then resumed on top of it (one refusal, then applied). Stored tail 4532 B vs file 4532 B.

## The cursor is the server's, not ours

Every response carries the authoritative offset for every session in the frame, accepted or refused, and this module **adopts** it rather than computing its own by adding `len(data)`. A local computation is right until the one time it is not, and then the two sides are permanently spliced with nothing saying so.

Hydration **replaces** the cursor map rather than merging into it — a session absent from the server's listing has no server-side cursor, and merging would leave a stale offset in place for exactly the session a database restore wiped.

## Four things that would be silent if they were wrong

- **A delta is cut at a newline.** Two jobs at once: no leading JSON fragment in the stored tail, and no multi-byte rune split across two frames (a newline is ASCII, so a cut there is always a rune boundary).
- **The decode is strict.** `errors="replace"` turns one bad byte into a 3-byte U+FFFD, the two sides' byte counts diverge, and — because the host re-reads from the *server's* offset — the same bytes are re-sent and re-refused **for ever**. A session that will not decode is left to the reconciler and counted under its **own** reason, not folded into the ordinary steady state.
- **A file this process has never `stat`'d is reseeded**, even when the server gave us an offset. The inode is the only thing distinguishing "this file grew" from "this is a different file at the same path", and on the first sighting there is none. Cost: one reseed per session per agent lifetime.
- **Past `MAX_LAG_BYTES` the host skips forward** with a reset instead of replaying. Replaying an unbounded backlog makes the stream slower the further behind it falls — the shape where a queue never drains. Lossy by construction, repaired by the reconciler.

## The bulk push stays, and gains the seam field

`fileBytes` is where a tail **ends** in the file, which the server stores as the resume cursor. Without it a bulk push replaces the tail while leaving the cursor describing the tail it replaced, and the next delta splices.

It is derived from what was actually **read** rather than from `size` (the file is being appended to as we read it), and reported as `0` = *unknown* whenever the `errors="replace"` decoded tail re-encodes **longer** than its own bytes — because the server rejects the whole atomic push over that and would take every other session in the request with it.

`MAX_PER_PUSH` 6 → 48, with a new `MAX_PUSH_BYTES` aggregate the builder stops at. 6-against-8 was a **coverage** cap wearing a safety cap's clothes.

## Worst-case gap on deploy

- **A frame lost to a rollout:** the agent catches it (its own `try`, never the write loop's, which would cost a typed reply a 60s backoff), logs once, clears `hydrated`, and resends next poll → **≤ one poll (~5s)** beyond however long clawgate was unreachable.
- **A response lost after the server committed:** one refusal + one poll → **~5s**, nothing duplicated, nothing skipped.
- **Stream cannot run at all:** the 5-minute bulk push is the floor → **~5 minutes**, i.e. exactly today's behaviour. Streaming is off wherever the reply agent is off (no `CLAWGATE_TERMINAL_TOKEN` ⇒ the agent exits 2) and wherever `CLAWGATE_HOOK_TOKEN` is absent — both stated in the log line at startup.

## Tests

Targeted suites, all green: `test_transcript_stream` **38**, `test_transcript_push` **40**, `test_tmux_reply_agent` **114** — **192 total, 0 failing** (174 before round 2, 142 at the base).

### Red→green matrix, at `97ec9912`

| test | at base | at HEAD |
|---|---|---|
| `test_every_pushed_session_carries_fileBytes_equal_to_its_file_size` | **RED** — `KeyError: 'fileBytes'` | green |
| `test_a_truncated_tail_reports_the_WHOLE_file_size_not_the_tail_length` | **RED** — `KeyError: 'fileBytes'` | green |
| `test_coverage_is_not_capped_at_eight_sessions` | **RED** — `one push carried 6 of 21 changed sessions` | green |
| `test_the_aggregate_byte_bound_stops_the_push_before_the_session_count_does` | **RED** — `carried 113040 bytes against a 75360-byte budget` | green |

The coverage fixture is **21** — not a multiple of 8 *or* 6, so a mutant restoring either old cap cannot pass by landing on a boundary.

The 24 tests in `test_transcript_stream.py` are **not** regression tests and are not claimed as such: the module did not exist at base, so they would fail to import rather than fail meaningfully. They are new-feature guards, carried by the battery below.

### The agent/stream seam — separately tested, separately mutated

The module and the agent were each tested in isolation, which is exactly the shape that leaves a defect in the seam nobody owns. Four tests drive the **real agent process** against the stub server:

- both surfaces' traffic from **one** poll — the whole claim of this transport;
- a **failing** stream does not disturb the write path (the seam defect: a stream exception reaching the loop's handler costs a typed reply a 60-second backoff);
- a missing `CLAWGATE_HOOK_TOKEN` turns streaming off and **says so**, without touching the write path;
- a stream failure forces a **re-hydration** — hydration is once per agent lifetime, and a redeploy is the most likely cause of the failure in the first place.

**5 seam mutants, 5 killed**, each on that test's own assertion. The last is mutated so it *keeps* the log line, or it would die at the log assertion and never reach the write-path one.

The stub server gained `do_GET` — without it `BaseHTTPRequestHandler` answers 501 and every streaming test would be measuring the stub.

### Round 2 — two PROVED stalls, a total-outage path, and a deploy gap

An adversarial audit ran 19 mutants against the green suite above and drove the tailer against fleet-shaped fixtures.

**Two liveness stalls, both 100% silent.** A record *larger than one delta* stalled the append path **for ever**: `_read_append` required a newline inside the 48 KiB window, so every poll re-read the same 48 KiB (~830 MB/day) and declined, and the lag escape could never fire (a record between `MAX_DELTA_BYTES` and `MAX_LAG_BYTES` never reaches that threshold). This is **not an edge case here** — the server's own `trimToTail` records the fleet measurement: a single tool-result record has been measured well past 256 KiB. The sessions with the biggest tool output were exactly the ones silently confined to the 5-minute feed. And a file whose *last* record exceeds the window could never reseed at all, which is a **permanent loop**: `plan_frame` only leaves the reseed branch once a cursor is adopted, and none can be adopted while the reseed declines. Hidden by an asymmetry — the bulk push reads a 192 KiB window, so for last-records between the two sizes it worked perfectly while the stream looped.

Both now cut on a **rune** boundary where there is no record boundary, streaming such a record in pieces; the tail ends mid-record for a few seconds, which the parser already tolerates. `len(raw) < budget` is the control that keeps an ordinary in-flight line waiting. A reseed additionally aligns its **start** to a rune boundary and **moves its offset by the bytes it dropped** — aligning the data without moving the offset is *worse* than not aligning, because everything then decodes, everything is accepted, and the cursor names a position the data does not start at.

**One duplicate id was a total, unrecoverable outage.** The server rejects the whole frame on a duplicate and the agent resends the same frame; nothing removed the offending session. Two routes closed: the same `<uuid>.jsonl` under two project dirs, and — because the server `TrimSpace`s the id and this side did not — `abc.jsonl` beside `abc .jsonl`. Measured: 0 duplicates in 949 files, so it was not live; the cost of it becoming live was total.

**The restart trigger, where it mattered least vs where it matters.** `tmux-reply-agent` is a **resident** service that loads `transcript_stream.py` (and `transcript_search.py` through it) once and runs for weeks; neither was a trigger, so a splice fix would land on disk while the running agent kept the old code. Meanwhile the transcript-push *timer*, where a stale copy costs five minutes, named both its halves and was pinned by a test. Now both are triggers, pinned two ways — an exact **set** (a membership check grows silently, which is how this gap opened) and a derivation from the **agent's own source**.

**Five guards nothing could observe**, now covered: the `fileBytes=0` UNKNOWN fallback (without it *one* undecodable byte 400s the entire host's push, atomically, every tick for 24 h); `fileBytes` derived from what was READ rather than from the stat; the frame aggregate accumulator, which was duplicated across the reseed and append arms with only the reseed copy reachable (now one `emit`); the candidate limit; and the `and sessions` exemption, without which a session bigger than the whole budget is dropped **first**, every tick, for ever.

**And the skip counters are now logged**, rate-limited. Both stalls were unobservable *by construction* because `run_round`'s result was discarded.

### Mutation battery on the module — round 1: 14 applied, 14 killed. Round 2: **17 applied, 17 killed**, each on that guard's own assertion


Run under `PYTHONDONTWRITEBYTECODE=1`: several mutants are single-character, same-length edits, and CPython validates a cached module on mtime-in-whole-seconds plus size — a same-length edit in the same second is invisible and would be scored SURVIVED without ever executing. Positive control first (unmutated module green, 24 passed).

first-sighting reseed · rotation detection · truncation detection · the lag bound · the newline cut · the strict decode · a null offset adopted as unknown · a malformed offset refused · hydration replacing rather than merging · the empty-frame suppression · the per-session cap · the frame **count** cap · the frame **aggregate** clamp · the shared enumerator.

### Two findings the battery produced, folded back into the code

- **The aggregate bound was enforced twice** — a `budget <= 0` break *and* a `min(max_delta_bytes, budget)` clamp — so neither could be mutation-tested: delete either and the other silently covered. Worse, the clamp held it **by accident**: a negative budget made `min` negative, which made the file read return nothing, which skipped the session. A bound enforced by a seek past EOF. One expression now computes the remaining allowance and both the break and the read use it; the count and the aggregate are separately killable, with fixtures each unreachable by the other guard.
- **The rotation fixture was asserting nothing.** `unlink` then create hands the same inode straight back on this host's tmpfs, so the "rotated" file had the *same* inode as before. It now creates the replacement alongside and `os.replace`s it, with an explicit assertion that the inode actually moved.

## Not done / not verified

- **Not deployed and not verified on either host.** Every number above is from this box against a locally-built clawgate.
- The once-only log **de-duplication** (a repeating stream condition logged once rather than 17,280 times a day) is not directly asserted; the tests only see the first occurrence.
- The full `scripts/tests` sweep was still running at 14% (0 failures) when this was pushed; I am relying on `tekton/devrc-pytests` for the rest of it.
- I have **not** verified that a genuinely rotated Claude Code transcript occurs in practice — the rotation path is defensive.

---

## Rounds 9–20

The ladder ran twelve more rounds, and stops at 20 for a stated reason. None found a defect in the streaming protocol; all three found the coverage or the prose claiming more than it delivered — which is the failure mode this ladder exists to catch, and round 11 caught round 10 committing it.

| round | what it found | severity |
|---|---|---|
| 9 | the duplicate-id guard went on the feed with the **smaller** blast radius. `plan_frame` strips and de-duplicates session ids; the bulk builder did neither — and on that side `NormalizePush` rejects the **whole push**, so one colliding id stalls **every** session on the host permanently, on every 5-minute tick. This arc widened the exposure itself (`MAX_PER_PUSH` 6 → 48). Not live, measured at **two points** rather than one: **962 files → 966 files**, **0 duplicates** after `TrimSpace` both times | high |
| 9 | round 8's two-reason fixture was a **race** — a `threading.Timer(0.5)` stagger fired before the agent's first poll in **3 of 12 runs**, putting the fixture in the degenerate configuration where the mutant survives, and the assertion `1 <= len(lines) <= 2` passed anyway. Re-measured with the mutant applied: killed 10/10 at ambient load, **SURVIVED 4/14 under load**. The stagger is now driven from the stub server's own handler on the agent's third poll, and the assertion is `== 2` | medium |
| 9 | a **tautological** ledger test built its expected set with the same predicate the code uses, so adding a sixth reason **passed** while its docstring claimed that case "moves this test" | medium |
| 10 | the transcript-push **timer never named `transcript_search.py`** in `X-Restart-Triggers`, although `build_transcript_push.py` imports it and exits `rc 1` without it. ⚠️ **The guard meant to catch this was pinning the set that omitted it** — adding the missing trigger made the ledger test go **red**. (Round 10 also claimed this meant the timer would run stale code indefinitely; **round 11 retracted that** — see below. The undeclared dependency is real; the consequence was one tick) | medium |
| 10 | four comments across both repos claimed more than the code does, including a **backoff that was measured not to happen** | medium |
| 11 | **round 10 overstated its own finding.** The transcript-push unit is `Type=oneshot` on a 5-minute timer whose `ExecStart` names the **working-tree** path, and the script resolves the builder through `readlink -f "$0"` — so the next tick execs current code with or without a trigger. A missing trigger costs **one tick**, not the "stale deploy, silently, with no error anywhere" round 10 claimed. This repo states that bound itself, 123 lines away | high |
| 11 | round 10's attribution was also wrong: *"the agent's list gained it when the tailer started loading it"* — git says `8eb1ff49` (tailer loads it) **touched `nix/home.nix` not at all**, the agent's trigger arrived two commits later as a fix, and the builder has imported it since `29a5c77d`, before the tailer existed. **Neither** unit followed the rule; the timer's gap was the older one | high |
| 11 | round 10's *"nothing consumes that count"* is true of production and false of the suite — **ten** assertions consume `applied`/`refused`, and the same comment two sentences later cites those tests as the reason the constants exist | medium |
| 11 | round 10 listed `1.8x` beside `2.0x` as if both were bound-to-bound ratios. They are not: the pair is **exactly 2.0**, and 1.8 is the JSON-escape factor the cap is *sized by*. As written it invites computing `8/1.8` and inferring 0.44 MiB of unused room | low |

**Round-9 battery: 6 mutants, 6 killed.** Both halves of the reconciler guard, the sticky-memo rebind (verified over **4 consecutive** runs, not one), the stagger degenerating, and the reason ledger in **both** directions.

**Round-10 battery: 5 mutants, 5 killed** — the new trigger removed, a pre-existing trigger removed, a **stray** trigger added (the ledger fails on growth as well as shrink), the sibling ledger on the resident-agent unit failing for **its own** reason (killed by both the hand-written and the source-derived test), and the builder driven with `transcript_search.py` hidden (`rc=1`, `ModuleNotFoundError`) against a positive control with the module present (`rc=0`).

⚠️ **Two battery faults in round 10, both facts about the instrument rather than findings**, reported because a battery that is never wrong is a battery nobody checked: the growth mutant's own read-back asserted the pattern **count drops by one**, which is true for a removal and false for an insertion; and the sibling-ledger mutant was first scored against the wrong suite (both `X-Restart-Triggers` ledgers live in `test_transcript_push.py`, not the agent suite) where `-k` selected **nothing**. Neither produced a wrong verdict about the code — both aborted or reported `WRONG-WHY` rather than a false `SURVIVED`.

**The one comment claim worth repeating, because a previous commit in this arc claimed to have removed it and had not:** the "refusal is a 200, not a 4xx" rationale rested on *"a 4xx would drive the agent into its 60 s backoff"*. It would not — the stream call has its own `except` in the producer's loop, above the handler that owns `BACKOFF_SECONDS`, precisely so a transcript hiccup cannot delay a typed reply. Measured, with a positive control on the other arm so the zero means something:

```
stream 400 : 222 requests in 4.1s, backoff lines []
claim  400 :   3 requests in 4.2s, "backing off 60s: … HTTP 400"
```

The instrument can see a backoff; the stream path simply does not take one. The status contract stands on the rest of the sentence.

### Round 11 also CLOSED the gap round 10 only disclosed

Round 10's own comment admitted the transcript-push timer had no source-derived ledger — only a hand-written `want` set, which is what graded the omission as correct in the first place. `test_every_lib_module_this_UNIT_hard_depends_on_IS_a_restart_trigger` now derives the expected set from the two files the unit actually runs.

🔴 **Both sources, because the unit has two — and the guard's own positive control caught the first draft.** Scanning only the builder's imports looked complete and was blind to `host_label.py`, which the **shell** resolves (fatal, exit 3) and the builder never imports. The control asserting one known dependency *per mechanism* failed immediately; without it, that draft would have shipped as a green ledger covering half the unit.

**Round-11 battery: 4 mutants, 4 killed** — the round-10 trigger removed (which *is* the pre-fix tree, so the new guard is red there and green here), the shell-resolved dependency removed (killing the **shell arm alone**, since the builder never imports it), and each scanner arm blinded in turn so the positive control fires rather than passing on an empty set.

⚠️ A fifth mutant was written and **discarded rather than reported**: forcing `missing = set()` makes the guard unable to fire, so the test passes and it scores SURVIVED by construction. A mutant whose expected outcome is SURVIVED measures nothing.

⚠️ **Reported, not fixed — the same class is open in four other units** in `nix/home.nix` (`tmux-snapshot-push`, `handoff-index-sync`, `mention-known-repos-refresh`, `analyze-service-index-backup`): each `ExecStart` script loads a `scripts/lib` module that is not a declared trigger. All four are oneshot+timer, so by the round-11 finding above the cost is one tick each. Out of scope for this branch; recorded so it is not re-derived.

### Round 12 — the guard round 11 added was idiom-shaped

The new ledger's docstring said it derives the unit's dependencies from source. Its body was two regexes, and the gap between those two sentences is the whole finding. Measured by adding one real-but-undeclared `scripts/lib` module in each shape and running the guard:

| dependency shape | round-11 guard | round-12 guard |
|---|---|---|
| indented import inside a function | **passed (green)** | killed |
| `try`/`except`-wrapped top-level import | **passed** | killed |
| second name on a shared import line | **passed** | killed |
| `os.path.join(_HERE, "x.py")` loader idiom | **passed** | killed |
| shell resolves a `lib/*.sh` helper | **passed** | killed |

None is hypothetical: `scripts/lib/transcript_search.py` — inside this unit's own dependency chain — carries a `try:`-wrapped import and an `import base64, json, sys`; the loader idiom is what `transcript_stream.py` and `tmux-reply-agent` use, and is the **only** thing the resident-agent sibling test scans for. The new guard was **narrower than the test it was modelled on**.

🔴 **And the positive control stayed true through all five.** A control over the *union* of the arms cannot separate "the scanner is complete" from "the scanner is idiom-shaped and this dependency uses another idiom". It is now **one control per arm**, each naming a dependency only that arm can see.

**The shell arm was scanning comments — wrong in both directions at once:**

```
a comment-only mention of scripts/lib/agent_ledger.py
    -> the guard DEMANDED a trigger for a file the script never opens

deleting line 99 — the only line that actually resolves host_label.py —
    -> 'host_label.py' still "needed", because line 79 mentions it in PROSE,
       so the control stayed green over an arm that had stopped seeing code
```

Two more, one of which **only the battery found**: `scripts/lib` really contains `host-role.sh`, and the pattern was `[a-z_][a-z0-9_]*` — it cannot match a **hyphen**, so a mutant adding exactly that dependency **survived**. And "the two files the unit actually runs" was one short — the unit runs **three** (the shell, then `python3 "$HOST_LABEL_PY"`, then `python3 "$BUILDER"`), so `host_label.py`'s own imports were never read.

**Round-12 battery: 9 mutants, 9 correct** — the five shapes now killed, the comment-only mention *correctly silent*, each arm's control firing when that arm alone is blinded, and the declared trigger removed.

⚠️ **One battery fault, reported rather than quietly fixed:** the builder-arm control mutant first scored SURVIVED. That was the mutant, not the guard — it blinded the `ast.Import` branch while the sentinel arrives as `ast.ImportFrom`, so the arm was working and the control was right to stay green. Retargeted at the branch the sentinel actually travels.

⚠️ **A correction to round 11's out-of-scope note:** of the four units it named, two are one hop off — `tmux-snapshot-push`'s ExecStart script references no lib module at all (the undeclared ones are loaded by `scripts/session-manager`, which *is* a declared trigger), and `mention-known-repos-refresh`'s import resolves to `scripts/collector/`, not `scripts/lib/`. The substance holds for all four; the mechanism description did not.

### Round 14 — the comment stripper hid a real dependency, and "three controls" were two

Round 12 fixed a guard whose docstring was wider than its body, and shipped two new instances of the same shape.

**The over-strip direction was declared safe and is not — it passes green.** Round 12's stripper was `#`-at-line-start plus `\s#.*$`, and its docstring said the approximation "can only make the scanner see LESS, which the per-arm controls turn into a failure rather than a silent pass". Measured, false — a real executable line resolving `scripts/lib/host-role.sh` (a file that exists and is **not** declared), on a line that also carries a quoted `#`:

```
printf "fmt: a #b\n"; ROLE="$(bash "$(dirname "$(readlink -f "$0")")/lib/host-role.sh")"
    -> guard PASSES green; the dependency vanished at the quoted hash
    -> same line without the quoted #: FAILS correctly, naming host-role.sh
```

The controls pin two named modules; **any other** module lost to over-strip is a silent pass.

**And the under-strip direction reproduced the defect round 12 reported fixed.** bash starts a comment at `#` after an operator with no space — verified against bash itself, a script of four such lines prints only `A` and `END`. `\s#` matches none of them, so each minted a **phantom requirement** for a file the script never opens (`;#`, `|#`, `&&#`, `)#`).

The stripper is now a quote-aware walk: `#` opens a comment only outside quotes and only at the start of a word. `X=y#foo` is left alone, because bash does not treat that as a comment either. **9/9 cases correct, both directions, against a bash oracle.** A here-doc body is still not modelled, and is written down as a limit rather than left implied.

**"Three arms, three separate positive controls" — there were two.** Arm (c)'s control was `assert from_host_label == set()`, satisfied identically by "the arm ran and found nothing" and "the arm is wired to nothing". Measured: **blinding arm (c) alone left the whole guard green.** It cannot be given an arm-exclusive sentinel honestly — its subject imports only stdlib, so its correct result *is* empty. It gets a synthetic probe of the shared helper instead, described by what it covers:

| | |
|---|---|
| **covered** | the helper is live; the `libdir` this call site passes resolves |
| **not covered** | a defect confined to arm (c)'s call site alone |

🔴 **And the probe is not independently demonstrable, which is said rather than glossed:** a shared-helper mutation is caught by arm (a)'s control *first*, so the probe never executes. Asserting the probe's own message in the battery would have been asserting an **unreachable guard**.

**A cited example that was not what it was quoted as.** Round 12 justified the AST rewrite partly with "`import base64, json, sys` … appears in `transcript_search.py`". It appears there inside a triple-quoted raw string, as the source of a script run on a *peer* — not an import. An AST walk correctly does not report it; **the old regex did**. So on that one shape the rewrite is *narrower*, deliberately, and the example argued against the change it was cited for.

The limits list is now enumerated by **running** each shape with a real undeclared module injected, rather than gesturing at "a mechanism none of the three use": `importlib.import_module`, `__import__`, an f-string path, a path with a nested call before the literal, `Path(__file__).parent`, **zero transitive hops** (the sibling guard follows one), and the embedded-script idiom.

**Round-14 battery: 16 mutants, 16 correct** — round 12's nine, plus the over-strip case now killed, the four operator-adjacent comment forms now correctly silent, the shared-helper mutation scored against the control that actually catches it, and **arm (c) blinded alone recorded as expected-SURVIVED** so the known gap lives in the battery rather than only in prose.

⚠️ A syntax error was introduced and caught by collection mid-round: the new docstring contained a literal triple quote, which closed it. Reported because the mechanism — quoting shell/python syntax inside a docstring *about* quoting — will recur.

### Rounds 15–16 — the over-strip class, closed; and the stripper had no tests

Round 15 (audit) found **no BLOCKER and no HIGH**, and the regression check was clean — but it found twelve disagreements with bash across 57 differential cases, and roughly half were in the **over-strip** direction: the walk deletes text bash would execute, so a `scripts/lib/<x>.py` inside it vanishes and the ledger passes **green** over an undeclared dependency. Round 16 fixed all five of those; every one was latent (absent from `transcript-push.sh` today).

| # | over-strip | fix |
|---|---|---|
| 1 | **quote state reset per line** — a bash string spans newlines, so a `#`-leading line *inside* a multi-line string was deleted | quote state now threads across lines |
| 2 | the mirror of (1) — the line after a closing quote read it as an *opening* one, keeping a real trailing comment (phantom requirement) | same fix |
| 3 | `prev` was the **raw** previous char — in `echo a\ #x` the `\ ` is an escaped *space*, so re-reading `line[i-1]` saw a space and called `#` a word start; bash makes it one word | tracked as a flag |
| 4 | a `)` **closing a substitution** is mid-word — `echo $(true)#x` and `echo $((1+2))#x` are one word | `$(`/`$((` push a depth counter; a bare `(` does not, because a *subshell*'s `)` genuinely is a word start |
| 5 | a **backslash-newline continuation** was not joined, so the following `#` line was deleted although bash joins it into one word | continuations joined first, counting trailing backslashes so an escaped backslash does not |

🔴 **I expected fix (1) to poison the real file and it does not — measured, not assumed.** `transcript-push.sh` has two lines with an odd `"` count and fifteen with an odd `'`, which looks like it would leave the walk permanently inside a string; every one is a full-line `#` comment, where the walk breaks at column 0 before reading any quote. Real-tree output is byte-identical before and after.

**The word-start set is now chosen by a safety asymmetry, not by completeness.** Round 14 had added `<` and `>` because bash *errored* when they were followed by `#` — but an error is not evidence the text became a comment. Probing each character individually settles it:

```
; | & ` and whitespace  -> comment            (in)
< >                     -> NOT a comment      (OUT — a measured over-strip)
) }                     -> context-dependent; `(true)#` and `{ …; }#` ARE
                           comments, so they stay in
```

The rule, written into the code: a character goes in only once measured as a comment start in a **realistic** shape. Omitting one bash would honour mints a phantom requirement — **loud**. Adding one bash would not hides a dependency — **silent**. When unsure, leave it out.

**Still not modelled, and acceptable:** a here-doc body, `$'…'` quoting, and a `#` inside `$(…)`/backticks nested in double quotes. All three are latent (0 occurrences) and all three are the **false-FAIL** direction, which is loud. Enumerated by running each against bash rather than gestured at.

**And the reason none of this was ever caught: the stripper had no tests.** On the real script it is a **no-op** — same module set stripped, unstripped, and under the old regex version — so its entire worth is prospective, and every defect it has had was found by a throwaway harness and then left unguarded. It now has a **17-row parametrised table** whose every expectation came from bash.

🔴 **The oracle itself was wrong first, and its own controls caught it.** The probe put `; echo SAW` on the line *after* the marker, where it always runs — so it reported "not a comment" for a plain `# comment` and scored a nonsense 8/17. The probe is now same-line and asserts a known-comment and a known-code control before any verdict is read. **Final: 17/17 agree with bash.**

**Tests:** **229 passing** across the three suites (was 212; +17 stripper rows), 0 failing. Battery unchanged at **16/16**. Real-tree scan identical before and after.

### Rounds 17–18 — the per-line walk was the common cause, and two justifications were refuted

Round 17 (audit) found **two HIGH over-strips whose justifications were round 16's own measurements**, plus a defect round 16 *created*. Round 18 replaced the architecture rather than patching the symptoms.

**Two word-start entries refuted by the rule that admitted them.** Round 16's stated rule was "a character goes in only once measured as a comment start in a realistic shape":

- **`}`** was admitted on the strength of `{ echo a; }#` — which **does not parse** (`syntax error: unexpected end of file from \`{' command`), so bash has no verdict to cite. The two `}#` shapes bash *does* accept both **keep** the text (`echo ${V}#x` → `1#x`; `echo {a,b}#x` → `a#x b#x`), and the walk was stripping both. Removed.
- **backtick** was admitted as a flat word-start character, which is half true: it has exactly the `(`/`)` asymmetry round 16 had already fixed for parens — an *opening* backtick starts a comment context, a *closing* one is mid-word. Now tracked with a depth toggle. 🔴 And nothing pinned it: **deleting the backtick from the set left all 17 rows green** — a character the probe table asserted as measured, guarded by no test at all.

**One design, three over-strips.** `sub_depth` reset per line while quote state was threaded, so a `$( … )` spanning a real newline left its `)` looking like a word start; the continuation pre-pass swallowed the next line when the first was a **comment** (bash ends a comment at the newline whatever the backslash does) — 🔴 **a defect introduced by round 16's own fix**; and the join left `prev` reading the raw previous character, a newline, so the joined word looked like a line start. The walk is now a **single pass over the whole source**, where comment state is known.

**Two "acceptable" shapes were the silent direction, not the loud one.** Round 16 wrote that its three unmodelled shapes were "all the false-FAIL direction, which is LOUD". Measured, two of three were over-strips:

| shape | bash | old walk | direction |
|---|---|---|---|
| heredoc body `#` line | **keeps** (it is content) | stripped | **over (silent)** |
| `$'a\'b #/lib/x.py'` | **keeps** | stripped | **over (silent)** |
| `#` in `$(…)` inside `"…"` | comments | keeps | under (loud) ✓ |

Both are now handled — heredoc bodies copied verbatim to the terminator, `$'…'` given its own quote state because backslash escapes there and does not in plain `'…'`.

**The table** is 23 agreement rows plus 3 named divergences (was 17). Two rows were **removed as refuted** rather than kept and re-explained: `}#`, and `>#` — bash *does* comment after a redirect (`echo hi > a#foo` creates the file `a#foo`; `echo hi >#foo` is a syntax error and creates **no** file), so round 16's "bash keeps it" was inverted. `<`/`>` stay out anyway, now as a *named divergence* with the trade written down instead of an agreement claim.

🔴 **One row was vacuous and is now paired.** `F=/lib/MARK.py#tag` puts the marker *before* the `#`, and the walk keeps what it accumulated before breaking — so it passes even under a mutant where **every** `#` starts a comment. Its mirror `F=#tag/lib/MARK.py` is the killing fixture and now sits beside it.

🔴 **The oracle was wrong a third time, in a new way.** For a backtick substitution inside double quotes, the `; echo SAW` probe reports "kept" because that `echo` sits *outside* the substitution and runs either way — bash actually prints `[]`. Caught by cross-checking stdout. All three oracle faults are recorded in the docstring so they are not re-derived.

**Corrections to round 16's own claims:** "real-tree output is byte-identical" was **false** (309 → 288 lines; the join collapses 21 continuations) — what is invariant is the derived **module set**, which the guard actually consumes, and the claim now says set rather than bytes. "Fifteen odd-`'` lines, every one a full-line comment" was 13 of 15 — the other two are executable and safe for a *different* reason. And round 17 reproduced `1 failed, 228 passed` in a single sweep on a pre-existing order-dependent test in a suite this branch does not touch; it did not reproduce in mine (238 passed), so it is reported rather than dropped.

**Tests:** **238 passing in one sweep**, 0 failing. Stripper vs bash: **24/24** agreeing shapes, both directions, oracle gated on known-comment and known-code controls. Battery unchanged at **16/16**. Derived module set identical under the new walk, every previous walk, and no stripping at all.

### Rounds 19–20 — fail-safe instead of enumeration, and why the ladder stops here

Round 19 found **seven more over-strips**, every one a group delimiter the counter could not pair, every one the silent direction:

```
V=$( (cd / && pwd) )#/lib/x.py     a plain subshell inside $( )
V=$(case a in b) echo Z;; esac)#…  a case pattern's ) inside $( )
echo $(( (1+2)*3 ))#/lib/x.py      a nested ( inside $(( ))
wc -l <(echo z)#/lib/x.py          a process substitution
echo x\`#/lib/x.py                 an ESCAPED backtick read as an opening one
cat <<A <<B                        the SECOND heredoc never armed
cat <<\EOF  /  cat <<$T            terminator forms the regex did not match
<<EOF … "  EOF"                    .strip() ended the heredoc EARLY, then lexed
                                   the remaining BODY as shell
```

**So round 20's fix is not another seven cases — it is two fail-safes.**

- **`saw_subst`** — once a substitution opens on a line, every later `)` is mid-word, so a following `#` is **kept**. Deliberately one-way and deliberately imprecise: a `case` pattern's `)` inside `$( … )` is genuinely unbalanced and no counter can pair it. Erring toward "not a word start" turns the whole family into a loud under-strip.
- **`unmodelled`** — a `<<` whose terminator this walk cannot resolve sets a flag and the function returns the source **unstripped**. Structural rather than enumerated: it covers heredoc forms nobody has thought of yet, converting them from silent holes into loud phantom requirements *by construction*.

Plus precise fixes where precision exists: `(` counts inside a substitution and after `<`/`>`; heredoc terminators are a **queue**, drained back-to-back (`cmd <<A <<B` runs the bodies with no newline between them); the terminator match is **exact**, tabs allowed only under `<<-`; the opening-backtick clause is gated on `not prev_was_escape` like every clause beside it.

**Three mechanisms the docstring asserted as measured and no row covered.** Round 19 mutated the walk and watched all 26 rows stay green for each:

| mutant | before | after |
|---|---|---|
| delete `(` from the word-start set | **survived** | killed (`1 failed, 37 passed`) |
| delete the opening-backtick clause | **survived** | killed |
| replace `prev == "\n"` with `or False` | **survived** | killed |

The third is the clause doing almost all the real work (288 of 309 lines survive stripping, overwhelmingly full-line comments on lines ≥ 2).

⚠️ **The second is the same defect this arc already named once.** Round 18's message says of the backtick: *"a character the probe table asserted as measured, guarded by no test at all"* — and the fix it shipped covered the **closing** half while leaving the **opening** half equally unguarded. The lesson did not generalise the first time it was written down.

🔴 **Why the ladder stops here, stated plainly.** Rounds 13, 15, 17 and 19 each found real over-strips in this hand-rolled shell lexer; rounds 14, 16, 18 and 20 each fixed them and each introduced or exposed more. **The defect rate is not falling**, and the cause is structural — this is a shell lexer written by hand in a test helper. Every finding across all four rounds has also been **latent**: `transcript-push.sh`, the only file this guard reads, has zero heredocs, zero `$( (`, zero process substitutions, zero `$'…'`, zero executable backticks, and the derived **module set is identical under every version of the walk and under no stripping at all**. The two fail-safes are what makes stopping defensible — an unmodelled construct now yields a loud phantom requirement rather than a silent hole. The right structural fix (do not hand-roll a shell lexer for this) is a **scope decision**, recorded here rather than taken unilaterally.

**Tests:** **250 passing** in one sweep (was 238; +12 rows), 0 failing. Stripper vs bash: **35/35** agreeing shapes across both harnesses, both directions, oracle gated on known-comment and known-code controls on every run. Battery **16/16**. Module set on the real script unchanged.

### Rebased onto current mainline (both branches)

Both branches were green while sitting well behind their mainline — **#771 was 23 behind `trunk`, #1408 17 behind `main`** — and a green on a stale branch says nothing about the tree its merge creates. Both are now rebased onto the current remote tip and force-pushed with `--force-with-lease`; both report **0 behind**.

- **homelab:** the `containers/clawgate` tree is **byte-identical between the old and new rebase bases**, so every red-at-base result below carries over unchanged — established by content, not assumed.
- **devrc:** `nix/home.nix` is the one file both sides touched. The single upstream commit to it (`9300f234`, pinning `cairn`) edits lines ~1444–1497; my trigger blocks are at ~3730 and ~3899. The merged region was **read**, not inferred from a clean rebase: both units' trigger lists survive intact, the file parses (`nix-instantiate --parse`), and both ledger guards pass on the merged tree.

Re-run after the rebase: **devrc 212 passed / 0 failed**; **clawgate 24 packages ok / 0 FAIL**; the 16-mutant battery **16/16**; the six headline acceptance tests **6/6**.

### The write-ledger test

This PR touches `internal/api/terminal_write_ledger_test.go`, and the change is **purely additive** — one new entry in `allowedNonTerminalWrites` documenting `POST /api/transcripts/stream`. Nothing was weakened or re-shaped. The ledger **demanded** it: removing the entry makes `TestEveryTerminalSurfaceWriteIsBehindTheFailClosedWrapper` fail with

```
terminal_write_ledger_test.go:458: transcripts.go:102 registers the terminal-surface WRITE
"POST /api/transcripts/stream" behind "requireHookToken".
```

The route is registered `mux.HandleFunc("POST /api/transcripts/stream", s.requireHookToken(...))` — the hook tier, exactly as the entry states. ⚠️ That ledger's own header calls itself an **invariant guard, not regression coverage**, and it is counted as one here.

### Added to "not verified"

- 🔴 **Criterion 1 says "measured on both hosts". It was measured on ONE** — this box. The producer is host-agnostic by construction (`host_label.py` is the single rule, and `host-changed` is a first-class refusal reason with its own test), but that is an argument, not a measurement. The second host needs the branch deployed, which is out of scope here.
- The card's process brief states *".envrc is TRACKED in BOTH repos"*. **True for homelab-infra, false for devrc** — measured at six points (both primary clones and all four worktrees): devrc's `.envrc` is untracked and exists only in the primary clone, so a devrc worktree has none. Nothing was copied or staged; every command here used an explicit `nix develop <path> -c …` rather than direnv.
- 🔴 **Four tests failed in the FULL local `run-tests.sh` tier and I did not isolate the mechanism.** They are in `scripts/tests/test_run_tests_targets.py` — a file this branch does not touch — and they reproduce only inside the full parallel run: they pass **4/4 in isolation at three separate points** (pre-rebase tip, pre-rebase base, rebased tip). The definitive control, a full `run-tests.sh` at `origin/main`, was attempted **twice and killed both times** before finishing, so “not mine” rests on the isolation runs and the untouched-file fact, not on a same-conditions control. I am not claiming it resolved. The hermetic CI tier (`devrc-pytests`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JAuWGDWCNMXDaATw8LFfU


---

## Round-2 addendum: two fixtures that were asserting nothing

Both found by the battery, not by reading:

- the **rotation** fixture did `unlink` then create, and this host's tmpfs hands the same inode straight back — so the "rotated" file had the *same* inode and the test pinned nothing. It now creates the replacement alongside and `os.replace`s it, asserting the inode actually moved.
- the **mid-rune reseed** fixture padded *before* the runes, which shifts the file length and the rune grid by the same amount — so all three paddings landed exactly on a boundary and the alignment never ran. It pads after now, with a positive control asserting at least one padding really does land mid-rune.


---

## Round 3 — the round-2 fix had a blocker in it

An adversarial **delta** audit of round 2 (its own rule: an audit fix resets the verification gate) found that the host guard round 2 added made `host` a correctness predicate **while the two feeders derived it differently**:

| feeder | rule | value |
|---|---|---|
| bulk `transcript-push.sh` | `${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}` — but `ACTIVITY_HOST` lives in a **file the unit never sources**, so it fell through | `nixos` (**on both machines**) |
| stream `tmux-reply-agent` | reads that file | `workbench` |

And on the deployed server every stored row already said `host: nixos` — the column has been useless since it existed. `PutAll` sets `host` unconditionally, so every 5-minute push would stamp `nixos` back and every 5-second poll would then reseed **up to 48 KiB per session, for ever**, with `truncated` set sticky-true each time. Before the guard, that same state was a cheap `offset-mismatch` carrying a usable offset.

**Fixed by consolidation**, not a special case: `scripts/lib/host_label.py` is the one rule, both feeders read it, and a failure to resolve is **fatal** — falling back to `uname -n` is what produced the defect silently. The test asserts *that the two agree*, not that either is right: pinning each side to a literal separately is exactly what let them drift, and both would have stayed green.

Verified end to end against a real clawgate on a real Postgres, with the bulk push run through the **real shell script and no override**:

```
shared label: workbench
round1 (stream seeds): {'sent': 1, 'applied': 1, 'refused': 0}
bulk rc=0: pushed 619B … {"ok":true,"sessions":["hostseam-1"]}
stored host after the bulk push: workbench
round2 (stream, after bulk): {'refused': 1}     # correct: the bulk moved the cursor
round3:                      {'applied': 1}
CONVERGED: True in 2 round(s) | stored host 'workbench' == stream host 'workbench'
```
(with a control that fails the run if the bulk push skipped on the digest and wrote nothing — the first attempt did exactly that, which would have made "the hosts match" a fact about the stream's own write.)

**Also in round 3:** a tail ending **mid-record** was being counted as `Malformed` — the corruption signal — on every over-sized record for the ~30 s it takes to stream, and this fleet writes tool results well past 256 KiB. `Parse` now exempts a trailing partial the way it already exempted a leading one, reported as a **separate** field because the two have different lifetimes (a leading partial is permanent; a trailing one is seconds from completing). A broken record in the *middle* is still `Malformed`, asserted as the negative control. Plus: the `FOR UPDATE` check became an **allowlist** (`FOR UPDATE SKIP  LOCKED` with two spaces already walked the denylist its comment called exhaustive); a fixture-validity guard that could not fire; the reseed path's missing in-flight discriminator; an exact `at_eof` instead of `len(raw) < budget`; and the host-blind `ApplyDelta` wrapper removed so no unit test exercises a path production never takes.

**Round-3 mutation battery: 14 applied, 14 killed.** Three first scored wrong and all three were facts about the *battery* — two patterns that did not match (it now asserts every substitution applied), one mutant that could not compile, and one scored against a test that does not hold the guard (disabling hydration **survived** the cross-writer tests, correctly: what makes those recover is the cursor the *refusal* carries back).

### Re-measured after round 3

| poll interval | n | min | median | max | mean |
|---|---|---|---|---|---|
| **5s** | 14 | 0.381s | 2.445s | 4.855s | 2.380s |
| 1s | 12 | 0.094s | 0.562s | 1.012s | 0.481s |

Coverage 21/21 in one poll; the reconciler still repairs a 40-line induced gap (40/40 → 0/40) and the stream resumes on the next poll; stored tail 4532 B vs file 4532 B.


---

## Round 4 — and the `devrc-pytests` red that was NOT this change

### The CI red, attributed rather than assumed

`tekton/devrc-pytests` went **red on the round-3 commit** and is **green again on round 4** — with no change between them that touches the failing area. Attributed with a three-way control before drawing any conclusion:

| run | tier | result |
|---|---|---|
| my branch, local `run-tests.sh` | non-hermetic | **PASS**, 13130 passed |
| my branch, `nix build .#checks.x86_64-linux.pytests` | hermetic | 20 failed / 13111 passed |
| **my branch BASE `97ec9912`** (none of my commits), same tier, same host, same hour | hermetic | **20 failed / 13048 passed — the identical 17 named tests** |

`comm` over the two failure-name lists: **0 tests fail on my branch that do not also fail at the base, and 0 the other way.** All 17 are a nebula/relay config-patcher suite failing at `rc=126` — nothing transcript-shaped. My branch adds **+63 passing tests and zero new failures**.

⚠️ **What I did NOT establish:** when that red began, or why CI now passes the same tree that failed an hour earlier. The failure reproduces on this host at both revisions and does not reproduce in CI now, so it is environment-sensitive, not a function of the tree. The two tiers disagreeing is itself the point — the local tier is structurally blind to it, so "the local gate is green" was never evidence about this gate.

### What round 4 fixed

An audit of round 3 found no blocker and six should-fixes. The one that matters: round 3 taught the parser to exempt a trailing partial **and did not carry the flag to the view that renders the claim**, so the page went from saying something *wrong* to asserting something *stronger and false*:

```
round 3   footer says "the whole stored tail is shown" : true   (a record IS missing off the end)
round 2   footer says "the whole stored tail is shown" : true
          footer says "unreadable line"                : true   (wrong, but it said something)
```

Reachable with no host truncation at all — `MaxDeltaBytes` 48 KiB vs `MaxTailBytes` 256 KiB, so every record between them streams in pieces. `TrailingPartial` is now carried end to end and rendered **separately** from `Truncated`, because "earlier messages are gone" and "the newest record is seconds away" call for different actions.

Also: the `trailingPartial` API key had **zero** coverage (deleting it left the module green); `ApplyDelta`'s `storedHost != ""` exemption described a state the code cannot take and its mutant **survived**, so the clause is gone; the host-label consolidation had left a **fourth copy** — the env-file *path* — so `HOST_LABEL_ENV_FILE` was dead for the agent and pointing it elsewhere changed nothing; the reseed's new `start == 0` narrowing was pinned in one direction only (widening it back **survived**, and reintroduces the permanent loop); `transcript-push.sh` gained a third hard dependency whose restart trigger was not added while the same commit added the agent's; and four comments had become false, including `Malformed`'s own doc — the one round 3's commit message cites as its authority.

**Round-4 battery: 6 mutants, 6 killed.** Every Go mutant is now **built before it is scored**, because round 3 produced a "finding" that was really a mutant that could not compile — not a measurement in either direction.


---

## Rounds 5–8, and the `devrc-pytests` red resolved

The audit ladder ran to **eight rounds**; a round ends it only by finding nothing, and each of these found something the previous round's fix had introduced.

| round | what it found | severity |
|---|---|---|
| 5 | the round-4 seam test asserted a struct literal **against itself** — the fold it forbade could never fire, and OR-ing `TrailingPartial` into `Truncated` **survived the whole module**; one of four footer arms had no test | medium |
| 6 | round 3's trailing-partial exemption fired on **terminated** garbage — every bulk-feeder tail ends with a newline, so a corrupt final record reported `malformed=0` and the page said a record "is still arriving" when it never would | medium |
| 7 | the skip memo still flooded on a **flapping** reason (39 log lines / 40 polls, measured); its test asserted `<= 1`, which passes at **zero** | low |
| 8 | `stream_skips \|= fresh` → **rebind** survived all 208 tests and restores the flood; no test drove the loop with **two** reasons | medium |

Each fix is mutation-verified: **27 / 27** (round 2), **14 / 14** (3), **6 / 6** (4), **4 / 4** (5), **8 / 8** (6), **6 / 6** (7–8). Three mutants across the ladder first scored wrong and **all three were faults in the battery, not findings** — two patterns that did not match (it now asserts every substitution applied) and one mutant that did not compile (Go mutants are now built before they are scored).

### The CI red, resolved

`tekton/devrc-pytests` failed on the round-3 commit. Attributed rather than assumed, with a three-way control: **the identical 17 tests failed at my branch base with none of my commits**, on the same host in the same hour — a nebula/relay suite at `rc=126`, nothing transcript-shaped. Current `origin/main` was **green** (13,244 passed), so the red was inherited from a base 26 commits stale, fixed upstream by devrc#1407 (*"run the relay verifier through this shell, not /usr/bin/env"*).

Both branches were then **rebased onto current mainlines** — which is the right hygiene anyway (gate on the merged tree, not the stale branch). Verified: the rebase range touches **zero files** either branch edits, `0034` is still the only migration with that number, and the gate now reports

```
tekton/devrc-pytests success :: TOTAL collected=21395  passed=21393  skipped=2  failed=0
```









