### PR TITLE
fix(docs): a CLIENT subdomain literal is committed to this PUBLIC repo — resolve it through bar-url

### DIFF
--- a/claudedocs/handoff-civitai-app-fleet.md
+++ b/claudedocs/handoff-civitai-app-fleet.md
@@ -198,10 +198,17 @@ done
 git -C ~/workspace/civit/civitai-app-sensei show \
   origin/trunk:src/toolchain-lockstep.test.ts | grep -cE '^\s*it\('
 
-# all six released apps serve
+# all six released apps serve.
+# 🔴 The apex is a CLIENT hostname and this repo is PUBLIC, so it is not
+# committed. Put `civitai_apps_apex=<apex-domain>` (bare domain, no scheme) in
+# ~/.config/bar/urls.env (0600, untracked) and `bar-url` resolves it — the same
+# indirection the civitai bar block uses for its Grafana link. An unset key
+# exits 3 naming the key and the file, so this loop can never silently check
+# nothing. See scripts/bar-url.
+apex=$(bar-url civitai_apps_apex) || exit 3
 for h in app-requests generate-from-model custom-generators \
          playable-collections model-benchmarking sensei; do
-  curl -sS -o /dev/null -w "$h %{http_code}\n" https://$h.civit.ai/
+  curl -sS -o /dev/null -w "$h %{http_code}\n" "https://$h.$apex/"
 done
 
 # the skill's own gates (six named files)


### PR DESCRIPTION
## The problem

`main` fails `scripts/tests/test_no_client_hostnames.py::test_no_client_subdomain_literal_is_committed`, on **both** tiers:

```
a CLIENT subdomain is committed to a PUBLIC repo — this is internal topology
  claudedocs/handoff-civitai-app-fleet.md:204: h.civit.ai
    | curl -sS -o /dev/null -w "$h %{http_code}\n" https://$h.civit.ai/
```

Added by `6d488a1b` (#1402). `CLAUDE.md`: *this repo is PUBLIC — never commit a real third-party hostname used as an example.* The apex is client topology.

## The fix

The snippet is a **live check the operator actually runs**, so placeholdering it would leave a command that goes nowhere. Per the guard's own guidance the *value* moves out of tracked source instead:

```sh
apex=$(bar-url civitai_apps_apex) || exit 3
… curl … "https://$h.$apex/"
```

`bar-url` reads `~/.config/bar/urls.env` (0600, untracked) — the same indirection the `civitai` bar block already uses for its Grafana link, for exactly this reason (`scripts/bar-url`'s own docstring cites the public-repo rule). An unset key **exits 3 naming the key and the file**, so the loop cannot silently check nothing.

## Verification — red→green, control watched failing

Same test, same instrument, `nix develop … -c python3 -m pytest`:

| tree | result |
|---|---|
| `origin/main` @ `27d5028d`, unfixed | **1 failed**, 17 passed |
| this branch | **18 passed** |

**Scope checked, not assumed.** The other tracked `civit.ai` occurrences are all `<slug>.civit.ai` placeholders, which the guard tolerates by design. This changes only the one literal it flags — `git grep` output reviewed rather than counted.

## ⚠ Forward-only

This fixes it going forward. **The literal remains in git history**, and all four content gates read `git ls-files`, so they are blind to it (`SECRETS.md` → *"Dead credentials in reachable history"*). Whether to rewrite history on a public repo is the operator's call, not this PR's.

## Context — `main` is red for TWO independent reasons

This is one of them. The other is #1407 (20 nebula tests failing on the sandbox tier, `/usr/bin/env` absent in the nix build sandbox). They are unrelated and neither fixes the other:

| tree | pytest failures |
|---|---|
| `main` @ `27d5028d` | 21 |
| `main` + #1407 | 1 ← this leak |
| `main` + this PR | 20 |
| both | 0 (verifying) |
