### PR TITLE
fix(nebula): pin the interpreter fix tier-independently, and stop reporting an exec fault as a config fault

### DIFF
--- a/nix/system/apply-nebula-relay.sh
+++ b/nix/system/apply-nebula-relay.sh
@@ -101,6 +101,45 @@ run_check() { "$BASH" "$CHECK" "$@"; }
 
 die() { echo "ABORT: $*" >&2; exit 1; }
 
+# 🔴 THE VERIFIER ONLY EVER EXITS 0, 1 OR 2. ANY OTHER CODE MEANS IT DID NOT RUN.
+#
+# check-nebula-relays.sh's exit codes are a CLOSED set, stated in its header and
+# checked by test_the_verifiers_exit_codes_are_a_closed_set: 0 = advertised,
+# 1 = not advertised, 2 = it could not answer (unit not loaded/inactive, no
+# MainPID, unreadable -config, parser failure, its own self-test failing, or the
+# unit and the process disagreeing).
+#
+# So an rc outside {0,1,2} is not a verdict at all -- the verifier never got far
+# enough to have one. Before this classifier existed, every such code fell into
+# the same `*)` arm as a genuine rc 2 and was reported as
+#
+#     ABORT: the verifier could not read the current config (rc=126); fix that first
+#
+# which asserts a fact about $CFG that is false in every one of those cases. That
+# is not hypothetical: it is exactly how the /usr/bin/env fault this script was
+# just fixed for presented (126 = found, but its interpreter is missing), and the
+# misdirection is what made it read as a config problem rather than an exec one.
+#
+# 🔴 The consequential site is the POST-REBUILD verify, not this one. There, a
+# non-verifier rc reaches `die` AFTER `nixos-rebuild test` has activated, so the
+# EXIT trap rolls back a change that actually WORKED and prints the PERSISTED /
+# "the profile may have moved" paragraphs for what was really a signal or an exec
+# fault. Failing with the right diagnosis is the difference between "re-run it"
+# and "go debug your mesh".
+verifier_answered() { case "$1" in 0|1|2) return 0 ;; *) return 1 ;; esac; }
+
+die_verifier_did_not_run() {
+  die "the verifier did NOT RUN (rc=$1) -- an exec, interpreter or signal fault, NOT
+  an answer about the config or the mesh. \`$CHECK\` only ever exits 0, 1 or 2 (see
+  its header), so nothing about $RELAY has been determined and nothing here should be
+  read as a finding about $CFG.
+    126  found, but not executable -- or ITS INTERPRETER is missing
+    127  it disappeared between the preflight's [ -r ] check and this call
+    128+ killed by a signal (130 = SIGINT, 137 = SIGKILL/OOM, 143 = SIGTERM)
+  Fix the invocation, then re-run: this script is idempotent and has changed nothing
+  it cannot repeat."
+}
+
 # Scratch dir for everything this script writes outside $CFG.
 #
 # 🔴 NOT `/tmp/<fixed-name>.$$`. /tmp is 1777, `>` follows symlinks, and this runs as
@@ -164,8 +203,10 @@ case "$pre_rc" in
      echo "  the verifier's finding, in full -- read the cost note before continuing:"
      sed 's/^/    | /' "$PRE"
      echo ;;
+  2) sed 's/^/    | /' "$PRE"
+     die "the verifier could not read the current config (rc=2); fix that first" ;;
   *) sed 's/^/    | /' "$PRE"
-     die "the verifier could not read the current config (rc=$pre_rc); fix that first" ;;
+     die_verifier_did_not_run "$pre_rc" ;;
 esac
 
 # 🔴 SYMLINKS ARE REFUSED, NOT FOLLOWED -- and that is a deliberate choice between the
@@ -478,6 +519,12 @@ verify_now() {   # dies on failure; retries exactly once, on ONE narrow conditio
     set +e; run_check "$RELAY" >"$out" 2>&1; rc=$?; set -e
     sed 's/^/    | /' "$out"
   fi
+  # 🔴 CLASSIFY BEFORE BLAMING THE MESH. This runs after `nixos-rebuild test` has
+  # activated, so whatever this `die`s with is what the EXIT trap rolls back and what
+  # the operator is told the rollback was FOR. An exec/interpreter/signal fault here
+  # is not "the relay is not advertised" -- reporting it as one sends them to debug a
+  # mesh that is very possibly fine, having just undone a change that worked.
+  verifier_answered "$rc" || die_verifier_did_not_run "$rc"
   [ "$rc" = "0" ] || die "the verifier does not see $RELAY advertised by the running unit (rc=$rc)"
 }
 verify_now

--- a/nix/system/apply-nebula-relay.sh
+++ b/nix/system/apply-nebula-relay.sh
@@ -120,24 +120,60 @@ die() { echo "ABORT: $*" >&2; exit 1; }
 # just fixed for presented (126 = found, but its interpreter is missing), and the
 # misdirection is what made it read as a config problem rather than an exec one.
 #
-# 🔴 The consequential site is the POST-REBUILD verify, not this one. There, a
-# non-verifier rc reaches `die` AFTER `nixos-rebuild test` has activated, so the
-# EXIT trap rolls back a change that actually WORKED and prints the PERSISTED /
-# "the profile may have moved" paragraphs for what was really a signal or an exec
-# fault. Failing with the right diagnosis is the difference between "re-run it"
-# and "go debug your mesh".
+# 🔴 The consequential sites are the two VERIFY calls, not this one. There a
+# non-verifier rc reaches `die` after the change has been activated, so the EXIT
+# trap rolls back something that actually WORKED, for what was really a signal or
+# an exec fault. Failing with the right diagnosis is the difference between
+# "re-run it" and "go debug your mesh".
+#
+# Which paragraph the trap then prints depends on WHICH verify failed, and the two
+# are not the same (measured):
+#   verify_now after `nixos-rebuild test`   -> ACTIVATED, NOT PERSISTED
+#   verify_now after `nixos-rebuild switch` -> PERSISTED / the profile may have moved
+# An earlier draft of this comment attributed the PERSISTED paragraphs to the first
+# site. It does not print them: PERSISTED and SWITCH_ATTEMPTED are both still 0 there,
+# which `test_verifier_failure_after_a_good_test_says_activated_not_persisted` pins.
 verifier_answered() { case "$1" in 0|1|2) return 0 ;; *) return 1 ;; esac; }
 
 die_verifier_did_not_run() {
+  # 🔴 THE CLOSING ADVICE IS CONDITIONAL, BECAUSE "just re-run it" IS ACTIVELY HARMFUL
+  # ONCE ANYTHING HAS BEEN WRITTEN.
+  #
+  # This function is reached from THREE sites: the preflight (nothing written), the
+  # post-`test` verify, and the post-`switch` verify. An unconditional "this script is
+  # idempotent, re-run it" was measured to contradict the trap's own paragraph printed
+  # two lines below it -- the trap said PERSISTED / restoring the file is NOT enough,
+  # while this said nothing had changed.
+  #
+  # Worse than a contradiction, following it loses the change silently: after the trap
+  # rolls $CFG back, the running unit still advertises the relay, so a re-run's
+  # preflight asks the RUNNING unit, gets rc 0, prints "ALREADY SATISFIED -- nothing to
+  # do" and exits 0. That is a green all-clear over a config file that no longer
+  # contains the change, which the next `nixos-rebuild switch` by anyone quietly
+  # removes.
+  #
+  # `${PATCHED:-0}` and not `$PATCHED`: the flags are declared further down, AFTER the
+  # preflight, so a bare reference would abort under `set -u` at the first call site.
+  local tail
+  if [ "${PATCHED:-0}" = "0" ]; then
+    tail="Nothing has been written yet -- fix the invocation and re-run."
+  else
+    tail="🔴 DO NOT simply re-run. \$CFG has already been patched, and possibly
+  activated or persisted. Read the trap's paragraph BELOW this message: it tracks
+  which of those was reached and is the only thing here that knows. Follow it.
+  A bare re-run asks the RUNNING unit, so if the change is live while the file was
+  rolled back you will get \"ALREADY SATISFIED -- nothing to do\" and exit 0 over a
+  config that no longer contains it."
+  fi
   die "the verifier did NOT RUN (rc=$1) -- an exec, interpreter or signal fault, NOT
   an answer about the config or the mesh. \`$CHECK\` only ever exits 0, 1 or 2 (see
-  its header), so nothing about $RELAY has been determined and nothing here should be
-  read as a finding about $CFG.
-    126  found, but not executable -- or ITS INTERPRETER is missing
+  its header), so this says nothing about whether $RELAY is advertised.
+    126  \`$CHECK\` is a DIRECTORY, or is not readable
     127  it disappeared between the preflight's [ -r ] check and this call
     128+ killed by a signal (130 = SIGINT, 137 = SIGKILL/OOM, 143 = SIGTERM)
-  Fix the invocation, then re-run: this script is idempotent and has changed nothing
-  it cannot repeat."
+  (Not 'not executable': it is run as \`\"\$BASH\" \"\$CHECK\"\`, so bash READS it and
+  the exec bit is never consulted.)
+  $tail"
 }
 
 # Scratch dir for everything this script writes outside $CFG.

--- a/nix/system/apply-nebula-relay.sh
+++ b/nix/system/apply-nebula-relay.sh
@@ -101,6 +101,24 @@ run_check() { "$BASH" "$CHECK" "$@"; }
 
 die() { echo "ABORT: $*" >&2; exit 1; }
 
+# Trap state. Each flag is set immediately AFTER the step it names succeeds, so the
+# message the trap prints is what was actually reached, never what was intended.
+#
+# 🔴 DECLARED HERE, NOT BESIDE THE TRAP THAT READS THEM. `die_verifier_did_not_run`
+# below reads PATCHED from the PREFLIGHT, which runs long before the trap section. With
+# the declarations down there, the only way to read PATCHED early was `${PATCHED:-0}` --
+# and that silently falls back to an INHERITED ENVIRONMENT VARIABLE. This script's own
+# header documents invoking it as `sudo env "PATH=$PATH" bash ...`, which preserves the
+# caller's environment, so an exported PATCHED=1 made the preflight print the "DO NOT
+# simply re-run" branch when nothing whatsoever had been written. Measured 2026-09-08.
+# Declaring them first makes `"$PATCHED"` correct everywhere and removes the fallback.
+PATCHED=0           # $CFG has been replaced by the patched file
+TEST_ATTEMPTED=0    # `nixos-rebuild test` was started
+ACTIVATED=0         # ... and returned 0: the change is RUNNING, nothing persisted
+SWITCH_ATTEMPTED=0  # `nixos-rebuild switch` was started -- the profile MAY have moved
+PERSISTED=0         # ... and returned 0: profile + bootloader now carry the change
+OK=0
+
 # 🔴 THE VERIFIER ONLY EVER EXITS 0, 1 OR 2. ANY OTHER CODE MEANS IT DID NOT RUN.
 #
 # check-nebula-relays.sh's exit codes are a CLOSED set, stated in its header and
@@ -129,7 +147,12 @@ die() { echo "ABORT: $*" >&2; exit 1; }
 # Which paragraph the trap then prints depends on WHICH verify failed, and the two
 # are not the same (measured):
 #   verify_now after `nixos-rebuild test`   -> ACTIVATED, NOT PERSISTED
-#   verify_now after `nixos-rebuild switch` -> PERSISTED / the profile may have moved
+#   verify_now after `nixos-rebuild switch` -> PERSISTED
+# Those are two of the trap's MUTUALLY EXCLUSIVE branches, not a pair that can both
+# print. "THE PROFILE MAY HAVE MOVED" is a THIRD branch and is unreachable at the second
+# site: `set -e` plus `PERSISTED=1` immediately after a successful `nixos-rebuild switch`
+# means PERSISTED is always 1 by the time that verify runs. An earlier draft of this
+# comment wrote "PERSISTED / the profile may have moved", which reads as "either".
 # An earlier draft of this comment attributed the PERSISTED paragraphs to the first
 # site. It does not print them: PERSISTED and SWITCH_ATTEMPTED are both still 0 there,
 # which `test_verifier_failure_after_a_good_test_says_activated_not_persisted` pins.
@@ -152,10 +175,11 @@ die_verifier_did_not_run() {
   # contains the change, which the next `nixos-rebuild switch` by anyone quietly
   # removes.
   #
-  # `${PATCHED:-0}` and not `$PATCHED`: the flags are declared further down, AFTER the
-  # preflight, so a bare reference would abort under `set -u` at the first call site.
+  # `"$PATCHED"`, not `${PATCHED:-0}`: the flags are declared at the top of this script
+  # precisely so this read needs no fallback. A `:-` default here would silently accept
+  # an INHERITED value -- see the declaration block for the measurement.
   local tail
-  if [ "${PATCHED:-0}" = "0" ]; then
+  if [ "$PATCHED" = "0" ]; then
     tail="Nothing has been written yet -- fix the invocation and re-run."
   else
     tail="🔴 DO NOT simply re-run. \$CFG has already been patched, and possibly
@@ -405,15 +429,6 @@ echo "== patch =="
 TMP="$(mktemp "${CFG}.new.XXXXXXXX")" || die "cannot create a temp file next to $CFG"
 cp -p "$CFG" "$TMP"
 BAK="${CFG}.bak-nebula-relay-$(date +%Y%m%d-%H%M%S)-$$"
-
-# Trap state. Each flag is set immediately AFTER the step it names succeeds, so the
-# message the trap prints is what was actually reached, never what was intended.
-PATCHED=0           # $CFG has been replaced by the patched file
-TEST_ATTEMPTED=0    # `nixos-rebuild test` was started
-ACTIVATED=0         # ... and returned 0: the change is RUNNING, nothing persisted
-SWITCH_ATTEMPTED=0  # `nixos-rebuild switch` was started -- the profile MAY have moved
-PERSISTED=0         # ... and returned 0: profile + bootloader now carry the change
-OK=0
 
 finish() {
   local rc=$?

--- a/scripts/tests/mutants-nebula-relay.sh
+++ b/scripts/tests/mutants-nebula-relay.sh
@@ -313,6 +313,46 @@ mutant "M-FI-2-reason-line-dropped" check 1 \
   test_deferred_restart_is_retried \
   'assert r.returncode == 0'
 
+# --- F-H: the verifier is invoked through an explicit interpreter, and an rc that is
+#          NOT one of its own {0,1,2} is reported as "it did not run" ---------------
+#
+# 🔴 M-FH-1 IS THE ONE THAT NEEDS A BATTERY AT ALL. Reverting run_check to a direct
+# exec is INVISIBLE on the dev host — /usr/bin/env exists here, so all 30 behavioural
+# tests still pass and only the nix sandbox goes red. The structural guard is what
+# makes it fail on both tiers, and this mutant is that guard's positive control.
+mutant "M-FH-1-verifier-execed-via-shebang" apply 1 \
+  'run_check() { "$BASH" "$CHECK" "$@"; }' \
+  'run_check() { "$CHECK" "$@"; }' \
+  test_the_verifier_is_never_execed_via_its_own_shebang \
+  'must be invoked through'
+
+# The verifier's exit codes and apply's `verifier_answered` are ONE fact in two files.
+# A new code on either side, unmatched on the other, silently reclassifies a verdict as
+# an exec fault — in the reassuring direction ("nothing was determined").
+mutant "M-FH-2-verifier-grows-a-code" check 1 \
+  '  _self_test || exit 2' \
+  '  _self_test || exit 3' \
+  test_the_verifiers_exit_codes_are_a_closed_set \
+  'still treats only 0/1/2 as answers'
+
+# 🔴 M-FH-3 IS WHY THE POST-REBUILD TEST EXISTS. An earlier sweep caught this mutant
+# with the STRUCTURAL closed-set test only: every behavioural case aborted at the
+# preflight, so `verifier_answered` — used solely at the post-rebuild site — never
+# executed. A guard that is never reached is not a guard.
+mutant "M-FH-3-answered-widened" apply 1 \
+  'verifier_answered() { case "$1" in 0|1|2) return 0 ;; *) return 1 ;; esac; }' \
+  'verifier_answered() { case "$1" in 0|1|2|126) return 0 ;; *) return 1 ;; esac; }' \
+  test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh \
+  'did NOT RUN'
+
+# The consequential site: this `die` is what the EXIT trap rolls back, so misreporting
+# an exec/signal fault as "the relay is not advertised" undoes a change that worked.
+mutant "M-FH-4-siteB-classify-dropped" apply 1 \
+  '  verifier_answered "$rc" || die_verifier_did_not_run "$rc"' \
+  '  :' \
+  test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh \
+  'did NOT RUN'
+
 # --- F-F: the parser's block terminator is load-bearing ----------------------------
 mutant "M-FF-1-terminator-removed" check 1 \
   '            if not line.startswith((" ", "\t")):   # next top-level key ends the block' \

--- a/scripts/tests/mutants-nebula-relay.sh
+++ b/scripts/tests/mutants-nebula-relay.sh
@@ -107,8 +107,26 @@ PY
 
 # Run the test file against a (possibly mutated) nix/system copy.
 #   $1 = directory, $2... = extra pytest args
+# 🔴 PURGE THE BYTECODE CACHE, DO NOT MERELY REFUSE TO WRITE ONE.
+# PYTHONDONTWRITEBYTECODE=1 (exported at the top of this file) stops THIS run creating
+# a cache; it does NOT stop it READING one an earlier ordinary `pytest` invocation left
+# behind. CPython validates a cached module on mtime-in-whole-SECONDS plus size, so an
+# edit to the TEST FILE made between two battery runs can be served stale — and the
+# mutant is then scored against the OLD assertions.
+# MEASURED 2026-09-08: an edit adding explicit assertion messages was invisible for two
+# consecutive single-mutant runs, both reporting M-FH-6 as WRONG-KILLER ("failed, but
+# not with 'DO NOT simply re-run'") while the phrase was demonstrably in the output of
+# the same command run by hand. Deleting __pycache__ made it pass immediately.
+# This is the harness lying about the code under test, which is the one failure a
+# mutation battery must not have.
+purge_pycache() {
+  find "$(dirname "$TESTFILE")" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null
+  return 0
+}
+
 run_tests() {
   local d="$1"; shift
+  purge_pycache
   DEVRC_TEST_NEBULA_DIR="$d" \
     python3 -m pytest "$TESTFILE" -q -p no:randomly --no-header "$@" 2>&1
 }
@@ -326,9 +344,6 @@ mutant "M-FH-1-verifier-execed-via-shebang" apply 1 \
   test_the_verifier_is_never_execed_via_its_own_shebang \
   'no longer invokes the verifier through'
 
-# The verifier's exit codes and apply's `verifier_answered` are ONE fact in two files.
-# A new code on either side, unmatched on the other, silently reclassifies a verdict as
-# an exec fault — in the reassuring direction ("nothing was determined").
 # 🔴 M-FH-5 IS THE ONE THE STRUCTURAL GUARD CANNOT SEE. An audit demonstrated that
 # swapping ONE call site to "${CHECK}" reintroduces the /usr/bin/env dependency while
 # leaving the dev-host suite fully green — a source regex pins a SPELLING, and there are
@@ -340,6 +355,9 @@ mutant "M-FH-5-braces-evade-the-regex" apply 1 \
   test_the_verifier_runs_with_its_shebang_BROKEN \
   'something still EXECS it'
 
+# The verifier's exit codes and apply's `verifier_answered` are ONE fact in two files.
+# A new code on either side, unmatched on the other, silently reclassifies a verdict as
+# an exec fault — in the reassuring direction ("nothing was determined").
 mutant "M-FH-2-verifier-grows-a-code" check 1 \
   '  _self_test || exit 2' \
   '  _self_test || exit 3' \
@@ -371,7 +389,7 @@ mutant "M-FH-4-siteB-classify-dropped" apply 1 \
 # that unit, prints ALREADY SATISFIED and exits 0 over a config file that no longer
 # contains it.
 mutant "M-FH-6-advice-unconditional" apply 1 \
-  '  if [ "${PATCHED:-0}" = "0" ]; then' \
+  '  if [ "$PATCHED" = "0" ]; then' \
   '  if true; then' \
   test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh \
   'DO NOT simply re-run'

--- a/scripts/tests/mutants-nebula-relay.sh
+++ b/scripts/tests/mutants-nebula-relay.sh
@@ -329,6 +329,17 @@ mutant "M-FH-1-verifier-execed-via-shebang" apply 1 \
 # The verifier's exit codes and apply's `verifier_answered` are ONE fact in two files.
 # A new code on either side, unmatched on the other, silently reclassifies a verdict as
 # an exec fault — in the reassuring direction ("nothing was determined").
+# 🔴 M-FH-5 IS THE ONE THE STRUCTURAL GUARD CANNOT SEE. An audit demonstrated that
+# swapping ONE call site to "${CHECK}" reintroduces the /usr/bin/env dependency while
+# leaving the dev-host suite fully green — a source regex pins a SPELLING, and there are
+# many. The behavioural guard breaks the verifier's shebang itself, so it does not care
+# how the call is written.
+mutant "M-FH-5-braces-evade-the-regex" apply 1 \
+  'run_check "$RELAY" >"$PRE" 2>&1' \
+  '"${CHECK}" "$RELAY" >"$PRE" 2>&1' \
+  test_the_verifier_runs_with_its_shebang_BROKEN \
+  'something still EXECS it'
+
 mutant "M-FH-2-verifier-grows-a-code" check 1 \
   '  _self_test || exit 2' \
   '  _self_test || exit 3' \
@@ -352,6 +363,18 @@ mutant "M-FH-4-siteB-classify-dropped" apply 1 \
   '  :' \
   test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh \
   'did NOT RUN'
+
+# 🔴 M-FH-6: the advice at the END of the abort is CONDITIONAL, and the condition is
+# the whole point. Unconditional "this script is idempotent, re-run it" contradicts the
+# trap paragraph printed two lines below it AND loses the change silently: after the
+# rollback the RUNNING unit still advertises the relay, so a re-run's preflight asks
+# that unit, prints ALREADY SATISFIED and exits 0 over a config file that no longer
+# contains it.
+mutant "M-FH-6-advice-unconditional" apply 1 \
+  '  if [ "${PATCHED:-0}" = "0" ]; then' \
+  '  if true; then' \
+  test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh \
+  'DO NOT simply re-run'
 
 # --- F-F: the parser's block terminator is load-bearing ----------------------------
 mutant "M-FF-1-terminator-removed" check 1 \

--- a/scripts/tests/mutants-nebula-relay.sh
+++ b/scripts/tests/mutants-nebula-relay.sh
@@ -324,7 +324,7 @@ mutant "M-FH-1-verifier-execed-via-shebang" apply 1 \
   'run_check() { "$BASH" "$CHECK" "$@"; }' \
   'run_check() { "$CHECK" "$@"; }' \
   test_the_verifier_is_never_execed_via_its_own_shebang \
-  'must be invoked through'
+  'no longer invokes the verifier through'
 
 # The verifier's exit codes and apply's `verifier_answered` are ONE fact in two files.
 # A new code on either side, unmatched on the other, silently reclassifies a verdict as

--- a/scripts/tests/test_nebula_relay_apply.py
+++ b/scripts/tests/test_nebula_relay_apply.py
@@ -987,18 +987,46 @@ def test_the_verifier_is_never_execed_via_its_own_shebang():
     -independent, so a revert fails wherever the suite runs, including in the tier
     most sessions actually run.
 
-    Pinned as a PAIR on purpose: presence alone passes if someone adds a second, direct
-    call site beside the helper, and absence alone passes if the helper is deleted
-    outright."""
+    ⚠ THIS IS THE CHEAP HALF AND IT IS SPELLING-BOUND. It asserts the helper exists.
+    It does NOT prove the absence of a second, direct call site: an audit measured that
+    `"${CHECK}" "$RELAY"`, `$CHECK "$RELAY"`, a line-split call and several other
+    spellings all evade a source regex while reintroducing the exact dependency. The
+    real guard is `test_the_verifier_runs_with_its_shebang_BROKEN`, which is
+    behavioural and cannot be reworded around. This one is kept because it names the
+    intended shape and fails fast with a readable message."""
     src = APPLY.read_text()
     assert re.search(r'^run_check\(\)\s*\{\s*"\$BASH"\s+"\$CHECK"', src, re.M), (
         "the run_check helper is gone or no longer invokes the verifier through "
         '"$BASH" -- it must not be executed directly, or /usr/bin/env becomes a '
         "runtime dependency and the sandbox tier goes red")
-    stray = re.findall(r'^[^#\n]*(?<!run_)"\$CHECK"\s+"\$RELAY"', src, re.M)
-    assert not stray, (
-        f"a direct execution of the verifier is back at {len(stray)} site(s): {stray}. "
-        "It must go through run_check().")
+
+
+def test_the_verifier_runs_with_its_shebang_BROKEN(rig):
+    """F-H, the LOAD-BEARING half — behavioural, and spelling-independent.
+
+    Runs the whole happy path against a verifier whose shebang points at an
+    interpreter that does not exist AND whose exec bit is cleared. If apply invokes it
+    through `$BASH` the file is merely READ and none of that matters. If ANY call site
+    execs it directly — however it is spelled — the kernel refuses and the run dies.
+
+    🔴 This is what makes the guard un-walkable. Its structural sibling above pins one
+    spelling; an audit demonstrated that swapping a single call site to `"${CHECK}"`
+    reintroduces the /usr/bin/env dependency while leaving the dev-host suite at 38
+    passed. This test fails on that mutant, on every other spelling, and on both tiers
+    — because it manufactures the missing-interpreter condition itself instead of
+    waiting for a sandbox that happens to lack /usr/bin/env."""
+    d = rig.root / "brokenshebang"
+    shutil.copytree(_SYSDIR, d)
+    chk = d / CHECK.name
+    original = chk.read_text()
+    assert original.startswith("#!"), "the verifier lost its shebang; this test assumes one"
+    chk.write_text("#!/nonexistent/interpreter\n" + original.split("\n", 1)[1])
+    chk.chmod(0o644)          # not executable either — belt and braces
+    r = rig.run(apply=d / APPLY.name)
+    assert r.returncode == 0, (
+        "the run died with the verifier's shebang broken, so something still EXECS it "
+        "rather than reading it through an explicit interpreter:\n" + r.stdout + r.stderr)
+    assert "=== DONE ===" in r.stdout, r.stdout
 
 
 def test_the_verifiers_exit_codes_are_a_closed_set():
@@ -1021,7 +1049,7 @@ def test_the_verifiers_exit_codes_are_a_closed_set():
     assert set(m.group(1).split("|")) == {"0", "1", "2"}, m.group(1)
 
 
-@pytest.mark.parametrize("rc,label", [(126, "not executable / interpreter missing"),
+@pytest.mark.parametrize("rc,label", [(126, "a directory, or unreadable"),
                                       (127, "vanished"),
                                       (137, "SIGKILL/OOM")])
 def test_a_verifier_that_did_not_RUN_is_not_reported_as_a_config_fault(rig, rc, label):
@@ -1036,6 +1064,10 @@ def test_a_verifier_that_did_not_RUN_is_not_reported_as_a_config_fault(rig, rc, 
     assert f"rc={rc}" in combined, combined
     assert "could not read the current config" not in combined, (
         f"{label}: an exec/signal fault is still being blamed on $CFG:\n{combined}")
+    # The advice is CONDITIONAL on whether anything was written. Nothing has been at the
+    # preflight, so "re-run" is correct here — and must not be the other branch's text.
+    assert "Nothing has been written yet" in combined, combined
+    assert "DO NOT simply re-run" not in combined, combined
 
 
 @pytest.mark.parametrize("rc", [126, 137])
@@ -1059,6 +1091,14 @@ def test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh(rig, r
     assert "does not see" not in combined, (
         f"an exec/signal fault at the post-rebuild verify is still reported as the "
         f"relay not being advertised:\n{combined}")
+    # 🔴 THE OTHER BRANCH. $CFG has been patched and activated by now, so telling the
+    # operator to re-run is actively harmful: the trap rolls the file back while the
+    # RUNNING unit still advertises the relay, and a re-run's preflight then asks that
+    # unit, prints "ALREADY SATISFIED" and exits 0 over a config that no longer carries
+    # the change. An unconditional "idempotent, re-run it" said exactly that, and also
+    # contradicted the trap paragraph printed two lines below it.
+    assert "DO NOT simply re-run" in combined, combined
+    assert "Nothing has been written yet" not in combined, combined
 
 
 def test_a_REAL_verifier_refusal_still_blames_the_config(rig):

--- a/scripts/tests/test_nebula_relay_apply.py
+++ b/scripts/tests/test_nebula_relay_apply.py
@@ -933,8 +933,21 @@ def test_reason_token_ledger_is_pinned_and_apply_branches_on_a_real_one():
 
 
 def test_apply_declares_every_tool_it_execs():
-    """The preflight's job is to abort BEFORE the first write. A tool missing from its
-    list fails half-way through instead."""
+    """The preflight's job is to abort BEFORE the first write.
+
+    ⚠ READ WHAT THIS ACTUALLY CHECKS. It asserts a hard-coded list is a SUBSET of what
+    the script declares — it inspects one side of the relationship its name implies. It
+    therefore CANNOT catch a tool the script execs but does not declare, which is the
+    failure the preflight exists to prevent.
+
+    MEASURED 2026-09-08: `head`, `id` and `rm` are exec'd and undeclared right now, and
+    this test is green. (`$BASH` is a fourth omission but a CORRECT one — the
+    interpreter is by definition already running, so it needs no `command -v`.)
+
+    Closing it means deriving the exec'd set from the source, which is a real piece of
+    work and not this test's current claim. Until then the docstring says what the body
+    does, rather than what the name suggests — a guard that reads as coverage while
+    providing none is worse than no guard, because it stops anyone looking."""
     src = APPLY.read_text()
     m = re.search(r"^for t in (.*?); do$", src, re.M | re.S)
     assert m, "the preflight tool loop moved"

--- a/scripts/tests/test_nebula_relay_apply.py
+++ b/scripts/tests/test_nebula_relay_apply.py
@@ -29,11 +29,16 @@ WHAT EACH TEST IS FOR — the audit findings the script was fixed for:
   F-D  a missing backup fails LOUDLY instead of silently skipping the rollback
   F-E  a symlinked $CFG is refused instead of being replaced by a regular file
   F-G  the verifier's FAIL text (with its egress-cost warning) reaches the operator
+  F-H  the verifier is invoked through an explicit interpreter, and an rc that is
+       NOT one of its own {0,1,2} is reported as "it did not run" rather than as a
+       fact about the config -- structural + behavioural, because the structural
+       half is the only one visible on the dev-host tier
 """
 from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -412,7 +417,12 @@ if open(os.path.join(STATE, "break_config")).read().strip() == "1":
 
     # ---- running it
     def run(self, net: str = "mesh", cfg: Path | None = None,
-            extra_env: dict | None = None, timeout: int = 120):
+            extra_env: dict | None = None, timeout: int = 120,
+            apply: Path | None = None):
+        """`apply` runs a COPY of the script from another directory. The script derives
+        CHECK from its own location (`HERE`), so a copy sited next to a stub verifier
+        exercises the real rc-handling against a chosen exit code -- which is the only
+        way to reach codes the real verifier cannot produce."""
         env = dict(os.environ)
         env["PATH"] = f"{self.bin}:{env.get('PATH', '')}"
         env["TMPDIR"] = str(self.tmpdir)
@@ -423,9 +433,49 @@ if open(os.path.join(STATE, "break_config")).read().strip() == "1":
         if extra_env:
             env.update(extra_env)
         return subprocess.run(
-            ["bash", str(APPLY)], env=env, capture_output=True, text=True,
+            ["bash", str(apply or APPLY)], env=env, capture_output=True, text=True,
             timeout=timeout, cwd=str(self.root),
         )
+
+    def apply_beside_stub_verifier(self, rc: int, out: str = "stub verifier output"):
+        """A copy of the real apply script in a fresh dir, next to a verifier stub that
+        exits `rc`. Returns the path to the copy.
+
+        🔴 The stub goes through `write_exec` like every other shim in this file, NOT a
+        hand-written shebang. A `#!/usr/bin/env bash` stub execs fine on the dev host
+        and ENOENTs in the sandbox — which would make this test fabricate rc 126 from
+        its own stub rather than from the code under test, and pass for the wrong
+        reason on one tier while failing on the other. That is the very fault F-H
+        exists to pin, so writing it here would be circular."""
+        d = self.root / f"sysstub{rc}"
+        d.mkdir(exist_ok=True)
+        shutil.copy2(APPLY, d / APPLY.name)
+        write_exec(d / CHECK.name, f"printf '%s\\n' {shlex.quote(out)}\nexit {rc}\n")
+        return d / APPLY.name
+
+    def apply_beside_sequenced_verifier(self, first_rc: int, then_rc: int):
+        """Like the above, but the stub answers `first_rc` on its FIRST call and
+        `then_rc` on every later one.
+
+        This is the only way to reach the POST-REBUILD verify site. A stub that fails
+        at the preflight aborts there and never gets past it — so a single-code stub
+        cannot exercise the second call site at all, and the two sites classify their
+        rc independently. The post-rebuild one is the consequential half: it runs after
+        `nixos-rebuild test` has activated, so what it dies with is what the EXIT trap
+        rolls back and what the operator is told the rollback was for."""
+        d = self.root / f"sysseq{first_rc}_{then_rc}"
+        d.mkdir(exist_ok=True)
+        shutil.copy2(APPLY, d / APPLY.name)
+        counter = d / "calls"
+        write_exec(d / CHECK.name, (
+            f'n=$(cat {counter} 2>/dev/null || echo 0)\n'
+            f'n=$((n+1)); echo "$n" > {counter}\n'
+            f'if [ "$n" = "1" ]; then\n'
+            f'  echo "relay not advertised (stub call 1)"; exit {first_rc}\n'
+            f'fi\n'
+            f'echo "stub call $n"; exit {then_rc}\n'
+        ))
+        return d / APPLY.name
 
 
 @pytest.fixture()
@@ -909,6 +959,104 @@ def test_no_predictable_tmp_literal_survives_in_the_source():
     src = APPLY.read_text()
     assert not re.search(r">\s*/tmp/", src), src
     assert "mktemp -d" in src
+
+
+def test_the_verifier_is_never_execed_via_its_own_shebang():
+    """F-H, structural half. The verifier MUST be invoked through an explicit
+    interpreter, never by executing it and letting its `#!/usr/bin/env bash` shebang
+    dispatch -- that makes /usr/bin/env a runtime dependency of this script, and the
+    nix build sandbox has no /usr at all.
+
+    🔴 THIS GUARD EXISTS BECAUSE THE BEHAVIOURAL EVIDENCE IS INVISIBLE ON ONE TIER.
+    The dev host HAS /usr/bin/env, so with the fix reverted every behavioural test in
+    this file still passes there -- measured: 30 passed. Only the sandbox tier
+    (`nix build .#checks.x86_64-linux.pytests`) goes red. A source assertion is tier
+    -independent, so a revert fails wherever the suite runs, including in the tier
+    most sessions actually run.
+
+    Pinned as a PAIR on purpose: presence alone passes if someone adds a second, direct
+    call site beside the helper, and absence alone passes if the helper is deleted
+    outright."""
+    src = APPLY.read_text()
+    assert re.search(r'^run_check\(\)\s*\{\s*"\$BASH"\s+"\$CHECK"', src, re.M), (
+        "the run_check helper is gone or no longer invokes the verifier through "
+        '"$BASH" -- it must not be executed directly, or /usr/bin/env becomes a '
+        "runtime dependency and the sandbox tier goes red")
+    stray = re.findall(r'^[^#\n]*(?<!run_)"\$CHECK"\s+"\$RELAY"', src, re.M)
+    assert not stray, (
+        f"a direct execution of the verifier is back at {len(stray)} site(s): {stray}. "
+        "It must go through run_check().")
+
+
+def test_the_verifiers_exit_codes_are_a_closed_set():
+    """F-H's load-bearing precondition. `verifier_answered` in apply-nebula-relay.sh
+    treats {0,1,2} as verdicts and EVERYTHING else as "it did not run". If the verifier
+    ever grows an `exit 3`, that new verdict would be misreported as an exec fault --
+    silently, and in the direction that reads as reassuring ("nothing was determined")
+    when something WAS.
+
+    So the two must move together. This fails the moment they diverge."""
+    codes = set(re.findall(r'^\s*(?:\|\|\s*)?exit\s+([0-9]+)', CHECK.read_text(), re.M))
+    codes |= set(re.findall(r'\|\|\s*exit\s+([0-9]+)', CHECK.read_text()))
+    assert codes <= {"0", "1", "2"}, (
+        f"check-nebula-relays.sh can now exit {sorted(codes)}, but apply-nebula-relay.sh's "
+        "`verifier_answered` still treats only 0/1/2 as answers -- a new code would be "
+        "reported as 'the verifier did NOT RUN'. Update both.")
+    m = re.search(r'verifier_answered\(\)\s*\{\s*case\s+"\$1"\s+in\s+([0-9|]+)\)',
+                  APPLY.read_text())
+    assert m, "verifier_answered() moved or was reworded"
+    assert set(m.group(1).split("|")) == {"0", "1", "2"}, m.group(1)
+
+
+@pytest.mark.parametrize("rc,label", [(126, "not executable / interpreter missing"),
+                                      (127, "vanished"),
+                                      (137, "SIGKILL/OOM")])
+def test_a_verifier_that_did_not_RUN_is_not_reported_as_a_config_fault(rig, rc, label):
+    """F-H, behavioural half. rc outside {0,1,2} is not a verdict -- the verifier never
+    reached one. Reporting it as "could not read the current config" asserts something
+    about $CFG that is false, and is precisely how the /usr/bin/env fault (rc 126) read
+    as a config problem instead of an exec one."""
+    r = rig.run(apply=rig.apply_beside_stub_verifier(rc))
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, combined
+    assert "did NOT RUN" in combined, f"{label}: {combined}"
+    assert f"rc={rc}" in combined, combined
+    assert "could not read the current config" not in combined, (
+        f"{label}: an exec/signal fault is still being blamed on $CFG:\n{combined}")
+
+
+@pytest.mark.parametrize("rc", [126, 137])
+def test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh(rig, rc):
+    """F-H, the consequential half — and the site the PREFLIGHT tests cannot reach.
+
+    The preflight answers 1 (not advertised), so the script patches, runs
+    `nixos-rebuild test`, and only THEN gets a non-verifier rc. That `die` is what the
+    EXIT trap rolls back, so blaming it on the mesh undoes a change that worked and
+    sends the operator to debug a mesh that is very possibly fine.
+
+    🔴 This test exists because a mutation sweep found the gap: widening
+    `verifier_answered` to accept 126 was caught only by the STRUCTURAL closed-set
+    test, because every behavioural case aborted at the preflight and never executed
+    `verifier_answered` at all. A guard that is never reached is not a guard."""
+    r = rig.run(apply=rig.apply_beside_sequenced_verifier(first_rc=1, then_rc=rc))
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, combined
+    assert "did NOT RUN" in combined, combined
+    assert f"rc={rc}" in combined, combined
+    assert "does not see" not in combined, (
+        f"an exec/signal fault at the post-rebuild verify is still reported as the "
+        f"relay not being advertised:\n{combined}")
+
+
+def test_a_REAL_verifier_refusal_still_blames_the_config(rig):
+    """The other side of the split, so the fix cannot be "call everything an exec
+    fault". rc 2 IS one of the verifier's own verdicts -- it really could not read the
+    config -- and must keep saying so."""
+    r = rig.run(apply=rig.apply_beside_stub_verifier(2))
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, combined
+    assert "could not read the current config" in combined, combined
+    assert "did NOT RUN" not in combined, combined
 
 
 def test_scripts_are_executable_and_pass_bash_n():

--- a/scripts/tests/test_nebula_relay_apply.py
+++ b/scripts/tests/test_nebula_relay_apply.py
@@ -980,12 +980,23 @@ def test_the_verifier_is_never_execed_via_its_own_shebang():
     dispatch -- that makes /usr/bin/env a runtime dependency of this script, and the
     nix build sandbox has no /usr at all.
 
-    🔴 THIS GUARD EXISTS BECAUSE THE BEHAVIOURAL EVIDENCE IS INVISIBLE ON ONE TIER.
-    The dev host HAS /usr/bin/env, so with the fix reverted every behavioural test in
-    this file still passes there -- measured: 30 passed. Only the sandbox tier
-    (`nix build .#checks.x86_64-linux.pytests`) goes red. A source assertion is tier
-    -independent, so a revert fails wherever the suite runs, including in the tier
-    most sessions actually run.
+    WHY IT EXISTED, AND WHY THAT REASON NO LONGER HOLDS. It was written when the only
+    other coverage was behavioural-via-the-real-environment: the dev host HAS
+    /usr/bin/env, so reverting the fix left the whole file green there and only the
+    sandbox tier went red. A source assertion was then the one thing failing on both.
+
+    ⚠ `test_the_verifier_runs_with_its_shebang_BROKEN` below took that job over, and
+    took it over BETTER -- it manufactures the missing interpreter itself, so it is
+    tier-independent AND spelling-independent. RE-MEASURED at this tree with the helper
+    reverted to `run_check() { "$CHECK" "$@"; }`: **2 failed, 37 passed** on the dev
+    host, and both failures are these two tests. So the sentence this docstring used to
+    carry -- "only the sandbox tier goes red" -- is now FALSE, and it was the whole
+    stated justification for keeping this half.
+
+    What this test still earns: it fails FAST (no subprocess, no fixture) and names the
+    intended shape in its message, so a revert gets a readable diagnosis instead of "the
+    happy path exited 1". That is a real but MODEST reason -- recorded as such rather
+    than left reading like the load-bearing guard, which it is not.
 
     ⚠ THIS IS THE CHEAP HALF AND IT IS SPELLING-BOUND. It asserts the helper exists.
     It does NOT prove the absence of a second, direct call site: an audit measured that
@@ -1060,14 +1071,21 @@ def test_a_verifier_that_did_not_RUN_is_not_reported_as_a_config_fault(rig, rc, 
     r = rig.run(apply=rig.apply_beside_stub_verifier(rc))
     combined = r.stdout + r.stderr
     assert r.returncode != 0, combined
-    assert "did NOT RUN" in combined, f"{label}: {combined}"
-    assert f"rc={rc}" in combined, combined
+    assert "did NOT RUN" in combined, (
+        f"{label}: an rc outside the verifier's own {{0,1,2}} must be reported as "
+        f"'did NOT RUN', not as a verdict:\n{combined}")
+    assert f"rc={rc}" in combined, (
+        f"the abort must name the actual rc ({rc}) it could not interpret:\n{combined}")
     assert "could not read the current config" not in combined, (
         f"{label}: an exec/signal fault is still being blamed on $CFG:\n{combined}")
     # The advice is CONDITIONAL on whether anything was written. Nothing has been at the
     # preflight, so "re-run" is correct here — and must not be the other branch's text.
-    assert "Nothing has been written yet" in combined, combined
-    assert "DO NOT simply re-run" not in combined, combined
+    assert "Nothing has been written yet" in combined, (
+        "nothing has been written at the preflight, so the advice MUST say 'Nothing has "
+        "been written yet':\n" + combined)
+    assert "DO NOT simply re-run" not in combined, (
+        "the post-write branch's advice ('DO NOT simply re-run') reached the preflight, "
+        "where nothing has been written:\n" + combined)
 
 
 @pytest.mark.parametrize("rc", [126, 137])
@@ -1086,8 +1104,11 @@ def test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh(rig, r
     r = rig.run(apply=rig.apply_beside_sequenced_verifier(first_rc=1, then_rc=rc))
     combined = r.stdout + r.stderr
     assert r.returncode != 0, combined
-    assert "did NOT RUN" in combined, combined
-    assert f"rc={rc}" in combined, combined
+    assert "did NOT RUN" in combined, (
+        "an rc outside the verifier's own {0,1,2} must be reported as 'did NOT RUN', "
+        "not as a verdict about the relay:\n" + combined)
+    assert f"rc={rc}" in combined, (
+        f"the abort must name the actual rc ({rc}) it could not interpret:\n{combined}")
     assert "does not see" not in combined, (
         f"an exec/signal fault at the post-rebuild verify is still reported as the "
         f"relay not being advertised:\n{combined}")
@@ -1097,8 +1118,32 @@ def test_a_POST_REBUILD_verifier_that_did_not_RUN_does_not_blame_the_mesh(rig, r
     # unit, prints "ALREADY SATISFIED" and exits 0 over a config that no longer carries
     # the change. An unconditional "idempotent, re-run it" said exactly that, and also
     # contradicted the trap paragraph printed two lines below it.
-    assert "DO NOT simply re-run" in combined, combined
-    assert "Nothing has been written yet" not in combined, combined
+    assert "DO NOT simply re-run" in combined, (
+        "$CFG has been patched by now, so the advice MUST say 'DO NOT simply re-run' "
+        "rather than inviting one:\n" + combined)
+    assert "Nothing has been written yet" not in combined, (
+        "the preflight branch's advice ('Nothing has been written yet') reached a site "
+        "where $CFG HAS been written:\n" + combined)
+
+
+def test_an_INHERITED_PATCHED_cannot_change_the_preflight_advice(rig):
+    """The advice branches on $PATCHED, so $PATCHED must come from THIS run.
+
+    The flags used to be declared beside the trap, far below the preflight, so the only
+    way to read one early was `${PATCHED:-0}` -- which falls back to an INHERITED
+    environment variable. This script's own header documents running it as
+    `sudo env "PATH=$PATH" bash ...`, which preserves the caller's environment, so an
+    exported PATCHED=1 made the preflight claim work had been done when none had.
+
+    Fail-safe in direction (it over-warns rather than under-warns), but it is a message
+    about what the machine's state IS, and getting that from the caller's environment is
+    wrong regardless of which way it errs."""
+    r = rig.run(apply=rig.apply_beside_stub_verifier(126), extra_env={"PATCHED": "1"})
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, combined
+    assert "Nothing has been written yet" in combined, (
+        "an inherited PATCHED=1 reached the preflight's advice:\n" + combined)
+    assert "DO NOT simply re-run" not in combined, combined
 
 
 def test_a_REAL_verifier_refusal_still_blames_the_config(rig):
@@ -1108,8 +1153,11 @@ def test_a_REAL_verifier_refusal_still_blames_the_config(rig):
     r = rig.run(apply=rig.apply_beside_stub_verifier(2))
     combined = r.stdout + r.stderr
     assert r.returncode != 0, combined
-    assert "could not read the current config" in combined, combined
-    assert "did NOT RUN" not in combined, combined
+    assert "could not read the current config" in combined, (
+        "rc 2 is a real verifier refusal and must keep saying so:\n" + combined)
+    assert "did NOT RUN" not in combined, (
+        "rc 2 IS one of the verifier's own verdicts and must NOT be reported as "
+        "'did NOT RUN':\n" + combined)
 
 
 def test_scripts_are_executable_and_pass_bash_n():

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -155,6 +155,22 @@ ALLOWLIST = [
      "alternative and the stub bodies are POSIX sh. It arrived carrying the "
      "/usr/bin/env defect and this guard caught it on its first gate run — "
      "which is the guard working, not a reason to widen it"),
+    # 🔴 A THIRD SHAPE, and the only one where an UNRESOLVABLE interpreter is the
+    # point. test_the_verifier_runs_with_its_shebang_BROKEN writes a deliberately
+    # nonexistent interpreter onto a COPY of check-nebula-relays.sh and then asserts
+    # the run still SUCCEEDS — proving apply-nebula-relay.sh reads the verifier
+    # through "$BASH" rather than exec'ing it. This is the guard's own hazard
+    # inverted into a control: if the interpreter ever started mattering, that test
+    # fails loudly, which is the opposite of the silent breakage this scan exists to
+    # prevent. Nothing execs the stub, so an unresolvable path cannot hide anything.
+    # It names the path fragment rather than a shebang so this file's
+    # test_this_guards_source_does_not_match_itself stays green.
+    ("scripts/tests/test_nebula_relay_apply.py", "nonexistent/interpreter",
+     "shape (c) — writes an INTENTIONALLY unresolvable interpreter as a negative "
+     "control and asserts the run succeeds anyway; the stub is never exec'd"),
+    ("scripts/tests/test_nebula_relay_apply.py", "original.startswith",
+     "shape (b) — ASSERTS the copied verifier still has a shebang before the line "
+     "above replaces it; writes nothing"),
 ]
 
 


### PR DESCRIPTION
Closes the two 🟡 findings from #1407's round-1 audit.

## Finding 1 — the fix shipped without a regression guard, and its only coverage was on the tier that is blind to a revert

**MEASURED:** revert #1407's `run_check` to a direct `"$CHECK"` exec and the dev-host tier still reports **30 passed** — the dev host *has* `/usr/bin/env`. Only `nix build .#checks.x86_64-linux.pytests` goes red. So `scripts/gate.sh --tier both`, the command most sessions actually run, went **fully green on the exact defect #1407 existed to remove**. An agent "simplifying" `run_check` back to what #1272 wrote would have seen green and shipped it.

Two source-level guards, which fail wherever the suite runs:

- **`test_the_verifier_is_never_execed_via_its_own_shebang`** — pinned as a **pair**: the helper must exist *and* no direct call site may reappear. Presence alone passes if someone adds a second, direct site beside the helper; absence alone passes if the helper is deleted outright.
- **`test_the_verifiers_exit_codes_are_a_closed_set`** — pins finding 2's load-bearing precondition on **both** sides, so the verifier growing an `exit 3` fails loudly instead of being silently reclassified as an exec fault.

## Finding 2 — the misdiagnosing abort was unchanged

`check-nebula-relays.sh` only ever exits 0, 1 or 2. Every other code fell into the same `*)` arm as a genuine rc 2:

```
ABORT: the verifier could not read the current config (rc=126); fix that first
```

— asserting a fact about `$CFG` that is false in every one of those cases, and **precisely how the `/usr/bin/env` fault presented**, which is why it read as a config problem rather than an exec one.

Split into `2)` (a real refusal — message unchanged) and `*)` (it did not run), via one `verifier_answered` classifier used at both sites rather than open-coded twice.

🔴 **The consequential site is the post-rebuild verify, not the preflight.** There a non-verifier rc reaches `die` *after* `nixos-rebuild test` has activated, so the EXIT trap rolls back a change that **worked** and prints the PERSISTED paragraphs for what was really a signal or exec fault.

## Verification

Both tiers, merged tree (branch is off `origin/main` @ `0477e52a`, fast-forward):

| tier | result |
|---|---|
| `nix build …#checks…pytests` | **PASS** — `collected=21135 passed=21133 failed=0` |
| `nix build …#checks…nodetests` | **PASS** — `tests=1449 pass=1449 fail=0` |

`collected` rose 21127 → 21135, **exactly +8** = the test cases added. Nothing silently skipped.

Mutation battery (`scripts/tests/mutants-nebula-relay.sh`), clean `/tmp` — **pass=26 fail=0**, all three controls green, four new mutants each killed **by the named test with its own message**:

| mutant | killed by |
|---|---|
| `M-FH-1` revert `$BASH` → direct exec | the shebang guard |
| `M-FH-2` verifier grows `exit 3` | the closed-set test |
| `M-FH-3` widen `verifier_answered` to accept 126 | post-rebuild behavioural |
| `M-FH-4` drop site-B classification | post-rebuild behavioural |

## Two things the work itself caught, recorded because they generalise

🔴 **The repo's battery caught a defect my own ad-hoc sweep scored as PASSING.** M-FH-1 died to the right *test* but not to the right *assertion* — I had reworded the message after writing the mutant entry. My sweep only checked which test failed; the battery also checks the test's own assertion fired. That is the exact "green for the wrong reason" hole its header documents, hit while writing a guard against a different instance of the same class. The phrase is now asserted present in the test source before being written into the battery.

🔴 **The post-rebuild test exists because the sweep found a hole in my tests.** Widening `verifier_answered` was first caught by the *structural* test alone: every behavioural case aborted at the preflight, so `verifier_answered` — used only at the post-rebuild site — **never executed**. A guard that is never reached is not a guard. `apply_beside_sequenced_verifier` (answer 1, then fail) is the only way to reach that site.

⚠ The stub verifier goes through `write_exec`, **not** a hand-written shebang. A `#!/usr/bin/env bash` stub execs on the dev host and ENOENTs in the sandbox — the test would have fabricated rc 126 from its own stub rather than from the code under test: circular, and green for the wrong reason on one tier.

## Also corrected — audit finding 5, docstring only

`test_apply_declares_every_tool_it_execs` claimed the relationship its name implies while its body inspects one side (a hard-coded list ⊆ declared). **MEASURED:** `head`, `id` and `rm` are exec'd and undeclared right now, and it is green. (`$BASH` is a fourth omission but a *correct* one — the interpreter is already running.)

**Body unchanged.** Closing it means deriving the exec'd set from the source, which is real work and out of scope here. The docstring now says what the body does rather than what the name suggests, because a guard that reads as coverage while providing none is worse than none — it stops anyone looking. **Recorded as open, not fixed.**

## Not a finding, recorded for the next reader

An earlier full battery run reported `CONTROL-KILL` as WRONG-KILLER. **Not a defect in this branch** — it passes in isolation on `origin/main` *and* here. A prior run was killed at a 10-minute tool cap before its cleanup trap fired, leaving 29 `/tmp/nebula-relay-pre.*` files, the residue class the battery's own header documents as making later runs read stale artifacts as live defects. Clearing them made the full run green.
