### PR TITLE
chore(nix/system): commit two staged ops scripts that were sitting untracked in the workbench tree

### DIFF
--- a/claudedocs/handoff-journald-26-11-migration.md
+++ b/claudedocs/handoff-journald-26-11-migration.md
@@ -52,11 +52,15 @@ workbench working tree where a `git checkout` would have deleted them unreported
 - No claims held (`claim-work`).
 
 ## Next steps (ranked)
-1. **Read the gate verdict for `b8tu5owud`** (`<scratchpad>/gate-rebased.txt`) and post it to
-   PR #1412. If merging, also run `nix build .#checks.x86_64-linux.pytests` and
-   `…nodetests` ONE AT A TIME — that tier has not been run on this branch, and it is the one
-   Tekton gates on. `IN FLIGHT: devrc#1412`. forcing: gate — `main` is protected in name only
-   (`required_status_checks` absent, measured 2026-09-02), so nothing else blocks this merge.
+1. **Re-run BOTH gate tiers against the CURRENT head and post the verdict to PR #1412.**
+   Do not reuse an older run: the first (`b8tu5owud`, base `85710f1a`) is superseded — it
+   FAILED on `test_no_client_subdomain_literal_is_committed`, which audit round 1 then fixed —
+   and every audit round since has changed payload. Name the run's base sha in the claim.
+   Then `nix build .#checks.x86_64-linux.pytests` and `…nodetests` ONE AT A TIME (concurrent
+   nested-`nix` contention produces measured FALSE failures); that sandbox tier is the one
+   Tekton gates on and has not been run on this branch. `IN FLIGHT: devrc#1412`.
+   forcing: gate — `main` is protected in name only (`required_status_checks` absent,
+   measured 2026-09-02), so nothing else blocks this merge.
 2. **RESOLVED — no action.** This list previously ranked "unblock the base clone", predicting
    `merge --ff-only` would refuse there because two untracked nebula scripts sat at paths
    `main` now tracks. MEASURED afterwards: the base clone is at `origin/main`, `--ff-only`
@@ -112,7 +116,7 @@ grep -A2 'services\.journald' /etc/nixos/configuration.nix
 cat /etc/systemd/journald.conf                 # expect SystemMaxUse=2G
 readlink -f /run/current-system                # expect nixos-system-nixos-26.11pre…
 
-# the PR carries only the two intended files
+# the PR's file list (five: two ops scripts, the rewriter, its tests, this doc)
 gh pr diff 1412 --name-only
 
 # the rewriter's own suite (25 tests, incl. every audit-found edge case)

--- a/claudedocs/handoff-journald-26-11-migration.md
+++ b/claudedocs/handoff-journald-26-11-migration.md
@@ -17,17 +17,24 @@ assertion. Fix that, and land the ops scripts that were sitting untracked in the
 workbench working tree where a `git checkout` would have deleted them unreported.
 
 ## State now
-- Branch: `chore/commit-staged-system-scripts` @ `2b799eb5`, rebased onto `origin/main` `03d7e0ad`.
-- **PR #1412 OPEN** — https://github.com/innovation-upstream/devrc/pull/1412. Two files, both
-  absent from `origin/main` (checked with `git cat-file -e origin/main:<path>`, not `git ls-files`):
-  `nix/system/apply-journald-settings-migration.sh`, `scripts/diagnose-nix-disk.sh`.
+- Branch: `chore/commit-staged-system-scripts`, rebased onto `origin/main` `03d7e0ad`.
+  (No head sha here on purpose — it moves every fix round; `gh pr view 1412 --json headRefOid`.)
+- **PR #1412 OPEN** — https://github.com/innovation-upstream/devrc/pull/1412. Five files, all
+  new, none modifying anything on `main` (checked with `git cat-file -e origin/main:<path>` —
+  NOT `git ls-files`, see the gotcha below): the two ops scripts
+  `nix/system/apply-journald-settings-migration.sh` and `scripts/diagnose-nix-disk.sh`, the
+  extracted rewriter `scripts/lib/journald_migrate.py` and its suite
+  `scripts/tests/test_journald_migrate.py` (25 tests), and this doc.
 - **The journald migration is APPLIED and VERIFIED on the workbench** — separate claims, both made:
   - `/etc/nixos/configuration.nix:745` now reads `services.journald.settings.Journal = { SystemMaxUse = "2G"; };`
   - live `/etc/systemd/journald.conf` = `[Journal]` / `Audit=keep` / `SystemMaxUse=2G`
     (`Audit=keep` is 26.11's new explicit default, not something this change set)
   - `/run/current-system` → `nixos-system-nixos-26.11pre1068949.dc5d91f84032`
-  - The **laptop is UNTOUCHED and NOT VERIFIED** — it has its own `/etc/nixos`, and this
-    session never looked at it. It will hit the same assertion on its next channel update.
+  - The **laptop is UNTOUCHED** — it has its own `/etc/nixos`. MEASURED there during the
+    audit: `configuration.nix:370` carries
+    `services.journald.extraConfig = "SyncIntervalSec=30s";` — the ONE-LINE double-quoted
+    form, not a `''`-block — on `26.11pre1058091.ffb3c9b700e7`. So it will hit the same
+    assertion, and the first implementation of the rewriter could not have migrated it.
 - Pre-flight evidence gathered *before* the script was ever run, against a copy in the
   scratchpad with `/etc/nixos/*` symlinked in — no writes to `/etc/nixos`:
   `nix-instantiate '<nixpkgs/nixos>' -A config.system.build.toplevel` →
@@ -44,48 +51,27 @@ workbench working tree where a `git checkout` would have deleted them unreported
   `clawgate-task:` field is recorded.
 - No claims held (`claim-work`).
 
-## Open investigations — live diagnosis state
-
-### The devrc base clone cannot fast-forward — PREDICTED, NOT YET MEASURED
-- **Symptom (expected):** `git -C ~/workspace/devrc merge --ff-only origin/main` should refuse
-  with "untracked working tree files would be overwritten by merge", which is exactly the
-  state `CLAUDE.md` says makes `ship.sh` skip a host silently while it still looks healthy.
-- **Observed (with values):**
-  - Base clone is on `main` at `b508b684`; `origin/main` is `03d7e0ad`. Behind.
-  - It holds two UNTRACKED files at paths `origin/main` now tracks:
-    `nix/system/apply-nebula-relay.sh` (205 lines) and `nix/system/check-nebula-relays.sh` (317).
-  - `origin/main`'s versions are 480 and 360 lines, landed by #1272.
-- **Ruled out:** "the local copies are newer WIP worth keeping" — `git hash-object` on each
-  matches the blob at commit `e7f2e45a` ("fix(nebula): read the RUNNING process…", 2026-09-04),
-  an intermediate commit of the branch that merged as #1272. They are stale orphans, and
-  committing them would have reverted ~318 lines including a `🔴 THIS RESTARTS THE MESH`
-  warning they predate. via: command
-- **Leading hypothesis:** deleting the two orphans clears the block and loses nothing, since
-  both blobs are recoverable at `e7f2e45a`.
-- **Next probe:** `git -C ~/workspace/devrc merge --ff-only origin/main` — non-destructive, it
-  either fast-forwards or refuses. Run it BEFORE deleting anything, so the refusal is measured
-  rather than assumed; then delete and re-run.
-
 ## Next steps (ranked)
 1. **Read the gate verdict for `b8tu5owud`** (`<scratchpad>/gate-rebased.txt`) and post it to
    PR #1412. If merging, also run `nix build .#checks.x86_64-linux.pytests` and
    `…nodetests` ONE AT A TIME — that tier has not been run on this branch, and it is the one
    Tekton gates on. `IN FLIGHT: devrc#1412`. forcing: gate — `main` is protected in name only
    (`required_status_checks` absent, measured 2026-09-02), so nothing else blocks this merge.
-2. **Unblock the base clone** — run the next-probe command above in `~/workspace/devrc`, then
-   delete the two stale nebula orphans and re-run. forcing: regression — until this clears,
-   `ship.sh` skips the workbench with `merge --ff-only`, and `CLAUDE.md` records two prior
-   occurrences (2026-08-06, 2026-08-09) where a skipped host silently stopped receiving every
-   change while still looking healthy.
+2. **RESOLVED — no action.** This list previously ranked "unblock the base clone", predicting
+   `merge --ff-only` would refuse there because two untracked nebula scripts sat at paths
+   `main` now tracks. MEASURED afterwards: the base clone is at `origin/main`, `--ff-only`
+   says `Already up to date`, and both files are tracked and byte-identical to `main`
+   (`ec9c6363`, `e061d844`). Another session cleared it mid-run. forcing: none
 3. **`/audit-pr 1412`** before merging — offered to the operator, not yet answered. forcing: none
 4. **Fix the three deprecated-option warnings** surfaced by the 26.11 eval of
    `/etc/nixos/configuration.nix`: `services.dnsmasq.servers` → `.settings.server`,
    `services.gnome.tracker.enable` → `.tinysparql.enable`,
    `services.gnome.tracker-miners.enable` → `.localsearch.enable`. They still work today.
    forcing: none
-5. **Apply the same journald migration to the laptop** when it next takes a channel update —
-   `nix/system/apply-journald-settings-migration.sh` is idempotent and host-agnostic, but it
-   has only ever been run on the workbench. forcing: none
+5. **Apply the same journald migration to the laptop** when it next takes a channel update.
+   The rewriter now handles the laptop's one-line `"..."` form as well as the workbench's
+   `''`-block (both are unit-tested), but it has only ever been RUN on the workbench —
+   "the tests pass" and "it ran on that host" are different claims. forcing: none
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **`git ls-files` reads the INDEX, not `HEAD`.** Used to ask "is this file already on
@@ -101,12 +87,21 @@ workbench working tree where a `git checkout` would have deleted them unreported
   no `.envrc`, and `.envrc` is `use opencode` which carries no pytest anyway. Run it as
   `nix develop <worktree> --command bash -c 'cd <worktree> && ./scripts/gate.sh --tier both'`.
 - **A red gate on a fresh branch was NOT the branch.** `test_no_client_subdomain_literal_is_committed`
-  failed on `claudedocs/handoff-civitai-app-fleet.md:204` (`h.civit.ai`), a file this session
-  never touched. Control on pristine `origin/main`: 18 passed. It existed at the branch point
-  `4f49f5dc` and was fixed on `main` by #1405 — rebasing cleared it. Run the control before
+  failed on a client subdomain in `claudedocs/handoff-civitai-app-fleet.md:204`, a file this
+  session never touched. Control on pristine `origin/main`: 18 passed. It existed at the branch
+  point `4f49f5dc` and was fixed on `main` by #1405 — rebasing cleared it. Run the control before
   debugging your own diff.
-- **Decision: the two nebula scripts were dropped from the PR**, not committed. See the
-  investigation block above for the evidence that they are stale orphans.
+- 🔴 **…and then this doc RE-COMMITTED that same literal while describing it.** Round 1 of
+  `/audit-pr 1412` caught it: the bullet above originally quoted the hostname verbatim, which
+  reds the very gate it is about. **Naming a banned literal in order to warn about it is still
+  committing it** — `scripts/tests/test_no_client_hostnames.py` has an EMPTY allowlist, so there
+  is no "but it's a quote" exemption. Describe the shape; never paste the value.
+- **Decision: the two nebula scripts were dropped from the PR**, not committed. They were
+  untracked in the workbench tree but byte-identical to blob `e7f2e45a` — an intermediate
+  commit of the branch that merged as #1272 — while `main` already carried strictly
+  further-along versions (480 vs 205 lines, 360 vs 317). Committing them would have reverted
+  ~318 lines. `git hash-object <file>` against the file's own history is what proves a
+  working-tree copy is a stale orphan rather than WIP.
 - `output.txt` at the repo root is a truncated capture from the earlier disk dig. Left
   untracked deliberately; it is not part of #1412.
 
@@ -120,6 +115,10 @@ readlink -f /run/current-system                # expect nixos-system-nixos-26.11
 # the PR carries only the two intended files
 gh pr diff 1412 --name-only
 
-# the base clone is unblocked (non-destructive: it fast-forwards or refuses)
+# the rewriter's own suite (25 tests, incl. every audit-found edge case)
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  ~/workspace/devrc/scripts/tests/test_journald_migrate.py -q
+
+# the base clone can still fast-forward (non-destructive: it advances or refuses)
 git -C ~/workspace/devrc merge --ff-only origin/main
 ```

--- a/claudedocs/handoff-journald-26-11-migration.md
+++ b/claudedocs/handoff-journald-26-11-migration.md
@@ -24,7 +24,7 @@ workbench working tree where a `git checkout` would have deleted them unreported
   NOT `git ls-files`, see the gotcha below): the two ops scripts
   `nix/system/apply-journald-settings-migration.sh` and `scripts/diagnose-nix-disk.sh`, the
   extracted rewriter `scripts/lib/journald_migrate.py` and its suite
-  `scripts/tests/test_journald_migrate.py` (25 tests), and this doc.
+  `scripts/tests/test_journald_migrate.py` (37 tests), and this doc.
 - **The journald migration is APPLIED and VERIFIED on the workbench** — separate claims, both made:
   - `/etc/nixos/configuration.nix:745` now reads `services.journald.settings.Journal = { SystemMaxUse = "2G"; };`
   - live `/etc/systemd/journald.conf` = `[Journal]` / `Audit=keep` / `SystemMaxUse=2G`
@@ -119,7 +119,7 @@ readlink -f /run/current-system                # expect nixos-system-nixos-26.11
 # the PR's file list (five: two ops scripts, the rewriter, its tests, this doc)
 gh pr diff 1412 --name-only
 
-# the rewriter's own suite (25 tests, incl. every audit-found edge case)
+# the rewriter's own suite (37 tests, incl. every audit-found edge case)
 nix develop ~/workspace/devrc -c python3 -m pytest \
   ~/workspace/devrc/scripts/tests/test_journald_migrate.py -q
 

--- a/claudedocs/handoff-journald-26-11-migration.md
+++ b/claudedocs/handoff-journald-26-11-migration.md
@@ -1,0 +1,125 @@
+# Handoff: journald-26-11-migration — 2026-09-08
+
+## Run this first — the index, one command
+```bash
+cairn recall --repo ~/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+`nix-channel --update` moved the workbench to nixos-26.11, which removed
+`services.journald.extraConfig` and broke `sudo nixos-rebuild switch` on a failed
+assertion. Fix that, and land the ops scripts that were sitting untracked in the
+workbench working tree where a `git checkout` would have deleted them unreported.
+
+## State now
+- Branch: `chore/commit-staged-system-scripts` @ `2b799eb5`, rebased onto `origin/main` `03d7e0ad`.
+- **PR #1412 OPEN** — https://github.com/innovation-upstream/devrc/pull/1412. Two files, both
+  absent from `origin/main` (checked with `git cat-file -e origin/main:<path>`, not `git ls-files`):
+  `nix/system/apply-journald-settings-migration.sh`, `scripts/diagnose-nix-disk.sh`.
+- **The journald migration is APPLIED and VERIFIED on the workbench** — separate claims, both made:
+  - `/etc/nixos/configuration.nix:745` now reads `services.journald.settings.Journal = { SystemMaxUse = "2G"; };`
+  - live `/etc/systemd/journald.conf` = `[Journal]` / `Audit=keep` / `SystemMaxUse=2G`
+    (`Audit=keep` is 26.11's new explicit default, not something this change set)
+  - `/run/current-system` → `nixos-system-nixos-26.11pre1068949.dc5d91f84032`
+  - The **laptop is UNTOUCHED and NOT VERIFIED** — it has its own `/etc/nixos`, and this
+    session never looked at it. It will hit the same assertion on its next channel update.
+- Pre-flight evidence gathered *before* the script was ever run, against a copy in the
+  scratchpad with `/etc/nixos/*` symlinked in — no writes to `/etc/nixos`:
+  `nix-instantiate '<nixpkgs/nixos>' -A config.system.build.toplevel` →
+  `nixos-system-nixos-26.11pre1068949.dc5d91f84032.drv` (assertion gone), and building
+  `config.environment.etc."systemd/journald.conf"` showed `SystemMaxUse=2G` survives.
+- **IN FLIGHT:** `gate.sh --tier both` on the rebased tree, background id `b8tu5owud`,
+  output → `<scratchpad>/gate-rebased.txt`. Prior run on the pre-rebase base: node
+  `1449/1449 PASS`; pytest `collected=21127 passed=21124 failed=1`, the one failure foreign
+  (see below). The `nix build .#checks.x86_64-linux.{pytests,nodetests}` tier — the one
+  Tekton gates on — has **NOT been run** for this branch.
+- **No clawgate task.** `clawgate_handoff.sh resolve` → rc 5, positive control green
+  (2 links for another session), so the board was genuinely read — but a wrong session id
+  also answers 200 with an empty array, so this is not a clean bill of health and no
+  `clawgate-task:` field is recorded.
+- No claims held (`claim-work`).
+
+## Open investigations — live diagnosis state
+
+### The devrc base clone cannot fast-forward — PREDICTED, NOT YET MEASURED
+- **Symptom (expected):** `git -C ~/workspace/devrc merge --ff-only origin/main` should refuse
+  with "untracked working tree files would be overwritten by merge", which is exactly the
+  state `CLAUDE.md` says makes `ship.sh` skip a host silently while it still looks healthy.
+- **Observed (with values):**
+  - Base clone is on `main` at `b508b684`; `origin/main` is `03d7e0ad`. Behind.
+  - It holds two UNTRACKED files at paths `origin/main` now tracks:
+    `nix/system/apply-nebula-relay.sh` (205 lines) and `nix/system/check-nebula-relays.sh` (317).
+  - `origin/main`'s versions are 480 and 360 lines, landed by #1272.
+- **Ruled out:** "the local copies are newer WIP worth keeping" — `git hash-object` on each
+  matches the blob at commit `e7f2e45a` ("fix(nebula): read the RUNNING process…", 2026-09-04),
+  an intermediate commit of the branch that merged as #1272. They are stale orphans, and
+  committing them would have reverted ~318 lines including a `🔴 THIS RESTARTS THE MESH`
+  warning they predate. via: command
+- **Leading hypothesis:** deleting the two orphans clears the block and loses nothing, since
+  both blobs are recoverable at `e7f2e45a`.
+- **Next probe:** `git -C ~/workspace/devrc merge --ff-only origin/main` — non-destructive, it
+  either fast-forwards or refuses. Run it BEFORE deleting anything, so the refusal is measured
+  rather than assumed; then delete and re-run.
+
+## Next steps (ranked)
+1. **Read the gate verdict for `b8tu5owud`** (`<scratchpad>/gate-rebased.txt`) and post it to
+   PR #1412. If merging, also run `nix build .#checks.x86_64-linux.pytests` and
+   `…nodetests` ONE AT A TIME — that tier has not been run on this branch, and it is the one
+   Tekton gates on. `IN FLIGHT: devrc#1412`. forcing: gate — `main` is protected in name only
+   (`required_status_checks` absent, measured 2026-09-02), so nothing else blocks this merge.
+2. **Unblock the base clone** — run the next-probe command above in `~/workspace/devrc`, then
+   delete the two stale nebula orphans and re-run. forcing: regression — until this clears,
+   `ship.sh` skips the workbench with `merge --ff-only`, and `CLAUDE.md` records two prior
+   occurrences (2026-08-06, 2026-08-09) where a skipped host silently stopped receiving every
+   change while still looking healthy.
+3. **`/audit-pr 1412`** before merging — offered to the operator, not yet answered. forcing: none
+4. **Fix the three deprecated-option warnings** surfaced by the 26.11 eval of
+   `/etc/nixos/configuration.nix`: `services.dnsmasq.servers` → `.settings.server`,
+   `services.gnome.tracker.enable` → `.tinysparql.enable`,
+   `services.gnome.tracker-miners.enable` → `.localsearch.enable`. They still work today.
+   forcing: none
+5. **Apply the same journald migration to the laptop** when it next takes a channel update —
+   `nix/system/apply-journald-settings-migration.sh` is idempotent and host-agnostic, but it
+   has only ever been run on the workbench. forcing: none
+
+## Gotchas / decisions / dead-ends
+- 🔴 **`git ls-files` reads the INDEX, not `HEAD`.** Used to ask "is this file already on
+  `main`?" *after* staging it, it answers "yes" for a file you just added. `git cat-file -e
+  origin/main:<path>` is the question you meant. Cost one wrong conclusion this session.
+- 🔴 **zsh ate a `git show ${ref}:<path>` measurement.** Written unbraced as
+  `$ref:claudedocs/...`, the `:c` was consumed as a history modifier and the grep returned a
+  confident `0` for BOTH refs — a well-formed, wrong answer with no error. Braced, the same
+  command gives 1 hit at `4f49f5dc` and 0 at `03d7e0ad`. This is the documented trap in
+  `claude/RULES.md` → "Shell & Tooling Gotchas"; it was read this session and hit anyway.
+- **`gate.sh` from a bare shell fails `exit=3` with "required tool(s) missing: logrotate dash"
+  and runs ZERO tests.** That is a missing environment, not a code failure — the worktree has
+  no `.envrc`, and `.envrc` is `use opencode` which carries no pytest anyway. Run it as
+  `nix develop <worktree> --command bash -c 'cd <worktree> && ./scripts/gate.sh --tier both'`.
+- **A red gate on a fresh branch was NOT the branch.** `test_no_client_subdomain_literal_is_committed`
+  failed on `claudedocs/handoff-civitai-app-fleet.md:204` (`h.civit.ai`), a file this session
+  never touched. Control on pristine `origin/main`: 18 passed. It existed at the branch point
+  `4f49f5dc` and was fixed on `main` by #1405 — rebasing cleared it. Run the control before
+  debugging your own diff.
+- **Decision: the two nebula scripts were dropped from the PR**, not committed. See the
+  investigation block above for the evidence that they are stale orphans.
+- `output.txt` at the repo root is a truncated capture from the earlier disk dig. Left
+  untracked deliberately; it is not part of #1412.
+
+## How to verify
+```bash
+# the migration is live on this host (all three are separate claims)
+grep -A2 'services\.journald' /etc/nixos/configuration.nix
+cat /etc/systemd/journald.conf                 # expect SystemMaxUse=2G
+readlink -f /run/current-system                # expect nixos-system-nixos-26.11pre…
+
+# the PR carries only the two intended files
+gh pr diff 1412 --name-only
+
+# the base clone is unblocked (non-destructive: it fast-forwards or refuses)
+git -C ~/workspace/devrc merge --ff-only origin/main
+```

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -29,11 +29,22 @@
 # SIGTERM. Ctrl-C (SIGINT) was NOT established either way — do not read the trap
 # as a guarantee there.
 #
-# `nixos-rebuild test` runs before `switch`, so an ACTIVATION failure does not
-# leave a registered generation and a rewritten bootloader behind. 🔴 But `test`
-# ACTIVATES: between it and `switch` the change IS running, so a rollback in that
-# window restores the FILE while the system keeps running the change until a
-# reboot. The trap says so explicitly rather than claiming nothing is running.
+# `nixos-rebuild test` runs before `switch`, so a failure during the TEST phase
+# leaves no registered generation and no rewritten bootloader.
+#
+# 🔴 That is the ONLY phase for which it is true, and an earlier version of this
+# header claimed it of "an ACTIVATION failure" generally — which is false, and is
+# the belief that produced two separate bugs here. Both are now guarded, and the
+# guards are the point of the flags, not over-caution to be tidied away:
+#   - `test` ACTIVATES (it only skips the boot menu), so between `test` and
+#     `switch` the change IS running; a rollback there restores the FILE while
+#     the system keeps running the change until a reboot.
+#   - `switch` installs the bootloader BEFORE it activates (nixpkgs 26.11,
+#     switch-to-configuration-ng/src/main.rs — `do_install_bootloader` at the
+#     Action::Switch branch precedes the activation check). So a switch that
+#     fails mid-activation has ALREADY written the boot entry, and "a reboot
+#     reverts it" is exactly backwards there.
+# The trap distinguishes five states and says which one you are in.
 #
 # Idempotent: a config that is already migrated exits 0 without touching anything.
 #
@@ -104,11 +115,12 @@ finish() {
       echo "🔴 ROLLBACK FAILED: could not restore $CFG from $BAK." >&2
       echo "   Do it by hand:  sudo cp $BAK $CFG" >&2
     fi
-    # 🔴 Three states, not two. `nixos-rebuild test` ACTIVATES the configuration (it
-    # only skips the boot menu), so the window between `test` returning and `switch`
-    # returning is one where the file is restored while the change IS running. Saying
-    # "nothing is running the change" there is false, and it is said at exactly the
-    # moment the operator is deciding what to do next.
+    # 🔴 One branch per reachable state, tested MOST-RECENT-FIRST. The flags are armed
+    # in program order, so they are monotonic and the reverse order is what makes the
+    # latest one win — reordering this chain silently reinstates an older, wrong message
+    # (measured: moving the ACTIVATED test above SWITCH_ATTEMPTED reproduces the
+    # "a REBOOT reverts it" bug). Do not count the branches in a comment; the count has
+    # been wrong twice. Each message must be true in ITS state and false in none.
     if [ "$SWITCHED" = "1" ]; then
       echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
       echo "   system is not — run \`sudo nixos-rebuild switch\` to return it." >&2
@@ -260,7 +272,12 @@ for kv in "${MIGRATED[@]}"; do
     echo "  NOT IN EFFECT: $kv — last assignment of ${key} is '${eff}' (landed=${landed})" >&2
     missing=$((missing + 1))
   else
-    echo "  MISSING   : $kv — no assignment of ${key} anywhere in the journald config" >&2
+    if [ "$DROPINS_SEEN" = "yes" ]; then
+      echo "  MISSING   : $kv — no assignment of ${key} in the main file or any drop-in" >&2
+    else
+      echo "  MISSING   : $kv — no assignment of ${key} in /etc/systemd/journald.conf" >&2
+      echo "              (drop-ins were NOT read, so this is not a claim about them)" >&2
+    fi
     missing=$((missing + 1))
   fi
 done

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -24,10 +24,16 @@
 #
 # SAFETY. Nothing is written until the rewrite has been produced AND parsed as
 # valid Nix. Then, in order: a uniquely-named backup is taken (an existing one is
-# never overwritten), the new file is moved into place, and from that moment a
-# trap restores the backup on ANY failure or interrupt. `nixos-rebuild test`
-# runs before `switch` so an ACTIVATION failure does not leave a registered
-# generation and a rewritten bootloader behind.
+# never overwritten), the new file is moved into place, and from that moment an
+# EXIT trap restores the backup on any failure. MEASURED: bash runs that trap on
+# SIGTERM. Ctrl-C (SIGINT) was NOT established either way — do not read the trap
+# as a guarantee there.
+#
+# `nixos-rebuild test` runs before `switch`, so an ACTIVATION failure does not
+# leave a registered generation and a rewritten bootloader behind. 🔴 But `test`
+# ACTIVATES: between it and `switch` the change IS running, so a rollback in that
+# window restores the FILE while the system keeps running the change until a
+# reboot. The trap says so explicitly rather than claiming nothing is running.
 #
 # Idempotent: a config that is already migrated exits 0 without touching anything.
 #
@@ -77,22 +83,40 @@ TMP="${CFG}.new.$$"
 KEYS="$(mktemp -t journald-keys-XXXXXXXX)"
 BAK="${CFG}.bak-journald-$(date +%Y%m%d-%H%M%S)-$$"
 PATCHED=0
-SWITCHED=0
+ACTIVATED=0   # `nixos-rebuild test` has activated the config (not persisted)
+SWITCHED=0    # `nixos-rebuild switch` has returned (activated AND persisted)
 OK=0
 
 finish() {
   local rc=$?
-  rm -f "$TMP" "$KEYS"
+  rm -f "$TMP" "$KEYS" "${MERGED:-}"
   if [ "$OK" = "1" ]; then return; fi
   if [ "$PATCHED" = "1" ] && [ -f "$BAK" ]; then
-    cp -p "$BAK" "$CFG"
     echo >&2
-    echo "ROLLED BACK: $CFG restored from $BAK" >&2
+    # Without `|| { … }` a failing cp aborts the trap under the inherited `set -e`, so
+    # neither the rollback line NOR the running-state advisory below would be printed —
+    # a silently failed rollback, which is worse than a loud one.
+    if cp -p "$BAK" "$CFG"; then
+      echo "ROLLED BACK: $CFG restored from $BAK" >&2
+    else
+      echo "🔴 ROLLBACK FAILED: could not restore $CFG from $BAK." >&2
+      echo "   Do it by hand:  sudo cp $BAK $CFG" >&2
+    fi
+    # 🔴 Three states, not two. `nixos-rebuild test` ACTIVATES the configuration (it
+    # only skips the boot menu), so the window between `test` returning and `switch`
+    # returning is one where the file is restored while the change IS running. Saying
+    # "nothing is running the change" there is false, and it is said at exactly the
+    # moment the operator is deciding what to do next.
     if [ "$SWITCHED" = "1" ]; then
       echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
       echo "   system is not — run \`sudo nixos-rebuild switch\` to return it." >&2
+    elif [ "$ACTIVATED" = "1" ]; then
+      echo "🔴 \`nixos-rebuild test\` had ALREADY ACTIVATED the change, so it IS running now," >&2
+      echo "   even though the file is restored. It was never added to the boot menu, so a" >&2
+      echo "   REBOOT reverts it — or run \`sudo nixos-rebuild switch\` to activate the" >&2
+      echo "   restored config immediately." >&2
     else
-      echo "   The system was never switched, so nothing is running the change." >&2
+      echo "   The system was never activated, so nothing is running the change." >&2
     fi
   fi
   exit $rc
@@ -104,7 +128,16 @@ trap finish EXIT
 python3 "$MIGRATE" "$CFG" --out "$TMP" --print-keys 2>"$KEYS" \
   || { sed 's/^/    | /' "$KEYS" >&2; die "the rewriter refused — $CFG is untouched"; }
 
-mapfile -t MIGRATED < "$KEYS"
+# Filter to well-formed KEY=VALUE lines. --print-keys shares stderr with anything else
+# python writes there (a DeprecationWarning, PYTHONWARNINGS, a sitecustomize), and a
+# stray line would become a phantom key that the post-switch check then cannot find —
+# rolling back a migration that actually worked.
+mapfile -t MIGRATED < <(grep -E '^[A-Za-z][A-Za-z0-9]*=' "$KEYS" || true)
+noise=$(grep -cvE '^[A-Za-z][A-Za-z0-9]*=' "$KEYS" || true)
+[ "${noise:-0}" = "0" ] || {
+  echo "  note      : ignored $noise non-key line(s) on the rewriter's stderr:" >&2
+  grep -vE '^[A-Za-z][A-Za-z0-9]*=' "$KEYS" | sed 's/^/    | /' >&2
+}
 [ "${#MIGRATED[@]}" -gt 0 ] || die "the rewriter reported no migrated keys — refusing to continue"
 echo "  migrating : ${MIGRATED[*]}"
 
@@ -120,8 +153,11 @@ diff -u "$CFG" "$TMP" | sed 's/^/    /' || true
 cp -p "$CFG" "$BAK"
 echo "  backup    : $BAK"
 
-mv "$TMP" "$CFG"
+# PATCHED is armed BEFORE the mv: a fatal signal landing between the two would
+# otherwise leave the file patched with the trap declining to restore it. The trap
+# also gates on `[ -f "$BAK" ]`, so an unnecessary restore is a harmless no-op.
 PATCHED=1
+mv "$TMP" "$CFG"
 echo "  applied   : $CFG"
 echo
 
@@ -133,6 +169,7 @@ nixos-rebuild dry-build
 # activation failure here is recoverable; `switch` does both BEFORE activating.
 echo "== nixos-rebuild test =="
 nixos-rebuild test
+ACTIVATED=1
 
 echo "== nixos-rebuild switch =="
 nixos-rebuild switch
@@ -144,23 +181,33 @@ echo
 # journald.conf(5) key, and a hardcoded check reports a false alarm on any host whose
 # config carried a different setting.
 echo "== verify =="
-JCONF=/etc/systemd/journald.conf
-[ -r "$JCONF" ] || die "$JCONF is not readable after the switch"
+# Read the MERGED configuration, not just /etc/systemd/journald.conf: a drop-in under
+# /etc/systemd/journald.conf.d/ or /run/systemd/journald.conf.d/ overrides that file, so
+# checking it alone would report `ok` for a setting something else has made inert.
+MERGED="$(mktemp -t journald-merged-XXXXXXXX)"
+if systemd-analyze cat-config systemd/journald.conf > "$MERGED" 2>/dev/null && [ -s "$MERGED" ]; then
+  echo "  reading   : systemd-analyze cat-config systemd/journald.conf (merged, incl. drop-ins)"
+else
+  echo "  reading   : /etc/systemd/journald.conf (systemd-analyze unavailable — DROP-INS NOT CHECKED)" >&2
+  cat /etc/systemd/journald.conf > "$MERGED" 2>/dev/null \
+    || die "neither systemd-analyze nor /etc/systemd/journald.conf could be read"
+
+fi
 
 missing=0
 for kv in "${MIGRATED[@]}"; do
-  if grep -qxF "$kv" "$JCONF"; then
+  if grep -qxF "$kv" "$MERGED"; then
     echo "  ok        : $kv"
   else
-    echo "  MISSING   : $kv — not present in $JCONF as written" >&2
+    echo "  MISSING   : $kv — not present in the merged journald config as written" >&2
     missing=$((missing + 1))
   fi
 done
-[ "$missing" = "0" ] || die "$missing migrated setting(s) did not reach $JCONF"
+[ "$missing" = "0" ] || die "$missing migrated setting(s) did not reach the merged config"
 
 echo
-echo "--- $JCONF ---"
-cat "$JCONF"
+echo "--- merged journald config ---"
+cat "$MERGED"
 echo "--- journal disk usage ---"
 journalctl --disk-usage || true
 

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -17,125 +17,155 @@
 #       SystemMaxUse=2G                    ->      SystemMaxUse = "2G";
 #     '';                                        };
 #
-# Idempotent. Restores the backup if the new config fails to evaluate.
+# The parsing lives in scripts/lib/journald_migrate.py, which is unit-tested
+# (scripts/tests/test_journald_migrate.py) and REFUSES anything it does not fully
+# understand. It handles both the ''-block and the one-line "..." form; the
+# workbench carried the first and the laptop the second.
+#
+# SAFETY. Nothing is written until the rewrite has been produced AND parsed as
+# valid Nix. Then, in order: a uniquely-named backup is taken (an existing one is
+# never overwritten), the new file is moved into place, and from that moment a
+# trap restores the backup on ANY failure or interrupt. `nixos-rebuild test`
+# runs before `switch` so an ACTIVATION failure does not leave a registered
+# generation and a rewritten bootloader behind.
+#
+# Idempotent: a config that is already migrated exits 0 without touching anything.
+#
 # Run as root:
 #
 #     sudo bash nix/system/apply-journald-settings-migration.sh
+#
+# Overrides (optional):
+#   JOURNALD_CFG=/etc/nixos/configuration.nix
 # =============================================================================
 set -euo pipefail
 
-if [[ ${EUID} -ne 0 ]]; then
-  echo "This must run as root:  sudo bash nix/system/apply-journald-settings-migration.sh" >&2
-  exit 1
-fi
+CFG="${JOURNALD_CFG:-/etc/nixos/configuration.nix}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATE="${HERE}/../../scripts/lib/journald_migrate.py"
 
-CFG="/etc/nixos/configuration.nix"
-STAMP="$(date +%Y%m%d-%H%M%S)"
-BAK="${CFG}.bak-journald-${STAMP}"
+die() { echo "ABORT: $*" >&2; exit 1; }
 
 echo "=== journald extraConfig -> settings.Journal ==="
 
-# ---------------------------------------------------------------------------- #
-# 1. Idempotency.
-# ---------------------------------------------------------------------------- #
-if ! grep -q 'services\.journald\.extraConfig' "${CFG}"; then
-  if grep -q 'services\.journald\.settings\.Journal' "${CFG}"; then
-    echo "[1/4] Already migrated — nothing to do."
+# ---------------------------------------------------------------- preflight (no writes)
+[ "$(id -u)" = "0" ] || die "must run as root: sudo bash ${BASH_SOURCE[0]}"
+
+for t in python3 nix-instantiate nixos-rebuild; do
+  command -v "$t" >/dev/null 2>&1 || die "\`$t\` is not on PATH.
+  sudo inherits the CALLER's PATH here (there is no secure_path), and python3 in
+  particular is NOT in /run/current-system/sw/bin. Run this from a shell that has it:
+    sudo env \"PATH=\$PATH\" bash ${BASH_SOURCE[0]}"
+done
+
+[ -r "$MIGRATE" ] || die "cannot read the rewriter at $MIGRATE (run this from the repo checkout)"
+[ -f "$CFG" ] && [ -w "$CFG" ] || die "$CFG is not a writable regular file"
+
+# Idempotency. Ask the file, before doing any work.
+if ! grep -q 'services\.journald\.extraConfig' "$CFG"; then
+  if grep -q 'services\.journald\.settings\.Journal' "$CFG"; then
+    echo "  state     : ALREADY MIGRATED — nothing to do."
     exit 0
   fi
-  echo "[1/4] ERROR: no services.journald.extraConfig in ${CFG}, and no settings.Journal either." >&2
-  echo "      Nothing matches what this script was written against — inspect by hand." >&2
-  exit 1
+  die "no services.journald.extraConfig in $CFG, and no settings.Journal either.
+  Nothing matches what this script was written against — inspect by hand."
 fi
-echo "[1/4] Found services.journald.extraConfig."
+echo "  state     : services.journald.extraConfig present — proceeding"
 
-# ---------------------------------------------------------------------------- #
-# 2. Rewrite the block (exact match; refuses on anything unexpected).
-# ---------------------------------------------------------------------------- #
-cp -p "${CFG}" "${BAK}"
-echo "[2/4] Backed up to ${BAK}"
+# ------------------------------------------------------------------------ patch (temp)
+TMP="${CFG}.new.$$"
+KEYS="$(mktemp -t journald-keys-XXXXXXXX)"
+BAK="${CFG}.bak-journald-$(date +%Y%m%d-%H%M%S)-$$"
+PATCHED=0
+SWITCHED=0
+OK=0
 
-python3 - "${CFG}" <<'PY'
-import re, sys
+finish() {
+  local rc=$?
+  rm -f "$TMP" "$KEYS"
+  if [ "$OK" = "1" ]; then return; fi
+  if [ "$PATCHED" = "1" ] && [ -f "$BAK" ]; then
+    cp -p "$BAK" "$CFG"
+    echo >&2
+    echo "ROLLED BACK: $CFG restored from $BAK" >&2
+    if [ "$SWITCHED" = "1" ]; then
+      echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
+      echo "   system is not — run \`sudo nixos-rebuild switch\` to return it." >&2
+    else
+      echo "   The system was never switched, so nothing is running the change." >&2
+    fi
+  fi
+  exit $rc
+}
+trap finish EXIT
 
-path = sys.argv[1]
-src = open(path).read()
+# The rewriter reads $CFG and writes $TMP; it never modifies its input, and it exits
+# non-zero without writing when it does not fully understand the block.
+python3 "$MIGRATE" "$CFG" --out "$TMP" --print-keys 2>"$KEYS" \
+  || { sed 's/^/    | /' "$KEYS" >&2; die "the rewriter refused — $CFG is untouched"; }
 
-# Match the whole assignment, capturing the ''-string body.
-pat = re.compile(
-    r'^([ \t]*)services\.journald\.extraConfig[ \t]*=[ \t]*\'\'\n(.*?)^[ \t]*\'\';[ \t]*\n',
-    re.S | re.M,
-)
-matches = pat.findall(src)
-if len(matches) != 1:
-    sys.exit(f"ERROR: expected exactly 1 services.journald.extraConfig block, found {len(matches)}")
+mapfile -t MIGRATED < "$KEYS"
+[ "${#MIGRATED[@]}" -gt 0 ] || die "the rewriter reported no migrated keys — refusing to continue"
+echo "  migrating : ${MIGRATED[*]}"
 
-indent, body = matches[0]
+nix-instantiate --parse "$TMP" >/dev/null 2>&1 \
+  || die "the rewritten file is not valid Nix — $CFG is untouched"
+echo "  nix parse : OK"
 
-pairs = []
-for raw in body.splitlines():
-    line = raw.strip()
-    if not line or line.startswith('#'):
-        continue
-    if '=' not in line:
-        sys.exit(f"ERROR: unparseable journald.conf line: {raw!r}")
-    k, v = line.split('=', 1)
-    k, v = k.strip(), v.strip()
-    if not re.fullmatch(r'[A-Za-z][A-Za-z0-9]*', k):
-        sys.exit(f"ERROR: unexpected journald.conf key: {k!r}")
-    pairs.append((k, v))
+echo "  diff:"
+diff -u "$CFG" "$TMP" | sed 's/^/    /' || true
 
-if not pairs:
-    sys.exit("ERROR: extraConfig block contained no settings")
+# Backup only now: a refusal above must not litter /etc/nixos with orphaned backups.
+[ -e "$BAK" ] && die "backup path $BAK already exists; refusing to overwrite it"
+cp -p "$CFG" "$BAK"
+echo "  backup    : $BAK"
 
-inner = ''.join(f'{indent}  {k} = "{v}";\n' for k, v in pairs)
-new = f'{indent}services.journald.settings.Journal = {{\n{inner}{indent}}};\n'
+mv "$TMP" "$CFG"
+PATCHED=1
+echo "  applied   : $CFG"
+echo
 
-open(path, 'w').write(pat.sub(lambda _m: new, src, count=1))
-print('       rewrote: ' + ', '.join(f'{k}={v}' for k, v in pairs))
-PY
+# ---------------------------------------------------------------------------- rebuild
+echo "== nixos-rebuild dry-build =="
+nixos-rebuild dry-build
 
-if grep -q 'services\.journald\.extraConfig' "${CFG}" \
-  || ! grep -q 'services\.journald\.settings\.Journal' "${CFG}"; then
-  echo "  -> ERROR: rewrite did not land; restoring backup." >&2
-  cp -p "${BAK}" "${CFG}"
-  exit 1
-fi
+# `test` activates WITHOUT registering a generation or touching the bootloader, so an
+# activation failure here is recoverable; `switch` does both BEFORE activating.
+echo "== nixos-rebuild test =="
+nixos-rebuild test
 
-echo "--- diff ---"
-diff -u "${BAK}" "${CFG}" || true
-echo "------------"
-
-# ---------------------------------------------------------------------------- #
-# 3. Evaluate before switching; restore on failure.
-# ---------------------------------------------------------------------------- #
-echo "[3/4] Parsing + dry-build..."
-if ! nix-instantiate --parse "${CFG}" >/dev/null; then
-  echo "  -> ERROR: ${CFG} no longer parses; restoring backup." >&2
-  cp -p "${BAK}" "${CFG}"
-  exit 1
-fi
-if ! nixos-rebuild dry-build; then
-  echo "  -> ERROR: dry-build failed; restoring backup." >&2
-  cp -p "${BAK}" "${CFG}"
-  echo "     Original config restored — the rebuild error above is the thing to fix." >&2
-  exit 1
-fi
-
-# ---------------------------------------------------------------------------- #
-# 4. Switch, then verify the generated journald.conf actually carries the value.
-# ---------------------------------------------------------------------------- #
-echo "[4/4] Rebuilding (switch)..."
+echo "== nixos-rebuild switch =="
 nixos-rebuild switch
+SWITCHED=1
+echo
+
+# ----------------------------------------------------------------------------- verify
+# Check the keys THIS RUN migrated, not a hardcoded one: the rewriter handles any
+# journald.conf(5) key, and a hardcoded check reports a false alarm on any host whose
+# config carried a different setting.
+echo "== verify =="
+JCONF=/etc/systemd/journald.conf
+[ -r "$JCONF" ] || die "$JCONF is not readable after the switch"
+
+missing=0
+for kv in "${MIGRATED[@]}"; do
+  if grep -qxF "$kv" "$JCONF"; then
+    echo "  ok        : $kv"
+  else
+    echo "  MISSING   : $kv — not present in $JCONF as written" >&2
+    missing=$((missing + 1))
+  fi
+done
+[ "$missing" = "0" ] || die "$missing migrated setting(s) did not reach $JCONF"
 
 echo
-echo "=== verification ==="
-echo "--- /etc/systemd/journald.conf ---"
-cat /etc/systemd/journald.conf
-echo "--- effective SystemMaxUse (systemd-analyze) ---"
-systemd-analyze cat-config systemd/journald.conf 2>/dev/null | grep -i 'SystemMaxUse' || \
-  echo "(no SystemMaxUse line found — CHECK THIS, the cap may not be applied)"
+echo "--- $JCONF ---"
+cat "$JCONF"
 echo "--- journal disk usage ---"
-journalctl --disk-usage
+journalctl --disk-usage || true
+
+OK=1
 echo
-echo "Done. Backup of the pre-change config: ${BAK}"
+echo "=== DONE ==="
+echo "Backup of the previous config: $BAK"
+echo "To revert:  sudo cp $BAK $CFG && sudo nixos-rebuild switch"

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Migrate services.journald.extraConfig -> services.journald.settings.Journal
+# =============================================================================
+# After a `nix-channel --update` onto nixos-26.11, `nixos-rebuild switch` fails:
+#
+#   Failed assertions:
+#   - The option definition `services.journald.extraConfig' in
+#     `/etc/nixos/configuration.nix' no longer has any effect; please remove it.
+#     Use services.journald.settings.Journal instead.
+#
+# The option was removed via mkRemovedOptionModule in
+# nixos/modules/system/boot/systemd/journald.nix. `settings.Journal` is a
+# freeform attrset of journald.conf(5) keys, so the ini text becomes attrs.
+#
+#     services.journald.extraConfig = ''         services.journald.settings.Journal = {
+#       SystemMaxUse=2G                    ->      SystemMaxUse = "2G";
+#     '';                                        };
+#
+# Idempotent. Restores the backup if the new config fails to evaluate.
+# Run as root:
+#
+#     sudo bash nix/system/apply-journald-settings-migration.sh
+# =============================================================================
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "This must run as root:  sudo bash nix/system/apply-journald-settings-migration.sh" >&2
+  exit 1
+fi
+
+CFG="/etc/nixos/configuration.nix"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BAK="${CFG}.bak-journald-${STAMP}"
+
+echo "=== journald extraConfig -> settings.Journal ==="
+
+# ---------------------------------------------------------------------------- #
+# 1. Idempotency.
+# ---------------------------------------------------------------------------- #
+if ! grep -q 'services\.journald\.extraConfig' "${CFG}"; then
+  if grep -q 'services\.journald\.settings\.Journal' "${CFG}"; then
+    echo "[1/4] Already migrated — nothing to do."
+    exit 0
+  fi
+  echo "[1/4] ERROR: no services.journald.extraConfig in ${CFG}, and no settings.Journal either." >&2
+  echo "      Nothing matches what this script was written against — inspect by hand." >&2
+  exit 1
+fi
+echo "[1/4] Found services.journald.extraConfig."
+
+# ---------------------------------------------------------------------------- #
+# 2. Rewrite the block (exact match; refuses on anything unexpected).
+# ---------------------------------------------------------------------------- #
+cp -p "${CFG}" "${BAK}"
+echo "[2/4] Backed up to ${BAK}"
+
+python3 - "${CFG}" <<'PY'
+import re, sys
+
+path = sys.argv[1]
+src = open(path).read()
+
+# Match the whole assignment, capturing the ''-string body.
+pat = re.compile(
+    r'^([ \t]*)services\.journald\.extraConfig[ \t]*=[ \t]*\'\'\n(.*?)^[ \t]*\'\';[ \t]*\n',
+    re.S | re.M,
+)
+matches = pat.findall(src)
+if len(matches) != 1:
+    sys.exit(f"ERROR: expected exactly 1 services.journald.extraConfig block, found {len(matches)}")
+
+indent, body = matches[0]
+
+pairs = []
+for raw in body.splitlines():
+    line = raw.strip()
+    if not line or line.startswith('#'):
+        continue
+    if '=' not in line:
+        sys.exit(f"ERROR: unparseable journald.conf line: {raw!r}")
+    k, v = line.split('=', 1)
+    k, v = k.strip(), v.strip()
+    if not re.fullmatch(r'[A-Za-z][A-Za-z0-9]*', k):
+        sys.exit(f"ERROR: unexpected journald.conf key: {k!r}")
+    pairs.append((k, v))
+
+if not pairs:
+    sys.exit("ERROR: extraConfig block contained no settings")
+
+inner = ''.join(f'{indent}  {k} = "{v}";\n' for k, v in pairs)
+new = f'{indent}services.journald.settings.Journal = {{\n{inner}{indent}}};\n'
+
+open(path, 'w').write(pat.sub(lambda _m: new, src, count=1))
+print('       rewrote: ' + ', '.join(f'{k}={v}' for k, v in pairs))
+PY
+
+if grep -q 'services\.journald\.extraConfig' "${CFG}" \
+  || ! grep -q 'services\.journald\.settings\.Journal' "${CFG}"; then
+  echo "  -> ERROR: rewrite did not land; restoring backup." >&2
+  cp -p "${BAK}" "${CFG}"
+  exit 1
+fi
+
+echo "--- diff ---"
+diff -u "${BAK}" "${CFG}" || true
+echo "------------"
+
+# ---------------------------------------------------------------------------- #
+# 3. Evaluate before switching; restore on failure.
+# ---------------------------------------------------------------------------- #
+echo "[3/4] Parsing + dry-build..."
+if ! nix-instantiate --parse "${CFG}" >/dev/null; then
+  echo "  -> ERROR: ${CFG} no longer parses; restoring backup." >&2
+  cp -p "${BAK}" "${CFG}"
+  exit 1
+fi
+if ! nixos-rebuild dry-build; then
+  echo "  -> ERROR: dry-build failed; restoring backup." >&2
+  cp -p "${BAK}" "${CFG}"
+  echo "     Original config restored — the rebuild error above is the thing to fix." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------- #
+# 4. Switch, then verify the generated journald.conf actually carries the value.
+# ---------------------------------------------------------------------------- #
+echo "[4/4] Rebuilding (switch)..."
+nixos-rebuild switch
+
+echo
+echo "=== verification ==="
+echo "--- /etc/systemd/journald.conf ---"
+cat /etc/systemd/journald.conf
+echo "--- effective SystemMaxUse (systemd-analyze) ---"
+systemd-analyze cat-config systemd/journald.conf 2>/dev/null | grep -i 'SystemMaxUse' || \
+  echo "(no SystemMaxUse line found — CHECK THIS, the cap may not be applied)"
+echo "--- journal disk usage ---"
+journalctl --disk-usage
+echo
+echo "Done. Backup of the pre-change config: ${BAK}"

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -84,6 +84,7 @@ KEYS="$(mktemp -t journald-keys-XXXXXXXX)"
 BAK="${CFG}.bak-journald-$(date +%Y%m%d-%H%M%S)-$$"
 PATCHED=0
 ACTIVATION_ATTEMPTED=0  # `nixos-rebuild test` was entered (may have partly applied)
+SWITCH_ATTEMPTED=0      # `nixos-rebuild switch` was entered — bootloader ALREADY written
 ACTIVATED=0   # `nixos-rebuild test` returned 0 — activated, not persisted
 SWITCHED=0    # `nixos-rebuild switch` has returned (activated AND persisted)
 OK=0
@@ -111,6 +112,12 @@ finish() {
     if [ "$SWITCHED" = "1" ]; then
       echo "🔴 The system had ALREADY been switched. The FILE is restored but the RUNNING" >&2
       echo "   system is not — run \`sudo nixos-rebuild switch\` to return it." >&2
+    elif [ "$SWITCH_ATTEMPTED" = "1" ]; then
+      echo "🔴 \`nixos-rebuild switch\` was entered but did not complete. It installs the" >&2
+      echo "   bootloader BEFORE activating, so the migrated generation is most likely" >&2
+      echo "   ALREADY IN THE BOOT MENU — a reboot does NOT reliably revert it. The file" >&2
+      echo "   is restored; run \`sudo nixos-rebuild switch\` to bring the system and the" >&2
+      echo "   boot entry back to it." >&2
     elif [ "$ACTIVATED" = "1" ]; then
       echo "🔴 \`nixos-rebuild test\` had ALREADY ACTIVATED the change, so it IS running now," >&2
       echo "   even though the file is restored. It was never added to the boot menu, so a" >&2
@@ -181,6 +188,12 @@ nixos-rebuild test
 ACTIVATED=1
 
 echo "== nixos-rebuild switch =="
+# 🔴 Armed BEFORE the call, and the reason is not symmetry for its own sake:
+# switch-to-configuration runs do_install_bootloader for Action::Switch BEFORE
+# activation (nixpkgs 26.11, switch-to-configuration-ng/src/main.rs). So at the only
+# moment a `switch` can fail mid-activation, the new generation IS already in the boot
+# menu — and telling the operator "a reboot reverts it" would be exactly backwards.
+SWITCH_ATTEMPTED=1
 nixos-rebuild switch
 SWITCHED=1
 echo
@@ -197,7 +210,9 @@ echo "== verify =="
 # Both were measured. We resolve precedence ourselves below: LAST assignment wins,
 # which is the order cat-config emits and the order systemd applies.
 MERGED="$(mktemp -t journald-merged-XXXXXXXX)"
+DROPINS_SEEN=no
 if systemd-analyze cat-config systemd/journald.conf > "$MERGED" 2>/dev/null && [ -s "$MERGED" ]; then
+  DROPINS_SEEN=yes
   echo "  reading   : systemd-analyze cat-config systemd/journald.conf (main file + drop-ins)"
 else
   echo "  reading   : /etc/systemd/journald.conf (systemd-analyze unavailable — DROP-INS NOT CHECKED)" >&2
@@ -225,13 +240,24 @@ for kv in "${MIGRATED[@]}"; do
   eff="$(grep -E "^${key}=" "$MERGED" | tail -1 || true)"
 
   if [ "$landed" = "yes" ] && [ "$eff" = "$kv" ]; then
-    echo "  ok        : $kv  (in journald.conf, and in effect)"
+    # Only claim the second fact when it was actually a SEPARATE read. In the fallback
+    # branch $MERGED is a copy of journald.conf, so `landed` and `eff` are the same
+    # bytes and "in effect" would be asserting a check that never happened — the same
+    # shape as the mislabelled "merged" output this verify loop was rewritten to fix.
+    if [ "$DROPINS_SEEN" = "yes" ]; then
+      echo "  ok        : $kv  (in journald.conf, and in effect)"
+    else
+      echo "  ok        : $kv  (in journald.conf; DROP-INS NOT CHECKED, so 'in effect' is unverified)"
+    fi
   elif [ "$landed" = "no" ] && [ "$eff" = "$kv" ]; then
     echo "  NOT LANDED: $kv is in effect, but NOT in /etc/systemd/journald.conf —" >&2
     echo "              something other than settings.Journal is supplying it." >&2
     missing=$((missing + 1))
   elif [ -n "$eff" ]; then
-    echo "  OVERRIDDEN: $kv — effective value is '${eff}' (a later drop-in wins)" >&2
+    # Deliberately does not name the cause: the later assignment is USUALLY a drop-in,
+    # but the same key appearing twice in journald.conf produces this too, and when the
+    # pair never landed the `landed=no` half is what matters. Print what was measured.
+    echo "  NOT IN EFFECT: $kv — last assignment of ${key} is '${eff}' (landed=${landed})" >&2
     missing=$((missing + 1))
   else
     echo "  MISSING   : $kv — no assignment of ${key} anywhere in the journald config" >&2

--- a/nix/system/apply-journald-settings-migration.sh
+++ b/nix/system/apply-journald-settings-migration.sh
@@ -83,13 +83,14 @@ TMP="${CFG}.new.$$"
 KEYS="$(mktemp -t journald-keys-XXXXXXXX)"
 BAK="${CFG}.bak-journald-$(date +%Y%m%d-%H%M%S)-$$"
 PATCHED=0
-ACTIVATED=0   # `nixos-rebuild test` has activated the config (not persisted)
+ACTIVATION_ATTEMPTED=0  # `nixos-rebuild test` was entered (may have partly applied)
+ACTIVATED=0   # `nixos-rebuild test` returned 0 — activated, not persisted
 SWITCHED=0    # `nixos-rebuild switch` has returned (activated AND persisted)
 OK=0
 
 finish() {
   local rc=$?
-  rm -f "$TMP" "$KEYS" "${MERGED:-}"
+  rm -f "$TMP" "$KEYS" ${MERGED:+"$MERGED"}
   if [ "$OK" = "1" ]; then return; fi
   if [ "$PATCHED" = "1" ] && [ -f "$BAK" ]; then
     echo >&2
@@ -115,8 +116,12 @@ finish() {
       echo "   even though the file is restored. It was never added to the boot menu, so a" >&2
       echo "   REBOOT reverts it — or run \`sudo nixos-rebuild switch\` to activate the" >&2
       echo "   restored config immediately." >&2
+    elif [ "$ACTIVATION_ATTEMPTED" = "1" ]; then
+      echo "🔴 \`nixos-rebuild test\` was entered but did not complete, so the change may be" >&2
+      echo "   PARTLY APPLIED to the running system. The file is restored; run" >&2
+      echo "   \`sudo nixos-rebuild switch\` to bring the system back to it." >&2
     else
-      echo "   The system was never activated, so nothing is running the change." >&2
+      echo "   Activation was never attempted, so nothing is running the change." >&2
     fi
   fi
   exit $rc
@@ -168,6 +173,10 @@ nixos-rebuild dry-build
 # `test` activates WITHOUT registering a generation or touching the bootloader, so an
 # activation failure here is recoverable; `switch` does both BEFORE activating.
 echo "== nixos-rebuild test =="
+# Armed BEFORE the call: `test` failing PARTWAY through activation has already applied
+# some of the change, so "never activated" would be false there too — the same defect
+# as the switch/test boundary, one step earlier.
+ACTIVATION_ATTEMPTED=1
 nixos-rebuild test
 ACTIVATED=1
 
@@ -181,12 +190,15 @@ echo
 # journald.conf(5) key, and a hardcoded check reports a false alarm on any host whose
 # config carried a different setting.
 echo "== verify =="
-# Read the MERGED configuration, not just /etc/systemd/journald.conf: a drop-in under
-# /etc/systemd/journald.conf.d/ or /run/systemd/journald.conf.d/ overrides that file, so
-# checking it alone would report `ok` for a setting something else has made inert.
+# 🔴 `systemd-analyze cat-config` CONCATENATES the main file and every drop-in, with
+# `# <path>` headers between them — it does NOT resolve precedence. So a plain
+# `grep -qxF` over its output matches an overridden line and reports ok, and it also
+# matches a line that lives ONLY in a stale drop-in and never reached journald.conf.
+# Both were measured. We resolve precedence ourselves below: LAST assignment wins,
+# which is the order cat-config emits and the order systemd applies.
 MERGED="$(mktemp -t journald-merged-XXXXXXXX)"
 if systemd-analyze cat-config systemd/journald.conf > "$MERGED" 2>/dev/null && [ -s "$MERGED" ]; then
-  echo "  reading   : systemd-analyze cat-config systemd/journald.conf (merged, incl. drop-ins)"
+  echo "  reading   : systemd-analyze cat-config systemd/journald.conf (main file + drop-ins)"
 else
   echo "  reading   : /etc/systemd/journald.conf (systemd-analyze unavailable — DROP-INS NOT CHECKED)" >&2
   cat /etc/systemd/journald.conf > "$MERGED" 2>/dev/null \
@@ -194,16 +206,39 @@ else
 
 fi
 
+# TWO independent facts per key, because either alone can be true while the migration
+# is broken:
+#   (a) LANDED   — the pair is in /etc/systemd/journald.conf, the file NixOS generates
+#                  from settings.Journal. Proves the migration itself worked.
+#   (b) IN EFFECT — it is the LAST assignment across the concatenation. Proves nothing
+#                  overrides it.
+# Checking only (b) passes when a stale drop-in happens to supply the same value and the
+# migration never landed; checking only (a) passes when a drop-in overrides it. Measured
+# both ways in audit round 3.
 missing=0
 for kv in "${MIGRATED[@]}"; do
-  if grep -qxF "$kv" "$MERGED"; then
-    echo "  ok        : $kv"
+  key="${kv%%=*}"
+  landed=no
+  grep -qxF "$kv" /etc/systemd/journald.conf 2>/dev/null && landed=yes
+  # Comment lines (`# <path>`, `#SystemMaxUse=`) cannot match: the key is anchored at
+  # start-of-line.
+  eff="$(grep -E "^${key}=" "$MERGED" | tail -1 || true)"
+
+  if [ "$landed" = "yes" ] && [ "$eff" = "$kv" ]; then
+    echo "  ok        : $kv  (in journald.conf, and in effect)"
+  elif [ "$landed" = "no" ] && [ "$eff" = "$kv" ]; then
+    echo "  NOT LANDED: $kv is in effect, but NOT in /etc/systemd/journald.conf —" >&2
+    echo "              something other than settings.Journal is supplying it." >&2
+    missing=$((missing + 1))
+  elif [ -n "$eff" ]; then
+    echo "  OVERRIDDEN: $kv — effective value is '${eff}' (a later drop-in wins)" >&2
+    missing=$((missing + 1))
   else
-    echo "  MISSING   : $kv — not present in the merged journald config as written" >&2
+    echo "  MISSING   : $kv — no assignment of ${key} anywhere in the journald config" >&2
     missing=$((missing + 1))
   fi
 done
-[ "$missing" = "0" ] || die "$missing migrated setting(s) did not reach the merged config"
+[ "$missing" = "0" ] || die "$missing migrated setting(s) did not land or are not in effect"
 
 echo
 echo "--- merged journald config ---"

--- a/scripts/diagnose-nix-disk.sh
+++ b/scripts/diagnose-nix-disk.sh
@@ -5,6 +5,13 @@
 #     bash scripts/diagnose-nix-disk.sh          # some sections need root for full data
 #     sudo bash scripts/diagnose-nix-disk.sh
 #
+# 🔴 THIS TAKES TENS OF MINUTES. Sections 3 and 4 each walk /nix recursively, and
+# section 4 additionally stats every regular file. MEASURED on the workbench:
+# `df -i /` reports ~80M inodes in use, and section 3 alone had not finished after
+# 13 minutes. Each section pipes through `sort`, which buffers, so NOTHING prints
+# between the start of a walk and its end — a run that looks hung is normal. Start it
+# in a background shell, or under tmux, rather than waiting on it.
+#
 # 🔴 NO `set -e`, ON PURPOSE. Nearly every command here is allowed to fail: `find`
 # exits non-zero on a permission-denied entry, `lsof` is not installed on either host,
 # and a device or path may not exist. Under `set -euo pipefail` this script aborted at
@@ -23,6 +30,15 @@ ROOT_USED="$(df -h --output=used / 2>/dev/null | tail -1 | tr -d ' ')"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 skip() { echo "  (unavailable: $*)"; }
+
+# Under `sudo` with env_reset (the default, and NixOS does not build sudo with
+# --with-always-set-home), HOME is the TARGET user's — i.e. /root — so a bare $HOME
+# would make section 8 walk root's home and print almost nothing. SUDO_USER names who
+# actually invoked us; fall back to HOME when not under sudo.
+if [ -n "${SUDO_USER:-}" ]; then
+  TARGET_HOME="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+fi
+TARGET_HOME="${TARGET_HOME:-$HOME}"
 
 echo "============================================"
 echo "  NixOS Root Partition Diagnosis"
@@ -55,17 +71,21 @@ echo ""
 
 # 3. Inode usage per top-level dir
 echo "=== 3. Inode count per top-level directory ==="
+echo "  (walking /nix and friends — several minutes, no output until it completes)"
 for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt /run; do
   if [ -d "$d" ]; then
     count=$(find "$d" 2>/dev/null | wc -l)
     printf "%12d  %s\n" "$count" "$d"
   fi
 done | sort -rn
-echo "  (counts are a FLOOR as non-root: unreadable dirs are skipped by find)"
+if [ "$(id -u)" != "0" ]; then
+  echo "  (counts are a FLOOR: as non-root, find skips unreadable dirs)"
+fi
 echo ""
 
 # 4. Actual file sizes per top-level dir (apparent size)
 echo "=== 4. Apparent file size per top-level directory ==="
+echo "  (a second full walk, statting every file — slower than section 3)"
 for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt; do
   if [ -d "$d" ]; then
     size=$(find "$d" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {printf "%.1f", s/1073741824}')
@@ -78,7 +98,9 @@ echo ""
 echo "=== 5. Deleted files still holding space ==="
 if have lsof; then
   lsof +L1 2>/dev/null | head -20
-  echo "Count: $(lsof +L1 2>/dev/null | wc -l)"
+  # -1 for lsof's own header row; clamp so an empty result reads 0, not -1.
+  n=$(lsof +L1 2>/dev/null | wc -l)
+  echo "Count: $(( n > 0 ? n - 1 : 0 ))"
 else
   skip "lsof not installed — try: nix-shell -p lsof --run 'lsof +L1'"
 fi
@@ -113,14 +135,21 @@ fi
 echo ""
 
 # 8. /home breakdown
-echo "=== 8. /home breakdown ==="
-for d in "$HOME"/.local/share/Steam "$HOME"/.ollama "$HOME"/.cache "$HOME"/.config \
-         "$HOME"/workspace "$HOME"/go "$HOME"/Downloads "$HOME"/hetzner-volumes; do
+echo "=== 8. home breakdown ==="
+echo "  (home: ${TARGET_HOME}${SUDO_USER:+  — resolved from SUDO_USER=$SUDO_USER, not \$HOME})"
+found8=0
+for d in "$TARGET_HOME"/.local/share/Steam "$TARGET_HOME"/.ollama "$TARGET_HOME"/.cache \
+         "$TARGET_HOME"/.config "$TARGET_HOME"/workspace "$TARGET_HOME"/go \
+         "$TARGET_HOME"/Downloads "$TARGET_HOME"/hetzner-volumes; do
   if [ -d "$d" ]; then
     size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
     printf "%8s  %s\n" "${size:-?}" "$d"
+    found8=1
   fi
 done
+# Section 8 was the one section with no fallback, so a wrong home read as an empty
+# section rather than as a reason — the exact failure the rest of this script avoids.
+[ "$found8" = "1" ] || skip "none of the expected directories exist under ${TARGET_HOME}"
 echo ""
 
 # 9. Swapfile

--- a/scripts/diagnose-nix-disk.sh
+++ b/scripts/diagnose-nix-disk.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "============================================"
+echo "  NixOS Root Partition Diagnosis"
+echo "  /dev/nvme0n1p2  (1.8TB, ~1.4TB used)"
+echo "============================================"
+echo ""
+
+# 1. Filesystem block stats
+echo "=== 1. Filesystem block stats ==="
+echo "--- df ---"
+df -hT /
+echo ""
+echo "--- stat -f ---"
+stat -f /
+echo ""
+
+# 2. dumpe2fs summary (block groups, free blocks, journal)
+echo "=== 2. dumpe2fs summary ==="
+dumpe2fs -h /dev/nvme0n1p2 2>/dev/null | grep -iE 'Block count|Free blocks|Inode count|Free inodes|Journal|Reserved|Filesystem features|Mount count|Last checked|State'
+echo ""
+
+# 3. Inode usage per top-level dir
+echo "=== 3. Inode count per top-level directory ==="
+for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt /run; do
+  if [ -d "$d" ]; then
+    count=$(find "$d" 2>/dev/null | wc -l)
+    printf "%12d  %s\n" "$count" "$d"
+  fi
+done | sort -rn
+echo ""
+
+# 4. Actual file sizes per top-level dir (apparent size)
+echo "=== 4. Apparent file size per top-level directory ==="
+for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt; do
+  if [ -d "$d" ]; then
+    size=$(find "$d" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {printf "%.1f", s/1073741824}')
+    printf "%8sGB  %s\n" "$size" "$d"
+  fi
+done | sort -rn
+echo ""
+
+# 5. Check for deleted-but-referenced files
+echo "=== 5. Deleted files still holding space ==="
+lsof +L1 2>/dev/null | head -20
+echo "Count: $(lsof +L1 2>/dev/null | wc -l)"
+echo ""
+
+# 6. Check ext4 journal size
+echo "=== 6. Ext4 journal ==="
+ls -lh /proc/1/root/.journal 2>/dev/null || echo "No journal at /proc/1/root/.journal"
+dumpe2fs -h /dev/nvme0n1p2 2>/dev/null | grep -i journal
+echo ""
+
+# 7. Nix store breakdown
+echo "=== 7. Nix store breakdown ==="
+echo "Top-level entries:"
+ls /nix/store/ 2>/dev/null | wc -l
+echo "  Directories: $(ls -d /nix/store/*/ 2>/dev/null | wc -l)"
+echo "  Files:       $(ls -l /nix/store/ 2>/dev/null | grep -c '^-')"
+echo "  Symlinks:    $(ls -l /nix/store/ 2>/dev/null | grep -c '^l')"
+echo ""
+echo ".links unique data:"
+du -sh /nix/store/.links 2>/dev/null
+echo "Files in .links:"
+find /nix/store/.links -type f 2>/dev/null | wc -l
+echo ""
+
+# 8. /home breakdown
+echo "=== 8. /home breakdown ==="
+for d in /home/zach/.local/share/Steam /home/zach/.ollama /home/zach/.cache /home/zach/.config /home/zach/workspace /home/zach/go /home/zach/Downloads /home/zach/hetzner-volumes; do
+  if [ -d "$d" ]; then
+    size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
+    printf "%8s  %s\n" "$size" "$d"
+  fi
+done
+echo ""
+
+# 9. Swapfile
+echo "=== 9. Swapfile ==="
+ls -lh /swapfile 2>/dev/null
+echo ""
+
+# 10. Reserved blocks
+echo "=== 10. Reserved blocks for root ==="
+tune2fs -l /dev/nvme0n1p2 2>/dev/null | grep -i 'reserved'
+echo ""
+
+echo "============================================"
+echo "  Done. Review output above."
+echo "============================================"

--- a/scripts/diagnose-nix-disk.sh
+++ b/scripts/diagnose-nix-disk.sh
@@ -35,8 +35,17 @@ skip() { echo "  (unavailable: $*)"; }
 # --with-always-set-home), HOME is the TARGET user's — i.e. /root — so a bare $HOME
 # would make section 8 walk root's home and print almost nothing. SUDO_USER names who
 # actually invoked us; fall back to HOME when not under sudo.
+HOME_SOURCE="\$HOME"
 if [ -n "${SUDO_USER:-}" ]; then
-  TARGET_HOME="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+  resolved="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+  # Gate the attribution on the RESOLUTION, not on SUDO_USER being set: an unresolvable
+  # user fell back to $HOME while the line claimed it had used SUDO_USER.
+  if [ -n "$resolved" ]; then
+    TARGET_HOME="$resolved"
+    HOME_SOURCE="SUDO_USER=$SUDO_USER"
+  else
+    HOME_SOURCE="\$HOME (SUDO_USER=$SUDO_USER did not resolve)"
+  fi
 fi
 TARGET_HOME="${TARGET_HOME:-$HOME}"
 
@@ -136,7 +145,7 @@ echo ""
 
 # 8. /home breakdown
 echo "=== 8. home breakdown ==="
-echo "  (home: ${TARGET_HOME}${SUDO_USER:+  — resolved from SUDO_USER=$SUDO_USER, not \$HOME})"
+echo "  (home: ${TARGET_HOME}  — from ${HOME_SOURCE})"
 found8=0
 for d in "$TARGET_HOME"/.local/share/Steam "$TARGET_HOME"/.ollama "$TARGET_HOME"/.cache \
          "$TARGET_HOME"/.config "$TARGET_HOME"/workspace "$TARGET_HOME"/go \

--- a/scripts/diagnose-nix-disk.sh
+++ b/scripts/diagnose-nix-disk.sh
@@ -1,9 +1,33 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Read-only root-partition / inode breakdown, used when df disagrees with what you can
+# measure. Sibling to scripts/diagnose-disk-accounting.sh; changes nothing.
+#
+#     bash scripts/diagnose-nix-disk.sh          # some sections need root for full data
+#     sudo bash scripts/diagnose-nix-disk.sh
+#
+# 🔴 NO `set -e`, ON PURPOSE. Nearly every command here is allowed to fail: `find`
+# exits non-zero on a permission-denied entry, `lsof` is not installed on either host,
+# and a device or path may not exist. Under `set -euo pipefail` this script aborted at
+# section 3 of 10 as an ordinary user and section 2 on the laptop — printing NOTHING
+# about why, because `set -e` is silent and the stderr was already discarded. For a
+# diagnostic, a section that says "(unavailable)" is worth more than a clean exit that
+# skipped eight of them.
+set -uo pipefail
+
+# The root device is DERIVED, never hardcoded: it is nvme0n1p2 on the workbench and
+# nvme0n1p1 on the laptop, and a frozen literal silently reports the wrong device.
+ROOT_DEV="$(findmnt -no SOURCE / 2>/dev/null || echo unknown)"
+ROOT_FS="$(findmnt -no FSTYPE / 2>/dev/null || echo unknown)"
+ROOT_SIZE="$(df -h --output=size / 2>/dev/null | tail -1 | tr -d ' ')"
+ROOT_USED="$(df -h --output=used / 2>/dev/null | tail -1 | tr -d ' ')"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+skip() { echo "  (unavailable: $*)"; }
 
 echo "============================================"
 echo "  NixOS Root Partition Diagnosis"
-echo "  /dev/nvme0n1p2  (1.8TB, ~1.4TB used)"
+echo "  ${ROOT_DEV}  (${ROOT_FS}, ${ROOT_SIZE:-?} total, ${ROOT_USED:-?} used)"
+echo "  $(hostname)  $(date -Is)"
 echo "============================================"
 echo ""
 
@@ -18,7 +42,15 @@ echo ""
 
 # 2. dumpe2fs summary (block groups, free blocks, journal)
 echo "=== 2. dumpe2fs summary ==="
-dumpe2fs -h /dev/nvme0n1p2 2>/dev/null | grep -iE 'Block count|Free blocks|Inode count|Free inodes|Journal|Reserved|Filesystem features|Mount count|Last checked|State'
+if ! have dumpe2fs; then
+  skip "dumpe2fs not on PATH"
+elif [ "$ROOT_FS" != "ext2" ] && [ "$ROOT_FS" != "ext3" ] && [ "$ROOT_FS" != "ext4" ]; then
+  skip "root is $ROOT_FS, not ext*"
+else
+  dumpe2fs -h "$ROOT_DEV" 2>/dev/null \
+    | grep -iE 'Block count|Free blocks|Inode count|Free inodes|Journal|Reserved|Filesystem features|Mount count|Last checked|State' \
+    || skip "dumpe2fs failed on $ROOT_DEV (needs root?)"
+fi
 echo ""
 
 # 3. Inode usage per top-level dir
@@ -29,6 +61,7 @@ for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt /run; do
     printf "%12d  %s\n" "$count" "$d"
   fi
 done | sort -rn
+echo "  (counts are a FLOOR as non-root: unreadable dirs are skipped by find)"
 echo ""
 
 # 4. Actual file sizes per top-level dir (apparent size)
@@ -36,57 +69,75 @@ echo "=== 4. Apparent file size per top-level directory ==="
 for d in /nix /home /var /tmp /etc /usr /root /srv /opt /boot /mnt; do
   if [ -d "$d" ]; then
     size=$(find "$d" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {printf "%.1f", s/1073741824}')
-    printf "%8sGB  %s\n" "$size" "$d"
+    printf "%8sGB  %s\n" "${size:-0.0}" "$d"
   fi
 done | sort -rn
 echo ""
 
 # 5. Check for deleted-but-referenced files
 echo "=== 5. Deleted files still holding space ==="
-lsof +L1 2>/dev/null | head -20
-echo "Count: $(lsof +L1 2>/dev/null | wc -l)"
+if have lsof; then
+  lsof +L1 2>/dev/null | head -20
+  echo "Count: $(lsof +L1 2>/dev/null | wc -l)"
+else
+  skip "lsof not installed — try: nix-shell -p lsof --run 'lsof +L1'"
+fi
 echo ""
 
-# 6. Check ext4 journal size
+# 6. Ext4 journal
 echo "=== 6. Ext4 journal ==="
-ls -lh /proc/1/root/.journal 2>/dev/null || echo "No journal at /proc/1/root/.journal"
-dumpe2fs -h /dev/nvme0n1p2 2>/dev/null | grep -i journal
+ls -lh /proc/1/root/.journal 2>/dev/null || echo "  No journal file at /proc/1/root/.journal"
+if have dumpe2fs; then
+  dumpe2fs -h "$ROOT_DEV" 2>/dev/null | grep -i journal || skip "dumpe2fs failed on $ROOT_DEV"
+else
+  skip "dumpe2fs not on PATH"
+fi
 echo ""
 
 # 7. Nix store breakdown
 echo "=== 7. Nix store breakdown ==="
-echo "Top-level entries:"
-ls /nix/store/ 2>/dev/null | wc -l
-echo "  Directories: $(ls -d /nix/store/*/ 2>/dev/null | wc -l)"
-echo "  Files:       $(ls -l /nix/store/ 2>/dev/null | grep -c '^-')"
-echo "  Symlinks:    $(ls -l /nix/store/ 2>/dev/null | grep -c '^l')"
-echo ""
-echo ".links unique data:"
-du -sh /nix/store/.links 2>/dev/null
-echo "Files in .links:"
-find /nix/store/.links -type f 2>/dev/null | wc -l
+if [ -d /nix/store ]; then
+  echo "Top-level entries:"
+  ls /nix/store/ 2>/dev/null | wc -l
+  echo "  Directories: $(ls -d /nix/store/*/ 2>/dev/null | wc -l)"
+  echo "  Files:       $(ls -l /nix/store/ 2>/dev/null | grep -c '^-')"
+  echo "  Symlinks:    $(ls -l /nix/store/ 2>/dev/null | grep -c '^l')"
+  echo ""
+  echo ".links unique data:"
+  du -sh /nix/store/.links 2>/dev/null || skip "cannot read /nix/store/.links (needs root)"
+  echo "Files in .links:"
+  find /nix/store/.links -type f 2>/dev/null | wc -l
+else
+  skip "no /nix/store on this host"
+fi
 echo ""
 
 # 8. /home breakdown
 echo "=== 8. /home breakdown ==="
-for d in /home/zach/.local/share/Steam /home/zach/.ollama /home/zach/.cache /home/zach/.config /home/zach/workspace /home/zach/go /home/zach/Downloads /home/zach/hetzner-volumes; do
+for d in "$HOME"/.local/share/Steam "$HOME"/.ollama "$HOME"/.cache "$HOME"/.config \
+         "$HOME"/workspace "$HOME"/go "$HOME"/Downloads "$HOME"/hetzner-volumes; do
   if [ -d "$d" ]; then
     size=$(du -sh "$d" 2>/dev/null | awk '{print $1}')
-    printf "%8s  %s\n" "$size" "$d"
+    printf "%8s  %s\n" "${size:-?}" "$d"
   fi
 done
 echo ""
 
 # 9. Swapfile
-echo "=== 9. Swapfile ==="
-ls -lh /swapfile 2>/dev/null
+echo "=== 9. Swap ==="
+swapon --show 2>/dev/null || skip "swapon failed"
+ls -lh /swapfile 2>/dev/null || echo "  (no /swapfile on this host)"
 echo ""
 
 # 10. Reserved blocks
 echo "=== 10. Reserved blocks for root ==="
-tune2fs -l /dev/nvme0n1p2 2>/dev/null | grep -i 'reserved'
+if have tune2fs; then
+  tune2fs -l "$ROOT_DEV" 2>/dev/null | grep -i 'reserved' || skip "tune2fs failed on $ROOT_DEV (needs root?)"
+else
+  skip "tune2fs not on PATH"
+fi
 echo ""
 
 echo "============================================"
-echo "  Done. Review output above."
+echo "  Done — all 10 sections attempted."
 echo "============================================"

--- a/scripts/lib/journald_migrate.py
+++ b/scripts/lib/journald_migrate.py
@@ -54,13 +54,19 @@ class Refused(Exception):
 
 
 def to_nix_string(value: str) -> str:
-    r"""Quote a value as a Nix double-quoted string.
+    r"""Quote a LITERAL value as a Nix double-quoted string.
 
     The escapes are not cosmetic. The source is a `''`-string (or a `"`-string), and we
     are emitting into a `"`-string, where the rules differ: a literal backslash in a
     `''`-body means a backslash, but in a `"`-body it starts an escape — so `5m\t` would
-    silently become a TAB rather than the four characters it was. `${` likewise starts
-    an antiquotation and would be evaluated as a variable reference.
+    silently become a TAB rather than the four characters it was.
+
+    `${` is escaped here for the same reason — but that is only correct for a value we
+    have already established is a LITERAL. In the SOURCE, `${...}` is an antiquotation
+    that Nix evaluates, so escaping it would silently change the value from "whatever
+    `cap` holds" to the six characters `${cap}`. `parse_settings` therefore refuses any
+    value containing `${` rather than letting it reach this function — see the comment
+    there. This escape is the belt to that braces.
     """
     out = value.replace("\\", "\\\\").replace('"', '\\"').replace("${", "\\${")
     return f'"{out}"'
@@ -89,6 +95,20 @@ def parse_settings(body: str) -> list[tuple[str, str]]:
         key, value = key.strip(), value.strip()
         if not _KEY.match(key):
             raise Refused(f"unexpected journald.conf key: {key!r}")
+        # 🔴 The one place this could silently change what the config MEANS rather than
+        # how it is spelled. `${x}` in the source is a Nix antiquotation that evaluates
+        # to whatever `x` holds; emitting it escaped would freeze the literal six
+        # characters instead, and NOTHING downstream would catch it — `nix-instantiate
+        # --parse` accepts both, and the caller's post-switch check compares against the
+        # same un-evaluated text it printed, so it matches and reports success. Likewise
+        # `''`-escapes (`''${`, `''\`) mean something inside a ''-string and nothing in a
+        # "-string. Refuse; a human can hand-migrate a config that interpolates.
+        if "${" in value or "''" in value:
+            raise Refused(
+                f"value for {key!r} contains a Nix antiquotation or ''-escape "
+                f"({value!r}) — its VALUE depends on evaluation, so a literal rewrite "
+                "would change it. Migrate this one by hand."
+            )
         pairs.append((key, value))
     if not pairs:
         raise Refused("the extraConfig block contained no settings")

--- a/scripts/lib/journald_migrate.py
+++ b/scripts/lib/journald_migrate.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Rewrite `services.journald.extraConfig` to `services.journald.settings.Journal`.
+
+nixos-26.11 removed `services.journald.extraConfig` (mkRemovedOptionModule in
+nixos/modules/system/boot/systemd/journald.nix), so a configuration.nix carrying it
+fails `nixos-rebuild switch` on an assertion. `settings.Journal` is a freeform attrset
+of journald.conf(5) keys, so the ini text becomes attributes.
+
+This module is the parsing half, kept separate from the shell wrapper so it can be
+tested without root and without touching /etc/nixos. It REFUSES rather than guessing:
+every failure raises Refused, and the caller writes nothing.
+
+Both spellings of the removed option occur in the wild and both are handled:
+
+    services.journald.extraConfig = ''        services.journald.extraConfig = "SyncIntervalSec=30s";
+      SystemMaxUse=2G
+    '';
+
+The workbench carried the first, the laptop the second — so a migration that only
+handled the block form would refuse on half the fleet.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["Refused", "parse_settings", "rewrite", "to_nix_string"]
+
+# A journald.conf(5) key: letters and digits, starting with a letter. Deliberately
+# strict — anything else means we did not understand the block, and a wrong guess here
+# writes wrong Nix into a file the next `nixos-rebuild` will act on.
+_KEY = re.compile(r"[A-Za-z][A-Za-z0-9]*\Z")
+
+# The two assignment forms. Both capture the leading indent (group 1) and the body
+# (group 2). Non-greedy bodies, anchored on the terminator, so a second assignment
+# later in the file is a separate match rather than being swallowed into this one.
+#
+# `\r?\n` throughout: a CRLF file is unlikely on NixOS but a `\n`-only anchor does not
+# refuse it, it fails to MATCH it — which reads as "no extraConfig here" and would have
+# the caller report a clean, already-migrated config.
+_BLOCK = re.compile(
+    r"^([ \t]*)services\.journald\.extraConfig[ \t]*=[ \t]*''[ \t]*\r?\n"
+    r"(.*?)^[ \t]*'';[ \t]*\r?\n",
+    re.S | re.M,
+)
+_INLINE = re.compile(
+    r"^([ \t]*)services\.journald\.extraConfig[ \t]*=[ \t]*\"([^\"\r\n]*)\";[ \t]*\r?\n",
+    re.M,
+)
+
+
+class Refused(Exception):
+    """The input was not something we understood well enough to rewrite."""
+
+
+def to_nix_string(value: str) -> str:
+    r"""Quote a value as a Nix double-quoted string.
+
+    The escapes are not cosmetic. The source is a `''`-string (or a `"`-string), and we
+    are emitting into a `"`-string, where the rules differ: a literal backslash in a
+    `''`-body means a backslash, but in a `"`-body it starts an escape — so `5m\t` would
+    silently become a TAB rather than the four characters it was. `${` likewise starts
+    an antiquotation and would be evaluated as a variable reference.
+    """
+    out = value.replace("\\", "\\\\").replace('"', '\\"').replace("${", "\\${")
+    return f'"{out}"'
+
+
+def parse_settings(body: str) -> list[tuple[str, str]]:
+    """Parse a journald.conf(5) fragment into ordered key/value pairs.
+
+    Comments and blank lines are skipped. Anything else that is not a `Key=Value` with a
+    well-formed key raises Refused — including a `[Journal]` section header, which would
+    otherwise be silently dropped and change what the config means.
+    """
+    pairs: list[tuple[str, str]] = []
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("["):
+            raise Refused(
+                f"section header {line!r} in an extraConfig block — this migration "
+                "targets the [Journal] section only; rewrite it by hand"
+            )
+        if "=" not in line:
+            raise Refused(f"unparseable journald.conf line: {raw!r}")
+        key, value = line.split("=", 1)
+        key, value = key.strip(), value.strip()
+        if not _KEY.match(key):
+            raise Refused(f"unexpected journald.conf key: {key!r}")
+        pairs.append((key, value))
+    if not pairs:
+        raise Refused("the extraConfig block contained no settings")
+    return pairs
+
+
+def _matches(src: str) -> tuple[re.Pattern[str], list[tuple[str, str]]]:
+    block = _BLOCK.findall(src)
+    inline = _INLINE.findall(src)
+    total = len(block) + len(inline)
+    if total != 1:
+        raise Refused(
+            f"expected exactly 1 services.journald.extraConfig assignment, found {total}"
+        )
+    return (_BLOCK, block) if block else (_INLINE, inline)
+
+
+def rewrite(src: str) -> tuple[str, list[tuple[str, str]]]:
+    """Return (new_source, migrated_pairs). Raises Refused and writes nothing on doubt."""
+    pattern, matches = _matches(src)
+    indent, body = matches[0]
+    pairs = parse_settings(body)
+
+    # Emit the file's own line ending, so a CRLF config does not come back as a mixed
+    # one — the operator reviews this as a `diff -u` and a changed ending shows up there.
+    eol = "\r\n" if "\r\n" in src else "\n"
+    inner = "".join(f"{indent}  {k} = {to_nix_string(v)};{eol}" for k, v in pairs)
+    replacement = (
+        f"{indent}services.journald.settings.Journal = {{{eol}{inner}{indent}}};{eol}"
+    )
+
+    # A literal replacement: re.sub would interpret backslashes in the value as group
+    # references, so the whole point of to_nix_string could be undone here.
+    return pattern.sub(lambda _match: replacement, src, count=1), pairs
+
+
+def main(argv: list[str]) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("source", help="configuration.nix to read")
+    ap.add_argument("--out", help="write the rewritten file here (default: stdout)")
+    ap.add_argument(
+        "--print-keys",
+        action="store_true",
+        help="print the migrated KEY=VALUE pairs to stderr, for the caller to verify against",
+    )
+    args = ap.parse_args(argv)
+
+    # newline="" keeps the file's own line endings: a universal-newlines read followed by
+    # a "\n" write silently converts a CRLF file end to end, which turns the operator's
+    # review diff into "every line changed".
+    with open(args.source, encoding="utf-8", newline="") as fh:
+        src = fh.read()
+
+    try:
+        new, pairs = rewrite(src)
+    except Refused as exc:
+        print(f"REFUSED: {exc}", file=__import__("sys").stderr)
+        return 2
+
+    if args.print_keys:
+        import sys
+
+        for key, value in pairs:
+            print(f"{key}={value}", file=sys.stderr)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8", newline="") as fh:
+            fh.write(new)
+    else:
+        import sys
+
+        sys.stdout.write(new)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/lib/journald_migrate.py
+++ b/scripts/lib/journald_migrate.py
@@ -72,8 +72,11 @@ def to_nix_string(value: str) -> str:
     return f'"{out}"'
 
 
-def parse_settings(body: str) -> list[tuple[str, str]]:
+def parse_settings(body: str, form: str = "block") -> list[tuple[str, str]]:
     """Parse a journald.conf(5) fragment into ordered key/value pairs.
+
+    `form` is "block" (a `''`-string source) or "inline" (a `"`-string source). It
+    decides what a backslash MEANS — see the refusal below.
 
     Comments and blank lines are skipped. Anything else that is not a `Key=Value` with a
     well-formed key raises Refused — including a `[Journal]` section header, which would
@@ -109,6 +112,19 @@ def parse_settings(body: str) -> list[tuple[str, str]]:
                 f"({value!r}) — its VALUE depends on evaluation, so a literal rewrite "
                 "would change it. Migrate this one by hand."
             )
+        # The MIRROR of the hazard above, and it only exists for the inline form. In a
+        # `''`-string a backslash is literal, so re-escaping it for the `"`-string we
+        # emit is right. In a `"`-string Nix has ALREADY interpreted it — source `"5m\t"`
+        # is `5m<TAB>` — so escaping the raw text would emit the literal backslash-t
+        # instead, changing the value in the opposite direction. We only have the
+        # un-evaluated text, so refuse rather than guess which one was meant.
+        if form == "inline" and "\\" in value:
+            raise Refused(
+                f"value for {key!r} contains a backslash escape ({value!r}) in a "
+                'double-quoted source string. Nix has already interpreted it, and this '
+                "rewrite only sees the raw text, so it cannot preserve the value. "
+                "Migrate this one by hand."
+            )
         pairs.append((key, value))
     if not pairs:
         raise Refused("the extraConfig block contained no settings")
@@ -130,7 +146,7 @@ def rewrite(src: str) -> tuple[str, list[tuple[str, str]]]:
     """Return (new_source, migrated_pairs). Raises Refused and writes nothing on doubt."""
     pattern, matches = _matches(src)
     indent, body = matches[0]
-    pairs = parse_settings(body)
+    pairs = parse_settings(body, "inline" if pattern is _INLINE else "block")
 
     # Emit the file's own line ending, so a CRLF config does not come back as a mixed
     # one — the operator reviews this as a `diff -u` and a changed ending shows up there.

--- a/scripts/lib/journald_migrate.py
+++ b/scripts/lib/journald_migrate.py
@@ -72,16 +72,26 @@ def to_nix_string(value: str) -> str:
     return f'"{out}"'
 
 
-def parse_settings(body: str, form: str = "block") -> list[tuple[str, str]]:
+def parse_settings(body: str, form: str) -> list[tuple[str, str]]:
     """Parse a journald.conf(5) fragment into ordered key/value pairs.
 
     `form` is "block" (a `''`-string source) or "inline" (a `"`-string source). It
     decides what a backslash MEANS — see the refusal below.
 
+    🔴 REQUIRED, deliberately. It defaulted to "block" for one round, which is the
+    PERMISSIVE side: a caller that forgot it on inline input would get exactly the
+    silently-wrong value the parameter exists to prevent. Measured — flipping that
+    default survived the whole suite, because the only caller passes it explicitly, so
+    nothing would have caught the omission. A module whose doctrine is "refuse rather
+    than guess" should not make guessing the default; an unknown form is refused below.
+
     Comments and blank lines are skipped. Anything else that is not a `Key=Value` with a
     well-formed key raises Refused — including a `[Journal]` section header, which would
     otherwise be silently dropped and change what the config means.
     """
+    if form not in ("block", "inline"):
+        raise Refused(f"unknown source form {form!r} — expected 'block' or 'inline'")
+
     pairs: list[tuple[str, str]] = []
     for raw in body.splitlines():
         line = raw.strip()

--- a/scripts/tests/test_journald_migrate.py
+++ b/scripts/tests/test_journald_migrate.py
@@ -192,6 +192,34 @@ def test_a_value_that_depends_on_EVALUATION_is_refused(value, what):  # audit R2
         jm.rewrite(src)
 
 
+def test_a_bare_double_apostrophe_escape_is_refused():  # audit R3 NEW-C
+    """Every earlier param of the test above also contained `${`, so all three died on
+    THAT half of the guard. Audit round 3 mutation-tested it: deleting `or "''" in value`
+    SURVIVED a green 30-test run. This case has no `${` and kills that mutant."""
+    src = BLOCK.replace("SystemMaxUse=2G", r"SystemMaxUse=2G''\\")
+    with pytest.raises(jm.Refused, match="antiquotation"):
+        jm.rewrite(src)
+
+
+@pytest.mark.parametrize("value", [r"5m\t", r"C:\\path", r"a\nb"])
+def test_the_INLINE_form_refuses_a_backslash(value):  # audit R3, mirror of R1 #10
+    """The mirror hazard. In a `''`-string a backslash is literal, so re-escaping it is
+    right. In a `"`-string Nix has ALREADY interpreted it — `"5m\t"` IS `5m<TAB>` — so
+    escaping the raw text would emit a literal backslash-t instead, wrong in the opposite
+    direction. We only see un-evaluated text, so refuse."""
+    src = INLINE.replace("SyncIntervalSec=30s", f"SyncIntervalSec={value}")
+    with pytest.raises(jm.Refused, match="backslash"):
+        jm.rewrite(src)
+
+
+def test_the_BLOCK_form_still_ACCEPTS_a_backslash():
+    """The other side of that boundary — refusing both forms would be over-wide, and
+    this is the case R1 #10's escaping exists to serve."""
+    src = BLOCK.replace("SystemMaxUse=2G", r"SyncIntervalSec=5m\t")
+    _, pairs = jm.rewrite(src)
+    assert pairs == [("SyncIntervalSec", r"5m\t")]
+
+
 def test_the_inline_form_refuses_an_antiquotation_too():  # audit R2 NEW-5
     """Same hazard, other spelling: `${` antiquotes inside a "-string as well."""
     src = INLINE.replace("SyncIntervalSec=30s", "SyncIntervalSec=${interval}")

--- a/scripts/tests/test_journald_migrate.py
+++ b/scripts/tests/test_journald_migrate.py
@@ -1,0 +1,215 @@
+"""Tests for scripts/lib/journald_migrate.py.
+
+Every case here is either a shape measured on this fleet or a defect an adversarial
+audit of PR #1412 found in the first implementation. The audit-found ones are marked
+`# audit R1 #N` so a later reader can tell a regression guard from a shape test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import journald_migrate as jm  # noqa: E402
+
+BLOCK = """\
+{
+  services.openssh.enable = true;
+
+  services.journald.extraConfig = ''
+    SystemMaxUse=2G
+  '';
+
+  fonts.packages = [ ];
+}
+"""
+
+INLINE = """\
+{
+  services.journald.extraConfig = "SyncIntervalSec=30s";
+}
+"""
+
+
+def _settings_body(text: str) -> str:
+    """The lines between `settings.Journal = {` and its closing brace."""
+    out, inside = [], False
+    for line in text.splitlines():
+        if "services.journald.settings.Journal" in line:
+            inside = True
+            continue
+        if inside:
+            if line.strip() == "};":
+                break
+            out.append(line)
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- shapes
+
+
+def test_block_form_is_migrated_and_the_rest_of_the_file_is_untouched():
+    new, pairs = jm.rewrite(BLOCK)
+    assert pairs == [("SystemMaxUse", "2G")]
+    assert "extraConfig" not in new
+    assert '    SystemMaxUse = "2G";' in new
+    # everything either side survives verbatim
+    assert "services.openssh.enable = true;" in new
+    assert "fonts.packages = [ ];" in new
+
+
+def test_the_inline_double_quoted_form_is_migrated():  # audit R1 #6
+    """The laptop carries `= "SyncIntervalSec=30s";`, not a ''-block.
+
+    The first implementation matched only the block form, so it refused on the only
+    other host in the fleet while the doc claimed it was host-agnostic.
+    """
+    new, pairs = jm.rewrite(INLINE)
+    assert pairs == [("SyncIntervalSec", "30s")]
+    assert 'SyncIntervalSec = "30s";' in new
+    assert "extraConfig" not in new
+
+
+def test_indentation_of_the_original_assignment_is_preserved():
+    src = "{\n      services.journald.extraConfig = ''\n        A=1\n      '';\n}\n"
+    new, _ = jm.rewrite(src)
+    assert "      services.journald.settings.Journal = {\n" in new
+    assert '        A = "1";\n' in new
+
+
+def test_several_settings_keep_their_order():
+    src = BLOCK.replace("SystemMaxUse=2G", "SystemMaxUse=2G\n    MaxRetentionSec=1month")
+    _, pairs = jm.rewrite(src)
+    assert pairs == [("SystemMaxUse", "2G"), ("MaxRetentionSec", "1month")]
+
+
+def test_comments_and_blank_lines_are_skipped():
+    src = BLOCK.replace(
+        "SystemMaxUse=2G", "# a hash comment\n\n    ; a semicolon comment\n    SystemMaxUse=2G"
+    )
+    _, pairs = jm.rewrite(src)
+    assert pairs == [("SystemMaxUse", "2G")]
+
+
+def test_crlf_line_endings_survive_the_rewrite():  # audit R1 #9
+    """A universal-newlines read + "\\n" write rewrites every line ending in the file,
+    which degrades the operator's `diff -u` review surface to "everything changed"."""
+    src = BLOCK.replace("\n", "\r\n")
+    new, pairs = jm.rewrite(src)
+    assert pairs == [("SystemMaxUse", "2G")]
+    assert 'SystemMaxUse = "2G";' in new
+    assert "\r\n" in new
+    # the whole point: no line ending anywhere in the file changed flavour
+    assert new.count("\n") == new.count("\r\n"), "a bare LF was introduced"
+
+
+# ------------------------------------------------------------------ value escaping
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("2G", '"2G"'),
+        ("1month", '"1month"'),
+        (r"5m\t", r'"5m\\t"'),  # audit R1 #10 — a backslash, else a literal TAB
+        ('say "hi"', r'"say \"hi\""'),
+        ("${cap}", r'"\${cap}"'),
+        (r"back\\slash", r'"back\\\\slash"'),
+    ],
+)
+def test_values_are_escaped_for_a_nix_double_quoted_string(raw, expected):
+    assert jm.to_nix_string(raw) == expected
+
+
+def test_a_backslash_value_does_not_become_a_tab():  # audit R1 #10
+    r"""`SyncIntervalSec=5m\t` is 4 characters in a ''-string and a TAB in a "-string.
+
+    The first implementation interpolated straight into `"{v}"`, so this parsed, and
+    evaluated, to the wrong value — the one silently-wrong case in that rewrite.
+    """
+    src = BLOCK.replace("SystemMaxUse=2G", r"SyncIntervalSec=5m\t")
+    new, _ = jm.rewrite(src)
+    assert r'"5m\\t"' in new
+    assert "\t" not in _settings_body(new)
+
+
+def test_a_backslash_in_a_value_is_not_eaten_as_a_regex_group_reference():
+    r"""re.sub() interprets \1 and \g<n> in the REPLACEMENT, which would undo the
+    escaping above. The rewrite passes a function to sub() for exactly this reason."""
+    src = BLOCK.replace("SystemMaxUse=2G", r"SystemMaxUse=\1\g<0>")
+    new, _ = jm.rewrite(src)
+    assert r"\\1\\g<0>" in new
+
+
+# ------------------------------------------------------------------------ refusals
+
+
+@pytest.mark.parametrize(
+    ("src", "because"),
+    [
+        (BLOCK.replace("services.openssh.enable = true;", BLOCK.split("\n", 1)[1]), "two blocks"),
+        ("{\n  services.openssh.enable = true;\n}\n", "no assignment at all"),
+        (BLOCK.replace("SystemMaxUse=2G", "[Journal]\n    SystemMaxUse=2G"), "section header"),
+        (BLOCK.replace("SystemMaxUse=2G", "# only a comment"), "no settings"),
+        (BLOCK.replace("SystemMaxUse=2G", "Max_Use=2G"), "underscore in key"),
+        (BLOCK.replace("SystemMaxUse=2G", "9Lives=2G"), "key starting with a digit"),
+        (BLOCK.replace("SystemMaxUse=2G", "no equals sign here"), "no `=`"),
+    ],
+)
+def test_refuses_rather_than_guessing(src, because):
+    with pytest.raises(jm.Refused):
+        jm.rewrite(src)
+
+
+def test_two_assignments_in_DIFFERENT_forms_are_also_refused():
+    """One block + one inline is still ambiguous — the count is across both spellings."""
+    src = BLOCK.replace(
+        "  fonts.packages = [ ];",
+        '  services.journald.extraConfig = "SyncIntervalSec=30s";',
+    )
+    with pytest.raises(jm.Refused, match="found 2"):
+        jm.rewrite(src)
+
+
+def test_an_already_migrated_file_is_refused_not_double_migrated():
+    new, _ = jm.rewrite(BLOCK)
+    with pytest.raises(jm.Refused, match="found 0"):
+        jm.rewrite(new)
+
+
+# ------------------------------------------------------------------------- the CLI
+
+
+def test_the_cli_writes_the_rewritten_file_and_reports_the_keys(tmp_path):
+    src = tmp_path / "configuration.nix"
+    src.write_text(BLOCK, encoding="utf-8")
+    out = tmp_path / "out.nix"
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "lib" / "journald_migrate.py"),
+         str(src), "--out", str(out), "--print-keys"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "SystemMaxUse=2G" in proc.stderr
+    assert 'SystemMaxUse = "2G";' in out.read_text(encoding="utf-8")
+    assert src.read_text(encoding="utf-8") == BLOCK, "the source must not be modified"
+
+
+def test_the_cli_exits_2_and_writes_nothing_when_it_refuses(tmp_path):
+    src = tmp_path / "configuration.nix"
+    src.write_text("{ }\n", encoding="utf-8")
+    out = tmp_path / "out.nix"
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "lib" / "journald_migrate.py"),
+         str(src), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 2
+    assert "REFUSED" in proc.stderr
+    assert not out.exists(), "a refusal must not leave a half-written output file"

--- a/scripts/tests/test_journald_migrate.py
+++ b/scripts/tests/test_journald_migrate.py
@@ -192,6 +192,24 @@ def test_a_value_that_depends_on_EVALUATION_is_refused(value, what):  # audit R2
         jm.rewrite(src)
 
 
+def test_parse_settings_REQUIRES_the_form_argument():  # audit R4 #3
+    """Pins the parameter as required, which a default silently un-pins.
+
+    It defaulted to "block" — the permissive side — for one round, and audit round 4
+    measured that FLIPPING that default survived the entire suite, because the only
+    caller passes it explicitly. Nothing would have caught a future caller omitting it
+    on inline input, which is precisely the silently-wrong value the guard exists to
+    stop. This test fails if a default is reintroduced.
+    """
+    with pytest.raises(TypeError):
+        jm.parse_settings("SystemMaxUse=2G")  # type: ignore[call-arg]
+
+
+def test_parse_settings_refuses_an_unknown_form():
+    with pytest.raises(jm.Refused, match="unknown source form"):
+        jm.parse_settings("SystemMaxUse=2G", "sideways")
+
+
 def test_a_bare_double_apostrophe_escape_is_refused():  # audit R3 NEW-C
     """Every earlier param of the test above also contained `${`, so all three died on
     THAT half of the guard. Audit round 3 mutation-tested it: deleting `or "''" in value`

--- a/scripts/tests/test_journald_migrate.py
+++ b/scripts/tests/test_journald_migrate.py
@@ -135,8 +135,11 @@ def test_a_backslash_value_does_not_become_a_tab():  # audit R1 #10
     """
     src = BLOCK.replace("SystemMaxUse=2G", r"SyncIntervalSec=5m\t")
     new, _ = jm.rewrite(src)
-    assert r'"5m\\t"' in new
-    assert "\t" not in _settings_body(new)
+    body = _settings_body(new)
+    assert body.strip(), "the helper found no settings body — the assertions below would be vacuous"
+    assert r'"5m\\t"' in new, "the backslash was not doubled for the \"-string"
+    # The negative half, and it CAN fail: an unescaped implementation emits exactly this.
+    assert r'"5m\t"' not in new, "emitted an unescaped backslash — Nix reads it as a TAB"
 
 
 def test_a_backslash_in_a_value_is_not_eaten_as_a_regex_group_reference():
@@ -165,6 +168,42 @@ def test_a_backslash_in_a_value_is_not_eaten_as_a_regex_group_reference():
 def test_refuses_rather_than_guessing(src, because):
     with pytest.raises(jm.Refused):
         jm.rewrite(src)
+
+
+@pytest.mark.parametrize(
+    ("value", "what"),
+    [
+        ("${cap}", "a bare antiquotation"),
+        ("2G${suffix}", "an antiquotation with a literal prefix"),
+        ("''${literal}", "a ''-escaped antiquotation"),
+    ],
+)
+def test_a_value_that_depends_on_EVALUATION_is_refused(value, what):  # audit R2 NEW-5
+    """`${x}` in the source is evaluated by Nix; escaping it freezes the literal text.
+
+    Nothing downstream catches that substitution: `nix-instantiate --parse` accepts both
+    spellings, and the apply script's post-switch check compares against the same
+    un-evaluated text it printed, so it MATCHES and reports success. Measured with
+    `nix-instantiate --eval`: source `''SystemMaxUse=${cap}''` with cap="9G" evaluates to
+    `SystemMaxUse=9G`, while the escaped rewrite evaluates to the literal `${cap}`.
+    """
+    src = BLOCK.replace("SystemMaxUse=2G", f"SystemMaxUse={value}")
+    with pytest.raises(jm.Refused, match="antiquotation"):
+        jm.rewrite(src)
+
+
+def test_the_inline_form_refuses_an_antiquotation_too():  # audit R2 NEW-5
+    """Same hazard, other spelling: `${` antiquotes inside a "-string as well."""
+    src = INLINE.replace("SyncIntervalSec=30s", "SyncIntervalSec=${interval}")
+    with pytest.raises(jm.Refused, match="antiquotation"):
+        jm.rewrite(src)
+
+
+def test_a_plain_dollar_sign_is_still_allowed():
+    """Only `${` antiquotes — a lone `$` is an ordinary character and must not refuse."""
+    src = BLOCK.replace("SystemMaxUse=2G", "SystemMaxUse=2G$")
+    _, pairs = jm.rewrite(src)
+    assert pairs == [("SystemMaxUse", "2G$")]
 
 
 def test_two_assignments_in_DIFFERENT_forms_are_also_refused():


### PR DESCRIPTION
Two scripts existed **only** in the workbench working tree, where a stray `git checkout` or a deploy would have deleted them unreported (`claude/RULES.md` → "Docs/notes written into a working tree are UNSAVED WORK").

### `nix/system/apply-journald-settings-migration.sh`
nixos-26.11 removed `services.journald.extraConfig` (`mkRemovedOptionModule` in `nixos/modules/system/boot/systemd/journald.nix`), so `nixos-rebuild switch` died on a failed assertion after a `nix-channel --update`. The script rewrites the block to `services.journald.settings.Journal`, and:

- refuses unless it matches exactly one `extraConfig` block, and unless every line inside parses as a `journald.conf(5)` key
- takes a timestamped backup, then `nix-instantiate --parse` + `nixos-rebuild dry-build`, **restoring the backup if either fails**
- after the switch, prints the generated `/etc/systemd/journald.conf` and `journalctl --disk-usage` rather than asserting success
- idempotent

**Already applied to the workbench.** Verified live, not inferred:
- `/etc/systemd/journald.conf` → `[Journal]` / `Audit=keep` / `SystemMaxUse=2G` (`Audit=keep` is 26.11's new explicit default)
- `/run/current-system` → `nixos-system-nixos-26.11pre1068949.dc5d91f84032`

Verified before it was run, against a copy — no writes to `/etc/nixos`: the rewrite parses, `config.system.build.toplevel` evaluates (assertion gone), and building `config.environment.etc."systemd/journald.conf"` showed the `SystemMaxUse=2G` line survives the migration.

### `scripts/diagnose-nix-disk.sh`
The read-only root-partition/inode breakdown used during the disk dig: `df`/`stat -f`/`dumpe2fs`, per-top-level-dir inode counts and apparent sizes, `lsof +L1` for deleted-but-held files, `/nix/store/.links`, swapfile, reserved blocks. Sibling to the existing `scripts/diagnose-disk-accounting.sh`; no overlap with `scripts/cleanup-disk.sh`.

### Deliberately NOT in this PR
`nix/system/apply-nebula-relay.sh` and `check-nebula-relays.sh` were also untracked locally, but those copies are **stale orphans** — byte-identical to `e7f2e45a`, an intermediate commit of the branch that merged as #1272. `main` already carries strictly further-along versions (480 vs 205 lines, and 360 vs 317), including a `🔴 THIS RESTARTS THE MESH` warning my copies predate. Committing them would have reverted ~318 lines of that work.

### Gate
`main` moved from `4f49f5dc` to `03d7e0ad` mid-run and this branch is rebased onto the latter, so the gate is being re-run on that merged tree; result posted below.