### PR TITLE
fix(escrow): age has more than three refusals — three ordinary corruptions were reaching "CANNOT SAY WHY"

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -360,7 +360,7 @@ disaster-recovery key gets rotated, or a tampered backup gets waved through:
 | `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |
 | `30` `ARTIFACT-UNREADABLE` | failed before the key was used | diagnose the object, not the key |
 | `25` `DECRYPT-FAILED` | age refused **before the payload**: wrong key **or** damaged header — **not separable**. ⚠ The same code also carries a second message, *"CANNOT SAY WHY"*, when age refuses in a way this tool cannot read — then **three** causes stay open, corruption included. Read the sentence, not just the number. | try a **different** artifact (`--scope <other>`) with the same escrowed copy: if another opens, the key is fine and this object's header is damaged. **Do not rotate first.** |
-| `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed the payload | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
+| `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed past it — a payload chunk that would not authenticate, or an artifact that ran out of bytes | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
 | `31` `ARTIFACT-EMPTY` | age exited **zero** on an empty payload (**the key worked**) | the artifact holds nothing; do not rotate |
 | `26` `RESTORE-FAILED` | decrypted fine, the git bundle is bad | artifact fault; do not rotate |
 
@@ -383,20 +383,45 @@ which is every artifact this subsystem produces. Left alone, that reported a
 TAMPERED backup as `25` — the row that points at your key.
 
 The distinction **survives**, but on weaker footing: it is now taken primarily
-from age's own refusal message (`failed to decrypt and authenticate payload
-chunk` vs `no identity matched any of the recipients` vs `failed to read
-header`), which is byte-identical on v1.3.1 and v1.3.2. File presence is kept as
-a second signal — still **sufficient**, no longer **necessary**. Both are
-combined in `escrow-verify.py`; the classification itself is
-`restore-verify.py::classify_age_refusal`.
+from age's own refusal message, which is byte-identical on v1.3.1 and v1.3.2.
+File presence is kept as a second signal — still **sufficient**, no longer
+**necessary**. Both are combined in `escrow-verify.py`; the classification itself
+is `restore-verify.py::classify_age_refusal`.
+
+🔴 **THE FIRST VERSION OF THAT TABLE HAD THREE ENTRIES AND MISSED THREE ORDINARY
+FAULTS (corrected 2026-09-09).** An adversarial audit of the change above drove
+really-damaged artifacts through the real verifier on both age versions and found
+that a flipped header-MAC bit, a payload stripped to nothing, and a payload
+truncated to 8 bytes each produce a refusal none of the three entries named — so
+they landed in the *"CANNOT SAY WHY"* message, which told the operator age had
+probably reworded when the artifact was simply damaged. The table is now keyed on
+**where age got to**, which is the thing the verdict actually turns on:
+
+| age said | reached | classification |
+|---|---|---|
+| `no identity matched any of the recipients` | header not opened | pre-auth → `25` |
+| `failed to read header`, `bad header MAC`, `failed to parse X25519 recipient` | header not opened | pre-auth → `25` |
+| `failed to decrypt and authenticate payload chunk` | **past the header** | post-auth → `33` |
+| `failed to read nonce`, `unexpected EOF`, `last chunk is empty` | **past the header** | post-auth → `33` |
+
+The pre-auth/post-auth split is measured, not reasoned: age authenticates the
+whole header before it reads the nonce, so truncating *inside* the header and
+truncating *after* it produce disjoint messages (every in-header truncation
+carries `failed to read header`). A post-auth refusal therefore proves the
+escrowed identity opened the header, which is exactly what `33` claims. Note the
+first line of `classify_age_refusal`'s marker tuple order is load-bearing for
+this: age's in-header EOF messages nest the post-auth clause inside the pre-auth
+one, so the pre-auth markers are matched first.
 
 ⚠ **Say plainly what that costs:** a substring match on another tool's prose is
 weaker than the phase observation it replaced, and this subsystem's own design
 notes argue against exactly that shape. The mitigation is that an
-**unrecognised** message is its own outcome — the verifier then says it *cannot
-say why* and names all three causes, rather than picking one. If you ever see
-that sentence, age has reworded: teach `classify_age_refusal` the new string
-rather than acting on a guess.
+**unrecognised** message is still its own outcome — the verifier then says it
+*cannot say why* and names all three causes, rather than picking one. If you see
+that sentence, age has said something no measured fault produces: teach
+`classify_age_refusal` the new string rather than acting on a guess. ⚠ And do not
+read "no measured fault reaches it" as "nothing can" — that is a claim about a
+sweep, and the sweep above is what the previous one's wording got wrong.
 
 ⚠ It cannot unlock the vault and will not try: every `bw` call runs with stdin on
 `/dev/null`, `--nointeraction`, and a timeout, so an unattended run **fails fast

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -399,10 +399,22 @@ probably reworded when the artifact was simply damaged. The table is now keyed o
 
 | age said | reached | classification |
 |---|---|---|
-| `no identity matched any of the recipients` | header not opened | pre-auth → `25` |
-| `failed to read header`, `bad header MAC`, `failed to parse X25519 recipient` | header not opened | pre-auth → `25` |
+| `no identity matched any of the recipients` | no identity shown to work | pre-auth → `25` |
+| `failed to read header`, `failed to parse X25519 recipient` | no identity shown to work | pre-auth → `25` |
+| `bad header MAC` | **a stanza unwrapped** — the key WORKS — but the header failed its integrity check | key proven → `33` |
 | `failed to decrypt and authenticate payload chunk` | **past the header** | post-auth → `33` |
 | `failed to read nonce`, `unexpected EOF`, `last chunk is empty` | **past the header** | post-auth → `33` |
+
+🔴 **`bad header MAC` is the one to read twice.** It was filed pre-auth in the
+first draft of this table, where row `25` tells the operator *"the escrowed
+identity does not match … if none open, the key is the likely cause"* — a
+rotation-shaped sentence about a key the message vindicates. The discriminating
+control, measured on both versions: decrypt the **same** damaged blob with the
+right identity and with a wrong one — `bad header MAC` vs `no identity matched`.
+age reaches the header's integrity check only after an identity has unwrapped a
+recipient stanza, so that message is positive evidence the escrow **works**. It
+gets `33` with its own sentence, because `33`'s usual wording asserts age
+*authenticated* the header, which is what a MAC failure means it did not.
 
 The pre-auth/post-auth split is measured, not reasoned: age authenticates the
 whole header before it reads the nonce, so truncating *inside* the header and

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -360,7 +360,7 @@ disaster-recovery key gets rotated, or a tampered backup gets waved through:
 | `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |
 | `30` `ARTIFACT-UNREADABLE` | failed before the key was used | diagnose the object, not the key |
 | `25` `DECRYPT-FAILED` | age refused **before the payload**: wrong key **or** damaged header — **not separable**. ⚠ The same code also carries a second message, *"CANNOT SAY WHY"*, when age refuses in a way this tool cannot read — then **three** causes stay open, corruption included. Read the sentence, not just the number. | try a **different** artifact (`--scope <other>`) with the same escrowed copy: if another opens, the key is fine and this object's header is damaged. **Do not rotate first.** |
-| `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed past it — a payload chunk that would not authenticate, or an artifact that ran out of bytes | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
+| `33` `ARTIFACT-CORRUPT` | age got past the header — **the key worked** — and then failed: a payload chunk that would not authenticate, or an artifact that ran out of bytes. ⚠ The same code carries a **second** message for a damaged header MAC, where age proved the key and never read a payload byte. Read the sentence, not just the number. | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
 | `31` `ARTIFACT-EMPTY` | age exited **zero** on an empty payload (**the key worked**) | the artifact holds nothing; do not rotate |
 | `26` `RESTORE-FAILED` | decrypted fine, the git bundle is bad | artifact fault; do not rotate |
 
@@ -400,7 +400,7 @@ probably reworded when the artifact was simply damaged. The table is now keyed o
 | age said | reached | classification |
 |---|---|---|
 | `no identity matched any of the recipients` | no identity shown to work | pre-auth → `25` |
-| `failed to read header`, `failed to parse X25519 recipient` | no identity shown to work | pre-auth → `25` |
+| `failed to read header`, `failed to parse X25519 recipient`, `invalid X25519 recipient block` | no identity shown to work | pre-auth → `25` |
 | `bad header MAC` | **a stanza unwrapped** — the key WORKS — but the header failed its integrity check | key proven → `33` |
 | `failed to decrypt and authenticate payload chunk` | **past the header** | post-auth → `33` |
 | `failed to read nonce`, `unexpected EOF`, `last chunk is empty` | **past the header** | post-auth → `33` |

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1623,7 +1623,25 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         # identity does not match" as an open cause, and the
                         # discriminating control in restore-verify's
                         # `AGE_REFUSED_HEADER_MAC` block EXCLUDES it.
-                        if phase["age_refusal"] == RV.AGE_REFUSED_HEADER_MAC:
+                        # 🔴 `cause` IS PART OF THIS CONDITION FOR THE SAME
+                        # REASON IT IS PART OF `_corrupt`'s — and it was missing
+                        # here for one commit, which is the predicate-right-at-
+                        # one-of-its-two-sites shape this repo keeps hitting.
+                        # This branch makes a claim of identical strength, so it
+                        # takes the identical guard: a future raise site that
+                        # attaches `age_refusal=` under a NEW cause must not
+                        # reach it and be certified "THE ESCROW IS FINE".
+                        #
+                        # ⚠ LABELLED SURVIVOR, exactly like `_corrupt`'s: a
+                        # mutation deleting this cause test passes the suite
+                        # today, because `age_refusal` is set at one raise site
+                        # and that site's cause is `age-refused`. It is kept for
+                        # the reason above — the property is of the RAISE SITES,
+                        # not of this condition, and it is the raise-side mutant
+                        # that proves the test load-bearing.
+                        if (phase["cause"] == RV.DECRYPT_AGE_REFUSED
+                                and phase["age_refusal"]
+                                == RV.AGE_REFUSED_HEADER_MAC):
                             raise EscrowError(
                                 "ARTIFACT-CORRUPT",
                                 f"🔴 {key} has a DAMAGED HEADER. The ESCROWED key "

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -398,13 +398,30 @@ EXIT_CODES: dict[str, int] = {
     # payload truncated to 8 bytes each produced a refusal the table did not
     # name, on BOTH versions, so three ordinary corruption shapes landed here
     # while the sentence told the operator age had probably reworded. Those three
-    # are now classified (see `_AGE_REFUSAL_MARKERS` in restore-verify.py). What
-    # survives is the genuine fall-through: a refusal nothing in that table
-    # matches. It exists because the discriminator rests on an upstream tool's
-    # PROSE — if age rewords, this admits it instead of picking whichever answer
-    # the fall-through happened to reach. Do not re-label it "not observed": the
-    # honest claim is that no CURRENTLY KNOWN fault reaches it, which is a
-    # statement about a sweep, not about age.
+    # are now classified (see `_AGE_REFUSAL_MARKERS` in restore-verify.py).
+    #
+    # 🔴 AND THE REPLACEMENT SENTENCE WAS WRONG TOO — it read "no CURRENTLY KNOWN
+    # fault reaches it", and the audit of THAT round measured three that do, on
+    # both versions. All three are faults of the RUN rather than of the artifact,
+    # which is why an artifact-shaped sweep kept missing them:
+    #
+    #     a corrupted escrowed identity  -> `malformed secret key: invalid character`
+    #     a truncated escrowed identity  -> `no identities found`
+    #     the output path uncreatable    -> `open <path>: no such file or directory`
+    #                                       (the ENOSPC / vanished-work-dir shape)
+    #
+    # They are deliberately NOT given markers: each is a fault in the run's own
+    # environment, and inventing an artifact verdict for it is how the first two
+    # rounds went wrong. This message is the right destination for them — it
+    # asserts nothing and forbids rotation. What was wrong was only the claim
+    # that nothing arrives here.
+    #
+    # So the honest statement, and do not narrow it again: THIS BRANCH IS
+    # REACHABLE, by an unrecognised age reword AND by a run-environment fault,
+    # and the three causes its message enumerates are the ARTIFACT-side ones —
+    # they are not exhaustive of why age refused. It exists because the
+    # discriminator rests on an upstream tool's PROSE: if age rewords, this
+    # admits it instead of picking whichever answer the fall-through reached.
     "DECRYPT-FAILED": 25,
     # 🔴 RAISED BEFORE ANY `bw` CALL — see `preflight_decrypt_imports`. Its own
     # code because the remedy is unlike every other one here: nothing is wrong
@@ -1591,13 +1608,42 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         # SAID which of the two it was, and an unrecognised
                         # refusal falls to the second DECRYPT-FAILED message
                         # below instead of borrowing this one's claim.
+                        # 🔴 KEY PROVEN, HEADER DAMAGED — the third state, and
+                        # it is ARTIFACT-CORRUPT's SECOND message rather than a
+                        # sixth exit code because the REMEDY is identical (the
+                        # backup is damaged; do not rotate) while the WITNESS is
+                        # not. `DECRYPT-FAILED` already carries two messages
+                        # under one code for the same reason.
+                        #
+                        # It must not borrow the message above: that one says
+                        # "age authenticated the header", which is exactly what
+                        # a MAC failure means it did NOT do. And it must not
+                        # fall to the pre-auth branch below, which is where an
+                        # audit found it — that sentence offers "the escrowed
+                        # identity does not match" as an open cause, and the
+                        # discriminating control in restore-verify's
+                        # `AGE_REFUSED_HEADER_MAC` block EXCLUDES it.
+                        if phase["age_refusal"] == RV.AGE_REFUSED_HEADER_MAC:
+                            raise EscrowError(
+                                "ARTIFACT-CORRUPT",
+                                f"🔴 {key} has a DAMAGED HEADER. The ESCROWED key "
+                                f"unwrapped one of its recipient stanzas — which "
+                                f"age only lets an identity that MATCHES do — and "
+                                f"the header then failed its own integrity check. "
+                                f"THE ESCROW IS FINE; THE BACKUP IS NOT. age never "
+                                f"reached the payload, so nothing is claimed about "
+                                f"it. Treat the artifact as unusable, check the "
+                                f"other retained objects for this scope, and do "
+                                f"NOT rotate the key.",
+                                detail=str(exc))
                         # The set is IMPORTED, not spelled — the same reason as
                         # `AGE_REFUSALS_POST_AUTH` above. A refusal published in
                         # restore-verify but named in neither set lands in the
                         # "CANNOT SAY WHY" message below, which is the safe
                         # place for it, and `test_the_STRONG_verdict_fires_on_
-                        # EVERY_post_auth_refusal_and_NO_other` walks both sets
-                        # so a new one cannot go quietly unhandled.
+                        # EVERY_post_auth_refusal_and_NO_other` walks every
+                        # published value so a new one cannot go quietly
+                        # unhandled.
                         if phase["age_refusal"] in RV.AGE_REFUSALS_PRE_AUTH:
                             raise EscrowError(
                                 "DECRYPT-FAILED",

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -391,12 +391,20 @@ EXIT_CODES: dict[str, int] = {
     # `restore_verify.classify_age_refusal` does not know — and that belongs in
     # the sentence an operator reads, not in a number a timer branches on.
     #
-    # ⚠ The second message is DEFENSIVE, NOT OBSERVED — the same status as
-    # `PUBKEY-DERIVATION-EMPTY` below and labelled for the same reason. On both
-    # measured age versions every refusal classifies. It exists because the
-    # discriminator now rests on an upstream tool's PROSE (see `AGE_REFUSED_*`
-    # in restore-verify.py): if age rewords, this admits it instead of picking
-    # whichever of the three answers the fall-through happened to reach.
+    # ⚠ THE SECOND MESSAGE IS REACHABLE, AND THIS COMMENT USED TO SAY IT WAS NOT.
+    # It read "DEFENSIVE, NOT OBSERVED … on both measured age versions every
+    # refusal classifies", and an adversarial audit measured that FALSE
+    # (2026-09-09): a flipped header-MAC bit, a payload stripped to nothing and a
+    # payload truncated to 8 bytes each produced a refusal the table did not
+    # name, on BOTH versions, so three ordinary corruption shapes landed here
+    # while the sentence told the operator age had probably reworded. Those three
+    # are now classified (see `_AGE_REFUSAL_MARKERS` in restore-verify.py). What
+    # survives is the genuine fall-through: a refusal nothing in that table
+    # matches. It exists because the discriminator rests on an upstream tool's
+    # PROSE — if age rewords, this admits it instead of picking whichever answer
+    # the fall-through happened to reach. Do not re-label it "not observed": the
+    # honest claim is that no CURRENTLY KNOWN fault reaches it, which is a
+    # statement about a sweep, not about age.
     "DECRYPT-FAILED": 25,
     # 🔴 RAISED BEFORE ANY `bw` CALL — see `preflight_decrypt_imports`. Its own
     # code because the remedy is unlike every other one here: nothing is wrong
@@ -845,7 +853,7 @@ def _rv():
 #                          presence is SUFFICIENT evidence, it just stopped
 #                          being NECESSARY.
 #     So the primary discriminator moved to `restore_verify.classify_age_refusal`
-#     — age's own three refusal messages, which are byte-identical on v1.3.1 and
+#     — age's own refusal messages, which are byte-identical on v1.3.1 and
 #     v1.3.2. Read the `AGE_REFUSED_*` block there before touching this: it says
 #     plainly that substring-matching another tool's prose is WEAKER than the
 #     phase observation it replaces, and why it was taken anyway.
@@ -1494,10 +1502,21 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         #     on v1.3.1 for every tamper, and on v1.3.2 only
                         #     once a whole 64 KiB chunk has gone out. Still
                         #     SUFFICIENT; no longer NECESSARY.
-                        #   * `age_refusal == payload-auth-failed` — age itself
-                        #     saying it got to the payload. Byte-identical on
-                        #     v1.3.1 and v1.3.2, and the only signal that
-                        #     survives the lazy-create change.
+                        #   * a POST-AUTH refusal — age itself saying it got
+                        #     past the header, either by failing a payload chunk
+                        #     or by running out of bytes after opening it.
+                        #     Byte-identical on v1.3.1 and v1.3.2, and the only
+                        #     signal that survives the lazy-create change.
+                        # 🔴 THE SECOND ARM TESTS A SET, NOT ONE VALUE, AND THE
+                        # SET LIVES IN restore-verify. It was `== payload-auth-
+                        # failed` alone, and an audit measured what that missed:
+                        # a payload stripped entirely, or truncated to 8 bytes,
+                        # makes age say "failed to read nonce" / "unexpected
+                        # EOF" — post-header faults, licensing exactly this
+                        # verdict, that fell through to "cannot say why".
+                        # `AGE_REFUSALS_POST_AUTH` is imported rather than
+                        # spelled so this predicate cannot drift from the table
+                        # that decides what post-auth means.
                         # An UNRECOGNISED refusal reaches NEITHER of the two
                         # strong verdicts below — it gets DECRYPT-FAILED's
                         # SECOND message, which names all three open causes.
@@ -1505,7 +1524,7 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                             phase["cause"] == RV.DECRYPT_AGE_REFUSED
                             and (bool(phase["plain_present"])
                                  or phase["age_refusal"]
-                                 == RV.AGE_REFUSED_PAYLOAD))
+                                 in RV.AGE_REFUSALS_POST_AUTH))
                         if _corrupt:
                             # 🔴 THE CAUSE IS PART OF THE CONDITION, not decoration.
                             # This branch makes the strongest claim in the file —
@@ -1529,29 +1548,37 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                             # the one that stops the strongest claim in the file
                             # being made about it by default.
                             #
-                            # age exited NON-ZERO after reaching the PAYLOAD —
+                            # age exited NON-ZERO after getting PAST THE HEADER —
                             # witnessed either by output it had already flushed
-                            # or by its own "failed to decrypt and authenticate
-                            # payload chunk". Reaching the payload at all means
-                            # age authenticated the HEADER, which requires the
-                            # identity to match. So the key worked and the bytes
-                            # did not.
+                            # or by its own message ("failed to decrypt and
+                            # authenticate payload chunk", or one of the
+                            # truncation refusals age only emits once the header
+                            # is open). Getting past the header at all means age
+                            # authenticated it, which requires the identity to
+                            # match. So the key worked and the bytes did not.
                             #
                             # 🔴 THE SENTENCE BELOW LOST THE WORDS "began
                             # writing plaintext", and that is a CORRECTION, not
                             # a reword: on age v1.3.2 a tampered artifact under
                             # 64 KiB writes NO plaintext, so the old wording
                             # asserted an act this branch can no longer observe.
-                            # What it CAN still assert — the header
-                            # authenticated with the escrowed key — is what it
-                            # now says, and nothing more.
+                            # 🔴 AND IT LOST "then FAILED on the payload" FOR THE
+                            # SAME REASON, 2026-09-09: the branch now also fires
+                            # on a TRUNCATED artifact, where age never reached a
+                            # payload chunk — it ran out of bytes reading the
+                            # nonce. Asserting the payload there would be the
+                            # identical mistake one version later. What it CAN
+                            # still assert on every arm — the header
+                            # authenticated with the escrowed key, and the run
+                            # failed after that — is what it now says.
                             raise EscrowError(
                                 "ARTIFACT-CORRUPT",
                                 f"🔴 {key} is TAMPERED, CORRUPT or TRUNCATED. age "
                                 f"authenticated the header with the ESCROWED key "
                                 f"— which a non-matching identity cannot do — and "
-                                f"then FAILED on the payload. THE ESCROW IS FINE; "
-                                f"THE BACKUP IS NOT. "
+                                f"then FAILED PAST IT: a payload chunk that would "
+                                f"not authenticate, or an artifact that ran out of "
+                                f"bytes. THE ESCROW IS FINE; THE BACKUP IS NOT. "
                                 f"This is the finding a backup verifier exists to "
                                 f"make: treat the artifact as unusable, check the "
                                 f"other retained objects for this scope, and do "
@@ -1564,8 +1591,14 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         # SAID which of the two it was, and an unrecognised
                         # refusal falls to the second DECRYPT-FAILED message
                         # below instead of borrowing this one's claim.
-                        if phase["age_refusal"] in (RV.AGE_REFUSED_NO_IDENTITY,
-                                                    RV.AGE_REFUSED_HEADER):
+                        # The set is IMPORTED, not spelled — the same reason as
+                        # `AGE_REFUSALS_POST_AUTH` above. A refusal published in
+                        # restore-verify but named in neither set lands in the
+                        # "CANNOT SAY WHY" message below, which is the safe
+                        # place for it, and `test_the_STRONG_verdict_fires_on_
+                        # EVERY_post_auth_refusal_and_NO_other` walks both sets
+                        # so a new one cannot go quietly unhandled.
+                        if phase["age_refusal"] in RV.AGE_REFUSALS_PRE_AUTH:
                             raise EscrowError(
                                 "DECRYPT-FAILED",
                                 f"age REFUSED {key} before reaching the payload at "
@@ -1585,7 +1618,7 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                             "DECRYPT-FAILED",
                             f"age REFUSED {key} and this verifier CANNOT SAY WHY. "
                             f"age exited non-zero without leaving plaintext, and "
-                            f"its message matched none of the three refusals this "
+                            f"its message matched none of the refusals this "
                             f"tool knows how to read. THREE THINGS ARE NOW EQUALLY "
                             f"CONSISTENT with what was seen and NONE is asserted: "
                             f"the escrowed identity does not match, the artifact's "

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1537,8 +1537,22 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         # An UNRECOGNISED refusal reaches NEITHER of the two
                         # strong verdicts below — it gets DECRYPT-FAILED's
                         # SECOND message, which names all three open causes.
+                        # 🔴 age's OWN CLASSIFICATION WINS OVER `plain_present`,
+                        # and the order of these two disjuncts is why. An audit
+                        # noted, out of its own delta, that this branch is
+                        # evaluated BEFORE the `AGE_REFUSED_HEADER_MAC` one and
+                        # that its first disjunct is file presence — so if age
+                        # ever left an `--output` file on a MAC failure, this
+                        # branch would swallow it and emit "age authenticated
+                        # the header with the ESCROWED key", the one statement a
+                        # MAC failure specifically disproves. Unreachable today
+                        # (`decrypt()` unlinks first, and v1.3.2 creates the
+                        # file lazily) — but the fix is one clause and does not
+                        # depend on that staying true, and the whole subsystem's
+                        # history is observables that stopped holding.
                         _corrupt = (
                             phase["cause"] == RV.DECRYPT_AGE_REFUSED
+                            and phase["age_refusal"] != RV.AGE_REFUSED_HEADER_MAC
                             and (bool(phase["plain_present"])
                                  or phase["age_refusal"]
                                  in RV.AGE_REFUSALS_POST_AUTH))

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -336,10 +336,18 @@ DECRYPT_CAUSES = frozenset(
 #   "no identity matched any of the recipients"         -> pre-auth
 #   "failed to read header"                             -> pre-auth
 #   "failed to parse x25519 recipient"                  -> pre-auth
+#   "invalid x25519 recipient block"                    -> pre-auth
 #   "bad header MAC"                                    -> KEY PROVEN, see below
 #   "failed to read nonce"                              -> TRUNCATED, post-auth
 #   "unexpected eof"                                    -> TRUNCATED, post-auth
 #   "last chunk is empty"                               -> TRUNCATED, post-auth
+#
+# ⚠ THIS SUMMARY IS A SECOND COPY OF `_AGE_REFUSAL_MARKERS`, and the first
+# version of it went stale within one commit — the round that ADDED
+# `invalid x25519 recipient block` listed eight entries for nine markers. It is
+# kept because it is what a reader reaches for, and it is now pinned against the
+# tuple by `test_the_marker_SUMMARY_TABLES_list_every_shipped_marker`, in both
+# directions, alongside the operator-facing table in `SECRETS.md`.
 #
 # ⚠ `bad header MAC` WAS PRE-AUTH IN THE FIRST DRAFT OF THIS TABLE and an
 # adversarial audit caught it: age reaches the header's integrity check only
@@ -422,11 +430,24 @@ AGE_REFUSALS_POST_AUTH = frozenset({AGE_REFUSED_PAYLOAD, AGE_REFUSED_TRUNCATED})
 # either claim by an `else`.
 AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
 
-# 🔴 THE PREDICATE THE "DO NOT ROTATE" ADVICE RESTS ON, published once. Every
-# member is a refusal age can only emit after an identity unwrapped a recipient
-# stanza, so each one is positive evidence the escrowed key WORKS. Derived from
-# the two sets rather than spelled, so a value added to either is covered here
-# without anybody remembering to.
+# 🔴 EVERY REFUSAL age CAN ONLY EMIT ONCE AN IDENTITY HAS UNWRAPPED A RECIPIENT
+# STANZA — so each member is positive evidence the escrowed key WORKS, and each
+# licenses a verdict that tells an operator NOT to rotate.
+#
+# ⚠ WHAT IT IS FOR, stated narrowly because an earlier draft of this comment
+# claimed a role it does not have. It is NOT read by a production branch:
+# `escrow-verify.py` needs two DIFFERENT messages on this side of the line (age
+# authenticated the header, versus age proved the key and then failed the
+# header's own MAC), so it branches on `AGE_REFUSALS_POST_AUTH` and on
+# `AGE_REFUSED_HEADER_MAC` separately. That earlier draft said a value added to
+# either set is "covered here without anybody remembering to" — false: nothing
+# downstream reads this, so adding a member covers nothing by itself.
+#
+# What it DOES own is the ORDER of `_AGE_REFUSAL_MARKERS` below, which is the
+# thing an audit measured to be unguarded: every marker on this side must be
+# matched AFTER every pre-auth one, or a message naming a pre-auth cause could
+# be scored as proof the key worked. That invariant is stated over this set
+# precisely so a third strong value cannot be added outside it.
 AGE_REFUSALS_KEY_PROVEN = AGE_REFUSALS_POST_AUTH | {AGE_REFUSED_HEADER_MAC}
 
 # 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with
@@ -441,15 +462,24 @@ AGE_REFUSALS_KEY_PROVEN = AGE_REFUSALS_POST_AUTH | {AGE_REFUSED_HEADER_MAC}
 # and a post-auth one, so a first-match scan can be made to answer either.
 #
 # 🔴 THE RULE IS THEREFORE TOTAL, NOT SPECIFIC TO THE PAIR THAT OVERLAPS TODAY:
-# EVERY PRE-AUTH MARKER COMES BEFORE EVERY POST-AUTH ONE. A message naming any
-# pre-auth cause can then never be scored post-auth, whatever else it also says
-# — and post-auth is the answer that lets `escrow-verify.py` assert the escrowed
-# identity opened the header. The narrower version of this rule (order only the
-# EOF family after the header markers) was written first and was WRONG in the
-# same way the bug this file is being repaired for was wrong: it fixed the
-# overlap somebody had seen rather than the class.
-# `test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER`
-# pins the whole cross-product; do not reorder this tuple across the divider.
+# EVERY PRE-AUTH MARKER COMES BEFORE EVERY `AGE_REFUSALS_KEY_PROVEN` ONE. A
+# message naming any pre-auth cause can then never be scored as proof the key
+# worked, whatever else it also says — and that is the answer letting
+# `escrow-verify.py` tell an operator their escrow is fine. The narrower version
+# of this rule (order only the EOF family after the header markers) was written
+# first and was WRONG in the same way the bug this file is being repaired for
+# was wrong: it fixed the overlap somebody had seen rather than the class.
+#
+# 🔴 AND THE SECOND DRAFT WAS NARROW TOO — it said "before every POST-AUTH one",
+# which left `bad header mac` unconstrained, because `AGE_REFUSED_HEADER_MAC` is
+# in neither set. An audit's mutation moved that marker PAST every post-auth
+# entry, across this divider, and the whole suite stayed green. The rule is now
+# stated over `AGE_REFUSALS_KEY_PROVEN`, which is exactly the set of kinds whose
+# verdict says the key is fine — so a third strong value cannot be added outside
+# it. `test_a_message_carrying_BOTH_a_pre_auth_and_a_KEY_PROVEN_marker_
+# classifies_as_PRE_AUTH` pins the whole cross-product and
+# `test_the_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another` pins
+# the index order; do not reorder this tuple across the divider.
 _AGE_REFUSAL_MARKERS = (
     # -- PRE-AUTH: no identity has been shown to work ------------------------ #
     ("no identity matched any of the recipients", AGE_REFUSED_NO_IDENTITY),
@@ -464,8 +494,21 @@ _AGE_REFUSAL_MARKERS = (
     # versions. That is the case for fixtures over enumeration: the marker list
     # only ever contains what somebody thought to provoke.
     ("invalid x25519 recipient block", AGE_REFUSED_HEADER),
+    # ===== THE DIVIDER. Everything below is `AGE_REFUSALS_KEY_PROVEN`: a
+    # message matching any of it says the escrowed identity WORKED, so nothing
+    # above may be reachable past it. Do not move an entry across this line. ==
+    #
+    # ⚠ ORDER *WITHIN* THIS BLOCK IS NOT PINNED, AND THAT IS DELIBERATE — say it
+    # rather than let a reader infer a guarantee. A mutation moving
+    # `bad header mac` to the very END of the tuple SURVIVES the suite, because
+    # it never crosses the divider and the stated invariant is about crossing
+    # it. The only behaviour that could differ is a message carrying BOTH a MAC
+    # clause and a truncation clause; measured 120/120 on both binaries, age
+    # emits `bad header MAC` bare. Both orderings would land on the same token
+    # and the same remedy in any case — only the witness sentence would differ.
+    #
     # -- KEY PROVEN, header damaged: age got here only by unwrapping a stanza,
-    #    but it did NOT authenticate the header, so neither block above fits -- #
+    #    but it did NOT authenticate the header, so neither block fits -------- #
     ("bad header mac", AGE_REFUSED_HEADER_MAC),
     # -- POST-AUTH: age opened the header, then the bytes failed it ---------- #
     ("failed to decrypt and authenticate payload chunk", AGE_REFUSED_PAYLOAD),
@@ -941,19 +984,43 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
          "--output", str(plain), str(cipher)],
         capture_output=True, text=True)
     if p.returncode != 0:
+        # 🔴 CLASSIFIED HERE, WHERE age's OWN stderr IS IN HAND. The consumer
+        # gets a published VALUE, never this message to substring-match: it is
+        # the only place the raw stream exists, and pushing the parse out to the
+        # caller is how two callers end up with two different parsers.
+        refusal = classify_age_refusal(p.stderr)
+        # 🔴 AND THIS MESSAGE READS IT TOO, which it did not until an audit
+        # pointed out that `SECRETS.md` sends operators HERE to tell a key fault
+        # from an artifact fault — while this sentence said "the identity …
+        # does not open it, or the ciphertext is damaged" for EVERY refusal,
+        # including the ones that disprove its first half three lines below the
+        # `classify_age_refusal` call that establishes it. The consumer was
+        # fixed and the sibling the consumer points at was not.
+        if refusal in AGE_REFUSALS_KEY_PROVEN:
+            diagnosis = (
+                f"the identity at {identity}{_identity_note(identity)} DID open "
+                f"it — age only gets this far with one that matches — and the "
+                f"CIPHERTEXT is damaged. This is an ARTIFACT fault; the key is "
+                f"not implicated")
+        elif refusal in AGE_REFUSALS_PRE_AUTH:
+            diagnosis = (
+                f"either the identity at {identity}{_identity_note(identity)} "
+                f"does not open it, or the ciphertext's HEADER is damaged. Those "
+                f"are NOT separable from age's message alone")
+        else:
+            diagnosis = (
+                f"age refused in a way this tool cannot classify, so NOTHING is "
+                f"asserted about the identity at "
+                f"{identity}{_identity_note(identity)} or about the ciphertext. "
+                f"Read age's own message above")
         raise RestoreVerifyError(
             f"DECRYPT FAILED for {cipher.name} (age rc={p.returncode}): "
-            f"{p.stderr.strip()}. The object was retrieved but the identity at "
-            f"{identity}{_identity_note(identity)} does not open it, or the ciphertext "
-            f"is damaged. This is "
+            f"{p.stderr.strip()}. The object was retrieved but {diagnosis}. This "
+            f"is "
             f"NOT a corruption verdict about the git history inside — nothing "
             f"here has read it.",
             cause=DECRYPT_AGE_REFUSED,
-            # 🔴 CLASSIFIED HERE, WHERE age's OWN stderr IS IN HAND. The consumer
-            # gets a published VALUE, never this message to substring-match: it
-            # is the only place the raw stream exists, and pushing the parse out
-            # to the caller is how two callers end up with two different parsers.
-            age_refusal=classify_age_refusal(p.stderr))
+            age_refusal=refusal)
     if not plain.is_file() or plain.stat().st_size == 0:
         # 🔴 MEASURED: `age` encrypts a ZERO-BYTE payload to a perfectly valid
         # 200-byte ciphertext, and decrypts it back at rc=0. So an object that

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -305,46 +305,135 @@ DECRYPT_CAUSES = frozenset(
 # A DOWNGRADE — say so rather than let the next reader assume it is as solid as
 # the phase observation it replaces. The module docstring above argues against
 # exactly this shape, for good reasons that still apply. It is done anyway
-# because the alternative is losing the distinction entirely, and the three
-# strings are IDENTICAL on both measured versions:
+# because the alternative is losing the distinction entirely, and the strings are
+# IDENTICAL on both measured versions.
 #
-#   "failed to decrypt and authenticate payload chunk"  -> payload
-#   "no identity matched any of the recipients"         -> wrong key
-#   "failed to read header"                             -> damaged header
+# 🔴 THE FIRST VERSION OF THIS TABLE HAD THREE ENTRIES AND A COMMENT SAYING "on
+# both measured age versions every refusal classifies". AN ADVERSARIAL AUDIT
+# MEASURED THAT FALSE (2026-09-09, both versions, driving the REAL escrow-verify
+# path with really-damaged artifacts). The sweep that built the three-entry table
+# varied payload SIZE across seven values and mangling SHAPE across five, and
+# none of the five produced a header-MAC-only fault or a payload-stripped one. So
+# three ORDINARY corruption shapes fell through to `unrecognised` and reached the
+# consumer's "CANNOT SAY WHY" verdict — which told the operator age had probably
+# REWORDED, when the artifact was simply damaged in a shape nothing named:
 #
-# The mitigation is that an UNRECOGNISED stderr is its own published value, so a
-# future age that rewords does NOT silently fall into one of the three answers —
-# it produces a refusal that says it could not classify. Fail-safe, not
-# fail-quiet.
+#     header MAC bit flipped     -> "bad header MAC"
+#     payload stripped entirely  -> "failed to read nonce: EOF"
+#     payload truncated to 8 B   -> "unexpected EOF"
+#
+# It failed SAFE — no rotation advice was given — but a verdict that says it
+# cannot classify an ordinary truncation is a verdict nobody can act on.
+#
+# 🔴 THE SPLIT BETWEEN "PRE-AUTH" AND "POST-AUTH" IS MEASURED, NOT REASONED. age
+# reads and authenticates the whole header, then reads a 16-byte nonce, then the
+# payload chunks. Truncating INSIDE the header and truncating AFTER it produce
+# disjoint messages — every in-header truncation carries `failed to read header`,
+# every post-header one carries `failed to read nonce` or a bare `unexpected EOF`
+# (measured at 8 offsets spanning both sides of the boundary, both versions):
+#
+#   "failed to decrypt and authenticate payload chunk"  -> payload, post-auth
+#   "no identity matched any of the recipients"         -> pre-auth
+#   "failed to read header"                             -> pre-auth
+#   "bad header MAC"                                    -> pre-auth
+#   "failed to parse x25519 recipient"                  -> pre-auth
+#   "failed to read nonce"                              -> TRUNCATED, post-auth
+#   "unexpected eof"                                    -> TRUNCATED, post-auth
+#   "last chunk is empty"                               -> TRUNCATED, post-auth
+#
+# A POST-AUTH refusal means age got past the header, which requires the identity
+# to match — so `AGE_REFUSED_TRUNCATED` licenses the same strong verdict as
+# `AGE_REFUSED_PAYLOAD` ("the key worked, the bytes did not"), and that is why it
+# is a separate value rather than folded into it: what age observed is a
+# truncation, not a failed chunk authentication, and a verdict should not assert
+# the one when it saw the other.
+#
+# The mitigation is unchanged and is the reason this can be widened safely: an
+# UNRECOGNISED stderr is still its own published value, so a future age that
+# rewords does NOT silently fall into one of the answers — it produces a refusal
+# that says it could not classify. Fail-safe, not fail-quiet.
 AGE_REFUSED_PAYLOAD = "payload-auth-failed"      # header OK, payload bad
-AGE_REFUSED_NO_IDENTITY = "no-identity-matched"  # the identity does not match
+# 🔴 NOT "the identity is wrong" — MEASURED 2026-09-09, ONE FLIPPED BIT in the
+# recipient stanza produces this message on both versions, and on v1.3.2 a bit in
+# the wrapped-file-key body does too. It is "age could not open the header WITH
+# THIS IDENTITY", which a damaged header causes just as well as a wrong key. The
+# consumer's verdict already says both and refuses to pick; this comment used to
+# say `-> wrong key` and was the one place that overclaimed.
+AGE_REFUSED_NO_IDENTITY = "no-identity-matched"
 AGE_REFUSED_HEADER = "header-unreadable"         # the header itself is damaged
+AGE_REFUSED_TRUNCATED = "truncated-after-header"  # header OK, bytes ran out
 AGE_REFUSED_UNRECOGNISED = "unrecognised"        # age said something new
 
 AGE_REFUSALS = frozenset({
     AGE_REFUSED_PAYLOAD, AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER,
-    AGE_REFUSED_UNRECOGNISED})
+    AGE_REFUSED_TRUNCATED, AGE_REFUSED_UNRECOGNISED})
+
+# The published refusals that mean AGE GOT PAST THE HEADER — i.e. it
+# authenticated the header, which requires the identity to match. Exported as a
+# SET rather than left for the consumer to spell, because `escrow-verify.py`
+# makes the strongest claim in the subsystem on exactly this predicate and a
+# second copy of it is a second place for it to be wrong.
+AGE_REFUSALS_POST_AUTH = frozenset({AGE_REFUSED_PAYLOAD, AGE_REFUSED_TRUNCATED})
+
+# The mirror: age NAMED a refusal and it happened BEFORE the header opened, so
+# exactly two causes remain (wrong identity, damaged header) and neither is
+# separable from here. Published for the same reason as the set above — the
+# consumer branches on it — and stated as its own set rather than as "everything
+# that is not post-auth", because `AGE_REFUSED_UNRECOGNISED` is in neither: age
+# said something nothing has measured, which is a third state and must not be
+# absorbed into either claim by an else.
+AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
 
 # 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with
 # the program name and appends a "report unexpected errors" URL line, and both
 # have moved between releases; matching the sentence in the middle survives that
 # while an anchored match would not. Each is the distinctive clause, with no
 # punctuation that could be re-styled.
+#
+# 🔴 ORDER IS LOAD-BEARING HERE, AND IT WAS NOT BEFORE. age's in-header EOF
+# message NESTS one clause inside another — `failed to read header: parsing age
+# header: unexpected EOF reading intro` (v1.3.2) carries BOTH a pre-auth marker
+# and a post-auth one, so a first-match scan can be made to answer either.
+#
+# 🔴 THE RULE IS THEREFORE TOTAL, NOT SPECIFIC TO THE PAIR THAT OVERLAPS TODAY:
+# EVERY PRE-AUTH MARKER COMES BEFORE EVERY POST-AUTH ONE. A message naming any
+# pre-auth cause can then never be scored post-auth, whatever else it also says
+# — and post-auth is the answer that lets `escrow-verify.py` assert the escrowed
+# identity opened the header. The narrower version of this rule (order only the
+# EOF family after the header markers) was written first and was WRONG in the
+# same way the bug this file is being repaired for was wrong: it fixed the
+# overlap somebody had seen rather than the class.
+# `test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER`
+# pins the whole cross-product; do not reorder this tuple across the divider.
 _AGE_REFUSAL_MARKERS = (
-    ("failed to decrypt and authenticate payload chunk", AGE_REFUSED_PAYLOAD),
+    # -- PRE-AUTH: age never opened the header ------------------------------- #
     ("no identity matched any of the recipients", AGE_REFUSED_NO_IDENTITY),
     ("failed to read header", AGE_REFUSED_HEADER),
+    ("bad header mac", AGE_REFUSED_HEADER),
+    ("failed to parse x25519 recipient", AGE_REFUSED_HEADER),
+    # -- POST-AUTH: age opened the header, then the bytes failed it ---------- #
+    ("failed to decrypt and authenticate payload chunk", AGE_REFUSED_PAYLOAD),
+    ("failed to read nonce", AGE_REFUSED_TRUNCATED),
+    ("last chunk is empty", AGE_REFUSED_TRUNCATED),
+    ("unexpected eof", AGE_REFUSED_TRUNCATED),
 )
 
 
 def classify_age_refusal(stderr: str) -> str:
-    """Which of age's three refusals this was — or that it was none of them.
+    """Which of age's refusals this was — or that it was none of them.
 
     🔴 NEVER GUESSES. An unmatched stderr returns `AGE_REFUSED_UNRECOGNISED`,
     which the consumer must handle as "cannot classify", not as a default. That
-    is the whole reason this returns a fourth value instead of `None` or the
-    most likely of the three: the caller's strongest claim — "your backup is
+    is the whole reason this returns a distinct value instead of `None` or the
+    most likely of the others: the caller's strongest claim — "your backup is
     tampered and your key is fine" — must never be reached by falling through.
+
+    🔴 THE COMPARISON IS CASE-FOLDED AND THE MARKERS ARE SPELLED LOWER-CASE. Both
+    halves are load-bearing together and neither is guarded by the other: an
+    audit's mutation battery removed this `.lower()` and the whole suite stayed
+    green, because every message age emits today is already lower-case in the
+    matched clause. `test_classify_age_refusal_is_CASE_FOLDED` is what makes the
+    fold non-vacuous.
     """
     low = (stderr or "").lower()
     for marker, kind in _AGE_REFUSAL_MARKERS:

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -445,22 +445,31 @@ AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
 # remembering to"; the second corrected that to "NOT read by a production
 # branch", which the SAME COMMIT falsified 560 lines below by adding one. So:
 #
-#   * `decrypt()` in this file branches on it to choose which of three
-#     diagnoses its operator-facing message carries. That IS a production read,
-#     and adding a member changes what an operator is told about their key.
 #   * the ORDER of `_AGE_REFUSAL_MARKERS` below is stated over it: every marker
 #     on this side must be matched AFTER every pre-auth one, or a message
 #     naming a pre-auth cause could be scored as proof the key worked. An audit
 #     measured that invariant unguarded when it was stated over the narrower
-#     `AGE_REFUSALS_POST_AUTH`.
+#     `AGE_REFUSALS_POST_AUTH`. This is the one place the set is load-bearing.
+#   * `decrypt()` in this file reads it — but only as the SECOND of four arms,
+#     after `AGE_REFUSED_HEADER_MAC` has been peeled off, so the arm it selects
+#     is reached by `AGE_REFUSALS_POST_AUTH` alone. 🔴 THE THIRD DRAFT OF THIS
+#     COMMENT SAID "which of three diagnoses" (the same commit had just made it
+#     four) AND "adding a member covers this file's diagnosis automatically" —
+#     the second is FALSE IN THE DANGEROUS DIRECTION: a future key-proven value
+#     that is not past-the-header would fall into the "DID open it" arm, which
+#     is exactly the overclaim the split was made to remove. Measured: swapping
+#     that arm's set to `AGE_REFUSALS_POST_AUTH` survives the whole suite, so
+#     the read is nominal today. ADD A MEMBER AND YOU MUST EDIT `decrypt()`.
 #   * `escrow-verify.py` does NOT read it, and that is deliberate rather than an
 #     oversight: it needs two DIFFERENT messages on this side of the line (age
 #     authenticated the header, versus age proved the key and then failed the
 #     header's own MAC), so it branches on `AGE_REFUSALS_POST_AUTH` and on
 #     `AGE_REFUSED_HEADER_MAC` separately.
 #
-# Adding a member therefore covers the marker ORDER and this file's diagnosis
-# automatically, and covers escrow-verify's verdicts NOT AT ALL — check both.
+# So adding a member covers the marker ORDER automatically and covers NOTHING
+# ELSE: `decrypt()`'s arms and escrow-verify's verdicts both need editing by
+# hand. `_side` in the table guard goes red on a new member, which is what makes
+# that a loud omission rather than a silent one.
 AGE_REFUSALS_KEY_PROVEN = AGE_REFUSALS_POST_AUTH | {AGE_REFUSED_HEADER_MAC}
 
 # 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -257,10 +257,15 @@ _STAMP_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6}Z)\.bundle\.age$")
 
 # 🔴 MACHINE-READABLE CAUSES FOR THE DECRYPT STEP. `decrypt()` below has three
 # distinct failure branches and they mean COMPLETELY different things to a
-# caller — one is an environment fault, one says the identity does not open the
-# artifact, and one says the identity DID open it and the artifact holds
-# nothing. Every one of them raises `RestoreVerifyError`, so from the outside
-# they were separable only by reading the message text.
+# caller — one is an environment fault, one is "age refused" and one says the
+# identity DID open the artifact and it holds nothing. Every one of them raises
+# `RestoreVerifyError`, so from the outside they were separable only by reading
+# the message text.
+#
+# ⚠ THE MIDDLE ONE USED TO BE DESCRIBED HERE AS "the identity does not open the
+# artifact", and that stopped being true when `AGE_REFUSED_*` arrived: the
+# `age-refused` branch now covers refusals that PROVE the identity works. Its
+# sub-classification is the `age_refusal` value, not the cause.
 #
 # `escrow-verify.py` has to make exactly that distinction to decide whether a
 # failure is a verdict on the ESCROWED KEY or on the ARTIFACT, and getting it
@@ -434,20 +439,28 @@ AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
 # STANZA — so each member is positive evidence the escrowed key WORKS, and each
 # licenses a verdict that tells an operator NOT to rotate.
 #
-# ⚠ WHAT IT IS FOR, stated narrowly because an earlier draft of this comment
-# claimed a role it does not have. It is NOT read by a production branch:
-# `escrow-verify.py` needs two DIFFERENT messages on this side of the line (age
-# authenticated the header, versus age proved the key and then failed the
-# header's own MAC), so it branches on `AGE_REFUSALS_POST_AUTH` and on
-# `AGE_REFUSED_HEADER_MAC` separately. That earlier draft said a value added to
-# either set is "covered here without anybody remembering to" — false: nothing
-# downstream reads this, so adding a member covers nothing by itself.
+# ⚠ WHAT READS IT, ENUMERATED — because the two previous drafts of this comment
+# were each false about exactly that, in opposite directions. The first claimed
+# a value added to either source set is "covered here without anybody
+# remembering to"; the second corrected that to "NOT read by a production
+# branch", which the SAME COMMIT falsified 560 lines below by adding one. So:
 #
-# What it DOES own is the ORDER of `_AGE_REFUSAL_MARKERS` below, which is the
-# thing an audit measured to be unguarded: every marker on this side must be
-# matched AFTER every pre-auth one, or a message naming a pre-auth cause could
-# be scored as proof the key worked. That invariant is stated over this set
-# precisely so a third strong value cannot be added outside it.
+#   * `decrypt()` in this file branches on it to choose which of three
+#     diagnoses its operator-facing message carries. That IS a production read,
+#     and adding a member changes what an operator is told about their key.
+#   * the ORDER of `_AGE_REFUSAL_MARKERS` below is stated over it: every marker
+#     on this side must be matched AFTER every pre-auth one, or a message
+#     naming a pre-auth cause could be scored as proof the key worked. An audit
+#     measured that invariant unguarded when it was stated over the narrower
+#     `AGE_REFUSALS_POST_AUTH`.
+#   * `escrow-verify.py` does NOT read it, and that is deliberate rather than an
+#     oversight: it needs two DIFFERENT messages on this side of the line (age
+#     authenticated the header, versus age proved the key and then failed the
+#     header's own MAC), so it branches on `AGE_REFUSALS_POST_AUTH` and on
+#     `AGE_REFUSED_HEADER_MAC` separately.
+#
+# Adding a member therefore covers the marker ORDER and this file's diagnosis
+# automatically, and covers escrow-verify's verdicts NOT AT ALL — check both.
 AGE_REFUSALS_KEY_PROVEN = AGE_REFUSALS_POST_AUTH | {AGE_REFUSED_HEADER_MAC}
 
 # 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with
@@ -503,9 +516,17 @@ _AGE_REFUSAL_MARKERS = (
     # `bad header mac` to the very END of the tuple SURVIVES the suite, because
     # it never crosses the divider and the stated invariant is about crossing
     # it. The only behaviour that could differ is a message carrying BOTH a MAC
-    # clause and a truncation clause; measured 120/120 on both binaries, age
-    # emits `bad header MAC` bare. Both orderings would land on the same token
-    # and the same remedy in any case — only the witness sentence would differ.
+    # clause and a truncation clause; measured 240/240 on both binaries — plus
+    # 24 artifacts damaged in a MAC clause AND a payload clause together — age
+    # emits `bad header MAC` bare, because the MAC check short-circuits before
+    # any payload read.
+    #
+    # ⚠ AND IF THAT EVER STOPPED HOLDING, THE ALTERNATIVE WOULD BE FALSE, NOT
+    # MERELY DIFFERENT — an earlier draft of this note said "only the witness
+    # sentence would differ", which understates its own case. The answer would
+    # become `truncated-after-header`, and escrow-verify then asserts "age
+    # authenticated the header with the ESCROWED key" — the exact statement a
+    # MAC failure disproves. Same token and same remedy; a wrong witness.
     #
     # -- KEY PROVEN, header damaged: age got here only by unwrapping a stanza,
     #    but it did NOT authenticate the header, so neither block fits -------- #
@@ -996,12 +1017,31 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
         # including the ones that disprove its first half three lines below the
         # `classify_age_refusal` call that establishes it. The consumer was
         # fixed and the sibling the consumer points at was not.
-        if refusal in AGE_REFUSALS_KEY_PROVEN:
+        # 🔴 TWO KEY-PROVEN SENTENCES, NOT ONE, and the split is a CORRECTION.
+        # A single "the identity DID open it" was written first and is FALSE for
+        # `header-mac-failed`: age unwrapped a recipient stanza and the header
+        # then failed its own MAC, so it never opened the artifact. That is the
+        # third instance in this subsystem of a message asserting an act one of
+        # its arms cannot observe — `escrow-verify.py` has already dropped
+        # "began writing plaintext" and "then FAILED on the payload" for exactly
+        # this reason, and says in terms that a MAC failure means age did NOT
+        # authenticate the header. Both arms still license the same conclusion
+        # (the key is not implicated); only the WITNESS differs, so only the
+        # witness clause differs.
+        if refusal == AGE_REFUSED_HEADER_MAC:
+            diagnosis = (
+                f"the identity at {identity}{_identity_note(identity)} UNWRAPPED "
+                f"one of its recipient stanzas — age only lets a MATCHING "
+                f"identity get that far — and the header then failed its own "
+                f"integrity check. age never reached the payload, so nothing is "
+                f"claimed about it. This is an ARTIFACT fault; the key is not "
+                f"implicated")
+        elif refusal in AGE_REFUSALS_KEY_PROVEN:
             diagnosis = (
                 f"the identity at {identity}{_identity_note(identity)} DID open "
-                f"it — age only gets this far with one that matches — and the "
-                f"CIPHERTEXT is damaged. This is an ARTIFACT fault; the key is "
-                f"not implicated")
+                f"it — age only gets past the header with one that matches — and "
+                f"the CIPHERTEXT is damaged beyond it. This is an ARTIFACT "
+                f"fault; the key is not implicated")
         elif refusal in AGE_REFUSALS_PRE_AUTH:
             diagnosis = (
                 f"either the identity at {identity}{_identity_note(identity)} "

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -335,11 +335,17 @@ DECRYPT_CAUSES = frozenset(
 #   "failed to decrypt and authenticate payload chunk"  -> payload, post-auth
 #   "no identity matched any of the recipients"         -> pre-auth
 #   "failed to read header"                             -> pre-auth
-#   "bad header MAC"                                    -> pre-auth
 #   "failed to parse x25519 recipient"                  -> pre-auth
+#   "bad header MAC"                                    -> KEY PROVEN, see below
 #   "failed to read nonce"                              -> TRUNCATED, post-auth
 #   "unexpected eof"                                    -> TRUNCATED, post-auth
 #   "last chunk is empty"                               -> TRUNCATED, post-auth
+#
+# ⚠ `bad header MAC` WAS PRE-AUTH IN THE FIRST DRAFT OF THIS TABLE and an
+# adversarial audit caught it: age reaches the header's integrity check only
+# after an identity has already unwrapped a recipient stanza, so the message
+# PROVES the escrowed key works. It belongs to neither block — see
+# `AGE_REFUSED_HEADER_MAC` below for the discriminating control that settles it.
 #
 # A POST-AUTH refusal means age got past the header, which requires the identity
 # to match — so `AGE_REFUSED_TRUNCATED` licenses the same strong verdict as
@@ -361,12 +367,42 @@ AGE_REFUSED_PAYLOAD = "payload-auth-failed"      # header OK, payload bad
 # say `-> wrong key` and was the one place that overclaimed.
 AGE_REFUSED_NO_IDENTITY = "no-identity-matched"
 AGE_REFUSED_HEADER = "header-unreadable"         # the header itself is damaged
+# 🔴 ITS OWN VALUE, AND NOT A SHADE OF `header-unreadable` — an adversarial audit
+# of the round that first classified this string caught it grouped with the
+# pre-auth refusals, where the operator-facing verdict says "the escrowed
+# identity does not match this artifact's recipients, or the artifact's HEADER is
+# damaged … if none open, the key is the likely cause."
+#
+# MEASURED 2026-09-09, BOTH VERSIONS, 3 RUNS EACH, with the discriminating
+# control that settles it — the SAME damaged blob decrypted twice:
+#
+#     RIGHT identity  ->  age: error: bad header MAC
+#     WRONG identity  ->  age: error: no identity matched any of the recipients
+#
+# age only reaches the header's integrity check AFTER an identity has unwrapped a
+# recipient stanza. So this message PROVES the escrowed key works and the
+# artifact is damaged: the two causes the pre-auth verdict calls inseparable are
+# separable here, and the one it names first is EXCLUDED. Grouping it pre-auth
+# pointed a rotation-shaped sentence at a key measurement had just vindicated.
+#
+# ⚠ It is NOT post-auth either, and that is why it is a third value rather than
+# a move from one set to the other: `ARTIFACT-CORRUPT`'s sentence asserts "age
+# authenticated the header", which is precisely what a MAC failure means it did
+# NOT do. Same REMEDY as post-auth (the backup is damaged, do not rotate), a
+# different WITNESS — so `escrow-verify.py` gives it that token with its own
+# message, the way `DECRYPT-FAILED` already carries two.
+#
+# 🔴 The fixture must decode the `--- <mac>` base64, flip a bit and RE-ENCODE.
+# Flipping a byte of the base64 TEXT lands on an illegal character often enough
+# to matter — measured 1 run in 20 — and age then fails earlier, on the closing
+# line, with a message that classifies as `header-unreadable`.
+AGE_REFUSED_HEADER_MAC = "header-mac-failed"     # key PROVEN, header damaged
 AGE_REFUSED_TRUNCATED = "truncated-after-header"  # header OK, bytes ran out
 AGE_REFUSED_UNRECOGNISED = "unrecognised"        # age said something new
 
 AGE_REFUSALS = frozenset({
     AGE_REFUSED_PAYLOAD, AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER,
-    AGE_REFUSED_TRUNCATED, AGE_REFUSED_UNRECOGNISED})
+    AGE_REFUSED_HEADER_MAC, AGE_REFUSED_TRUNCATED, AGE_REFUSED_UNRECOGNISED})
 
 # The published refusals that mean AGE GOT PAST THE HEADER — i.e. it
 # authenticated the header, which requires the identity to match. Exported as a
@@ -375,14 +411,23 @@ AGE_REFUSALS = frozenset({
 # second copy of it is a second place for it to be wrong.
 AGE_REFUSALS_POST_AUTH = frozenset({AGE_REFUSED_PAYLOAD, AGE_REFUSED_TRUNCATED})
 
-# The mirror: age NAMED a refusal and it happened BEFORE the header opened, so
-# exactly two causes remain (wrong identity, damaged header) and neither is
-# separable from here. Published for the same reason as the set above — the
-# consumer branches on it — and stated as its own set rather than as "everything
-# that is not post-auth", because `AGE_REFUSED_UNRECOGNISED` is in neither: age
-# said something nothing has measured, which is a third state and must not be
-# absorbed into either claim by an else.
+# The mirror: age NAMED a refusal and it happened BEFORE any identity was shown
+# to work, so exactly two causes remain (wrong identity, damaged header) and
+# neither is separable from here. Published for the same reason as the set above
+# — the consumer branches on it — and stated as its own set rather than as
+# "everything that is not post-auth", because two published values are in
+# NEITHER: `AGE_REFUSED_HEADER_MAC` (the key is proven, so the pre-auth sentence
+# is false about it) and `AGE_REFUSED_UNRECOGNISED` (age said something nothing
+# has measured). Both are states of their own and must not be absorbed into
+# either claim by an `else`.
 AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
+
+# 🔴 THE PREDICATE THE "DO NOT ROTATE" ADVICE RESTS ON, published once. Every
+# member is a refusal age can only emit after an identity unwrapped a recipient
+# stanza, so each one is positive evidence the escrowed key WORKS. Derived from
+# the two sets rather than spelled, so a value added to either is covered here
+# without anybody remembering to.
+AGE_REFUSALS_KEY_PROVEN = AGE_REFUSALS_POST_AUTH | {AGE_REFUSED_HEADER_MAC}
 
 # 🔴 SUBSTRINGS, DELIBERATELY NOT ANCHORED REGEXES. age prefixes its stderr with
 # the program name and appends a "report unexpected errors" URL line, and both
@@ -406,11 +451,22 @@ AGE_REFUSALS_PRE_AUTH = frozenset({AGE_REFUSED_NO_IDENTITY, AGE_REFUSED_HEADER})
 # `test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER`
 # pins the whole cross-product; do not reorder this tuple across the divider.
 _AGE_REFUSAL_MARKERS = (
-    # -- PRE-AUTH: age never opened the header ------------------------------- #
+    # -- PRE-AUTH: no identity has been shown to work ------------------------ #
     ("no identity matched any of the recipients", AGE_REFUSED_NO_IDENTITY),
     ("failed to read header", AGE_REFUSED_HEADER),
-    ("bad header mac", AGE_REFUSED_HEADER),
     ("failed to parse x25519 recipient", AGE_REFUSED_HEADER),
+    # 🔴 FOUND BY BUILDING THE FIXTURE THE ROUND ABOVE SHIPPED WITHOUT. Writing
+    # a provoking input for `failed to parse x25519 recipient` produced THIS
+    # message instead on the first attempt — a fourth real refusal nothing named,
+    # reaching `unrecognised`. Both are deterministic and they are different
+    # faults: an ILLEGAL base64 character in the stanza argument gives the parse
+    # error, a LEGAL but WRONG-LENGTH argument gives this one. Measured on both
+    # versions. That is the case for fixtures over enumeration: the marker list
+    # only ever contains what somebody thought to provoke.
+    ("invalid x25519 recipient block", AGE_REFUSED_HEADER),
+    # -- KEY PROVEN, header damaged: age got here only by unwrapping a stanza,
+    #    but it did NOT authenticate the header, so neither block above fits -- #
+    ("bad header mac", AGE_REFUSED_HEADER_MAC),
     # -- POST-AUTH: age opened the header, then the bytes failed it ---------- #
     ("failed to decrypt and authenticate payload chunk", AGE_REFUSED_PAYLOAD),
     ("failed to read nonce", AGE_REFUSED_TRUNCATED),
@@ -428,12 +484,18 @@ def classify_age_refusal(stderr: str) -> str:
     most likely of the others: the caller's strongest claim — "your backup is
     tampered and your key is fine" — must never be reached by falling through.
 
-    🔴 THE COMPARISON IS CASE-FOLDED AND THE MARKERS ARE SPELLED LOWER-CASE. Both
-    halves are load-bearing together and neither is guarded by the other: an
-    audit's mutation battery removed this `.lower()` and the whole suite stayed
-    green, because every message age emits today is already lower-case in the
-    matched clause. `test_classify_age_refusal_is_CASE_FOLDED` is what makes the
-    fold non-vacuous.
+    🔴 THE COMPARISON IS CASE-FOLDED AND THE MARKERS ARE SPELLED LOWER-CASE.
+    When that was first written it was guarded by nothing — a mutation battery
+    removed this `.lower()` and the whole suite stayed green, because every
+    clause age emitted was already lower-case, so
+    `test_classify_age_refusal_is_CASE_FOLDED` was added to make the fold
+    non-vacuous.
+
+    ⚠ That is no longer the only guard, and the sentence claiming it was became
+    false in the same commit that added `bad header MAC` — age spells MAC in
+    capitals, so the real binary's own fixture now kills the same mutant. The
+    built test still earns its place: it covers EVERY marker, including the ones
+    age happens to emit in lower case today.
     """
     low = (stderr or "").lower()
     for marker, kind in _AGE_REFUSAL_MARKERS:

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1346,10 +1346,38 @@ def _corrupt_payload(blob: bytes, offset: int = 400) -> bytes:
     return bytes(b)
 
 
+def _age_header_end(blob: bytes) -> int:
+    """One past the newline that closes age's `--- <mac>` header line."""
+    return blob.index(b"\n", blob.index(b"--- ")) + 1
+
+
+def _strip_payload(blob: bytes) -> bytes:
+    """Everything after the header removed. age opens the header, then has no
+    nonce left to read — a fault in the ARTIFACT, after the key has worked."""
+    end = _age_header_end(blob)
+    assert len(blob) > end, "fixture has no payload to strip"
+    return blob[:end]
+
+
+def _truncate_mid_nonce(blob: bytes) -> bytes:
+    end = _age_header_end(blob)
+    assert len(blob) > end + 8
+    return blob[:end + 8]
+
+
 @pytest.mark.parametrize("mangle,name", [
     (lambda blob: _corrupt_payload(blob, 400), "payload byte flipped"),
     (lambda blob: _corrupt_payload(blob, 300), "payload byte flipped, offset 300"),
     (lambda blob: blob[:-30], "ciphertext truncated"),
+    # 🔴 THE TWO AN ADVERSARIAL AUDIT FOUND MISCLASSIFIED (2026-09-09). Both are
+    # ordinary truncations, both leave the header INTACT and the identity
+    # RIGHT, and both used to reach DECRYPT-FAILED's "CANNOT SAY WHY" — a
+    # verdict that names a wrong key among its three open causes. The tail
+    # truncation above did NOT catch them: it removes 30 bytes from inside a
+    # payload chunk, which age reports as a chunk-authentication failure. These
+    # cut BEFORE any chunk, where age says something else entirely.
+    (_strip_payload, "payload stripped entirely"),
+    (_truncate_mid_nonce, "truncated 8 bytes into the nonce"),
 ])
 def test_a_TAMPERED_or_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_not_EMPTY(
         escrow_world, tmp_path, mangle, name):
@@ -1429,6 +1457,81 @@ def test_a_TAMPERED_payload_is_ARTIFACT_CORRUPT_even_when_age_WROTE_NOTHING(
     assert ei.value.token == "ARTIFACT-CORRUPT"
     assert ei.value.exit_code == 33
     assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
+
+
+def test_a_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_even_when_age_WROTE_NOTHING(
+        escrow_world, monkeypatch):
+    """🔴 THE SECOND POST-AUTH REFUSAL, FORCED IN ISOLATION (added 2026-09-09).
+
+    An adversarial audit measured that the OR's second arm was `== payload-auth-
+    failed` alone, so a truncation age reports as "failed to read nonce" or
+    "unexpected EOF" — the header opened, the bytes ran out — fell through to
+    "CANNOT SAY WHY", which lists a wrong key among its open causes.
+
+    The real-artifact params on `test_a_TAMPERED_or_TRUNCATED_artifact_is_
+    ARTIFACT_CORRUPT_not_EMPTY` cover this too, but only through whichever
+    signal the INSTALLED age happens to supply: on v1.3.1 they would still pass
+    through `plain_present`. This forces `plain_present` false so the refusal
+    value is the only thing that can produce the verdict, on every host.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_TRUNCATED, write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "ARTIFACT-CORRUPT"
+    assert ei.value.exit_code == 33
+    assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
+
+
+def test_the_STRONG_verdict_fires_on_EVERY_post_auth_refusal_and_NO_other(
+        escrow_world, monkeypatch):
+    """🔴 THE SEAM BETWEEN THE TWO MODULES, ASSERTED AS A LEDGER.
+
+    `escrow-verify.py` reads `RV.AGE_REFUSALS_POST_AUTH` to decide when to say
+    "THE ESCROW IS FINE; THE BACKUP IS NOT". A test that names two refusals by
+    hand goes quietly incomplete the day a third is published — the failure this
+    whole round exists to fix, one level up. So this walks the PUBLISHED set and
+    requires the strong verdict for every member, and requires that no
+    non-member can reach it.
+    """
+    RVmod = EV._rv()
+    assert RVmod.AGE_REFUSALS_POST_AUTH, "an empty set would pass vacuously"
+    assert RVmod.AGE_REFUSALS_PRE_AUTH, "an empty set would pass vacuously"
+    # 🔴 The three groups must PARTITION the published set. A refusal in neither
+    # named set is not a bug — it lands in the unclassified message on purpose —
+    # but it must be VISIBLE here rather than absorbed, so the arithmetic is
+    # asserted before the behaviour.
+    assert not (RVmod.AGE_REFUSALS_POST_AUTH & RVmod.AGE_REFUSALS_PRE_AUTH)
+    assert (RVmod.AGE_REFUSALS_POST_AUTH | RVmod.AGE_REFUSALS_PRE_AUTH
+            | {RVmod.AGE_REFUSED_UNRECOGNISED}) == RVmod.AGE_REFUSALS, (
+        "a published refusal belongs to neither named set and is not the "
+        "fall-through: it will silently take the unclassified verdict. Put it "
+        "in a set, or state here why it belongs with the unknown.")
+
+    for refusal in sorted(RVmod.AGE_REFUSALS_POST_AUTH):
+        _refusing_decrypt(RVmod, monkeypatch, refusal=refusal,
+                          write_plaintext=False)
+        with pytest.raises(EV.EscrowError) as ei:
+            _decrypt_run(escrow_world)
+        assert ei.value.token == "ARTIFACT-CORRUPT", refusal
+    for refusal in sorted(RVmod.AGE_REFUSALS_PRE_AUTH):
+        _refusing_decrypt(RVmod, monkeypatch, refusal=refusal,
+                          write_plaintext=False)
+        with pytest.raises(EV.EscrowError) as ei:
+            _decrypt_run(escrow_world)
+        assert ei.value.token == "DECRYPT-FAILED", refusal
+        # ...and the TWO-cause sentence, not the three-cause one: age named
+        # which side of the payload it stopped on.
+        assert "TWO CAUSES PRODUCE THIS" in ei.value.verdict, refusal
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_UNRECOGNISED,
+                      write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "DECRYPT-FAILED"
+    assert "CANNOT SAY WHY" in ei.value.verdict
+    assert "TWO CAUSES PRODUCE THIS" not in ei.value.verdict
 
 
 def test_a_TAMPERED_payload_is_ARTIFACT_CORRUPT_when_only_PLAINTEXT_says_so(
@@ -1664,8 +1767,9 @@ def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
     assert ei.value.verdict == (
         f"🔴 {KEY_DELTA_NEW} is TAMPERED, CORRUPT or TRUNCATED. age "
         f"authenticated the header with the ESCROWED key — which a non-matching "
-        f"identity cannot do — and then FAILED on the "
-        f"payload. THE ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a "
+        f"identity cannot do — and then FAILED PAST IT: a payload chunk that "
+        f"would not authenticate, or an artifact that ran out of bytes. "
+        f"THE ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a "
         f"backup verifier exists to make: treat the artifact as unusable, check "
         f"the other retained objects for this scope, and do NOT rotate the key.")
 
@@ -4377,10 +4481,17 @@ _PINNED_DESTRUCTIVE_TEXTS: frozenset[str] = frozenset({
     # tampered payload writes NO plaintext — the old clause asserted an act the
     # branch can no longer observe. What survives is the claim that is still
     # supported: the header authenticated with the escrowed key.
+    #
+    # 🔴 "then FAILED on the payload" WENT THE SAME WAY, one round later
+    # (2026-09-09). The branch now also fires on a TRUNCATED artifact, where age
+    # ran out of bytes reading the nonce and never reached a payload chunk —
+    # asserting the payload there would be the identical mistake in a new
+    # spelling. The sentence names the disjunction it can actually support.
     (
         '🔴 {key} is TAMPERED, CORRUPT or TRUNCATED. age authenticated the '
         'header with the ESCROWED key — which a non-matching identity cannot '
-        'do — and then FAILED on the payload. THE '
+        'do — and then FAILED PAST IT: a payload chunk that would not '
+        'authenticate, or an artifact that ran out of bytes. THE '
         'ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a backup '
         'verifier exists to make: treat the artifact as unusable, check the '
         'other retained objects for this scope, and do NOT rotate the key.'
@@ -4410,7 +4521,7 @@ _PINNED_DESTRUCTIVE_TEXTS: frozenset[str] = frozenset({
     (
         'age REFUSED {key} and this verifier CANNOT SAY WHY. age exited '
         'non-zero without leaving plaintext, and its message matched none of '
-        'the three refusals this tool knows how to read. THREE THINGS ARE NOW '
+        'the refusals this tool knows how to read. THREE THINGS ARE NOW '
         'EQUALLY CONSISTENT with what was seen and NONE is asserted: the '
         "escrowed identity does not match, the artifact's HEADER is damaged, "
         'or the PAYLOAD is tampered. 🔴 DO NOT ROTATE OR RE-ESCROW ON THIS. '

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1504,10 +1504,11 @@ def test_the_STRONG_verdict_fires_on_EVERY_post_auth_refusal_and_NO_other(
     # asserted before the behaviour.
     assert not (RVmod.AGE_REFUSALS_POST_AUTH & RVmod.AGE_REFUSALS_PRE_AUTH)
     assert (RVmod.AGE_REFUSALS_POST_AUTH | RVmod.AGE_REFUSALS_PRE_AUTH
-            | {RVmod.AGE_REFUSED_UNRECOGNISED}) == RVmod.AGE_REFUSALS, (
-        "a published refusal belongs to neither named set and is not the "
+            | {RVmod.AGE_REFUSED_HEADER_MAC, RVmod.AGE_REFUSED_UNRECOGNISED}
+            ) == RVmod.AGE_REFUSALS, (
+        "a published refusal belongs to no named group and is not the "
         "fall-through: it will silently take the unclassified verdict. Put it "
-        "in a set, or state here why it belongs with the unknown.")
+        "in a group, or state here why it belongs with the unknown.")
 
     for refusal in sorted(RVmod.AGE_REFUSALS_POST_AUTH):
         _refusing_decrypt(RVmod, monkeypatch, refusal=refusal,
@@ -1515,6 +1516,28 @@ def test_the_STRONG_verdict_fires_on_EVERY_post_auth_refusal_and_NO_other(
         with pytest.raises(EV.EscrowError) as ei:
             _decrypt_run(escrow_world)
         assert ei.value.token == "ARTIFACT-CORRUPT", refusal
+        # ...and the message that asserts age got PAST the header, which is the
+        # only one these refusals earn.
+        assert "authenticated the header with the ESCROWED key" in ei.value.verdict
+
+    # 🔴 THE THIRD STATE: the key is PROVEN and the header is damaged. Same
+    # token and exit code as above — the remedy is identical — and a DIFFERENT
+    # message, because "age authenticated the header" is precisely what a MAC
+    # failure means it did not do.
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_HEADER_MAC,
+                      write_plaintext=False)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "ARTIFACT-CORRUPT"
+    assert ei.value.exit_code == 33
+    assert "unwrapped one of its recipient stanzas" in ei.value.verdict
+    assert "authenticated the header with the ESCROWED key" not in ei.value.verdict
+    # 🔴 It must NOT offer the rotation-shaped cause the pre-auth verdict does.
+    assert "TWO CAUSES PRODUCE THIS" not in ei.value.verdict
+    assert "the key is the likely cause" not in ei.value.verdict
+    assert "do NOT rotate the key" in ei.value.verdict
+
     for refusal in sorted(RVmod.AGE_REFUSALS_PRE_AUTH):
         _refusing_decrypt(RVmod, monkeypatch, refusal=refusal,
                           write_plaintext=False)
@@ -4495,6 +4518,24 @@ _PINNED_DESTRUCTIVE_TEXTS: frozenset[str] = frozenset({
         'ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a backup '
         'verifier exists to make: treat the artifact as unusable, check the '
         'other retained objects for this scope, and do NOT rotate the key.'
+    ),
+    # ARTIFACT-CORRUPT, message 2 of 2 — the key is PROVEN and the HEADER is
+    # damaged.
+    #
+    # 🔴 SAME TOKEN AND EXIT CODE, DIFFERENT WITNESS, and the split is the
+    # table's own "split by REMEDY" doctrine rather than a shortcut: the remedy
+    # is identical (the backup is damaged, do not rotate) while the evidence is
+    # not. It may NOT borrow message 1, which asserts age "authenticated the
+    # header" — precisely what a MAC failure means it did not do — and it must
+    # not fall to the pre-auth verdict, which offers a non-matching identity as
+    # an open cause that the discriminating control EXCLUDES.
+    (
+        '🔴 {key} has a DAMAGED HEADER. The ESCROWED key unwrapped one of its '
+        'recipient stanzas — which age only lets an identity that MATCHES do — '
+        'and the header then failed its own integrity check. THE ESCROW IS '
+        'FINE; THE BACKUP IS NOT. age never reached the payload, so nothing is '
+        'claimed about it. Treat the artifact as unusable, check the other '
+        'retained objects for this scope, and do NOT rotate the key.'
     ),
     # DECRYPT-FAILED, message 1 of 2 — age NAMED a pre-payload refusal.
     #

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1484,6 +1484,34 @@ def test_a_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_even_when_age_WROTE_NOTHING(
     assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
 
 
+def test_a_MAC_failure_wins_over_LEFTOVER_PLAINTEXT(escrow_world, monkeypatch):
+    """🔴 age's OWN CLASSIFICATION BEATS FILE PRESENCE, forced in isolation.
+
+    `_corrupt` is evaluated BEFORE the `AGE_REFUSED_HEADER_MAC` branch and its
+    first disjunct is `plain_present`, so if age ever left an `--output` file on
+    a MAC failure the MAC arm would be unreachable and the operator would get
+    "age authenticated the header with the ESCROWED key" — the one statement a
+    MAC failure specifically disproves.
+
+    An audit raised this out of its own delta and did not probe it, on the
+    grounds that it is unreachable today (`decrypt()` unlinks any stale output
+    first, and v1.3.2 creates the file lazily). Unreachable is not the same as
+    guarded: this forces BOTH signals to disagree — plaintext present AND a MAC
+    refusal — which no real age produces, and requires the classification to
+    win. Without the exclusion clause the mutant survives the whole suite.
+    """
+    RVmod = EV._rv()
+    _refusing_decrypt(RVmod, monkeypatch,
+                      refusal=RVmod.AGE_REFUSED_HEADER_MAC, write_plaintext=True)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "ARTIFACT-CORRUPT"
+    assert "unwrapped one of its recipient stanzas" in ei.value.verdict
+    assert "authenticated the header with the ESCROWED key" not in ei.value.verdict, (
+        "leftover plaintext made the payload branch win over age's own MAC "
+        "refusal, so the verdict asserts an act a MAC failure disproves.")
+
+
 def test_the_STRONG_verdict_fires_on_EVERY_post_auth_refusal_and_NO_other(
         escrow_world, monkeypatch):
     """🔴 THE SEAM BETWEEN THE TWO MODULES, ASSERTED AS A LEDGER.

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1556,6 +1556,27 @@ def test_the_STRONG_verdict_fires_on_EVERY_post_auth_refusal_and_NO_other(
     assert "CANNOT SAY WHY" in ei.value.verdict
     assert "TWO CAUSES PRODUCE THIS" not in ei.value.verdict
 
+    # 🔴 THE WALK IS OVER THE PUBLISHED SET, and this loop is what makes that
+    # sentence true. The groups above are three hand-named collections; an audit
+    # pointed out that a SIXTH published value added to the partition literal
+    # satisfies every assertion above while being walked by none of them — and
+    # `AGE_REFUSED_HEADER_MAC` is itself the proof that "in neither group" is
+    # not a safe destination. So every value in `AGE_REFUSALS` is driven through
+    # the real consumer here, and each must produce one of the two tokens this
+    # branch family is allowed to emit. A new value that reaches something else
+    # — or nothing — fails without anyone remembering to extend a list.
+    for refusal in sorted(RVmod.AGE_REFUSALS):
+        _refusing_decrypt(RVmod, monkeypatch, refusal=refusal,
+                          write_plaintext=False)
+        with pytest.raises(EV.EscrowError) as ei:
+            _decrypt_run(escrow_world)
+        assert ei.value.token in ("ARTIFACT-CORRUPT", "DECRYPT-FAILED"), refusal
+        # And the strong token is reachable ONLY from the key-proven set.
+        if ei.value.token == "ARTIFACT-CORRUPT":
+            assert refusal in RVmod.AGE_REFUSALS_KEY_PROVEN, (
+                f"{refusal!r} reached ARTIFACT-CORRUPT — 'THE ESCROW IS FINE' — "
+                f"without being published as evidence the key worked.")
+
 
 def test_a_TAMPERED_payload_is_ARTIFACT_CORRUPT_when_only_PLAINTEXT_says_so(
         escrow_world, monkeypatch):
@@ -4773,9 +4794,22 @@ def test_EVERY_destructive_advice_message_is_pinned_WHOLE():
                 if _DESTRUCTIVE_ADVICE.search(text)}
     # POSITIVE CONTROL: if this ever collapses to nothing, the pattern or the
     # renderer has broken and the whole ledger would pass vacuously.
-    assert len(must_pin) >= 12, (
-        f"only {len(must_pin)} destructive-advice message(s) found — the "
-        f"renderer or the pattern has regressed; the measured count is 13")
+    #
+    # 🔴 THE FLOOR IS DERIVED, NOT SPELLED. It read `>= 12` beside a message
+    # saying "the measured count is 13" — and an audit measured 15. A literal
+    # here is a count kept beside the thing it counts, which is the shape this
+    # file's own rules say will drift; it had drifted before the round that
+    # added the fifteenth even touched it. The pin set below is forced equal to
+    # `must_pin` by the two assertions that follow, so its size IS the measured
+    # count and cannot go stale.
+    assert len(must_pin) >= len(_PINNED_DESTRUCTIVE_TEXTS), (
+        f"only {len(must_pin)} destructive-advice message(s) found against "
+        f"{len(_PINNED_DESTRUCTIVE_TEXTS)} pinned — the renderer or the pattern "
+        f"has regressed. A message that stops being SEEN here stops being "
+        f"guarded, silently.")
+    assert must_pin, (
+        "no destructive-advice message was found at all: the pattern or the "
+        "renderer is broken and this ledger would pass vacuously.")
 
     unpinned = must_pin - _PINNED_DESTRUCTIVE_TEXTS
     assert not unpinned, (

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -4795,21 +4795,28 @@ def test_EVERY_destructive_advice_message_is_pinned_WHOLE():
     # POSITIVE CONTROL: if this ever collapses to nothing, the pattern or the
     # renderer has broken and the whole ledger would pass vacuously.
     #
-    # 🔴 THE FLOOR IS DERIVED, NOT SPELLED. It read `>= 12` beside a message
-    # saying "the measured count is 13" — and an audit measured 15. A literal
-    # here is a count kept beside the thing it counts, which is the shape this
-    # file's own rules say will drift; it had drifted before the round that
-    # added the fifteenth even touched it. The pin set below is forced equal to
-    # `must_pin` by the two assertions that follow, so its size IS the measured
-    # count and cannot go stale.
-    assert len(must_pin) >= len(_PINNED_DESTRUCTIVE_TEXTS), (
-        f"only {len(must_pin)} destructive-advice message(s) found against "
-        f"{len(_PINNED_DESTRUCTIVE_TEXTS)} pinned — the renderer or the pattern "
-        f"has regressed. A message that stops being SEEN here stops being "
-        f"guarded, silently.")
-    assert must_pin, (
-        "no destructive-advice message was found at all: the pattern or the "
-        "renderer is broken and this ledger would pass vacuously.")
+    # 🔴 AN INDEPENDENT FLOOR, DELIBERATELY A LITERAL — and the previous two
+    # revisions of this line were each wrong in the opposite direction, so the
+    # reasoning is written down rather than re-derived.
+    #
+    # It began as `>= 12` beside a message saying "the measured count is 13",
+    # against a real 15; an audit caught the PROSE. The fix replaced the literal
+    # with `>= len(_PINNED_DESTRUCTIVE_TEXTS)` — which the next audit showed is
+    # implied by the `unpinned` and `stale` assertions below, since together
+    # they force `must_pin == _PINNED_DESTRUCTIVE_TEXTS`. A control that can
+    # only fail when the assertions it precedes also fail is not a control.
+    #
+    # What the original literal bought is a floor that survives someone
+    # "greening" this ledger by deleting pins: a renderer regression that stops
+    # SEEING messages then still goes red here. So the literal comes back,
+    # deliberately loose, with NO count quoted in prose beside it — the drift
+    # was in the sentence, never in the number.
+    assert len(must_pin) >= 12, (
+        f"only {len(must_pin)} destructive-advice message(s) found — the "
+        f"renderer or `_DESTRUCTIVE_ADVICE` has regressed, and a message that "
+        f"stops being SEEN here stops being guarded, silently. This floor is "
+        f"independent of `_PINNED_DESTRUCTIVE_TEXTS` on purpose; do not "
+        f"re-derive it from that set.")
 
     unpinned = must_pin - _PINNED_DESTRUCTIVE_TEXTS
     assert not unpinned, (

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -4560,7 +4560,62 @@ def test_bad_header_MAC_PROVES_the_key_worked(tmp_path):
         f"Re-measure before trusting `AGE_REFUSALS_KEY_PROVEN`.")
 
 
-def test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER():
+def test_the_marker_SUMMARY_TABLES_list_every_shipped_marker():
+    """🔴 TWO SECOND COPIES OF `_AGE_REFUSAL_MARKERS` EXIST, and both went stale
+    inside one commit — the round that ADDED `invalid x25519 recipient block`
+    listed 8 entries in restore-verify's own summary comment and 8 strings in
+    the operator-facing table in `SECRETS.md`, for 9 markers.
+
+    A reader who looks a string up in either and does not find it concludes it
+    reaches the unclassified verdict — its behaviour BEFORE it was classified,
+    i.e. exactly backwards. Both directions are checked: a marker missing from a
+    table fails, and a table naming a string the tuple does not carry fails too,
+    because that is the shape a marker RENAME leaves behind.
+    """
+    markers = [m for m, _ in RV._AGE_REFUSAL_MARKERS]
+    src = Path(RV.__file__).read_text(encoding="utf-8")
+
+    # 🔴 THE ROWS ARE EXTRACTED STRUCTURALLY, NOT SLICED. The first version of
+    # this test took the whole comment block between two anchors and asked
+    # whether each marker appeared ANYWHERE in it — and a mutation deleting the
+    # `invalid x25519 recipient block` ROW survived, because the ⚠ note a few
+    # lines below happens to NAME that marker while explaining why the table
+    # exists. The guard passed on prose ABOUT the table instead of the table.
+    # Reading only lines of the row shape `#   "<marker>" -> <kind>` is what
+    # makes a deleted row visible.
+    rows = {q.lower() for q in re.findall(r'^#   "([^"]+)"\s+->', src, re.M)}
+    assert rows, "no summary-table rows matched; the table's shape has changed"
+
+    secrets = (Path(RV.__file__).parents[2] / "SECRETS.md").read_text(
+        encoding="utf-8").lower()
+
+    for m in markers:
+        assert m.lower() in rows, (
+            f"marker {m!r} has no row in restore-verify's own summary table "
+            f"(rows present: {sorted(rows)}). That table is what a reader "
+            f"consults; a marker absent from it reads as unclassified.")
+        assert m in secrets, (
+            f"marker {m!r} is missing from the operator-facing table in "
+            f"SECRETS.md, which is where someone maps an exit code to a cause "
+            f"during a recovery.")
+
+    # 🔴 THE OTHER DIRECTION: a row naming a string the tuple no longer carries.
+    # A rename leaves precisely this, and it reads as coverage.
+    #
+    # ⚠ CASE-FOLDED, and the first draft of this check was not — it went red on
+    # `bad header MAC`, which is CORRECT in the table (it is age's own wording,
+    # which capitalises MAC) and necessarily lower-case in the tuple (because
+    # `classify_age_refusal` folds its input, so an upper-case marker could
+    # never match). The two spellings are both right; only a case-sensitive
+    # comparison of them is wrong.
+    assert rows <= {m.lower() for m in markers}, (
+        f"restore-verify's summary table has row(s) for "
+        f"{sorted(rows - {m.lower() for m in markers})}, which "
+        f"`_AGE_REFUSAL_MARKERS` does not carry. A stale entry reads as "
+        f"coverage that does not exist.")
+
+
+def test_a_message_carrying_BOTH_a_pre_auth_and_a_KEY_PROVEN_marker_classifies_as_PRE_AUTH():
     """🔴 THE ORDER OF `_AGE_REFUSAL_MARKERS` IS LOAD-BEARING, AND THIS IS WHY.
 
     age v1.3.2 NESTS the post-auth clause inside the pre-auth one — `failed to
@@ -4573,24 +4628,33 @@ def test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER
     from a live run, and both halves of that are deliberate. Spelling it would
     let the table drift away from the fixture. Taking it from the binary would
     make this test's SUBJECT version-dependent: MEASURED 2026-09-09, only v1.3.2
-    nests the two clauses — v1.3.1's in-header truncations say `failed to read
-    header: failed to parse header: failed to read line: EOF` and `failed to
-    read header: parsing age header: file is empty`, which carry no POST-auth
-    marker. A guard that can only fire on one of two installed binaries is not a
-    guard, and this property is about OUR tuple's order, which is version-free.
-    `test_the_real_binarys_in_header_truncations_are_NEVER_post_auth` is the live
-    half.
+    nests the two clauses. v1.3.1's in-header truncations produce FOUR shapes
+    over the 168 offsets, and every one of them opens `failed to read header:` —
+    `… failed to parse header: failed to read line: EOF` (95 offsets), `… failed
+    to read header: EOF` (45), `… parsing age header: file is empty` (22), `…
+    parsing age header: failed to read header: EOF` (6) — so none carries a
+    KEY-PROVEN marker. A guard that can only fire on one of two installed
+    binaries is not a guard, and this property is about OUR tuple's order, which
+    is version-free. `test_the_real_binarys_in_header_truncations_are_NEVER_post_auth`
+    is the live half.
 
-    ⚠ Both v1.3.1 strings are quoted WITH their `failed to read header:` prefix,
-    and an audit caught an earlier draft that dropped it. Without the prefix they
+    ⚠ Every one of those is quoted WITH its `failed to read header:` prefix, and
+    an audit caught an earlier draft that dropped it — and then a later audit
+    caught the replacement enumerating two of the four. Without the prefix they
     carry no marker at all, which would say v1.3.1's in-header truncations reach
     `unrecognised`. They reach `header-unreadable` — a different thing for the
     operator, and the difference is exactly the clause that was trimmed.
     """
     pre_markers = [(m, k) for m, k in RV._AGE_REFUSAL_MARKERS
                    if k in RV.AGE_REFUSALS_PRE_AUTH]
+    # 🔴 `KEY_PROVEN`, NOT `POST_AUTH`. An audit's mutation moved the
+    # `bad header mac` marker past every post-auth entry and the suite stayed
+    # green: `AGE_REFUSED_HEADER_MAC` is in neither set, so a rule stated over
+    # POST_AUTH left the marker whose verdict says "the escrow is fine"
+    # completely unconstrained. The set that matters is every kind whose verdict
+    # asserts the key worked.
     post_markers = [m for m, k in RV._AGE_REFUSAL_MARKERS
-                    if k in RV.AGE_REFUSALS_POST_AUTH]
+                    if k in RV.AGE_REFUSALS_KEY_PROVEN]
     assert pre_markers and post_markers, "nothing to overlap; table is empty"
     # 🔴 THE WHOLE CROSS-PRODUCT, not just the pair age happens to nest today.
     # The first draft of this test paired only the HEADER markers with the EOF
@@ -4666,6 +4730,53 @@ def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
     assert checked >= 4, f"only {checked} in-header offsets were exercised"
 
 
+@pytest.mark.parametrize("kind,must_say,must_not_say", [
+    # KEY PROVEN — the identity demonstrably opened the header, so the message
+    # must NOT offer "the identity does not open it" as a live possibility.
+    ("header-mac", "DID open", "does not open it"),
+    ("payload", "DID open", "does not open it"),
+    ("truncated-no-payload", "DID open", "does not open it"),
+    # PRE-AUTH — both causes genuinely open, and the message says so.
+    ("no-identity", "NOT separable", "DID open"),
+    ("header", "NOT separable", "DID open"),
+])
+def test_restore_verifys_OWN_message_reads_the_classification(
+        tmp_path, kind, must_say, must_not_say):
+    """🔴 `SECRETS.md` SENDS OPERATORS TO `restore-verify.py` TO TELL A KEY FAULT
+    FROM AN ARTIFACT FAULT — and until an audit said so, this message answered
+    "the identity … does not open it, or the ciphertext is damaged" for EVERY
+    refusal, including the ones that disprove its first half three lines below
+    the `classify_age_refusal` call that establishes it.
+
+    The consumer in `escrow-verify.py` was fixed and the sibling the consumer
+    POINTS AT was not — a predicate right at one of its two sites. This drives
+    the real `decrypt()` with really-damaged artifacts and reads the sentence.
+    """
+    ident = tmp_path / f"m-{kind}.key"
+    r = subprocess.run([AGE_KEYGEN, "-o", str(ident)], capture_output=True,
+                       text=True)
+    assert r.returncode == 0, r.stderr
+    err = _age_refusal_stderr(tmp_path, kind)          # builds the fixture set
+    refusal = RV.classify_age_refusal(err)
+
+    # Rebuild the same damaged artifact through the real `decrypt()` so the
+    # message under test is the one operators actually see.
+    cipher = tmp_path / f"bad-{kind}.age"
+    assert cipher.is_file(), "the fixture helper did not leave its artifact"
+    use = tmp_path / (f"other-{kind}.key" if kind == "no-identity"
+                      else f"id-{kind}.key")
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        RV.decrypt(cipher, tmp_path / f"plain-out-{kind}", use)
+    msg = str(ei.value)
+    assert ei.value.age_refusal == refusal, (refusal, ei.value.age_refusal)
+    assert must_say in msg, (
+        f"{kind} classified {refusal!r} but the message does not say "
+        f"{must_say!r}:\n{msg}")
+    assert must_not_say not in msg, (
+        f"{kind} classified {refusal!r} and the message still says "
+        f"{must_not_say!r}, which its own classification disproves:\n{msg}")
+
+
 def test_classify_age_refusal_is_CASE_FOLDED():
     """🔴 THE `.lower()` IS UNGUARDED WITHOUT THIS — an audit's mutation battery
     deleted it and the whole suite stayed green, because every clause age emits
@@ -4704,7 +4815,7 @@ def test_the_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
     marker-vs-marker check can see. This test keeps the markers themselves
     mutually non-containing so the tuple's order is the ONLY ordering fact
     anyone has to know, and
-    `test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER`
+    `test_a_message_carrying_BOTH_a_pre_auth_and_a_KEY_PROVEN_marker_classifies_as_PRE_AUTH`
     pins that one against the real binary.
 
     🔴 EVERY MARKER IS LOWER-CASE, and that is not style: `classify_age_refusal`
@@ -4744,10 +4855,26 @@ def test_the_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
     kinds_in_order = [k for _, k in RV._AGE_REFUSAL_MARKERS]
     last_pre = max(i for i, k in enumerate(kinds_in_order)
                    if k in RV.AGE_REFUSALS_PRE_AUTH)
-    first_post = min(i for i, k in enumerate(kinds_in_order)
-                     if k in RV.AGE_REFUSALS_POST_AUTH)
-    assert last_pre < first_post, (
-        f"a post-auth marker sits at index {first_post}, before the last "
+    # 🔴 OVER `KEY_PROVEN`, NOT `POST_AUTH` — see the note in the cross-product
+    # test above. Stated over POST_AUTH this assertion left `bad header mac`
+    # free to sit anywhere, and an audit's mutation moved it to the END of the
+    # tuple with the whole suite still green.
+    first_strong = min(i for i, k in enumerate(kinds_in_order)
+                       if k in RV.AGE_REFUSALS_KEY_PROVEN)
+    assert last_pre < first_strong, (
+        f"a KEY-PROVEN marker sits at index {first_strong}, before the last "
         f"pre-auth one at {last_pre}. A message naming a pre-auth cause could "
-        f"then be scored post-auth, which is what lets escrow-verify claim the "
-        f"escrowed key opened the header: {kinds_in_order}")
+        f"then be scored as proof the escrowed key worked, which is what lets "
+        f"escrow-verify tell an operator their escrow is fine: {kinds_in_order}")
+    # 🔴 AND EVERY KIND MUST BE ON ONE SIDE OR THE OTHER. Without this, a kind
+    # in neither group (which is exactly what `AGE_REFUSED_HEADER_MAC` was) has
+    # an unconstrained index and the two bounds above simply skip it.
+    ungrouped = [k for k in kinds_in_order
+                 if k not in RV.AGE_REFUSALS_PRE_AUTH
+                 and k not in RV.AGE_REFUSALS_KEY_PROVEN]
+    assert not ungrouped, (
+        f"marker kind(s) {sorted(set(ungrouped))} are in neither "
+        f"AGE_REFUSALS_PRE_AUTH nor AGE_REFUSALS_KEY_PROVEN, so their position "
+        f"in the tuple is pinned by nothing and they can be moved across the "
+        f"divider silently. Put each on a side, or state here why it has no "
+        f"ordering constraint.")

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -4641,10 +4641,35 @@ def test_the_marker_SUMMARY_TABLES_list_every_shipped_marker():
         if len(cells) != 3:
             continue
         for m in re.findall(r"`([^`]+)`", cells[0]):
-            secrets_rows[m.lower()] = _norm(cells[2])
+            # 🔴 THE WHOLE ROW, NOT THE ANSWER COLUMN. Keying only on `cells[2]`
+            # left the EXIT CODE beside it and the entire `reached` column
+            # unread — measured: rewriting the MAC row's `→ 33` to `→ 25`
+            # survived the suite, i.e. the founding bug reachable through the
+            # one column this table exists to provide, and rewriting the
+            # `reached` cell to "the key is proven and the header opened"
+            # survived too. The guard's own docstring calls this "where someone
+            # maps an EXIT CODE to a cause".
+            #
+            # 🔴 AND ROWS ARE REJECTED, NOT OVERWRITTEN. `secrets_rows[k] = …`
+            # was last-wins over the whole file, so a duplicate row inserted
+            # ABOVE the real table shadowed it — the founding bug verbatim, in
+            # the operator table, green. A second row for one marker is itself
+            # the defect: an operator reads whichever they reach first.
+            key = m.lower()
+            assert key not in secrets_rows, (
+                f"SECRETS.md has TWO rows for {m!r}. Whichever an operator "
+                f"reads first is the answer they act on, so a duplicate is not "
+                f"redundancy — it is an unreviewed second source of truth.")
+            secrets_rows[key] = _norm(" | ".join(cells[1:]))
     assert secrets_rows, (
         "no rows parsed out of SECRETS.md's classification table — its shape "
         "has changed and this guard is now reading nothing.")
+
+    # The exit code each side implies, so the table cannot name the right cause
+    # beside the wrong number. Derived from the consumer's own table rather than
+    # spelled: `escrow-verify.py` owns these, and a literal here would be a
+    # third copy of them.
+    _code = {"pre auth": "25", "post auth": "33", "key proven": "33"}
 
     for m in markers:
         want = _side[dict(RV._AGE_REFUSAL_MARKERS)[m]]
@@ -4666,18 +4691,37 @@ def test_the_marker_SUMMARY_TABLES_list_every_shipped_marker():
             f"tuple classifies it {want!r}. That table is what an operator "
             f"reads while deciding whether to rotate a disaster-recovery key.")
 
-        # 🔴 THE DIRECTIONAL CHECK, stated separately because it is the one that
-        # would have caught the founding bug: a PRE-AUTH marker must not be
-        # described by either table in language that says the key is proven.
-        # That is the sentence that sends an operator away from a wrong key.
-        if want == "pre auth":
-            for where, cell in (("restore-verify's summary", rows[m.lower()]),
-                                ("SECRETS.md", secrets_rows[m.lower()])):
-                assert "key proven" not in cell and "post auth" not in cell, (
-                    f"{where} describes the PRE-AUTH marker {m!r} as "
-                    f"{cell!r} — language that tells an operator the escrowed "
-                    f"key is fine, on a refusal that proves nothing of the "
-                    f"sort.")
+        # 🔴 THE EXIT CODE, pinned beside the cause. A row can otherwise name
+        # the right answer next to the wrong number, which is what an operator
+        # actually branches on during a recovery.
+        assert _code[want] in secrets_rows[m.lower()], (
+            f"SECRETS.md gives {m!r} a row that does not carry exit code "
+            f"{_code[want]}: {secrets_rows[m.lower()]!r}. `25` sends the "
+            f"operator at their key and `33` at the artifact — the number is "
+            f"the half a timer and a hurried human both read.")
+
+        # 🔴 THE DIRECTIONAL CHECK, IN BOTH DIRECTIONS — it was written for
+        # pre-auth only, and an audit measured the consequence: additive wrong
+        # language on a KEY-PROVEN row was invisible, so filing the MAC row as
+        # "key proven, post-auth" survived. "post-auth" said of a MAC failure is
+        # `escrow-verify`'s "age authenticated the header with the ESCROWED
+        # key", the one statement this whole change exists to deny. A check that
+        # covers one direction of a two-directional property is the same shape
+        # as the bug it was written for.
+        _forbidden = {
+            "pre auth": ("key proven", "post auth"),
+            "post auth": ("pre auth", "key proven"),
+            "key proven": ("pre auth", "post auth"),
+        }[want]
+        for where, cell in (("restore-verify's summary", rows[m.lower()]),
+                            ("SECRETS.md", secrets_rows[m.lower()])):
+            for bad in _forbidden:
+                assert bad not in cell, (
+                    f"{where} describes the {want.upper()} marker {m!r} as "
+                    f"{cell!r}, which also says {bad!r}. Every one of these "
+                    f"three answers licenses a different sentence to an "
+                    f"operator deciding whether to rotate a key; a row that "
+                    f"says two of them is a row that says nothing.")
 
     # 🔴 THE OTHER DIRECTION: a row naming a string the tuple no longer carries.
     # A rename leaves precisely this, and it reads as coverage.
@@ -4810,8 +4854,12 @@ def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
         # it by construction, being in neither set. That is the identical
         # predicate-right-at-one-of-its-sites shape the previous round FILED as
         # a finding, left live in the very commit that filed it. This is the
-        # only guard here that reads the real binary, so the narrow spelling
-        # made it the one place a reworded age could open the path unobserved.
+        # only guard of the ORDERING PAIR that reads the real binary — the
+        # cross-product test above it is built from the shipped markers — so the
+        # narrow spelling made it the one place in that pair where a reworded
+        # age could open the path unobserved. (Plenty of OTHER tests in this
+        # file drive the real binary; an earlier draft of this sentence said
+        # "the only guard here", which reads as a claim about the file.)
         assert got not in RV.AGE_REFUSALS_KEY_PROVEN, (
             f"a ciphertext truncated to {keep} bytes — INSIDE the header, which "
             f"age therefore never authenticated — classified as {got!r}, which "

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -47,6 +47,7 @@ wrong reason and stays green with the guard it claims to test deleted.
 from __future__ import annotations
 
 import ast
+import base64
 import hashlib
 import importlib.util
 from testlib import hermetic_git  # noqa: E402
@@ -4297,8 +4298,15 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
            ident.read_text(encoding="utf-8").splitlines()
            if ln.startswith("# public key:")][0]
 
+    # 🔴 THE PAYLOAD SIZE IS PART OF THE FIXTURE for one kind. age chunks the
+    # payload at 64 KiB; `last chunk is empty` is only reachable when a
+    # ciphertext whose payload spills ONE byte past a chunk boundary loses that
+    # byte, so the final chunk is empty rather than short. At 4 KiB the same
+    # truncation is an ordinary chunk-authentication failure. Measured on both
+    # versions.
+    size = 65537 if kind == "truncated-last-chunk-empty" else 4096
     plain = tmp_path / f"plain-{kind}"
-    plain.write_bytes(os.urandom(4096))
+    plain.write_bytes(os.urandom(size))
     cipher = tmp_path / f"c-{kind}.age"
     r = subprocess.run([AGE, "--encrypt", "--recipient", pub, "--output",
                         str(cipher), str(plain)], capture_output=True, text=True)
@@ -4324,13 +4332,46 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
         # Damaging the intro makes age fail to PARSE the header; damaging only
         # the trailing `--- <mac>` line leaves a well-formed header whose MAC
         # does not verify, and age says something else entirely for it.
+        #
+        # 🔴 DECODE, FLIP, RE-ENCODE — do NOT flip a byte of the base64 TEXT.
+        # An audit measured the text-flip version over 30 fresh keys per binary:
+        # 1 run in 20 lands on a character that makes the closing line ILLEGAL
+        # base64, so age fails EARLIER with `failed to read header: … malformed
+        # closing line`, which classifies as `header-unreadable`. Both answers
+        # were accepted by this test's own assertion, so on those runs the
+        # marker it exists to exercise was never reached and the guard was
+        # vacuous — silently, ~5% of the time.
         lines = bytes(blob).split(b"\n")
         i = next(n for n, ln in enumerate(lines) if ln.startswith(b"--- "))
-        mac = bytearray(lines[i])
-        before = mac[8]
-        mac[8] ^= 0x01
-        assert mac[8] != before
-        lines[i] = bytes(mac)
+        raw = bytearray(base64.b64decode(lines[i][4:] + b"=="))
+        before = raw[0]
+        raw[0] ^= 0x01
+        assert raw[0] != before
+        lines[i] = b"--- " + base64.b64encode(bytes(raw)).rstrip(b"=")
+        blob = bytearray(b"\n".join(lines))
+    elif kind == "stanza-arg-unparseable":
+        # 🔴 PROVOKES `failed to parse X25519 recipient`, which was added to the
+        # marker table with NO fixture — an audit's mutation battery deleted the
+        # marker and the whole suite stayed green. The comment at the head of
+        # this block says the fixture set IS the guard; this is that claim being
+        # made true rather than reworded.
+        #
+        # An ILLEGAL base64 character in the stanza argument. Deterministic on
+        # both versions: `illegal base64 data at input byte 0`.
+        lines = bytes(blob).split(b"\n")
+        j = next(n for n, ln in enumerate(lines) if ln.startswith(b"-> X25519 "))
+        arg = lines[j][len(b"-> X25519 "):]
+        lines[j] = b"-> X25519 " + b"!" * len(arg)
+        blob = bytearray(b"\n".join(lines))
+    elif kind == "stanza-arg-wrong-length":
+        # 🔴 A DIFFERENT FAULT, and it was found BY WRITING THE FIXTURE ABOVE —
+        # the first attempt at provoking the parse error used a legal-but-short
+        # base64 argument and produced `invalid X25519 recipient block`, a
+        # refusal nothing in the table named. Kept as its own kind so both stay
+        # provoked rather than one masking the other.
+        lines = bytes(blob).split(b"\n")
+        j = next(n for n, ln in enumerate(lines) if ln.startswith(b"-> X25519 "))
+        lines[j] = b"-> X25519 " + base64.b64encode(b"too-short").rstrip(b"=")
         blob = bytearray(b"\n".join(lines))
     elif kind == "truncated-no-payload":
         # Everything after the header removed: age opens the header, then has no
@@ -4340,6 +4381,12 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
     elif kind == "truncated-mid-nonce":
         assert len(blob) > hdr_end + 8
         blob = blob[:hdr_end + 8]
+    elif kind == "truncated-last-chunk-empty":
+        # See the payload-size note above: one byte off a payload that is one
+        # byte past a chunk boundary leaves age with an EMPTY final chunk, which
+        # it reports differently from a short one. The other marker in the table
+        # that had no fixture.
+        blob = blob[:-1]
     elif kind == "no-identity":
         other = tmp_path / f"other-{kind}.key"
         r = subprocess.run([AGE_KEYGEN, "-o", str(other)], capture_output=True,
@@ -4368,9 +4415,17 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
     # 🔴 THE THREE THE 2026-09-08 SWEEP MISSED. Each of these produced
     # `unrecognised` before 2026-09-09 and reached the consumer's "CANNOT SAY
     # WHY" verdict, which told the operator age had probably reworded.
-    ("header-mac", "AGE_REFUSED_HEADER"),
+    ("header-mac", "AGE_REFUSED_HEADER_MAC"),
     ("truncated-no-payload", "AGE_REFUSED_TRUNCATED"),
     ("truncated-mid-nonce", "AGE_REFUSED_TRUNCATED"),
+    # 🔴 THE TWO MARKERS THAT SHIPPED WITH NO FIXTURE AT ALL. An audit's
+    # mutation battery deleted each and the whole suite stayed green — the block
+    # above says the fixture set IS the guard, and for these two it was not.
+    ("stanza-arg-unparseable", "AGE_REFUSED_HEADER"),
+    ("truncated-last-chunk-empty", "AGE_REFUSED_TRUNCATED"),
+    # 🔴 FOUND BY WRITING THE FIXTURE ABOVE — a fourth real refusal the table
+    # never named, which the first attempt at that fixture produced by accident.
+    ("stanza-arg-wrong-length", "AGE_REFUSED_HEADER"),
 ])
 def test_classify_age_refusal_reads_the_REAL_binarys_refusals(
         tmp_path, kind, expected_attr):
@@ -4393,7 +4448,8 @@ def test_classify_age_refusal_reads_the_REAL_binarys_refusals(
 
 
 @pytest.mark.parametrize("kind", ["payload", "truncated-no-payload",
-                                  "truncated-mid-nonce"])
+                                  "truncated-mid-nonce",
+                                  "truncated-last-chunk-empty"])
 def test_the_POST_AUTH_set_is_exactly_what_licenses_the_STRONGEST_verdict(
         tmp_path, kind):
     """🔴 THE CLAIM `ARTIFACT-CORRUPT` MAKES, PINNED AT ITS SOURCE.
@@ -4408,18 +4464,100 @@ def test_the_POST_AUTH_set_is_exactly_what_licenses_the_STRONGEST_verdict(
     assert RV.classify_age_refusal(err) in RV.AGE_REFUSALS_POST_AUTH, err
 
 
-@pytest.mark.parametrize("kind", ["no-identity", "header", "header-mac"])
+@pytest.mark.parametrize("kind", ["no-identity", "header",
+                                  "stanza-arg-unparseable",
+                                  "stanza-arg-wrong-length"])
 def test_no_PRE_AUTH_refusal_is_EVER_scored_as_post_auth(tmp_path, kind):
     """🔴 THE MIRROR, AND THE ONE THAT MATTERS MOST. A pre-auth refusal scored
     post-auth would assert "THE ESCROW IS FINE; THE BACKUP IS NOT" about a run
     that never proved the identity opens anything — a confident wrong answer in
     the direction that stops an operator investigating their key.
+
+    ⚠ `header-mac` is deliberately NOT in this list any more, and its removal is
+    the finding rather than a narrowing: it is not a pre-auth refusal. See
+    `test_bad_header_MAC_PROVES_the_key_worked` for the control.
     """
     err = _age_refusal_stderr(tmp_path, kind)
     got = RV.classify_age_refusal(err)
-    assert got not in RV.AGE_REFUSALS_POST_AUTH, (
-        f"age's {kind} refusal now scores as post-auth ({got!r}), which lets "
-        f"escrow-verify claim the header authenticated. Its stderr was:\n{err}")
+    assert got in RV.AGE_REFUSALS_PRE_AUTH, (
+        f"age's {kind} refusal classifies as {got!r}, which is not a pre-auth "
+        f"refusal. Its stderr was:\n{err}")
+    assert got not in RV.AGE_REFUSALS_KEY_PROVEN, (
+        f"age's {kind} refusal now counts as evidence the escrowed key WORKS "
+        f"({got!r}) — it is not. Its stderr was:\n{err}")
+
+
+def test_bad_header_MAC_PROVES_the_key_worked(tmp_path):
+    """🔴 THE DISCRIMINATING CONTROL, and the reason `bad header MAC` is neither
+    pre-auth nor post-auth.
+
+    The first draft of the marker table filed it with the pre-auth refusals,
+    whose operator-facing verdict offers *"the escrowed identity does not match
+    this artifact's recipients"* as an open cause and ends *"if none open, the
+    key is the likely cause"* — a rotation-shaped sentence about a key this very
+    message vindicates.
+
+    The control is the SAME damaged blob decrypted twice. If the wrong identity
+    reports `no identity matched` where the right one reports `bad header MAC`,
+    then age reached the MAC check only because the identity unwrapped a stanza
+    — so the two causes the pre-auth verdict calls inseparable ARE separable
+    here, and the one it names first is excluded.
+
+    Measured on both installed binaries, 3 runs each, before this test existed.
+    """
+    err = _age_refusal_stderr(tmp_path, "header-mac")
+    assert RV.classify_age_refusal(err) == RV.AGE_REFUSED_HEADER_MAC, err
+    assert RV.AGE_REFUSED_HEADER_MAC in RV.AGE_REFUSALS_KEY_PROVEN
+    assert RV.AGE_REFUSED_HEADER_MAC not in RV.AGE_REFUSALS_PRE_AUTH
+    assert RV.AGE_REFUSED_HEADER_MAC not in RV.AGE_REFUSALS_POST_AUTH
+
+    # 🔴 THE CONTROL ITSELF: rebuild the same damaged artifact and decrypt it
+    # with a NON-MATCHING identity. Without this the test above is satisfied by
+    # any message containing the marker, and says nothing about what it proves.
+    ident = tmp_path / "ctrl-good.key"
+    r = subprocess.run([AGE_KEYGEN, "-o", str(ident)], capture_output=True,
+                       text=True)
+    assert r.returncode == 0, r.stderr
+    pub = [ln.split(": ", 1)[1].strip() for ln in
+           ident.read_text(encoding="utf-8").splitlines()
+           if ln.startswith("# public key:")][0]
+    other = tmp_path / "ctrl-other.key"
+    r = subprocess.run([AGE_KEYGEN, "-o", str(other)], capture_output=True,
+                       text=True)
+    assert r.returncode == 0, r.stderr
+
+    plain = tmp_path / "ctrl-plain"
+    plain.write_bytes(os.urandom(4096))
+    cipher = tmp_path / "ctrl.age"
+    r = subprocess.run([AGE, "--encrypt", "--recipient", pub, "--output",
+                        str(cipher), str(plain)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    lines = cipher.read_bytes().split(b"\n")
+    i = next(n for n, ln in enumerate(lines) if ln.startswith(b"--- "))
+    raw = bytearray(base64.b64decode(lines[i][4:] + b"=="))
+    before = raw[0]
+    raw[0] ^= 0x01
+    assert raw[0] != before
+    lines[i] = b"--- " + base64.b64encode(bytes(raw)).rstrip(b"=")
+    bad = tmp_path / "ctrl-bad.age"
+    bad.write_bytes(b"\n".join(lines))
+
+    seen = {}
+    for label, use in (("right", ident), ("wrong", other)):
+        out = tmp_path / f"ctrl-out-{label}"
+        out.unlink(missing_ok=True)
+        r = subprocess.run([AGE, "--decrypt", "--identity", str(use),
+                            "--output", str(out), str(bad)],
+                           capture_output=True, text=True)
+        assert r.returncode != 0, label
+        seen[label] = RV.classify_age_refusal(r.stderr)
+
+    assert seen["right"] == RV.AGE_REFUSED_HEADER_MAC, seen
+    assert seen["wrong"] == RV.AGE_REFUSED_NO_IDENTITY, (
+        f"the WRONG identity did not report a non-matching identity on this "
+        f"blob ({seen}), so `bad header MAC` no longer proves the key unwrapped "
+        f"a stanza — and the verdict keyed on that proof is no longer earned. "
+        f"Re-measure before trusting `AGE_REFUSALS_KEY_PROVEN`.")
 
 
 def test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER():
@@ -4435,12 +4573,19 @@ def test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER
     from a live run, and both halves of that are deliberate. Spelling it would
     let the table drift away from the fixture. Taking it from the binary would
     make this test's SUBJECT version-dependent: MEASURED 2026-09-09, only v1.3.2
-    nests the two clauses — v1.3.1's in-header truncations say `failed to parse
-    header: failed to read line: EOF` and `parsing age header: file is empty`,
-    which carry no post-auth marker at all. A guard that can only fire on one of
-    two installed binaries is not a guard, and this property is about OUR tuple's
-    order, which is version-free. `test_the_real_binarys_in_header_truncations_
-    are_NEVER_post_auth` is the live half.
+    nests the two clauses — v1.3.1's in-header truncations say `failed to read
+    header: failed to parse header: failed to read line: EOF` and `failed to
+    read header: parsing age header: file is empty`, which carry no POST-auth
+    marker. A guard that can only fire on one of two installed binaries is not a
+    guard, and this property is about OUR tuple's order, which is version-free.
+    `test_the_real_binarys_in_header_truncations_are_NEVER_post_auth` is the live
+    half.
+
+    ⚠ Both v1.3.1 strings are quoted WITH their `failed to read header:` prefix,
+    and an audit caught an earlier draft that dropped it. Without the prefix they
+    carry no marker at all, which would say v1.3.1's in-header truncations reach
+    `unrecognised`. They reach `header-unreadable` — a different thing for the
+    operator, and the difference is exactly the clause that was trimmed.
     """
     pre_markers = [(m, k) for m, k in RV._AGE_REFUSAL_MARKERS
                    if k in RV.AGE_REFUSALS_PRE_AUTH]
@@ -4585,6 +4730,12 @@ def test_the_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
     assert RV.AGE_REFUSED_UNRECOGNISED not in RV.AGE_REFUSALS_POST_AUTH
     assert RV.AGE_REFUSED_NO_IDENTITY not in RV.AGE_REFUSALS_POST_AUTH
     assert RV.AGE_REFUSED_HEADER not in RV.AGE_REFUSALS_POST_AUTH
+    # 🔴 `AGE_REFUSALS_KEY_PROVEN` is what the "do not rotate" advice rests on,
+    # so nothing may enter it that is not positive evidence the key worked. The
+    # fall-through especially: "age said something new" is not proof of anything.
+    assert RV.AGE_REFUSALS_POST_AUTH < RV.AGE_REFUSALS_KEY_PROVEN
+    assert not (RV.AGE_REFUSALS_KEY_PROVEN & RV.AGE_REFUSALS_PRE_AUTH)
+    assert RV.AGE_REFUSED_UNRECOGNISED not in RV.AGE_REFUSALS_KEY_PROVEN
     # 🔴 THE ORDER ITSELF, as structure rather than as behaviour: every pre-auth
     # marker sits before every post-auth one in the tuple. The behavioural test
     # above can only see the overlaps someone thought to build; this sees the

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -21,7 +21,7 @@ suite asserts BOTH halves, in the same file, deliberately:
 
   * `test_a_corrupted_artifact_FAILS_the_verifier` — the verifier catches it,
     on its own message, through the real CLI as well as the library.
-  * `test_git_bundle_verify_returns_ZERO_on_that_same_corrupted_bundle` — the
+  * `test_git_bundle_verify_returns_ZERO_on_a_pack_corrupted_bundle` — the
     weakness, pinned. If a future git tightens `bundle verify` this goes red and
     whoever sees it can re-argue the design with evidence rather than hope.
 
@@ -4393,6 +4393,22 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
                            text=True)
         assert r.returncode == 0, r.stderr
         use_ident = other
+    elif kind == "identity-malformed":
+        # 🔴 THE FALL-THROUGH, PROVOKED. `AGE_REFUSED_UNRECOGNISED` is the
+        # destination the whole fail-safe design rests on and it had no fixture
+        # — so nothing checked that a run-environment fault does not borrow a
+        # claim from one of the artifact arms. The ARTIFACT here is intact; the
+        # IDENTITY is corrupted, which is a fault of the run, and age says
+        # something no artifact-shaped sweep produces.
+        text = ident.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        for n, ln in enumerate(lines):
+            if ln.startswith("AGE-SECRET-KEY-"):
+                lines[n] = ln[:20] + "!" + ln[21:]
+                break
+        else:                                   # pragma: no cover - fixture bug
+            raise AssertionError("no secret line to corrupt")
+        ident.write_text("\n".join(lines) + "\n", encoding="utf-8")
     else:  # pragma: no cover - the caller's kinds are enumerated below
         raise AssertionError(kind)
 
@@ -4581,23 +4597,87 @@ def test_the_marker_SUMMARY_TABLES_list_every_shipped_marker():
     # `invalid x25519 recipient block` ROW survived, because the ⚠ note a few
     # lines below happens to NAME that marker while explaining why the table
     # exists. The guard passed on prose ABOUT the table instead of the table.
-    # Reading only lines of the row shape `#   "<marker>" -> <kind>` is what
-    # makes a deleted row visible.
-    rows = {q.lower() for q in re.findall(r'^#   "([^"]+)"\s+->', src, re.M)}
+    #
+    # 🔴 AND THE CLASSIFICATION IS CAPTURED, NOT DISCARDED. The second version
+    # captured only the marker and threw away everything right of `->`, so
+    # rewriting a row's ANSWER survived: `bad header MAC -> pre-auth` — the
+    # founding bug of this entire line of work — passed the suite green. The
+    # right-hand side is the half that was wrong; it is the half worth pinning.
+    # ⚠ HYPHENS AND SPACES ARE FOLDED, because the two tables legitimately
+    # differ on them — restore-verify's own reads `-> KEY PROVEN, see below`,
+    # SECRETS.md's reads `key proven → 33`, and the tuple's kinds are
+    # `key-proven`. Folding the separator keeps the ANSWER pinned without
+    # pinning a typography choice, which is the kind of tightness that gets a
+    # guard switched off.
+    def _norm(s: str) -> str:
+        return s.lower().replace("-", " ")
+
+    # Three groups, not two: both tables distinguish "past the header"
+    # (post-auth) from "the key is proven but the header failed" — that split is
+    # the whole point of the third state, so a check that collapsed them would
+    # accept a row calling a MAC failure a payload failure.
+    _side = {}
+    for k in RV.AGE_REFUSALS_PRE_AUTH:
+        _side[k] = "pre auth"
+    for k in RV.AGE_REFUSALS_POST_AUTH:
+        _side[k] = "post auth"
+    _side[RV.AGE_REFUSED_HEADER_MAC] = "key proven"
+    assert set(_side) == RV.AGE_REFUSALS - {RV.AGE_REFUSED_UNRECOGNISED}, (
+        "a published refusal has no expected table wording here, so its rows "
+        "would go unchecked in both tables")
+    rows = {m.lower(): _norm(rhs)
+            for m, rhs in re.findall(r'^#   "([^"]+)"\s+->\s*(.+)$', src, re.M)}
     assert rows, "no summary-table rows matched; the table's shape has changed"
 
-    secrets = (Path(RV.__file__).parents[2] / "SECRETS.md").read_text(
-        encoding="utf-8").lower()
+    # The operator-facing table is parsed as a TABLE too — `m in secrets` over
+    # the whole file was satisfied by prose elsewhere in it, so deleting AND
+    # INVERTING the `bad header MAC` row both survived.
+    secrets_path = Path(RV.__file__).parents[2] / "SECRETS.md"
+    secrets_rows: dict[str, str] = {}
+    for line in secrets_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("| `") or "→" not in line:
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != 3:
+            continue
+        for m in re.findall(r"`([^`]+)`", cells[0]):
+            secrets_rows[m.lower()] = _norm(cells[2])
+    assert secrets_rows, (
+        "no rows parsed out of SECRETS.md's classification table — its shape "
+        "has changed and this guard is now reading nothing.")
 
     for m in markers:
+        want = _side[dict(RV._AGE_REFUSAL_MARKERS)[m]]
         assert m.lower() in rows, (
             f"marker {m!r} has no row in restore-verify's own summary table "
             f"(rows present: {sorted(rows)}). That table is what a reader "
             f"consults; a marker absent from it reads as unclassified.")
-        assert m in secrets, (
-            f"marker {m!r} is missing from the operator-facing table in "
+        assert want in rows[m.lower()], (
+            f"restore-verify's summary table files {m!r} as {rows[m.lower()]!r}, "
+            f"but the tuple classifies it {want!r}. A row with the right string "
+            f"and the wrong answer is how `bad header MAC` came to be filed "
+            f"pre-auth in the first place.")
+        assert m.lower() in secrets_rows, (
+            f"marker {m!r} has no row in the operator-facing table in "
             f"SECRETS.md, which is where someone maps an exit code to a cause "
-            f"during a recovery.")
+            f"during a recovery (rows present: {sorted(secrets_rows)}).")
+        assert want in secrets_rows[m.lower()], (
+            f"SECRETS.md files {m!r} as {secrets_rows[m.lower()]!r}, but the "
+            f"tuple classifies it {want!r}. That table is what an operator "
+            f"reads while deciding whether to rotate a disaster-recovery key.")
+
+        # 🔴 THE DIRECTIONAL CHECK, stated separately because it is the one that
+        # would have caught the founding bug: a PRE-AUTH marker must not be
+        # described by either table in language that says the key is proven.
+        # That is the sentence that sends an operator away from a wrong key.
+        if want == "pre auth":
+            for where, cell in (("restore-verify's summary", rows[m.lower()]),
+                                ("SECRETS.md", secrets_rows[m.lower()])):
+                assert "key proven" not in cell and "post auth" not in cell, (
+                    f"{where} describes the PRE-AUTH marker {m!r} as "
+                    f"{cell!r} — language that tells an operator the escrowed "
+                    f"key is fine, on a refusal that proves nothing of the "
+                    f"sort.")
 
     # 🔴 THE OTHER DIRECTION: a row naming a string the tuple no longer carries.
     # A rename leaves precisely this, and it reads as coverage.
@@ -4608,11 +4688,16 @@ def test_the_marker_SUMMARY_TABLES_list_every_shipped_marker():
     # `classify_age_refusal` folds its input, so an upper-case marker could
     # never match). The two spellings are both right; only a case-sensitive
     # comparison of them is wrong.
-    assert rows <= {m.lower() for m in markers}, (
+    lowered = {m.lower() for m in markers}
+    assert set(rows) <= lowered, (
         f"restore-verify's summary table has row(s) for "
-        f"{sorted(rows - {m.lower() for m in markers})}, which "
-        f"`_AGE_REFUSAL_MARKERS` does not carry. A stale entry reads as "
-        f"coverage that does not exist.")
+        f"{sorted(set(rows) - lowered)}, which `_AGE_REFUSAL_MARKERS` does not "
+        f"carry. A stale entry reads as coverage that does not exist.")
+    assert set(secrets_rows) <= lowered, (
+        f"SECRETS.md's classification table has row(s) for "
+        f"{sorted(set(secrets_rows) - lowered)}, which `_AGE_REFUSAL_MARKERS` "
+        f"does not carry — an operator would look up a string the tool can no "
+        f"longer produce.")
 
 
 def test_a_message_carrying_BOTH_a_pre_auth_and_a_KEY_PROVEN_marker_classifies_as_PRE_AUTH():
@@ -4672,7 +4757,7 @@ def test_a_message_carrying_BOTH_a_pre_auth_and_a_KEY_PROVEN_marker_classifies_a
                 f"{nested!r} classified as {got!r}, not {pre_kind!r}. EVERY "
                 f"pre-auth marker must be matched BEFORE EVERY post-auth one; "
                 f"do not reorder `_AGE_REFUSAL_MARKERS` across the divider.")
-            assert got not in RV.AGE_REFUSALS_POST_AUTH
+            assert got not in RV.AGE_REFUSALS_KEY_PROVEN
 
 
 def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
@@ -4719,11 +4804,20 @@ def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
                            capture_output=True, text=True)
         assert r.returncode != 0, keep
         got = RV.classify_age_refusal(r.stderr)
-        assert got not in RV.AGE_REFUSALS_POST_AUTH, (
+        # 🔴 `KEY_PROVEN`, NOT `POST_AUTH`. This assertion was left on POST_AUTH
+        # while its two siblings were widened, so `header-mac-failed` — the one
+        # kind whose verdict says in so many words "THE ESCROW IS FINE" — passed
+        # it by construction, being in neither set. That is the identical
+        # predicate-right-at-one-of-its-sites shape the previous round FILED as
+        # a finding, left live in the very commit that filed it. This is the
+        # only guard here that reads the real binary, so the narrow spelling
+        # made it the one place a reworded age could open the path unobserved.
+        assert got not in RV.AGE_REFUSALS_KEY_PROVEN, (
             f"a ciphertext truncated to {keep} bytes — INSIDE the header, which "
-            f"age therefore never authenticated — classified as {got!r}, a "
-            f"post-auth refusal. escrow-verify would report ARTIFACT-CORRUPT "
-            f"and tell the operator their key is fine. stderr was:\n{r.stderr}")
+            f"age therefore never authenticated — classified as {got!r}, which "
+            f"this module publishes as evidence the escrowed key WORKED. "
+            f"escrow-verify would report ARTIFACT-CORRUPT and tell the operator "
+            f"their key is fine. stderr was:\n{r.stderr}")
         checked += 1
     # 🔴 POSITIVE CONTROL: an empty loop asserts nothing, and every `continue`
     # above is a way to reach one.
@@ -4731,14 +4825,22 @@ def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
 
 
 @pytest.mark.parametrize("kind,must_say,must_not_say", [
-    # KEY PROVEN — the identity demonstrably opened the header, so the message
-    # must NOT offer "the identity does not open it" as a live possibility.
-    ("header-mac", "DID open", "does not open it"),
+    # 🔴 KEY PROVEN, MAC ARM — the identity unwrapped a stanza but age did NOT
+    # authenticate the header, so this arm must NOT say "DID open". The first
+    # version of this test asserted that it DID, i.e. it pinned the overclaim
+    # rather than catching it: a guard that requires the wrong sentence is worse
+    # than no guard, because it makes the correction fail.
+    ("header-mac", "UNWRAPPED one of its recipient stanzas", "DID open"),
+    # KEY PROVEN, past-the-header arms — here "DID open" is earned.
     ("payload", "DID open", "does not open it"),
     ("truncated-no-payload", "DID open", "does not open it"),
     # PRE-AUTH — both causes genuinely open, and the message says so.
     ("no-identity", "NOT separable", "DID open"),
     ("header", "NOT separable", "DID open"),
+    # 🔴 THE FALL-THROUGH, which had no case at all. It is the destination the
+    # whole fail-safe design rests on, and nothing asserted that it does not
+    # borrow a claim from either arm above.
+    ("identity-malformed", "cannot classify", "DID open"),
 ])
 def test_restore_verifys_OWN_message_reads_the_classification(
         tmp_path, kind, must_say, must_not_say):

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -4265,16 +4265,29 @@ def test_restore_print_plan_is_SILENT_for_the_DEFAULT_identity(
 # mean "age authenticated the header", stopped being available on every artifact
 # this subsystem actually produces.
 #
-# The distinction SURVIVED, through age's own three refusal messages. That is a
-# WEAKER footing than the phase observation it replaces — it is a substring match
-# on another tool's prose, which this module's own docstring argues against — so
-# the classifier is validated against the REAL binary here rather than against
+# The distinction SURVIVED, through age's own refusal messages. That is a WEAKER
+# footing than the phase observation it replaces — it is a substring match on
+# another tool's prose, which this module's own docstring argues against — so the
+# classifier is validated against the REAL binary here rather than against
 # strings someone typed. If age rewords, THIS goes red, and it goes red saying
-# which of the three it can no longer see.
+# which refusal it can no longer see.
+#
+# 🔴 WIDENED 2026-09-09 BY AN ADVERSARIAL AUDIT OF THAT CHANGE. The first version
+# provoked THREE refusals and the code claimed every refusal classified. The
+# audit drove really-damaged artifacts through the real verifier and found three
+# more — a flipped header MAC, a payload stripped to nothing, and a payload
+# truncated to 8 bytes — all of which fell through to `unrecognised` and reached
+# the consumer's "CANNOT SAY WHY" verdict on BOTH versions.
+#
+# 🔴 THE FIXTURE SET IS THE GUARD. Every one of those shapes is provoked here
+# from the REAL binary; three of them were absent because the original sweep
+# varied payload SIZE and not mangling SHAPE. Adding a marker without adding the
+# fixture that provokes it would be pinning a string nobody watched age emit.
 # --------------------------------------------------------------------------- #
 def _age_refusal_stderr(tmp_path, kind: str) -> str:
-    """Provoke one of age's three refusals with the REAL binary and return its
-    stderr. Built, never spelled — a hardcoded fixture cannot notice a reword.
+    """Provoke one of age's refusals with the REAL binary and return its stderr.
+
+    Built, never spelled — a hardcoded fixture cannot notice a reword.
     """
     ident = tmp_path / f"id-{kind}.key"
     r = subprocess.run([AGE_KEYGEN, "-o", str(ident)], capture_output=True,
@@ -4306,6 +4319,27 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
         before = blob[40]
         blob[40] ^= 0xFF
         assert blob[40] != before
+    elif kind == "header-mac":
+        # 🔴 A DIFFERENT FAULT FROM `header` ABOVE, AND IT WAS THE MISSING ONE.
+        # Damaging the intro makes age fail to PARSE the header; damaging only
+        # the trailing `--- <mac>` line leaves a well-formed header whose MAC
+        # does not verify, and age says something else entirely for it.
+        lines = bytes(blob).split(b"\n")
+        i = next(n for n, ln in enumerate(lines) if ln.startswith(b"--- "))
+        mac = bytearray(lines[i])
+        before = mac[8]
+        mac[8] ^= 0x01
+        assert mac[8] != before
+        lines[i] = bytes(mac)
+        blob = bytearray(b"\n".join(lines))
+    elif kind == "truncated-no-payload":
+        # Everything after the header removed: age opens the header, then has no
+        # nonce to read. The header authenticated, so this is an ARTIFACT fault.
+        assert len(blob) > hdr_end
+        blob = blob[:hdr_end]
+    elif kind == "truncated-mid-nonce":
+        assert len(blob) > hdr_end + 8
+        blob = blob[:hdr_end + 8]
     elif kind == "no-identity":
         other = tmp_path / f"other-{kind}.key"
         r = subprocess.run([AGE_KEYGEN, "-o", str(other)], capture_output=True,
@@ -4331,15 +4365,21 @@ def _age_refusal_stderr(tmp_path, kind: str) -> str:
     ("payload", "AGE_REFUSED_PAYLOAD"),
     ("no-identity", "AGE_REFUSED_NO_IDENTITY"),
     ("header", "AGE_REFUSED_HEADER"),
+    # 🔴 THE THREE THE 2026-09-08 SWEEP MISSED. Each of these produced
+    # `unrecognised` before 2026-09-09 and reached the consumer's "CANNOT SAY
+    # WHY" verdict, which told the operator age had probably reworded.
+    ("header-mac", "AGE_REFUSED_HEADER"),
+    ("truncated-no-payload", "AGE_REFUSED_TRUNCATED"),
+    ("truncated-mid-nonce", "AGE_REFUSED_TRUNCATED"),
 ])
-def test_classify_age_refusal_reads_the_REAL_binarys_three_refusals(
+def test_classify_age_refusal_reads_the_REAL_binarys_refusals(
         tmp_path, kind, expected_attr):
     """🔴 POSITIVE CONTROL, against the installed age — not against a string.
 
     `escrow-verify.py` decides whether to tell an operator their BACKUP is
     tampered or their KEY might be wrong by reading this function's answer. If
-    age rewords any of the three, this is what goes red, naming the one that
-    moved, instead of the verdict quietly becoming wrong.
+    age rewords any of these, this is what goes red, naming the one that moved,
+    instead of the verdict quietly becoming wrong.
     """
     err = _age_refusal_stderr(tmp_path, kind)
     got = RV.classify_age_refusal(err)
@@ -4352,9 +4392,150 @@ def test_classify_age_refusal_reads_the_REAL_binarys_three_refusals(
         f"downstream of this answer.")
 
 
+@pytest.mark.parametrize("kind", ["payload", "truncated-no-payload",
+                                  "truncated-mid-nonce"])
+def test_the_POST_AUTH_set_is_exactly_what_licenses_the_STRONGEST_verdict(
+        tmp_path, kind):
+    """🔴 THE CLAIM `ARTIFACT-CORRUPT` MAKES, PINNED AT ITS SOURCE.
+
+    `escrow-verify.py` says "age authenticated the header with the ESCROWED key
+    — which a non-matching identity cannot do" on the strength of this set. Each
+    member is provoked here from a REAL artifact whose header is INTACT and
+    whose identity is the RIGHT one, so membership is earned by observation
+    rather than by someone's reading of age's source.
+    """
+    err = _age_refusal_stderr(tmp_path, kind)
+    assert RV.classify_age_refusal(err) in RV.AGE_REFUSALS_POST_AUTH, err
+
+
+@pytest.mark.parametrize("kind", ["no-identity", "header", "header-mac"])
+def test_no_PRE_AUTH_refusal_is_EVER_scored_as_post_auth(tmp_path, kind):
+    """🔴 THE MIRROR, AND THE ONE THAT MATTERS MOST. A pre-auth refusal scored
+    post-auth would assert "THE ESCROW IS FINE; THE BACKUP IS NOT" about a run
+    that never proved the identity opens anything — a confident wrong answer in
+    the direction that stops an operator investigating their key.
+    """
+    err = _age_refusal_stderr(tmp_path, kind)
+    got = RV.classify_age_refusal(err)
+    assert got not in RV.AGE_REFUSALS_POST_AUTH, (
+        f"age's {kind} refusal now scores as post-auth ({got!r}), which lets "
+        f"escrow-verify claim the header authenticated. Its stderr was:\n{err}")
+
+
+def test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER():
+    """🔴 THE ORDER OF `_AGE_REFUSAL_MARKERS` IS LOAD-BEARING, AND THIS IS WHY.
+
+    age v1.3.2 NESTS the post-auth clause inside the pre-auth one — `failed to
+    read header: parsing age header: unexpected EOF reading intro` carries both.
+    Matched in the wrong order it would score as a post-header truncation and
+    license the strongest verdict in the subsystem for a header that never
+    opened.
+
+    🔴 THE OVERLAP IS BUILT FROM THE SHIPPED MARKERS, not spelled and not taken
+    from a live run, and both halves of that are deliberate. Spelling it would
+    let the table drift away from the fixture. Taking it from the binary would
+    make this test's SUBJECT version-dependent: MEASURED 2026-09-09, only v1.3.2
+    nests the two clauses — v1.3.1's in-header truncations say `failed to parse
+    header: failed to read line: EOF` and `parsing age header: file is empty`,
+    which carry no post-auth marker at all. A guard that can only fire on one of
+    two installed binaries is not a guard, and this property is about OUR tuple's
+    order, which is version-free. `test_the_real_binarys_in_header_truncations_
+    are_NEVER_post_auth` is the live half.
+    """
+    pre_markers = [(m, k) for m, k in RV._AGE_REFUSAL_MARKERS
+                   if k in RV.AGE_REFUSALS_PRE_AUTH]
+    post_markers = [m for m, k in RV._AGE_REFUSAL_MARKERS
+                    if k in RV.AGE_REFUSALS_POST_AUTH]
+    assert pre_markers and post_markers, "nothing to overlap; table is empty"
+    # 🔴 THE WHOLE CROSS-PRODUCT, not just the pair age happens to nest today.
+    # The first draft of this test paired only the HEADER markers with the EOF
+    # family — the overlap that had actually been observed — and a control run
+    # against the other installed age caught it: the payload marker sat ahead of
+    # the header markers, so a synthetic `failed to read header: … payload
+    # chunk …` scored post-auth. Nothing in age produces that message today.
+    # Pinning only the seen overlap is the same mistake, one level down, as the
+    # sweep that produced the three-entry table.
+    for pre, pre_kind in pre_markers:
+        for post in post_markers:
+            nested = f"age: error: {pre}: parsing age header: {post} reading intro"
+            got = RV.classify_age_refusal(nested)
+            assert got == pre_kind, (
+                f"{nested!r} classified as {got!r}, not {pre_kind!r}. EVERY "
+                f"pre-auth marker must be matched BEFORE EVERY post-auth one; "
+                f"do not reorder `_AGE_REFUSAL_MARKERS` across the divider.")
+            assert got not in RV.AGE_REFUSALS_POST_AUTH
+
+
+def test_the_real_binarys_in_header_truncations_are_NEVER_post_auth(tmp_path):
+    """🔴 THE LIVE HALF OF THE ORDERING PROPERTY, and the one that would catch a
+    reword the built fixture above cannot see.
+
+    Every truncation that lands INSIDE the header must classify as something
+    other than post-auth, whatever age chooses to say about it — because a
+    post-auth answer would let `escrow-verify.py` assert that the escrowed
+    identity opened a header it never opened. This walks real truncation offsets
+    across the header and requires that of each.
+
+    ⚠ It does NOT require the answer to be `header-unreadable`: age is entitled
+    to describe an unopenable header in a way nothing has measured, and
+    `unrecognised` is the correct, safe answer to that. What is not negotiable
+    is that it never comes back post-auth.
+    """
+    ident = tmp_path / "id-inhdr.key"
+    r = subprocess.run([AGE_KEYGEN, "-o", str(ident)], capture_output=True,
+                       text=True)
+    assert r.returncode == 0, r.stderr
+    pub = [ln.split(": ", 1)[1].strip() for ln in
+           ident.read_text(encoding="utf-8").splitlines()
+           if ln.startswith("# public key:")][0]
+    plain = tmp_path / "plain-inhdr"
+    plain.write_bytes(os.urandom(4096))
+    cipher = tmp_path / "c-inhdr.age"
+    r = subprocess.run([AGE, "--encrypt", "--recipient", pub, "--output",
+                        str(cipher), str(plain)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    blob = cipher.read_bytes()
+    hdr_end = blob.index(b"\n", blob.index(b"--- ")) + 1
+
+    checked = 0
+    for keep in (10, 30, 60, hdr_end - 40, hdr_end - 5, hdr_end - 1):
+        if keep <= 0 or keep >= hdr_end:
+            continue
+        bad = tmp_path / "bad-inhdr.age"
+        bad.write_bytes(blob[:keep])
+        out = tmp_path / "out-inhdr"
+        out.unlink(missing_ok=True)
+        r = subprocess.run([AGE, "--decrypt", "--identity", str(ident),
+                            "--output", str(out), str(bad)],
+                           capture_output=True, text=True)
+        assert r.returncode != 0, keep
+        got = RV.classify_age_refusal(r.stderr)
+        assert got not in RV.AGE_REFUSALS_POST_AUTH, (
+            f"a ciphertext truncated to {keep} bytes — INSIDE the header, which "
+            f"age therefore never authenticated — classified as {got!r}, a "
+            f"post-auth refusal. escrow-verify would report ARTIFACT-CORRUPT "
+            f"and tell the operator their key is fine. stderr was:\n{r.stderr}")
+        checked += 1
+    # 🔴 POSITIVE CONTROL: an empty loop asserts nothing, and every `continue`
+    # above is a way to reach one.
+    assert checked >= 4, f"only {checked} in-header offsets were exercised"
+
+
+def test_classify_age_refusal_is_CASE_FOLDED():
+    """🔴 THE `.lower()` IS UNGUARDED WITHOUT THIS — an audit's mutation battery
+    deleted it and the whole suite stayed green, because every clause age emits
+    today is already lower-case. A guard nothing can break is not a guard.
+
+    Built from the shipped markers, so it cannot drift from them.
+    """
+    for marker, kind in RV._AGE_REFUSAL_MARKERS:
+        shouty = f"age: ERROR: {marker.upper()}"
+        assert RV.classify_age_refusal(shouty) == kind, shouty
+
+
 def test_classify_age_refusal_NEVER_guesses_on_something_it_has_not_seen():
-    """🔴 NEGATIVE CONTROL. An instrument that can only ever return one of three
-    answers is indistinguishable from one wired to nothing.
+    """🔴 NEGATIVE CONTROL. An instrument that can only ever return one of its
+    known answers is indistinguishable from one wired to nothing.
 
     The fall-through must be its own published value, because the consumer's
     STRONGEST claim — "your backup is tampered and your key is fine" — must
@@ -4364,21 +4545,58 @@ def test_classify_age_refusal_NEVER_guesses_on_something_it_has_not_seen():
                  "totally unrelated output", "failed to decrypt"):
         assert RV.classify_age_refusal(text) == RV.AGE_REFUSED_UNRECOGNISED, text
     # And the published set is closed, so a consumer's branch cannot be
-    # bypassed by inventing a fourth value at a raise site.
+    # bypassed by inventing another value at a raise site.
     with pytest.raises(KeyError):
         RV.RestoreVerifyError("x", age_refusal="invented")
 
 
-def test_the_three_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
+def test_the_markers_are_all_LOAD_BEARING_and_none_is_a_prefix_of_another():
     """A marker that another marker contains would make the answer depend on the
-    order of a tuple, which is not a property anyone should have to know."""
+    order of a tuple.
+
+    🔴 THAT ORDER IS NOW A REAL DEPENDENCE, BUT NOT VIA THE MARKERS — it comes
+    from age NESTING one clause inside another in a single MESSAGE, which no
+    marker-vs-marker check can see. This test keeps the markers themselves
+    mutually non-containing so the tuple's order is the ONLY ordering fact
+    anyone has to know, and
+    `test_a_message_carrying_BOTH_a_header_and_an_EOF_marker_classifies_as_HEADER`
+    pins that one against the real binary.
+
+    🔴 EVERY MARKER IS LOWER-CASE, and that is not style: `classify_age_refusal`
+    case-folds its input, so a marker carrying a capital could never match. A
+    shouty marker would be a dead entry that reads as coverage.
+    """
     markers = [m for m, _ in RV._AGE_REFUSAL_MARKERS]
-    assert len(markers) == 3
-    assert len(set(markers)) == 3
+    assert len(markers) >= 3
+    assert len(set(markers)) == len(markers)
     for a in markers:
         for b in markers:
             if a is not b:
                 assert a not in b, (a, b)
-    # Every published refusal except the fall-through has exactly one marker.
+        assert a == a.lower(), a
+    # Every published refusal except the fall-through has at least one marker,
+    # and no marker names a refusal the closed set does not publish.
     kinds = {k for _, k in RV._AGE_REFUSAL_MARKERS}
     assert kinds == RV.AGE_REFUSALS - {RV.AGE_REFUSED_UNRECOGNISED}
+    # The post-auth set is a strict subset of the published refusals and never
+    # includes the fall-through — the consumer's strongest claim must not be
+    # reachable from "age said something new".
+    assert RV.AGE_REFUSALS_POST_AUTH < RV.AGE_REFUSALS
+    assert RV.AGE_REFUSED_UNRECOGNISED not in RV.AGE_REFUSALS_POST_AUTH
+    assert RV.AGE_REFUSED_NO_IDENTITY not in RV.AGE_REFUSALS_POST_AUTH
+    assert RV.AGE_REFUSED_HEADER not in RV.AGE_REFUSALS_POST_AUTH
+    # 🔴 THE ORDER ITSELF, as structure rather than as behaviour: every pre-auth
+    # marker sits before every post-auth one in the tuple. The behavioural test
+    # above can only see the overlaps someone thought to build; this sees the
+    # property directly, so a new marker inserted on the wrong side of the
+    # divider goes red even if nothing yet produces a message carrying both.
+    kinds_in_order = [k for _, k in RV._AGE_REFUSAL_MARKERS]
+    last_pre = max(i for i, k in enumerate(kinds_in_order)
+                   if k in RV.AGE_REFUSALS_PRE_AUTH)
+    first_post = min(i for i, k in enumerate(kinds_in_order)
+                     if k in RV.AGE_REFUSALS_POST_AUTH)
+    assert last_pre < first_post, (
+        f"a post-auth marker sits at index {first_post}, before the last "
+        f"pre-auth one at {last_pre}. A message naming a pre-auth cause could "
+        f"then be scored post-auth, which is what lets escrow-verify claim the "
+        f"escrowed key opened the header: {kinds_in_order}")


### PR DESCRIPTION
Rank 13 of the `nix-disk-cleanup` handoff asked for an adversarial audit of the
merged `#1392` — the change that governs whether a corrupt backup means "rotate
your escrow key", which merged without one. This is the audit's one finding,
fixed.

## The audit first confirmed `#1392`

Re-measured independently rather than read off its table: 84 decrypt runs, 7
payload sizes × 6 fault shapes × age v1.3.1 (login shell) and v1.3.2 (dev shell).
v1.3.2 really does create `--output` lazily, its three re-keyed marker strings
really are byte-identical across both versions, and an 11-mutant battery on the
guards it shipped killed 10 (the 11th, deleting `classify_age_refusal`'s
`.lower()`, is guarded here). The three load-bearing mutants were re-run to name
their killer and each died to the guard that owns it. **The re-key was the right
repair.**

## The finding: a coverage claim measurement refutes

`escrow-verify.py` said of its unclassified verdict: *"DEFENSIVE, NOT OBSERVED …
on both measured age versions every refusal classifies"*, and the new test's
docstring repeated it. Driving really-damaged artifacts through the **real**
verifier, on **both** binaries, three ordinary corruption shapes produced a
refusal the three-entry table did not name:

| damage | age said | verdict it got |
|---|---|---|
| header MAC bit flipped | `bad header MAC` | `DECRYPT-FAILED` — "CANNOT SAY WHY" |
| payload stripped entirely | `failed to read nonce: EOF` | same |
| payload truncated to 8 B | `unexpected EOF` | same |

That message tells the operator age has probably **reworded** and to teach
`classify_age_refusal` the new string — wrong guidance for an artifact that is
simply damaged — and it lists a wrong key among its three open causes. It fails
**safe** (no rotation advice), so this is a coverage defect, not an inversion.
But `ARTIFACT-CORRUPT`'s own sentence and `SECRETS.md` row 33 both claim
TRUNCATED coverage that held only for truncations landing inside a payload chunk.

**Root cause of the miss, recorded because it is reusable:** `#1392`'s sweep
varied payload SIZE across seven values and mangling SHAPE across five, and none
of the five produced a header-MAC-only or a payload-stripped case.

## The repair

age authenticates the whole header, then reads a 16-byte nonce, then the payload
chunks. Truncating *inside* the header and *after* it produce disjoint messages —
measured at 8 offsets spanning the boundary on both versions, every in-header
truncation carries `failed to read header`. So the table is keyed on **where age
got to**, which is what the verdict actually turns on:

- **pre-auth** → `25`: `no identity matched any of the recipients`,
  `failed to read header`, `bad header MAC`, `failed to parse X25519 recipient`
- **post-auth** → `33`: `failed to decrypt and authenticate payload chunk`,
  `failed to read nonce`, `last chunk is empty`, `unexpected EOF`

`AGE_REFUSED_TRUNCATED` joins the closed set. `AGE_REFUSALS_POST_AUTH` and
`AGE_REFUSALS_PRE_AUTH` are published so `escrow-verify.py` branches on a set
owned by the module that classifies rather than on a value it spells itself.

🔴 **Order is now load-bearing, and the rule is total**: every pre-auth marker
precedes every post-auth one, because age v1.3.2 nests the clauses (`failed to
read header: parsing age header: unexpected EOF reading intro`). My first draft
ordered only the EOF family after the header markers — the overlap that had been
*observed* — which is the same "fix the instance, not the class" mistake one
level down; a control run against the other installed binary caught it.

## Controls, reported as pairs

- **RED AT BASE** — this branch's tests against `origin/main`'s two source files:
  **18 failed, 418 passed**. Every new guard names the absence of this fix.
- **GREEN ON BOTH BINARIES** — **436 passed** in the dev shell (age v1.3.2) and
  **436 passed** with v1.3.1 forced ahead on `PATH`. The gate runs 1.3.2; the
  login shell and the operator's `check-escrow.sh` nix-shell run 1.3.1, so one
  green is a claim about one binary.
  ⚠ The first version of that control expanded `$PATH` in the *outer* shell and
  so swapped the **interpreter** too — three unrelated tests went red on a
  missing `minio`. It now asserts `python3` is still the dev shell's before it
  scores anything.
- **GATE, both tiers, dev-host** — `GATE: RESULT=PASS exit=0`.
  pytest `scripts/tests` **13084 passed, 0 failed** (33:49); node
  **suites=5 files=41 tests=1449 pass=1449 fail=0** (floor 1367).
- **MUTATION, 4 new guards + a control** — all four KILLED, each by the guard
  that owns it (`failed to read nonce` marker; `bad header mac` marker; the
  marker ORDER; `_corrupt`'s set membership). The behaviour-free comment reword
  **SURVIVED**, so the scorer is shown able to emit both verdicts. The tree was
  checksummed before the battery and verified byte-identical to the gated state
  after it.
- Every new fixture is **built from the real binary**, never spelled, and
  `test_the_real_binarys_in_header_truncations_are_NEVER_post_auth` walks real
  in-header offsets on whatever age is installed — the live guard on the one
  genuinely weak marker, bare `unexpected EOF`.

## Scope — two audit findings deliberately NOT fixed here

1. **`no identity matched any of the recipients` is not exclusively a wrong-key
   signature.** One flipped bit in the recipient stanza produces it on both
   versions (on v1.3.2, a bit in the wrapped-file-key body does too). Only its
   code comment is corrected — it sits inside the block this change rewrites and
   leaving a known-false sentence was not an option. No operator-facing text
   changes: the verdict already names header damage as equally consistent and
   says do not rotate.
2. **`plain_present is None` (unobservable) is still reported downstream as
   "without leaving plaintext"**, contradicting the probe's own comment that
   `None` must never be read as "age wrote nothing". Narrow reachability
   (requires `Path.exists()` to raise EACCES mid-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EdUuMkYb4BghDqQTbSi9r
