### PR TITLE
fix(mention): GitHub refs resolve to /pull, and the constant is renamed to match

### DIFF
--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -1124,7 +1124,7 @@ def test_a_mention_emits_its_own_event_and_roundtrips(env):
     payload = json.loads(ev["payload"])
     assert payload["platform"] == "github"
     assert payload["reference_id"] == "1065"
-    assert payload["url"] == "https://github.com/civitai/talos-infra/issues/1065"
+    assert payload["url"] == "https://github.com/civitai/talos-infra/pull/1065"
     assert payload["candidates"] == "github"
     assert "civitai/talos-infra#1065" in payload["context"]
 

--- a/scripts/collector/mention_scan.py
+++ b/scripts/collector/mention_scan.py
@@ -31,7 +31,7 @@ WHAT IS DETECTED
 ----------------
 Both profiles:
   clickup   868abc123                 -> https://app.clickup.com/t/868abc123
-  github    owner/repo#12             -> https://github.com/owner/repo/issues/12
+  github    owner/repo#12             -> https://github.com/owner/repo/pull/12
   github    repo#12                   -> owner resolved by the CALLER (see below)
   ambiguous #12                       -> clawgate task 12 OR a GitHub issue 12
   github    /audit-pr 12   audit-pr 12   (the ONE wordy form that is clickable —
@@ -154,10 +154,31 @@ _TELEMETRY_ONLY = (PROFILE_TELEMETRY,)
 # redirect, not this module's — nothing here should mint one either way.
 CLAWGATE_TASKS_URL = "https://clawgate.zacx.dev/tasks"
 CLICKUP_TASK_URL = "https://app.clickup.com/t/{id}"
-# `/issues/<n>` is deliberate and not a bug: GitHub redirects /issues/<n> to
-# /pull/<n> when <n> is a pull request, so one template covers both and we never
-# have to know which it is.
-GITHUB_ISSUE_URL = "https://github.com/{repo}/issues/{id}"
+# 🔴 `/pull/<n>`, AND THE NAME IS `REF` RATHER THAN `ISSUE` BECAUSE THE TEMPLATE
+# DOES NOT KNOW WHICH IT IS. GitHub normalises BOTH forms in BOTH directions, so
+# either one "covers both" and the choice is about what the operator READS in the
+# picker row, not about what resolves.
+#
+# MEASURED 2026-09-09 on a public repo holding both kinds, following redirects:
+#     /issues/<pr>    -> 200  …/pull/<pr>
+#     /pull/<pr>      -> 200  …/pull/<pr>
+#     /issues/<issue> -> 200  …/issues/<issue>
+#     /pull/<issue>   -> 200  …/issues/<issue>      ← the leg that licenses this
+# and on 4 ISSUES-DISABLED repos, `/pull/<pr>` resolves too — that population is
+# in the picker universe on purpose, so it had to be checked rather than assumed.
+#
+# ⚠ THE COMMENT THIS REPLACES WAS TRUE BUT ONE-SIDED, and its one-sidedness is
+# what made `/issues` look forced. It read: "`/issues/<n>` is deliberate and not
+# a bug: GitHub redirects /issues/<n> to /pull/<n> when <n> is a pull request, so
+# one template covers both and we never have to know which it is." Every clause
+# is correct; it simply never tested the mirror leg, so it read as "only /issues
+# is safe". Operator preference 2026-09-09: default to `/pull`, because the
+# overwhelming majority of references clicked here are pull requests and the row
+# shows the URL before you choose it.
+#
+# 🔴 NOT A DEDUPE CONCERN, checked before changing it: the telemetry key is
+# `platform:raw[@owner/repo]`, never the URL, so no already-emitted row re-emits.
+GITHUB_REF_URL = "https://github.com/{repo}/pull/{id}"
 
 PLATFORM_CLAWGATE = "clawgate"
 PLATFORM_GITHUB = "github"
@@ -510,7 +531,7 @@ def _github_url(full_repo: str | None, num: str) -> str:
     not known. NEVER a guessed owner — see the module docstring."""
     if not full_repo or "/" not in full_repo:
         return ""
-    return GITHUB_ISSUE_URL.format(repo=full_repo, id=num)
+    return GITHUB_REF_URL.format(repo=full_repo, id=num)
 
 
 def clawgate_url(task_id: str) -> str:

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -120,7 +120,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent / "collector"))
 
 from mention_scan import (  # noqa: E402
-    GITHUB_ISSUE_URL,
+    GITHUB_REF_URL,
     PLATFORM_CLAWGATE,
     PLATFORM_CLICKUP,
     PLATFORM_GITHUB,
@@ -390,7 +390,7 @@ def universe_candidates(num: str, universe: list[str]) -> list[dict]:
     refusal. Nothing here is opened without a selection.
     """
     return [{"platform": PLATFORM_GITHUB, "id": num,
-             "url": GITHUB_ISSUE_URL.format(repo=full, id=num)}
+             "url": GITHUB_REF_URL.format(repo=full, id=num)}
             for full in universe]
 
 

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -87,7 +87,7 @@ def test_an_explicit_owner_repo_resolves_to_one_openable_candidate():
     span, cands = MO.resolve("civitai/talos-infra#1065")
     assert span["platform"] == "github"
     assert [c["url"] for c in cands] == [
-        "https://github.com/civitai/talos-infra/issues/1065"]
+        "https://github.com/civitai/talos-infra/pull/1065"]
 
 
 def test_a_clickup_id_resolves_to_one_openable_candidate():
@@ -121,7 +121,7 @@ def test_a_bare_number_with_a_repo_context_offers_both():
     _span, cands = MO.resolve("#370", default_repo="civitai/talos-infra")
     assert [(c["platform"], c["url"]) for c in cands] == [
         ("clawgate", "https://clawgate.zacx.dev/tasks/370"),
-        ("github", "https://github.com/civitai/talos-infra/issues/370"),
+        ("github", "https://github.com/civitai/talos-infra/pull/370"),
     ]
 
 
@@ -129,7 +129,7 @@ def test_a_measured_repo_mapping_resolves_the_short_form():
     _span, cands = MO.resolve("talos-infra#1065",
                               repos={"talos-infra": "civitai/talos-infra"})
     assert [c["url"] for c in cands] == [
-        "https://github.com/civitai/talos-infra/issues/1065"]
+        "https://github.com/civitai/talos-infra/pull/1065"]
 
 
 def test_an_unknown_short_form_repo_yields_NO_candidate_rather_than_a_guess():
@@ -164,7 +164,7 @@ def test_picker_rows_show_the_platform_and_the_url():
     assert len(rows) == 2
     assert rows[0].startswith("clawgate task 370 ")
     assert rows[0].endswith("https://clawgate.zacx.dev/tasks/370")
-    assert rows[1].endswith("https://github.com/civitai/talos-infra/issues/370")
+    assert rows[1].endswith("https://github.com/civitai/talos-infra/pull/370")
 
 
 def test_a_row_maps_back_to_its_own_url():
@@ -194,7 +194,7 @@ def test_the_matched_text_is_read_from_the_LAST_argument():
     from correct behaviour until the day an arg is added."""
     r = _run("--print", "--no-discovery", "civitai/talos-infra#1065")
     assert r.returncode == 0, r.stderr
-    assert r.stdout.strip() == "https://github.com/civitai/talos-infra/issues/1065"
+    assert r.stdout.strip() == "https://github.com/civitai/talos-infra/pull/1065"
 
     # Same match, now preceded by extra arguments — the answer must not move.
     r2 = _run("--print", "--no-discovery", "--default-repo", "civitai/talos-infra",
@@ -208,7 +208,7 @@ def test_an_ambiguous_click_prints_every_candidate():
     assert r.returncode == 0, r.stderr
     assert r.stdout.splitlines() == [
         "https://clawgate.zacx.dev/tasks/370",
-        "https://github.com/civitai/talos-infra/issues/370",
+        "https://github.com/civitai/talos-infra/pull/370",
     ]
 
 
@@ -427,7 +427,7 @@ def test_a_DISCOVERING_subprocess_resolves_through_the_FAKE_mapping(tmp_path,
     monkeypatch.setenv("DEVRC_WORKSPACE", str(tmp_path / "no-checkouts-here"))
     r = _run("--print", "--default-repo", "unused/by-this-shape", "loamfield#12")
     assert r.returncode == 0, r.stderr
-    assert r.stdout.strip() == "https://github.com/gardenersguild/trowelcast/issues/12", (
+    assert r.stdout.strip() == "https://github.com/gardenersguild/trowelcast/pull/12", (
         "the child did not resolve through the redirected mapping — it either "
         f"read the operator's real one or nothing at all: {r.stdout!r} {r.stderr!r}")
 
@@ -461,7 +461,7 @@ def test_an_unambiguous_click_opens_without_paying_for_discovery(spy):
     text already carries `owner/repo` must not pay for it — that latency lands
     on the operator every single time."""
     assert MO.main(["civitai/talos-infra#1065"]) == 0
-    assert spy == [("open", "https://github.com/civitai/talos-infra/issues/1065")]
+    assert spy == [("open", "https://github.com/civitai/talos-infra/pull/1065")]
 
 
 def test_a_clickup_click_also_skips_discovery(spy):
@@ -526,7 +526,7 @@ def test_the_guard_does_not_swallow_a_NORMAL_run(spy):
     goes wrong, or every assertion above would hold for a wrapper that always
     reported a failure."""
     assert MO.guarded_main(["civitai/talos-infra#1065"]) == 0
-    assert spy == [("open", "https://github.com/civitai/talos-infra/issues/1065")]
+    assert spy == [("open", "https://github.com/civitai/talos-infra/pull/1065")]
 
 
 def test_the_ENTRY_POINT_is_the_guarded_one():
@@ -544,7 +544,7 @@ def test_the_ENTRY_POINT_is_the_guarded_one():
 def test_a_short_form_repo_is_resolved_from_the_discovered_checkouts(spy):
     assert MO.main(["talos-infra#1065"]) == 0
     assert "discover" in spy
-    assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/issues/1065")
+    assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/pull/1065")
 
 
 def test_text_the_SCANNER_REFUSED_offers_the_picker_instead_of_refusing(spy):
@@ -929,7 +929,7 @@ def test_a_mapping_ONLY_name_resolves_end_to_end_through_main(tmp_path, monkeypa
     opened = []
     monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main(["plotwidget#42"]) == 0
-    assert opened == ["https://github.com/gardenersguild/plotwidget/issues/42"]
+    assert opened == ["https://github.com/gardenersguild/plotwidget/pull/42"]
 
 
 def test_the_loader_reads_the_path_at_CALL_time_not_at_import(tmp_path, monkeypatch):
@@ -954,7 +954,7 @@ def test_a_local_checkout_beats_the_mapping_for_the_same_name(tmp_path, monkeypa
 
 
 def test_a_three_segment_value_is_refused_rather_than_404ing(tmp_path, monkeypatch):
-    """`github.com/a/b/c/issues/12` 404s while looking authoritative — the same
+    """`github.com/a/b/c/pull/12` 404s while looking authoritative — the same
     rule `parse_owner_repo` enforces for a git remote."""
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _write_mapping(
         tmp_path, {"good": "gardenersguild/good", "bad": "gardenersguild/team/bad"}))
@@ -1117,7 +1117,7 @@ def test_an_UNREADABLE_checkout_does_not_ERASE_the_mappings_answer(
 
     Both directions are asserted: the mapping's row must SURVIVE, and a
     checkout the mapping never knew about must be ABSENT rather than present
-    with an empty value (an empty value builds `https://github.com//issues/12`).
+    with an empty value (an empty value builds `https://github.com//pull/12`).
     """
     p = tmp_path / "known_repos.json"
     p.write_text(json.dumps({"quillmarsh": "northgate/quillmarsh"}))
@@ -1191,7 +1191,7 @@ def test_the_picker_asks_rofi_for_FUZZY_matching(monkeypatch):
 
     monkeypatch.setattr(MO.subprocess, "run", fake_run)
     MO.pick([{"platform": "github", "id": "7",
-              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}])
+              "url": "https://github.com/gardenersguild/trowelcast/pull/7"}])
     assert seen["cmd"][0] == "rofi"
     assert "-matching" in seen["cmd"]
     assert seen["cmd"][seen["cmd"].index("-matching") + 1] == "fuzzy"
@@ -1222,7 +1222,7 @@ def test_fuzzy_matching_is_never_asked_for_WITHOUT_ranking(monkeypatch):
                         lambda cmd, **kw: seen.update(cmd=cmd)
                         or types.SimpleNamespace(returncode=1, stdout="", stderr=""))
     MO.pick([{"platform": "github", "id": "7",
-              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}])
+              "url": "https://github.com/gardenersguild/trowelcast/pull/7"}])
     cmd = seen["cmd"]
     fuzzy = "-matching" in cmd and cmd[cmd.index("-matching") + 1] == "fuzzy"
     assert fuzzy, "the picker must still MATCH fuzzily"
@@ -1498,7 +1498,7 @@ def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatc
 
 
 @pytest.mark.parametrize("value", [
-    "acme/widget/",      # trailing slash -> .../acme/widget//issues/12
+    "acme/widget/",      # trailing slash -> .../acme/widget//pull/12
     "acme//widget",      # empty middle segment
     "acme/widget ",      # trailing space inside the URL path
     "acme/wid\nget",     # embedded newline
@@ -1611,8 +1611,8 @@ def test_universe_candidates_build_one_openable_row_per_repo():
     cands = MO.universe_candidates("77", ["gardenersguild/trowelcast",
                                           "rivalorg/spadeworks"])
     assert [c["url"] for c in cands] == [
-        "https://github.com/gardenersguild/trowelcast/issues/77",
-        "https://github.com/rivalorg/spadeworks/issues/77"]
+        "https://github.com/gardenersguild/trowelcast/pull/77",
+        "https://github.com/rivalorg/spadeworks/pull/77"]
     assert {c["platform"] for c in cands} == {"github"}
     assert {c["id"] for c in cands} == {"77"}
 
@@ -1648,7 +1648,7 @@ def test_an_audit_pr_REFERENCE_resolves_through_the_PANE_repo(spy, text):
     # difference. The exact SEQUENCE is asserted, not a set: the pane must be
     # measured before the picker is raised, and the picker before the open.
     assert spy == ["tmux", "discover", ("pick", 1),
-                   ("open", "https://github.com/civitai/talos-infra/issues/1291")], spy
+                   ("open", "https://github.com/civitai/talos-infra/pull/1291")], spy
 
 
 # --------------------------------------------------------------------------- #
@@ -1688,7 +1688,7 @@ def test_a_GUESSED_repo_is_never_auto_opened_whatever_the_shape(monkeypatch, tex
     assert MO.main([text]) == 0
     # POSITIVE CONTROL — the pane's repo really WAS offered. A run that resolved
     # nothing would satisfy "did not auto-open" while proving nothing.
-    assert "https://github.com/wrongorg/wrongrepo/issues/1291" in seen["urls"], seen
+    assert "https://github.com/wrongorg/wrongrepo/pull/1291" in seen["urls"], seen
 
 
 def test_the_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
@@ -1758,10 +1758,10 @@ def test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess(monkeypatch):
 
 @pytest.mark.parametrize("text,expected", [
     # `mapped` — the mapping resolved the owner for a repo the TEXT named.
-    ("loamfield#12", "https://github.com/gardenersguild/trowelcast/issues/12"),
+    ("loamfield#12", "https://github.com/gardenersguild/trowelcast/pull/12"),
     # `explicit` — the operator wrote the owner out.
     ("civitai/talos-infra#1065",
-     "https://github.com/civitai/talos-infra/issues/1065"),
+     "https://github.com/civitai/talos-infra/pull/1065"),
 ])
 def test_a_repo_the_TEXT_named_still_opens_with_no_picker(monkeypatch, text,
                                                           expected):
@@ -2005,7 +2005,7 @@ def test_print_mode_never_invokes_the_picker_or_the_universe(spy, universe, caps
 def test_print_mode_still_prints_a_resolvable_url(spy, universe, capsys):
     assert MO.main(["--print", "gardenersguild/trowelcast#1065"]) == 0
     assert capsys.readouterr().out.strip() == (
-        "https://github.com/gardenersguild/trowelcast/issues/1065")
+        "https://github.com/gardenersguild/trowelcast/pull/1065")
 
 
 def test_a_bare_hash_N_with_NO_repo_context_offers_the_universe_BELOW_clawgate(
@@ -2101,7 +2101,7 @@ def test_a_six_digit_literal_BESIDE_a_real_reference_does_not_suppress_it(spy):
     survived the whole suite before this test existed."""
     assert MO.main(['background = "#282828"; fixed in talos-infra#1065']) == 0, (
         "a colour literal BESIDE a real reference suppressed the reference")
-    assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/issues/1065"), (
+    assert spy[-1] == ("open", "https://github.com/civitai/talos-infra/pull/1065"), (
         f"a colour literal BESIDE a real reference suppressed the "
         f"reference: {spy}")
 
@@ -2230,7 +2230,7 @@ def test_the_picker_passes_its_NOTE_to_rofi_as_mesg(monkeypatch):
 
     monkeypatch.setattr(MO.subprocess, "run", fake_run)
     cands = [{"platform": "github", "id": "7",
-              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}]
+              "url": "https://github.com/gardenersguild/trowelcast/pull/7"}]
     MO.pick(cands, mesg="nothing here knows widget<1> & co")
     assert "-mesg" in seen["cmd"], seen["cmd"]
     body = seen["cmd"][seen["cmd"].index("-mesg") + 1]
@@ -2625,7 +2625,7 @@ def test_the_universe_file_is_NOT_read_on_a_click_that_resolves(monkeypatch):
                         lambda *a, **k: reads.append(1) or [])
     monkeypatch.setattr(MO, "open_url", lambda url: reads.append(url) or 0)
     assert MO.main(["--no-discovery", "civitai/talos-infra#1065"]) == 0
-    assert reads == ["https://github.com/civitai/talos-infra/issues/1065"], (
+    assert reads == ["https://github.com/civitai/talos-infra/pull/1065"], (
         f"expected exactly one open and no universe read, got {reads}")
 
 
@@ -2882,7 +2882,7 @@ def test_an_EXPLICIT_owner_still_opens_directly_and_gets_NO_picker(monkeypatch):
     monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main(["civitai/talos-infra#1065"]) == 0
     assert picked == [], "an explicit owner must not raise a picker"
-    assert opened == ["https://github.com/civitai/talos-infra/issues/1065"], opened
+    assert opened == ["https://github.com/civitai/talos-infra/pull/1065"], opened
 
 
 # --------------------------------------------------------------------------- #
@@ -2938,7 +2938,7 @@ def test_the_bare_hash_N_ORDER_is_clawgate_then_the_guess_then_the_universe(
     assert len(urls) == 7, urls
     assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", (
         f"the MEASURED rows must stay on top: {urls}")
-    assert urls[1] == "https://github.com/wrongorg/wrongrepo/issues/1291", (
+    assert urls[1] == "https://github.com/wrongorg/wrongrepo/pull/1291", (
         f"the MEASURED rows must stay on top: {urls}")
     assert not any(UNIVERSE_ONLY in u or "acme/widget" in u for u in urls[:2]), urls
     assert UNIVERSE_ONLY in "\n".join(urls[2:]), urls
@@ -3042,7 +3042,7 @@ def test_the_DEFAULT_REPO_FLAG_rides_the_same_rung_as_the_pane(monkeypatch):
     assert MO.main(["--default-repo", "wrongorg/wrongrepo", "#1291"]) == 0
     urls = [c["url"] for c in seen["rows"]]
     assert urls[0] == "https://clawgate.zacx.dev/tasks/1291", urls
-    assert urls[1] == "https://github.com/wrongorg/wrongrepo/issues/1291", urls
+    assert urls[1] == "https://github.com/wrongorg/wrongrepo/pull/1291", urls
     assert any(UNIVERSE_ONLY in u for u in urls), urls
     assert "Row 2" in seen["mesg"], seen["mesg"]
 
@@ -3078,10 +3078,10 @@ def test_a_bare_hash_N_with_NO_pane_repo_is_UNCHANGED_by_this_widening(
     # host by construction), and the mapping's AGE already reaches the operator
     # through `staleness_note`. Putting a several-hundred-row picker in front of
     # every `repo#N` would tax the shape that carries its own evidence.
-    ("loamfield#12", "https://github.com/gardenersguild/trowelcast/issues/12"),
+    ("loamfield#12", "https://github.com/gardenersguild/trowelcast/pull/12"),
     # `explicit` — the strongest rung there is.
     ("civitai/talos-infra#1065",
-     "https://github.com/civitai/talos-infra/issues/1065"),
+     "https://github.com/civitai/talos-infra/pull/1065"),
 ])
 def test_the_TEXTS_OWN_evidence_still_opens_with_ZERO_keystrokes(monkeypatch,
                                                                 text, expected):

--- a/scripts/tests/test_mention_scan.py
+++ b/scripts/tests/test_mention_scan.py
@@ -63,15 +63,15 @@ def test_owner_repo_hash_number_is_unambiguously_github():
     assert m["id"] == "1065"
     assert m["raw"] == "civitai/talos-infra#1065"
     assert m["ambiguous"] is False
-    assert m["url"] == "https://github.com/civitai/talos-infra/issues/1065"
+    assert m["url"] == "https://github.com/civitai/talos-infra/pull/1065"
 
 
 def test_the_issues_url_is_used_for_prs_too():
-    """`/issues/<n>` is deliberate: GitHub redirects it to `/pull/<n>` when the
+    """`/pull/<n>` is deliberate: GitHub redirects it to `/pull/<n>` when the
     number is a PR, so one template covers both and the scanner never has to
     know which it is."""
     (m,) = MS.scan_mentions("innovation-upstream/devrc#992")
-    assert m["url"].endswith("/issues/992")
+    assert m["url"].endswith("/pull/992")
 
 
 def test_bare_repo_hash_number_is_github_but_has_no_url_without_an_owner():
@@ -85,12 +85,12 @@ def test_bare_repo_hash_number_is_github_but_has_no_url_without_an_owner():
 def test_a_measured_repo_mapping_supplies_the_owner():
     (m,) = MS.scan_mentions("see devrc#591",
                             repos={"devrc": "innovation-upstream/devrc"})
-    assert m["url"] == "https://github.com/innovation-upstream/devrc/issues/591"
+    assert m["url"] == "https://github.com/innovation-upstream/devrc/pull/591"
 
 
 def test_an_explicit_owner_beats_the_mapping():
     (m,) = MS.scan_mentions("civitai/devrc#1", repos={"devrc": "innovation-upstream/devrc"})
-    assert m["url"] == "https://github.com/civitai/devrc/issues/1"
+    assert m["url"] == "https://github.com/civitai/devrc/pull/1"
 
 
 def test_a_malformed_mapping_entry_yields_no_url_rather_than_a_broken_one():
@@ -182,7 +182,7 @@ def test_a_bare_number_gets_a_github_url_only_from_a_supplied_repo():
     (_clawgate, github) = MS.scan_mentions("#370")
     assert github["url"] == ""
     (_clawgate, github) = MS.scan_mentions("#370", default_repo="civitai/talos-infra")
-    assert github["url"] == "https://github.com/civitai/talos-infra/issues/370"
+    assert github["url"] == "https://github.com/civitai/talos-infra/pull/370"
 
 
 def test_a_span_reports_ambiguous_rather_than_picking_a_winner():
@@ -196,7 +196,7 @@ def test_an_unambiguous_span_carries_its_single_url():
     (span,) = MS.scan_mention_spans("civitai/talos-infra#1065")
     assert span["platform"] == "github"
     assert span["ambiguous"] is False
-    assert span["url"] == "https://github.com/civitai/talos-infra/issues/1065"
+    assert span["url"] == "https://github.com/civitai/talos-infra/pull/1065"
 
 
 def test_the_two_hash_patterns_never_claim_the_same_span():
@@ -500,7 +500,7 @@ def test_a_github_pull_url_is_a_mention_and_carries_its_own_owner():
     assert span["id"] == "7"
     assert span["repo"] == "gardenersguild/trowelcast"
     assert span["repo_source"] == MS.SOURCE_URL
-    assert span["url"] == "https://github.com/gardenersguild/trowelcast/issues/7"
+    assert span["url"] == "https://github.com/gardenersguild/trowelcast/pull/7"
 
 
 def test_a_github_issues_url_too_and_a_scheme_is_optional():
@@ -636,7 +636,7 @@ def test_A2_a_repo_token_immediately_before_the_ref_attributes_it():
     assert span["repo"] == "gardenersguild/trowelcast"
     assert span["repo_source"] == MS.SOURCE_ADJACENT
     assert span["candidates"][1]["url"] == (
-        "https://github.com/gardenersguild/trowelcast/issues/1291")
+        "https://github.com/gardenersguild/trowelcast/pull/1291")
 
 
 def test_A2_works_without_a_connector_word_too():
@@ -731,7 +731,7 @@ def test_A4_attributes_the_gh_cli_reference_beside_it():
     (span,) = MS.scan_mention_spans(
         "gh pr view 1291 --repo rivalorg/spadeworks", **TELEMETRY)
     assert span["repo"] == "rivalorg/spadeworks"
-    assert span["url"] == "https://github.com/rivalorg/spadeworks/issues/1291"
+    assert span["url"] == "https://github.com/rivalorg/spadeworks/pull/1291"
 
 
 def test_the_ladder_ranks_ADJACENT_above_URL_above_FLAG_above_DEFAULT():
@@ -990,3 +990,61 @@ def test_clean_repo_map_keeps_a_good_entry_and_is_total_on_junk():
         "a": "gardenersguild/trowelcast"}
     for junk in (None, [], "", 3, {1: "a/b"}):
         assert MS.clean_repo_map(junk) == {}
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 GITHUB REFS RESOLVE TO `/pull`, AND BOTH INPUT FORMS STILL PARSE
+#
+# Operator preference 2026-09-09: the row shows its URL before you choose it, and
+# the overwhelming majority of references clicked here are pull requests.
+#
+# MEASURED before changing it, because the old comment's reasoning ("GitHub
+# redirects /issues to /pull for a PR, so one template covers both") was true but
+# only tested ONE leg, which made `/issues` look forced. Following redirects on a
+# public repo holding both kinds:
+#     /issues/<pr>    -> 200 …/pull/<pr>      /pull/<pr>    -> 200 …/pull/<pr>
+#     /issues/<issue> -> 200 …/issues/<issue> /pull/<issue> -> 200 …/issues/<issue>
+# Both forms normalise in BOTH directions, so the choice is display, not
+# resolution — and `/pull/<pr>` was separately confirmed on 4 issues-disabled
+# repos, a population deliberately kept in the picker universe.
+# --------------------------------------------------------------------------- #
+def test_a_github_ref_resolves_to_PULL_not_issues():
+    """The output template. Pinned as a WHOLE normalised string rather than by
+    substring, because `"pull" in url` also passes for `…/pull-requests/…` and
+    for a repo named `pull`."""
+    assert MS.GITHUB_REF_URL == "https://github.com/{repo}/pull/{id}"
+    assert (MS.GITHUB_REF_URL.format(repo="acme/widget", id="12")
+            == "https://github.com/acme/widget/pull/12")
+
+
+def test_the_constant_is_named_for_what_it_BUILDS():
+    """🔴 A CONSTANT'S NAME IS A CLAIM. It was `GITHUB_ISSUE_URL` and it now
+    builds a `/pull/` URL; leaving the old name would have made every call site
+    read as issue-specific while doing the opposite. Renamed to `GITHUB_REF_URL`
+    — 'ref' because the template genuinely does NOT know which kind it is, which
+    is the whole reason either form works.
+
+    This asserts the old name is GONE rather than merely that the new one exists:
+    a module keeping both as aliases is how a false name survives a rename."""
+    assert not hasattr(MS, "GITHUB_ISSUE_URL"), (
+        "the old issue-specific name is back and now describes a /pull template")
+    assert MS.GITHUB_REF_URL.endswith("/pull/{id}")
+
+
+@pytest.mark.parametrize("form", ["issues", "pull"])
+def test_BOTH_url_forms_are_still_DETECTED_in_input_text(form):
+    """🔴 THE REGRESSION THIS CHANGE COULD HAVE CAUSED SILENTLY, and the reason
+    the rewrite protected one fixture by hand.
+
+    Changing the OUTPUT template must not narrow what the scanner RECOGNISES.
+    `GITHUB_URL_RE` matches `(?:pull|issues)` on purpose — the operator pastes
+    whichever GitHub gave them. A blind search-and-replace over the test files
+    would have rewritten the `/issues/` input fixture to `/pull/`, and the suite
+    would have stayed GREEN while silently losing all coverage of the `/issues/`
+    input form. That is a coverage loss no failure reports."""
+    text = f"https://github.com/hobbyist/plotwidget/{form}/4213"
+    (span,) = MS.scan_mention_spans(text, **TELEMETRY)
+    assert span["repo"] == "hobbyist/plotwidget", text
+    assert span["id"] == "4213", text
+    # …and whichever form arrived, the URL we hand back is the normalised one.
+    assert span["url"] == "https://github.com/hobbyist/plotwidget/pull/4213", text


### PR DESCRIPTION
Operator preference 2026-09-09: the picker row shows its URL before you choose it, and
the overwhelming majority of references clicked here are pull requests.

## Measured before changing it

The comment being replaced was **true but one-sided**, which is what made `/issues` look
forced rather than chosen. It read: *"GitHub redirects /issues/&lt;n&gt; to /pull/&lt;n&gt; when
&lt;n&gt; is a pull request, so one template covers both."* Every clause correct — it just
never tested the mirror leg. Following redirects on a public repo holding both kinds:

| requested | lands on |
|---|---|
| `/issues/<pr>` | `…/pull/<pr>` |
| `/pull/<pr>` | `…/pull/<pr>` |
| `/issues/<issue>` | `…/issues/<issue>` |
| `/pull/<issue>` | `…/issues/<issue>` ← the leg that licenses this change |

Both forms normalise in **both** directions, so neither is safer and the choice is about
what the operator reads. Separately confirmed `/pull/<pr>` resolves on **4
issues-disabled repos** — that population is in the picker universe on purpose (#1369),
so it had to be checked rather than assumed.

🔴 **Not a dedupe concern**, checked before touching it: the telemetry key is
`platform:raw[@owner/repo]`, never the URL, so no already-emitted row re-emits.

## Renamed, because a constant's name is a claim

`GITHUB_ISSUE_URL` → `GITHUB_REF_URL`. Left alone it would have read issue-specific at
all four call sites while building the opposite. `ref` is honest: the template genuinely
does not know which kind it is, which is the whole reason either form works. The module
docstring advertised `-> …/issues/12` too; corrected.

## 🔴 The silent regression this could have caused

`GITHUB_URL_RE` matches `(?:pull|issues)` on **input** — the operator pastes whichever
GitHub gave them. A blind find-replace across the test files would have rewritten the one
`/issues/` **input** fixture (`github.com/hobbyist/plotwidget/issues/4213`) into `/pull/`,
and **the suite would have stayed green while losing all coverage of that input form**.
No failure reports that.

So the rewrite fenced it by hand — 42 output URLs rewritten across three test files, 4
input fixtures protected, occurrences verified intact afterwards — and a new
parametrised test pins **both** input forms against the single normalised output.

## Tests

- output template pinned as a **whole string**, not by substring: `"pull" in url` also
  passes for `…/pull-requests/…` and for a repo literally named `pull`
- the rename guard asserts the **old name is gone**, not merely that the new one exists —
  keeping both as aliases is how a false name survives a rename
- both input forms (`/issues/`, `/pull/`) parametrised against one normalised output

## Gate — read this before merging

| tier | result |
|---|---|
| **sandbox pytests** (what a merge is gated on) | **PASS** — 21,291 passed, 0 failed |
| **sandbox nodetests** | **PASS** — 1,449 |
| dev-host nodetests | **PASS** — 1,449 |
| dev-host pytests | ⚠ **TIMED OUT**, not failed |

⚠ The dev-host pytest leg was **killed by the 3600s timeout** (exit 143 = SIGTERM), with
**0 `FAILED` lines in its log** and 0 targets completed — it never got through the suite.
Box load was **64** with **108 competing pytest processes** from other sessions. The
identical tree passed the sandbox tier with 21,291 tests, which is the control: same
code, isolated environment, green. Plus 421 passed across the three directly affected
suites. **No test failed anywhere in either tier** — one tier was starved, not red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FENxxrZztNTsrKgChnGT1X
