### PR TITLE
fix(mention-open): the picker filtered fuzzily but never RANKED — turn on rofi's fzf scoring

### DIFF
--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -693,7 +693,35 @@ def pick(candidates: list[dict], mesg: str = "") -> str:
                                .replace(">", "&gt;"))] if mesg else []
     try:
         r = subprocess.run(
+            # 🔴 `-sort -sorting-method fzf` IS NOT DECORATION — WITHOUT IT
+            # `-matching fuzzy` FILTERS BUT DOES NOT RANK, and rofi falls back
+            # to INPUT ORDER, which `repo_universe()` returns alphabetically.
+            #
+            # REPORTED FROM THE REAL PICKER 2026-09-08: typing `devrc` put
+            # `civitai/developer-docs` and `civitai/dev-runner-config` ABOVE the
+            # actual `devrc` repo. Not a matching bug — all three genuinely
+            # contain d-e-v…r…c as a subsequence — a RANKING one. Nothing was
+            # scoring them, so `c…` simply sorted before `i…`.
+            #
+            # MEASURED on a 7-row corpus in the exact shape `picker_rows()`
+            # builds, query `devrc`: input order puts the right repo **6th**;
+            # fzf scoring puts it **1st**, with the two decoys 2nd and 3rd.
+            #
+            # 🔴 NO NEW DEPENDENCY, AND THAT WAS THE RESEARCH RESULT. fzf's
+            # algorithm (Smith-Waterman-derived, with bonuses for consecutive
+            # runs and word/camel boundaries) is the de-facto standard the whole
+            # fzf/fzy/skim family implements — and rofi already ships it as
+            # `-sorting-method fzf`. Swapping in another picker would have
+            # bought the same algorithm plus a dependency and a theme that
+            # drifts from the launcher's (see NOT_FROM_THE_WRAPPER_PATH). The
+            # defect was never the library; it was a flag nobody passed.
+            #
+            # ⚠ PRE-SORTING IN PYTHON CANNOT FIX THIS. rofi re-filters on every
+            # keystroke, so an order we hand it only survives until the operator
+            # types one character — the ranking must live where the filtering
+            # does. That is why this is a rofi flag and not a `sorted()` call.
             ["rofi", "-dmenu", "-i", "-matching", "fuzzy",
+             "-sort", "-sorting-method", "fzf",
              "-p", "mention", "-theme", ROFI_THEME,
              "-format", "s", "-no-custom", *mesg_argv],
             input="\n".join(rows), capture_output=True, text=True, timeout=120)

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -1199,6 +1199,73 @@ def test_the_picker_asks_rofi_for_FUZZY_matching(monkeypatch):
     assert "-no-custom" in seen["cmd"]
 
 
+def test_fuzzy_matching_is_never_asked_for_WITHOUT_ranking(monkeypatch):
+    """🔴 THE RELATIONSHIP, NOT THE SPELLING — and the bug was the gap between
+    them. `-matching fuzzy` tells rofi WHICH rows survive; it says nothing about
+    their ORDER. With no `-sort`, rofi shows survivors in INPUT order, and
+    `repo_universe()` returns them alphabetically.
+
+    REPORTED FROM THE REAL PICKER 2026-09-08: typing `devrc` ranked
+    `civitai/developer-docs` and `civitai/dev-runner-config` ABOVE the actual
+    `devrc` repo. Every one of them genuinely contains d-e-v…r…c as a
+    subsequence, so the MATCH was correct and the ORDER was not — `c…` sorts
+    before `i…`. MEASURED on a 7-row corpus in the exact shape `picker_rows()`
+    builds: input order put the wanted repo **6th**, fzf scoring puts it
+    **1st**.
+
+    This asserts the pair rather than two independent flags, because either one
+    alone is a defect: fuzzy without sort is the reported bug, and sort without
+    fuzzy silently narrows what can be found at all. A test that only checked
+    `"-sort" in cmd` would pass on an argv that had dropped `fuzzy`."""
+    seen = {}
+    monkeypatch.setattr(MO.subprocess, "run",
+                        lambda cmd, **kw: seen.update(cmd=cmd)
+                        or types.SimpleNamespace(returncode=1, stdout="", stderr=""))
+    MO.pick([{"platform": "github", "id": "7",
+              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}])
+    cmd = seen["cmd"]
+    fuzzy = "-matching" in cmd and cmd[cmd.index("-matching") + 1] == "fuzzy"
+    assert fuzzy, "the picker must still MATCH fuzzily"
+    assert "-sort" in cmd, (
+        "`-matching fuzzy` without `-sort` filters but does not RANK — rofi "
+        "falls back to input order, which is alphabetical, and a scattered "
+        "subsequence outranks an exact name")
+    assert "-sorting-method" in cmd, "a sort with no method is rofi's levenshtein default"
+    assert cmd[cmd.index("-sorting-method") + 1] == "fzf", (
+        "fzf's scoring is what rewards CONSECUTIVE runs and word boundaries; "
+        "rofi's `normal` method is plain levenshtein and does not")
+
+
+def test_the_rofi_argv_stays_a_LIST_LITERAL_so_the_ledger_can_read_it():
+    """🔴 The AST ledger of spawnable executables reads `pick`'s argv as a list
+    literal whose first element is the constant `"rofi"`. Building it from a
+    variable reports `<computed>` and reddens the no-network guard for a reason
+    that has nothing to do with what is spawned — the module already carries
+    that warning in a comment, and this is the assertion behind it.
+
+    Kept beside the flag tests because the tempting way to add a conditional
+    flag is exactly the refactor that breaks it."""
+    import ast
+    src = HANDLER.read_text()
+    tree = ast.parse(src)
+    found = False
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and node.args):
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name != "run":
+            continue
+        first = node.args[0]
+        if (isinstance(first, ast.List) and first.elts
+                and isinstance(first.elts[0], ast.Constant)
+                and first.elts[0].value == "rofi"):
+            found = True
+            literals = [e.value for e in first.elts if isinstance(e, ast.Constant)]
+            assert "-sort" in literals and "fzf" in literals, (
+                f"the rofi argv literal lost its ranking flags: {literals}")
+    assert found, "no `subprocess.run([\"rofi\", …])` list literal found in the handler"
+
+
 @pytest.mark.parametrize("state,write,expected", [
     ("absent", None, "has no repo mapping"),
     ("unreadable", "not json at all", "could not be read"),


### PR DESCRIPTION
Reported 2026-09-08: typing `devrc` put `civitai/developer-docs` and
`civitai/dev-runner-config` **above** the actual `devrc` repo.

## Not a matching bug — nothing was scoring at all

All three genuinely contain `d-e-v…r…c` as a subsequence, so fuzzy matching was right to
keep them. The defect: `pick()` passed `-matching fuzzy` and **no `-sort`**. Without
`-sort`, rofi shows survivors in **input order** — and `repo_universe()` returns them
alphabetically, so `c…` sorts before `i…`. The 392-row universe made a latent flaw
obvious rather than causing it.

## Measured end-to-end through real rofi

Headless under Xvfb, so no window was raised on the operator's screen. 7-row corpus in
the exact shape `picker_rows()` builds; typed `devrc`, pressed Enter:

| | selects |
|---|---|
| before (today) | `civitai/dev-runner-config` ← reproduces the report |
| after (`-sort -sorting-method fzf`) | `innovation-upstream/devrc` |

## Research result: no new library, and that IS the finding

fzf's algorithm — Smith-Waterman-derived, bonuses for consecutive runs and word/camel
boundaries — is what the fzf/fzy/skim family implements and is current best practice
here. **rofi already ships it** as `-sorting-method fzf`. Swapping pickers buys the same
algorithm plus a dependency and a theme that drifts from the launcher's (rofi is
deliberately the system copy — see `NOT_FROM_THE_WRAPPER_PATH`). The defect was never
the library; it was a flag nobody passed.

⚠ **Pre-sorting in Python cannot fix this**, so nobody should try: rofi re-filters on
every keystroke, so an order we hand it survives until the operator types one character.
The ranking must live where the filtering does.

## The risk this carried, measured rather than assumed

`-sort` applies to **every** picker, including the two-row bare `#N` one where the
clawgate task must stay **first**. Several tests pin that — but only as the order of
candidates *passed* to rofi. They all stub `pick`, so none can see what rofi *displays*,
and a reordering would have shipped invisibly. rofi's docs say sort applies to the
"filtered menu", implying an empty query preserves order — a documentation claim about a
user-visible invariant. Measured instead, same headless harness: unfiltered list + Enter
still returns the **clawgate** row.

## Tests pin the relationship, not the spelling

`-matching fuzzy` without `-sort` is the reported bug; `-sort` without `fuzzy` silently
narrows what can be found. Both asserted together — a test checking only `"-sort" in cmd`
would pass on an argv that had dropped `fuzzy`. Plus an AST guard that the rofi argv
stays a **list literal** carrying the ranking flags, because the tempting way to add a
conditional flag is exactly the refactor that turns `argv[0]` into `<computed>` and
reddens the no-network ledger for an unrelated reason.

**Matrix:** both new guards RED at `5b564844` with their own assertion messages
(`… does not RANK …`, `… lost its ranking flags: [...]`), green at HEAD.

## Gate

- **dev-host `gate.sh --tier both`: PASS** — 21,127 pytest + 1,449 node, 0 failed
- **sandbox nodetests: PASS** — 1,449
- ⚠ **sandbox pytests: red twice, on two DIFFERENT unrelated tests** — `dl-router`'s
  `test_six_writers_with_a_tiny_busy_timeout_still_land_every_row`, then
  `test_live_cotenants_does_not_count_this_process`. Both under box load **47–52** with
  ~49 competing pytest processes from other sessions. Neither is reachable by this diff
  (it touches only `scripts/mention-open.py` and its test), and **both pass in isolation
  on this branch AND on pristine `origin/main`** — the control run in both directions.
  Two runs failing on two *different* single tests is contention, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FENxxrZztNTsrKgChnGT1X
