### PR TITLE
fix(gates): restore the round-2 checker — #1375's squash landed the doc but a STALE copy of its instrument

### DIFF
--- a/scripts/check-gate-inventory.py
+++ b/scripts/check-gate-inventory.py
@@ -28,8 +28,44 @@ import sys
 
 VERDICT_RX = re.compile(r"\*\*(KEEP|DROP|TIER)\b")
 NO_EVIDENCE = "no evidence found"
+
+# 🔴 EVIDENCE MUST BE AN IDENTIFIER, NOT A WORD.
+#
+# The first version of this regex also accepted the bare literal `CONFIRMED` and a
+# bare `×\d+` count. Both are vocabulary, not evidence: an audit demonstrated that
+# replacing ALL 81 evidence cells with the single word `CONFIRMED` still produced
+# `problems: 0 / RESULT: PASS`, so the instrument could not distinguish this
+# document from one carrying no evidence at all. That is the exact failure this
+# script exists to prevent, committed inside the script itself.
+#
+# So the alternation now requires something a reader can LOOK UP:
+#   * a UUID-shaped session id                (8-4-4-4-12)
+#   * an `agent-<hex>` subagent session id    (>= 12 hex, so `agent-abc` fails)
+#   * a git sha of >= 7 hex in backticks
+#   * a PR/issue reference `#<digits>`
+# A count alone no longer satisfies it, and neither does any English word.
+EVIDENCE_RX = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|agent-[0-9a-f]{12,}"
+    r"|`[0-9a-f]{7,}`"
+    r"|#\d{2,}"
+)
 # A data row in one of the inventory tables: starts with | then an id like A1/B5/E13/F2/G1/D10.
 ROW_RX = re.compile(r"^\|\s*([ABCDEFG]\d{1,2})\s*\|")
+
+# The document's own declaration of how many rows it should contain.
+ROWS_MARKER_HINT = "<!-- inventory-rows: N -->"
+ROWS_MARKER_RX = re.compile(r"<!--\s*inventory-rows:\s*(\d+)\s*-->")
+
+# 🔴 And its declaration of the verdict tally.
+#
+# This exists because the hand-written tally was WRONG IN BOTH ROUNDS -- 51/30 in
+# round 1, 47/32 in round 2 -- while the row LISTS printed beside it were correct
+# each time. A total kept next to what it counts is the classic drifting claim, so
+# it is checked rather than proofread. Absent marker => cannot vouch => exit 2.
+TALLY_MARKER_HINT = "<!-- inventory-tally: KEEP=n TIER=n DROP=n -->"
+TALLY_MARKER_RX = re.compile(
+    r"<!--\s*inventory-tally:\s*KEEP=(\d+)\s+TIER=(\d+)\s+DROP=(\d+)\s*-->")
 
 
 def split_cells(line: str) -> list[str]:
@@ -85,13 +121,10 @@ def check_rows(text: str, scoped: bool = True) -> tuple[list[str], int]:
             ev = cells[vi - 1]
             if not ev or ev in {"-", "--", "—"}:
                 problems.append(f"{rid} (line {lineno}): evidence cell is blank")
-            elif NO_EVIDENCE not in ev and not re.search(
-                r"[0-9a-f]{8}-[0-9a-f]{4}|agent-[0-9a-f]{8}|`[0-9a-f]{8}`|#\d{2,}|CONFIRMED|×\d+",
-                ev,
-            ):
+            elif NO_EVIDENCE not in ev and not EVIDENCE_RX.search(ev):
                 problems.append(
-                    f"{rid} (line {lineno}): evidence names no session id, sha, PR number "
-                    f"or count, and does not say {NO_EVIDENCE!r}"
+                    f"{rid} (line {lineno}): evidence names no session id, sha or PR number, "
+                    f"and does not say {NO_EVIDENCE!r}"
                 )
     return problems, checked
 
@@ -123,21 +156,50 @@ def self_test() -> int:
         ok = False
     else:
         print("  ok  accepts a well-formed row")
-    # Scoping control: a section-10-shaped row must be OUT of scope when scoped,
-    # and IN scope (and rejected) when not -- otherwise "scoped" could be doing
-    # nothing and the pass would be vacuous.
-    s10 = "## 10. x\n| A10 | validation | scripts/validation/** |\n"
-    _, n_scoped = check_rows(s10, scoped=True)
-    p_unscoped, n_unscoped = check_rows(s10, scoped=False)
-    if n_scoped != 0:
-        print(f"SELF-TEST FAIL (scoping): section-10 row still checked ({n_scoped})")
+    # 🔴 SCOPING CONTROL -- and the FIRST version of it was VACUOUS.
+    #
+    # It used the fixture "## 10. x\n| A10 | … |", which contains no `## 3. ` line,
+    # so `in_scope` was False from the first line REGARDLESS of whether SECTION_END
+    # existed. An audit demonstrated the miss mechanically: deleting the
+    # `elif SECTION_END…: in_scope = False` branch -- the exact half this control
+    # claims to cover -- left the self-test fully green, still printing "ok".
+    #
+    # The fixture must therefore OPEN the scope, put a good row inside it, and only
+    # THEN cross into section 10, so that the SECTION_END branch is the only thing
+    # that can keep the rule row out. Mutation-checked: with SECTION_END deleted,
+    # scoped now sees 2 rows and 1 problem, and this control goes red.
+    fixture = (
+        "## 3. Pytest targets\n"
+        "| A1 | x | 1 | 2 | `bfb2ae02-9576-4cb4-bdc3-5bc01b9504bc` ×3 | **KEEP** | reason |\n"
+        "## 10. Proposed selection rules\n"
+        "| A10 | validation | scripts/validation/** |\n"
+    )
+    p_scoped, n_scoped = check_rows(fixture, scoped=True)
+    p_unscoped, n_unscoped = check_rows(fixture, scoped=False)
+    if n_scoped != 1 or p_scoped:
+        print(f"SELF-TEST FAIL (scoping): expected the 1 in-scope row to pass, "
+              f"got rows={n_scoped} problems={p_scoped}")
         ok = False
-    elif n_unscoped != 1 or not p_unscoped:
-        print("SELF-TEST FAIL (scoping): unscoped run did not see/reject the row; "
-              "the scoping control proves nothing")
+    elif n_unscoped != 2 or not p_unscoped:
+        print(f"SELF-TEST FAIL (scoping): unscoped run must SEE both rows and reject "
+              f"the section-10 one, got rows={n_unscoped} problems={p_unscoped}; "
+              f"the scoping control proves nothing")
         ok = False
     else:
-        print("  ok  scoping excludes the section-10 rule table (and only it)")
+        print("  ok  scoping keeps the in-scope row and excludes the section-10 rule table")
+    # Evidence-strictness control: the word CONFIRMED, or a bare count, must NOT
+    # satisfy the evidence cell. An audit replaced all 81 cells with `CONFIRMED`
+    # and the checker still reported PASS.
+    for label, cell in (("bare CONFIRMED", "**CONFIRMED CATCH**"),
+                        ("bare count", "×12"),
+                        ("short agent id", "agent-abc")):
+        row = f"| A9 | x | 1 | 2 | {cell} | **KEEP** | reason |"
+        p, n = check_rows(row, scoped=False)
+        if n != 1 or not p:
+            print(f"SELF-TEST FAIL (evidence strictness): {label!r} was accepted")
+            ok = False
+        else:
+            print(f"  ok  rejects evidence that is only {label}")
     print("SELF-TEST: PASS" if ok else "SELF-TEST: FAIL")
     return 0 if ok else 1
 
@@ -151,13 +213,71 @@ def main(argv: list[str]) -> int:
     with open(argv[1], "r", encoding="utf-8") as fh:
         text = fh.read()
     problems, checked = check_rows(text)
+
+    # 🔴 A ZERO-ROW GUARD IS NARROWER THAN THE SENTENCE THAT DESCRIBES IT.
+    # The docstring promises a vacuous green cannot certify an empty table -- but
+    # `checked == 0` only catches the EMPTY case. A document truncated to a single
+    # row passed with `rows checked: 1 / RESULT: PASS`. So the document must state
+    # its own row count in a machine-readable marker, and this asserts against it.
+    # No marker => cannot vouch => exit 2, never a pass.
+    m = ROWS_MARKER_RX.search(text)
+    if not m:
+        print(f"ERROR: {argv[1]} carries no `{ROWS_MARKER_HINT}` marker, so the row count "
+              f"cannot be cross-checked. Refusing to vouch for a table whose expected "
+              f"size is unstated.")
+        return 2
+    expected = int(m.group(1))
+    if checked != expected:
+        print(f"ERROR: the document declares {expected} rows and {checked} were matched. "
+              f"Either the table was truncated/extended or the marker is stale — both are "
+              f"defects, and neither is a pass.")
+        return 2
     if checked == 0:
         print(f"ERROR: matched 0 inventory rows in {argv[1]} — refusing to report a pass "
               f"for a run that checked nothing.")
         return 2
+
+    # Ids must be unique: a duplicated row id means one row is silently shadowing
+    # another in every count derived from this table.
+    ids = ROW_RX.findall("\n".join(
+        l for l in text.splitlines() if ROW_RX.match(l)))
+    dupes = sorted({i for i in ids if ids.count(i) > 1})
+    if dupes:
+        problems.append(f"duplicate row id(s): {', '.join(dupes)}")
+
+    # Verdict tally, cross-checked against the document's own declaration.
+    tm = TALLY_MARKER_RX.search(text)
+    if not tm:
+        print(f"ERROR: {argv[1]} carries no `{TALLY_MARKER_HINT}` marker, so its verdict "
+              f"tally cannot be cross-checked. Refusing to vouch.")
+        return 2
+    counted = {"KEEP": 0, "TIER": 0, "DROP": 0}
+    in_scope = False
+    for line in text.splitlines():
+        if SECTION_START.match(line):
+            in_scope = True
+        elif SECTION_END.match(line):
+            in_scope = False
+        if not in_scope or not ROW_RX.match(line):
+            continue
+        for cell in split_cells(line):
+            mv = VERDICT_RX.search(cell)
+            if mv:
+                counted[mv.group(1)] += 1
+                break
+    declared = {"KEEP": int(tm.group(1)), "TIER": int(tm.group(2)), "DROP": int(tm.group(3))}
+    if counted != declared:
+        problems.append(
+            f"verdict tally disagrees with the document's own marker: "
+            f"counted {counted}, declared {declared}")
+    if sum(declared.values()) != expected:
+        problems.append(
+            f"declared tally sums to {sum(declared.values())} but the row marker "
+            f"declares {expected} rows")
+
     for p in problems:
         print(f"BAD  {p}")
-    print(f"\nrows checked: {checked}   problems: {len(problems)}")
+    print(f"\nrows checked: {checked} (declared: {expected})   problems: {len(problems)}")
     print("RESULT: PASS" if not problems else "RESULT: FAIL")
     return 0 if not problems else 1
 


### PR DESCRIPTION
Follow-up to #1375, which merged **partially**.

Measured on `origin/main` after that merge:
- `claudedocs/gate-inventory-2026-09-08.md` is **byte-identical** to the branch tip ✓
- `scripts/check-gate-inventory.py` is **166 lines** against the branch's **286**, and contains
  **zero** of the round-2 changes ✗

**Cause**, recorded because the failure mode is easy to repeat: the first
`gh pr merge --squash --delete-branch` errored locally with
`fatal: 'main' is already used by worktree at '…'` — but the API merge had **already fired**
against the PR head as GitHub knew it, before the last push propagated. The local error read as
"the merge did not happen". It had, partially.

🔴 **The state that left on `main` is worse than either version alone**: the document declares
`<!-- inventory-rows: 81 -->` and `<!-- inventory-tally: KEEP=51 TIER=30 DROP=0 -->`, and the
checker sitting beside it reads neither marker — so the document asserts it is machine-checked
while nothing checks it. It also reinstated all three defects an adversarial audit had found:

1. **The scoping control was VACUOUS.** Its fixture contained no `## 3. ` line, so `in_scope` was
   `False` from the first line regardless of the `SECTION_END` branch it claimed to cover.
   Deleting that branch left the self-test fully green. The round-2 fixture opens the scope
   first — mutation-checked: with the branch deleted the control now fails with **its own**
   error (`rows=2, problems=1`), i.e. it is reachable.
2. **Evidence acceptance was vocabulary, not evidence.** The bare word `CONFIRMED` and a bare
   `×N` count both passed. Decisive control: replacing all 81 evidence cells with `CONFIRMED`
   yielded `RESULT: PASS`. It now requires a lookup-able identifier — a UUID session id,
   `agent-<12+ hex>`, a ≥7-hex sha in backticks, or `#<digits>`. The same control now fails all
   81 rows.
3. **The zero-row guard was narrower than its docstring**, which promised a vacuous green could
   not certify an empty table. A document truncated to **one** row passed. It now cross-checks
   the row count *and* the verdict tally against the document's own markers, and exits 2 when
   either marker is missing — absent expectation means cannot-vouch, never a pass.

**No document change.** The doc already on `main` is the correct round-2 text; this is the
instrument catching up to it.

## Verification

Both tiers, on this tree (`origin/main` `5b564844` + this one file):

| tier | command | result |
|---|---|---|
| dev-host | `scripts/gate.sh --tier both` | `GATE: RESULT=PASS exit=0` — pytest 21,127 collected / 21,125 passed / 2 skipped / **0 failed** (floor 20,342); node 1,449/1,449; 43 PASS targets, 0 FAIL, 0 timeout panics |
| sandbox | `nix build .#checks.x86_64-linux.pytests` | `rc=0`, real streaming build, valid store output |
| sandbox | `nix build .#checks.x86_64-linux.nodetests` | `rc=0`, valid store output |
| instrument | `check-gate-inventory.py --self-test` | all 9 controls pass |
| instrument | vs the doc **on main** | `rows checked: 81 (declared: 81)  problems: 0` |

Sandbox derivations built **one at a time**; store-output validity is the check, since a failing
derivation produces no output path.

⚠ **One earlier gate run on this branch failed and it was my own contamination, not this change.**
`test_no_predictable_tmp_path_is_live_while_the_verifier_runs` tripped on 29 stale
`/tmp/nebula-relay-pre.<pid>` files left by my *earlier* runs against the pre-#1407 nebula code.
All 29 PIDs were dead; removed after re-checking liveness immediately before each delete. Current
`main` does not leak them — the file now runs 30/30 twice with zero leftovers. Reporting it
because "the gate failed once" would otherwise read as a red suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXxTANDijZTVxj398NrWBU