### PR TITLE
fix(cairn-cutover): retire P3 post-cutover — its exit-8 refusal is the last guard, not a bug

### DIFF
--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -49,9 +49,14 @@ PHASES AND THEIR ROLLBACKS
                                  is modified. Roll back by deleting the run dir.
   P1  plan the delta           — read-only; writes only into the run directory
   P2  ref-collision check      — read-only
-  P3  push the delta           — rollback: `--rollback-push <run-dir>` re-PUTs the
-                                 pre-push bytes this script saved for every entry
-                                 it was about to overwrite
+  P3  push the delta           — 🔴 RETIRED once P5 has frozen the store: it
+                                 refuses with RC_CUTOVER_COMPLETE (19) rather
+                                 than pushing a frozen mirror back over a pod
+                                 that has moved on. Live only for a host that
+                                 has NOT been cut over. Rollback for a run that
+                                 did push: `--rollback-push <run-dir>` re-PUTs
+                                 the pre-push bytes this script saved for every
+                                 entry it was about to overwrite.
   P4  acceptance + byte check  — read-only
   P5  freeze local disk        — records every mode, then chmods. Rollback:
                                  `--unfreeze`, which RESTORES the recorded modes
@@ -142,6 +147,7 @@ RC_FREEZE_INEFFECTIVE = 16  # the freeze was applied and a write STILL succeeded
 # editing this sentence, and count.
 RC_ACCEPTANCE = 17
 RC_COULD_NOT_MEASURE = 18   # an instrument did not answer; never folded into a pass
+RC_CUTOVER_COMPLETE = 19    # P3 is RETIRED on this store — the freeze is already applied
 
 # 🔴 THE DISCRIMINATOR THIS WHOLE MERGE RULE TURNS ON. `server.render_bullet`
 # terminates every API-appended bullet with exactly this shape, and nothing else
@@ -1031,7 +1037,10 @@ def build_parser() -> argparse.ArgumentParser:
                         "divergence is refused rather than silently superseded")
     p.add_argument("--run-dir", type=Path, default=None)
     p.add_argument("--push", default=None, metavar="NS/DEPLOY",
-                   help="hand the delta tree to seed.sh --push")
+                   help="hand the delta tree to seed.sh --push. RETIRED on a "
+                        "store whose entries already refuse a write: the cutover "
+                        "has completed there and P3 exits 19 rather than reverting "
+                        "the pod. Use `cairn append`/`cairn put` instead.")
     p.add_argument("--dest", default="/data")
     p.add_argument("--alias-owner", action="append", default=[], metavar="S:A=FILE",
                    help="acknowledge one LIVE ref collision by naming its owner")
@@ -1353,7 +1362,53 @@ def main(argv: list[str] | None = None) -> int:
             say(f"P2 {len(owners)} live collision(s) acknowledged by --alias-owner: "
                 f"{sorted(f'{s}:{a}' for s, a in owners)}")
 
-        # ---- P3 the push --------------------------------------------------
+        # ---- P3 the push — RETIRED ONCE THE FREEZE IS APPLIED ---------------
+        # 🔴 P3 IS DEAD POST-CUTOVER, AND THE OBVIOUS "FIX" IS THE DATA-LOSS BUG.
+        # This phase pushes LOCAL -> POD. That is correct exactly once: while the
+        # host still holds bytes the pod has never seen. After P5 freezes local
+        # disk the direction inverts — this header's own ordering argument says
+        # so ("After this cutover the hosts' stores are caches of the pod") — and
+        # the pod accumulates API-appended content the mirror will never have.
+        #
+        # What it looked like instead: `plan.shippable` is ADD + SUPERSEDES +
+        # MERGED, and SUPERSEDES/MERGED are BY DEFINITION entries whose pod bytes
+        # differ, which is what `seed.sh`'s pre-flight refuses. So P3 exits 8 the
+        # moment anything supersedes, and that reads as a shipped code path that
+        # can never complete — one `--allow-overwrite` away from working.
+        #
+        # 🔴 IT IS NOT. That refusal is the LAST GUARD between a stale mirror and
+        # authoritative content, and `--allow-overwrite` is the single change that
+        # would disarm it. `seed.sh`'s tar "adds and overwrites but never
+        # deletes", so a push from a frozen mirror silently reverts every entry
+        # the pod has moved on — MEASURED 2026-09-02/03: of 25 local-only bullet
+        # candidates, 5 were POD-NEWER, two of them `OPEN:` -> `RESOLVED` closures
+        # carrying ~20 lines of later corrections. It would report success.
+        #
+        # So this refuses instead, by the same instrument P5 uses. The signal is
+        # the freeze, not a flag or a date: a store whose entries all refuse a
+        # write has completed the cutover, and a store that is still writable has
+        # not — so a genuine first cutover is untouched and passes straight
+        # through. To get bytes to the pod now, use the write route (`cairn
+        # append` / `cairn put`), which is what replaced this phase.
+        # ⚠ NO `examined == 0` BRANCH HERE, DELIBERATELY. `survey` walks the same
+        # `read_store` population P0 already refused as RC_NO_STORE, so a zero is
+        # unreachable by the time this runs — and a guard that cannot execute is
+        # worse than none, because it reads as coverage. P5 keeps its own check
+        # because `--freeze` reaches it without passing P0.
+        frozen = survey(args.store)
+        say(f"P3 local store: {frozen}")
+        if frozen["writable"] == 0:
+            return refuse(RC_CUTOVER_COMPLETE, (
+                f"P3 is RETIRED on this store — all {frozen['examined']} entry "
+                f"file(s) already refuse a write, so the cutover has completed "
+                f"and local disk is a read-through CACHE of the pod. Pushing it "
+                f"back would overwrite every entry the pod has moved on since, "
+                f"and `seed.sh` never deletes, so it would report success. "
+                f"🔴 Do NOT pass --allow-overwrite to get past this: that is the "
+                f"silent revert, not the fix. Write to the pod through `cairn "
+                f"append` / `cairn put`. NOTHING was pushed."
+            ))
+
         if not args.apply:
             say(f"DRY RUN — {len(plan.shippable)} entr(ies) would be pushed "
                 f"({counts[ADD]} new, {counts[SUPERSEDES]} superseding, "

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1452,20 +1452,41 @@ def main(argv: list[str] | None = None) -> int:
             ))
         if frozen["refused"] > 0:
             # 🔴 THE MESSAGE STATES WHAT WAS MEASURED, NOT A CONCLUSION IT CANNOT
-            # REACH. An earlier draft said "so P5 has frozen it and local disk is
-            # a read-through CACHE" — false for a PARTIAL freeze, which this
-            # script produces as a first-class outcome (`RC_FREEZE_INEFFECTIVE`
-            # with `unknown > 0` leaves entries at 0444 on a store whose freeze
-            # did NOT take), and false again after a SIGINT mid-`set_entry_mode`.
-            # Mode bits cannot tell that apart from a completed cutover, so the
-            # message reports the count and names BOTH routes out.
+            # REACH — and this is the THIRD spelling, because the first two each
+            # asserted an absolute the mode bits do not establish. Draft 1: "so
+            # P5 has frozen it and local disk is a read-through CACHE", false for
+            # a PARTIAL freeze (`RC_FREEZE_INEFFECTIVE` with `unknown > 0` leaves
+            # entries at 0444 on a store whose freeze did NOT take) and after a
+            # SIGINT mid-`set_entry_mode`. Draft 2: "which only P5's freeze
+            # produces here", false for a never-cut-over store carrying one stray
+            # 0444 entry — and written in the very commit that DELETED the caveat
+            # recording that residual.
+            #
+            # 🔴 AND NO SINGLE PRESCRIBED ROUTE FOR THE MIXED CASE. Draft 2 told a
+            # MIXED store to "complete it with `--freeze --apply`". MEASURED, that
+            # advice does harm two ways:
+            #   * on a never-cut-over store it FREEZES entries that were never
+            #     pushed — the `34d00d90`/#1254 shape, content that exists only
+            #     locally and is dark to every reader — with P3 now retired over
+            #     it, so the ordinary route can never push it again;
+            #   * out of a genuinely interrupted freeze it writes a SECOND mode
+            #     ledger recording the 0444 the FIRST freeze already set, and
+            #     `--unfreeze` defaults to the NEWEST ledger — so a 0600 entry is
+            #     "restored" to 0444 and the rollback exits 0. That is
+            #     `save_modes`' documented widening hazard in mirror image: a
+            #     NARROWING presented as a restore.
+            # So the message names the ambiguity, puts the safe act first (get
+            # content to the pod), and carries the ledger caveat with the route.
             mixed = frozen["writable"] > 0
             return refuse(RC_CUTOVER_COMPLETE, (
                 f"P3 is RETIRED on this store — {frozen['refused']} of "
-                f"{frozen['examined']} entry file(s) refuse a write, which only "
-                f"P5's freeze produces here. Pushing local disk back would "
-                f"overwrite every entry the pod has moved on since, and "
-                f"`seed.sh` never deletes, so it would report success. "
+                f"{frozen['examined']} entry file(s) refuse a write. P5's freeze "
+                f"is what normally produces that, but it is not the only thing "
+                f"that can: a stray 0444 entry on a store that was NEVER cut "
+                f"over reads identically, and the mode bits cannot tell them "
+                f"apart. Pushing local disk back would overwrite every entry the "
+                f"pod has moved on since, and `seed.sh` never deletes, so it "
+                f"would report success. "
                 f"🔴 Do NOT pass --allow-overwrite to get past this: that is the "
                 f"silent revert, not the fix. Write to the pod through `cairn "
                 f"create` for an entry it has never seen, or `cairn append` / "
@@ -1473,14 +1494,19 @@ def main(argv: list[str] | None = None) -> int:
                 f"on a ref that does not resolve, so create is the verb for the "
                 f"ADD case."
                 + (
-                    f" ⚠ {frozen['writable']} entr(y/ies) here are still WRITABLE, "
-                    f"so this may instead be a PARTIAL or INTERRUPTED freeze "
-                    f"rather than a completed cutover — the mode bits cannot "
-                    f"tell the two apart. If P5 never finished, complete it with "
-                    f"`--freeze --apply` (which runs P5 alone and does not "
-                    f"re-enter this phase); if this IS a cut-over store, the "
-                    f"writable file is a post-freeze creation and belongs on the "
-                    f"pod via `cairn create`."
+                    f" ⚠ {frozen['writable']} entr(y/ies) here are still WRITABLE. "
+                    f"That is a completed cutover with a post-freeze creation, OR "
+                    f"a PARTIAL/INTERRUPTED freeze, OR a store never cut over at "
+                    f"all — indistinguishable by mode bits. Get any local-only "
+                    f"content onto the pod with `cairn create` FIRST: "
+                    f"`--freeze --apply` pushes NOTHING, so freezing before "
+                    f"sending strands whatever has not been sent. 🔴 And if you "
+                    f"run it to finish an interrupted freeze, roll back with "
+                    f"`--unfreeze --mode-ledger <the INTERRUPTED run>/"
+                    f"{MODE_LEDGER}` — a second freeze writes a second ledger "
+                    f"recording 0444, `--unfreeze` takes the NEWEST by default, "
+                    f"and the original modes are then lost with a success "
+                    f"message."
                     if mixed else ""
                 )
                 + " NOTHING was pushed."
@@ -1495,7 +1521,9 @@ def main(argv: list[str] | None = None) -> int:
                 f"--dest {args.dest}")
             say("DRY RUN — the freeze would then chmod 0444 over "
                 f"{len(local)} entry file(s) and require EVERY ONE to refuse a write.")
-            say("Nothing was changed. Re-run with --apply.")
+            say("Nothing was changed IN EITHER STORE. ⚠ P0 has already written "
+                f"{cache_dir} — a full plaintext copy of the SERVED store; "
+                f"delete the run dir to roll that back. Re-run with --apply.")
             return RC_OK
 
         if not plan.shippable:

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -74,13 +74,20 @@ covered the whole criterion.
 
 USAGE
 -----
-    cairn-cutover.py                       # dry run: plan and report, change nothing
+    cairn-cutover.py                       # dry run: plan and report, change no STORE
                                            # ⚠ on a store P5 has already frozen this
                                            # exits 19 (P3 retired) INSTEAD of reporting
                                            # a plan — deliberately: a plan you can never
-                                           # apply is not information. Still changes
-                                           # nothing.
+                                           # apply is not information.
+                                           # 🔴 "change nothing" is about the STORES. A
+                                           # dry run STILL creates <run-dir> holding a
+                                           # full plaintext copy of the SERVED store
+                                           # (P0 runs first); roll back by deleting it.
+                                           # An earlier draft of this note said "still
+                                           # changes nothing" flatly, which was false.
     cairn-cutover.py --apply --push <ns>/<deploy>
+    cairn-cutover.py --freeze --apply      # run P5 alone — the route out of a PARTIAL
+                                           # or interrupted freeze, which P3 now refuses
     cairn-cutover.py --unfreeze            # roll P5 back
     cairn-cutover.py --rollback-push <run-dir>
 
@@ -1399,56 +1406,84 @@ def main(argv: list[str] | None = None) -> int:
         # candidates, 5 were POD-NEWER, two of them `OPEN:` -> `RESOLVED` closures
         # carrying ~20 lines of later corrections. It would report success.
         #
-        # So this refuses instead, by the same instrument P5 uses. The signal is
-        # the freeze, not a flag or a date: a store whose entries all refuse a
-        # write has completed the cutover, and a store that is still writable has
-        # not — so a genuine first cutover is untouched and passes straight
-        # through. To get bytes to the pod now, use the write route (`cairn
-        # append` / `cairn put`), which is what replaced this phase.
-        # ⚠ NO `examined == 0` BRANCH HERE, DELIBERATELY. `survey` walks the same
+        # So this refuses instead, using the instrument P5 already uses. The
+        # signal is the FREEZE — evidence P5 leaves and nothing else here does —
+        # not a flag or a date, so a genuine first cutover passes straight
+        # through and P3 stays live for it.
+        #
+        # ⚠ NO `examined == 0` BRANCH, DELIBERATELY. `survey` walks the same
         # `read_store` population P0 already refused as RC_NO_STORE, so a zero is
-        # unreachable by the time this runs — and a guard that cannot execute is
-        # worse than none, because it reads as coverage. P5 keeps its own check
-        # because `--freeze` reaches it without passing P0.
-        # 🔴 THE PREDICATE IS `refused > 0`, NOT `writable == 0`, AND THE
-        # DIFFERENCE IS TWO REAL STATES — both measured, both wrong in the
-        # earlier spelling:
+        # unreachable here — and a guard that cannot execute is worse than none,
+        # because it reads as coverage. P5 keeps its own check because `--freeze`
+        # reaches it without passing P0.
+        #
+        # 🔴 `refused`, NOT `writable == 0` — the earlier spelling was wrong in
+        # BOTH directions, and both are real states:
         #   * `set_entry_mode` freezes FILES, never scope DIRECTORIES (see its
         #     docstring), so a genuinely NEW entry written after the freeze is
-        #     0644 and `writable == 0` goes FALSE on a store that HAS been cut
-        #     over. Measured on the real mirror 2026-09-02 (`34d00d90`): five
-        #     entries existed only on one host, created exactly that way. The
-        #     guard would have gone silent in the one situation that makes
-        #     someone reach for P3.
-        #   * `probe_writable` returns "refused" ONLY for `PermissionError`;
-        #     EROFS is a plain `OSError` and lands in `other`. A never-cut-over
-        #     store on a read-only mount therefore reads `writable == 0` and the
-        #     guard fired with a FALSE diagnosis, refusing a legitimate first
-        #     cutover.
-        # `refused` counts entries that answered EACCES to a real append, which
-        # is the thing P5's freeze produces and nothing else here does — so it is
-        # both the honest evidence and what the message below claims. P5 verifies
-        # its own work the same way (`refused != examined`); one instrument, one
-        # claim.
+        #     0644 and `writable == 0` went FALSE on a store that HAD been cut
+        #     over — silent in the one situation that makes someone reach for P3.
+        #     `34d00d90`/#1254 records five entries created exactly that way.
+        #   * a never-cut-over store on a read-only mount reads `writable == 0`
+        #     and the old predicate fired with a FALSE diagnosis.
         #
-        # ⚠ DIRECTION OF THE RESIDUAL: a never-cut-over store carrying a stray
-        # 0444 entry refuses P3. That is a false refusal, not a false push — it
-        # costs an operator one `chmod`, where the other direction costs the pod.
+        # 🔴 AND `other` IS ITS OWN OUTCOME, ABOVE THE RETIREMENT — because
+        # `refused > 0` ALONE FAILS OPEN ON THE BUCKET IT DOES NOT MEASURE, in
+        # the destructive direction. `probe_writable` returns "refused" only for
+        # `PermissionError`; EROFS is a plain `OSError` and lands in `other`. So
+        # a CUT-OVER store on a read-only mount — a natural hardening once local
+        # disk is declared a cache — reads `refused == 0` and would push the
+        # frozen mirror over the pod. Trading one direction for the other is not
+        # a fix. This file's own doctrine says it in one line: RC_COULD_NOT_
+        # MEASURE is "an instrument did not answer; never folded into a pass".
+        # An unreadable store is exactly that, so it gets that code rather than
+        # either verdict.
         frozen = survey(args.store)
         say(f"P3 local store: {frozen}")
+        if frozen["other"] > 0:
+            return refuse(RC_COULD_NOT_MEASURE, (
+                f"P3 could not measure {frozen['other']} of {frozen['examined']} "
+                f"entry file(s): the write probe answered neither 'writable' nor "
+                f"EACCES, so whether this store has been cut over is UNKNOWN — "
+                f"most likely a read-only mount (EROFS is not a PermissionError) "
+                f"or an I/O error. Both verdicts would be a guess in a direction "
+                f"that matters. Read the survey line above, fix the mount or the "
+                f"permissions, and re-run. NOTHING was pushed."
+            ))
         if frozen["refused"] > 0:
+            # 🔴 THE MESSAGE STATES WHAT WAS MEASURED, NOT A CONCLUSION IT CANNOT
+            # REACH. An earlier draft said "so P5 has frozen it and local disk is
+            # a read-through CACHE" — false for a PARTIAL freeze, which this
+            # script produces as a first-class outcome (`RC_FREEZE_INEFFECTIVE`
+            # with `unknown > 0` leaves entries at 0444 on a store whose freeze
+            # did NOT take), and false again after a SIGINT mid-`set_entry_mode`.
+            # Mode bits cannot tell that apart from a completed cutover, so the
+            # message reports the count and names BOTH routes out.
+            mixed = frozen["writable"] > 0
             return refuse(RC_CUTOVER_COMPLETE, (
                 f"P3 is RETIRED on this store — {frozen['refused']} of "
-                f"{frozen['examined']} entry file(s) refuse a write, so P5 has "
-                f"frozen it and local disk is a read-through CACHE of the pod. "
-                f"Pushing it back would overwrite every entry the pod has moved "
-                f"on since, and `seed.sh` never deletes, so it would report "
-                f"success. 🔴 Do NOT pass --allow-overwrite to get past this: "
-                f"that is the silent revert, not the fix. Write to the pod "
-                f"through `cairn create` for an entry it has never seen, or "
-                f"`cairn append` / `cairn put` for one it already holds — "
-                f"append and put BOTH 404 on a ref that does not resolve, so "
-                f"create is the verb for the ADD case. NOTHING was pushed."
+                f"{frozen['examined']} entry file(s) refuse a write, which only "
+                f"P5's freeze produces here. Pushing local disk back would "
+                f"overwrite every entry the pod has moved on since, and "
+                f"`seed.sh` never deletes, so it would report success. "
+                f"🔴 Do NOT pass --allow-overwrite to get past this: that is the "
+                f"silent revert, not the fix. Write to the pod through `cairn "
+                f"create` for an entry it has never seen, or `cairn append` / "
+                f"`cairn put` for one it already holds — append and put BOTH 404 "
+                f"on a ref that does not resolve, so create is the verb for the "
+                f"ADD case."
+                + (
+                    f" ⚠ {frozen['writable']} entr(y/ies) here are still WRITABLE, "
+                    f"so this may instead be a PARTIAL or INTERRUPTED freeze "
+                    f"rather than a completed cutover — the mode bits cannot "
+                    f"tell the two apart. If P5 never finished, complete it with "
+                    f"`--freeze --apply` (which runs P5 alone and does not "
+                    f"re-enter this phase); if this IS a cut-over store, the "
+                    f"writable file is a post-freeze creation and belongs on the "
+                    f"pod via `cairn create`."
+                    if mixed else ""
+                )
+                + " NOTHING was pushed."
             ))
 
         if not args.apply:

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -75,6 +75,11 @@ covered the whole criterion.
 USAGE
 -----
     cairn-cutover.py                       # dry run: plan and report, change nothing
+                                           # ⚠ on a store P5 has already frozen this
+                                           # exits 19 (P3 retired) INSTEAD of reporting
+                                           # a plan — deliberately: a plan you can never
+                                           # apply is not information. Still changes
+                                           # nothing.
     cairn-cutover.py --apply --push <ns>/<deploy>
     cairn-cutover.py --unfreeze            # roll P5 back
     cairn-cutover.py --rollback-push <run-dir>
@@ -999,14 +1004,24 @@ def set_entry_mode(store: Path, mode: int) -> int:
 
     🔴 FILES, NOT DIRECTORIES, AND THE ASYMMETRY IS A DESIGN DECISION WITH A
     KNOWN COST. Freezing the directories too would also stop a genuinely NEW
-    entry being created — and the hosted API has NO create route (`POST` and
-    `PUT` both resolve an existing ref; a ref that does not resolve is 404
-    `ref-unknown`), so the first entry for a new subsystem would have nowhere to
-    go at all. Freezing the files closes the hazard this cutover is about — an
-    append or an overwrite that lands only locally and dies at the next seed —
-    while leaving the one operation the API cannot yet serve. The gap is real and
-    is written down rather than papered over; see the design doc's "What
-    criterion 9 does NOT close".
+    entry being created. Freezing the files closes the hazard this cutover is
+    about — an append or an overwrite that lands only locally and dies at the
+    next seed — while leaving creation possible.
+
+    🔴 THE ORIGINAL REASON IS NOW STALE, AND SAYING SO MATTERS BECAUSE IT IS THE
+    SENTENCE P3'S RETIREMENT RESTS ON. This docstring used to argue the API had
+    "NO create route", so a new subsystem's first entry "would have nowhere to go
+    at all". That was true when written and is FALSE at HEAD: `cairn create`
+    (`scripts/cairn`, `PUT` + `If-None-Match: *`; server side `server.py:247`)
+    landed in `34d00d90`/#1254 precisely because writing new entries into this
+    frozen mirror had already cost five entries that were dark to every reader.
+    So creation has a hosted route now, and retiring P3 strands nothing.
+
+    ⚠ WHAT REMAINS TRUE is the mechanical consequence, which is why the files/
+    directories split stays: a directory left writable means an entry CAN still
+    be created on local disk, so `survey` can see a writable file on a store that
+    has been cut over. P3's retirement keys on `refused > 0` rather than
+    `writable == 0` for exactly that reason.
     """
     changed = 0
     for rel in read_store(store):
@@ -1395,18 +1410,45 @@ def main(argv: list[str] | None = None) -> int:
         # unreachable by the time this runs — and a guard that cannot execute is
         # worse than none, because it reads as coverage. P5 keeps its own check
         # because `--freeze` reaches it without passing P0.
+        # 🔴 THE PREDICATE IS `refused > 0`, NOT `writable == 0`, AND THE
+        # DIFFERENCE IS TWO REAL STATES — both measured, both wrong in the
+        # earlier spelling:
+        #   * `set_entry_mode` freezes FILES, never scope DIRECTORIES (see its
+        #     docstring), so a genuinely NEW entry written after the freeze is
+        #     0644 and `writable == 0` goes FALSE on a store that HAS been cut
+        #     over. Measured on the real mirror 2026-09-02 (`34d00d90`): five
+        #     entries existed only on one host, created exactly that way. The
+        #     guard would have gone silent in the one situation that makes
+        #     someone reach for P3.
+        #   * `probe_writable` returns "refused" ONLY for `PermissionError`;
+        #     EROFS is a plain `OSError` and lands in `other`. A never-cut-over
+        #     store on a read-only mount therefore reads `writable == 0` and the
+        #     guard fired with a FALSE diagnosis, refusing a legitimate first
+        #     cutover.
+        # `refused` counts entries that answered EACCES to a real append, which
+        # is the thing P5's freeze produces and nothing else here does — so it is
+        # both the honest evidence and what the message below claims. P5 verifies
+        # its own work the same way (`refused != examined`); one instrument, one
+        # claim.
+        #
+        # ⚠ DIRECTION OF THE RESIDUAL: a never-cut-over store carrying a stray
+        # 0444 entry refuses P3. That is a false refusal, not a false push — it
+        # costs an operator one `chmod`, where the other direction costs the pod.
         frozen = survey(args.store)
         say(f"P3 local store: {frozen}")
-        if frozen["writable"] == 0:
+        if frozen["refused"] > 0:
             return refuse(RC_CUTOVER_COMPLETE, (
-                f"P3 is RETIRED on this store — all {frozen['examined']} entry "
-                f"file(s) already refuse a write, so the cutover has completed "
-                f"and local disk is a read-through CACHE of the pod. Pushing it "
-                f"back would overwrite every entry the pod has moved on since, "
-                f"and `seed.sh` never deletes, so it would report success. "
-                f"🔴 Do NOT pass --allow-overwrite to get past this: that is the "
-                f"silent revert, not the fix. Write to the pod through `cairn "
-                f"append` / `cairn put`. NOTHING was pushed."
+                f"P3 is RETIRED on this store — {frozen['refused']} of "
+                f"{frozen['examined']} entry file(s) refuse a write, so P5 has "
+                f"frozen it and local disk is a read-through CACHE of the pod. "
+                f"Pushing it back would overwrite every entry the pod has moved "
+                f"on since, and `seed.sh` never deletes, so it would report "
+                f"success. 🔴 Do NOT pass --allow-overwrite to get past this: "
+                f"that is the silent revert, not the fix. Write to the pod "
+                f"through `cairn create` for an entry it has never seen, or "
+                f"`cairn append` / `cairn put` for one it already holds — "
+                f"append and put BOTH 404 on a ref that does not resolve, so "
+                f"create is the verb for the ADD case. NOTHING was pushed."
             ))
 
         if not args.apply:

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1430,6 +1430,16 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
                 dest = Path(argv[argv.index("--cache") + 1])
                 _tree(dest, pod_entries)
                 return cc.Ran(0, "synced (stubbed)", "")
+            # 🔴 SEED IS INTERCEPTED, NOT EXECUTED. `scripts/tests` is in
+            # run-tests.sh's HERMETIC_TARGETS ("safe to run offline in the nix
+            # sandbox") and `kubectl` is deliberately absent from REQUIRED_TOOLS
+            # — but `seed.sh --push` shells out to it, so letting this fall
+            # through really dialled localhost:8080 and made the outcome depend
+            # on an ambient KUBECONFIG, inside a `timeout=600` in a suite with a
+            # wall clock. The `seen` ledger still proves reachability, which is
+            # all these tests read it for.
+            if any(a.endswith("seed.sh") for a in argv):
+                return cc.Ran(0, "seed: OK (stubbed — not executed)", "")
             return real_run(argv, **kw)
 
         monkeypatch.setattr(cc, "run", fake_run)
@@ -1530,6 +1540,101 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
             f"seed.sh was reached from a cut-over store: {seen}"
         )
 
+    def test_the_MIXED_state_refusal_names_the_route_out_instead_of_a_conclusion(
+        self, cc, tmp_path, monkeypatch, capsys
+    ):
+        """🔴 MODE BITS CANNOT TELL A COMPLETED CUTOVER FROM A PARTIAL FREEZE.
+
+        `RC_FREEZE_INEFFECTIVE` with `unknown > 0` is a first-class outcome that
+        LEAVES entries at 0444 on a store whose freeze did not take, and a SIGINT
+        mid-`set_entry_mode` produces the same shape. An earlier draft's message
+        asserted "so P5 has frozen it and local disk is a read-through CACHE" —
+        false in exactly that state, and it left the operator with no route out,
+        because P3 now refuses before P5 is reached.
+
+        So a MIXED store must be told it might be a partial freeze and pointed at
+        `--freeze --apply`, which runs P5 alone and does not re-enter this phase.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        (root / "sc" / "later.md").write_text(_entry("sc", "later", "- 2026-01-02: y."))
+        assert cc.survey(root)["writable"] == 1, "fixture is not MIXED"
+
+        cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                 "--apply", "--push", "ns/dep"])
+        text = "".join(capsys.readouterr())
+        assert "--freeze --apply" in text, (
+            f"a MIXED store was refused with no route out — the partial-freeze "
+            f"operator cannot reach P5 through this phase.\n{text}"
+        )
+        assert "PARTIAL" in text, (
+            f"the refusal states a conclusion the mode bits cannot establish "
+            f"instead of naming the ambiguity.\n{text}"
+        )
+
+    def test_an_UNMEASURABLE_store_is_neither_retired_nor_pushed(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE BUCKET `refused > 0` DOES NOT MEASURE, AND IT FAILED OPEN.
+
+        `probe_writable` returns "refused" only for `PermissionError`. EROFS is a
+        plain `OSError` and lands in `other` — so a CUT-OVER store on a read-only
+        mount (a natural hardening once local disk is a cache) read `refused == 0`
+        and P3 PUSHED it. Measured: `survey` `{'writable':0,'refused':0,'other':1}`
+        gave rc 17 with seed.sh reached. A mutant widening the predicate to
+        `refused > 0 or other > 0` SURVIVED all 91 tests, so the suite was blind
+        to this bucket in both directions.
+
+        The answer is neither verdict: an instrument that did not answer gets
+        RC_COULD_NOT_MEASURE, which is this file's own stated doctrine.
+
+        ⚠ The unreadable state is injected by stubbing `probe_writable` rather
+        than by mounting a real read-only filesystem, which needs root. The
+        errno mapping underneath it (EACCES/EPERM -> PermissionError; EROFS/EIO
+        -> plain OSError) is the part that makes the injection faithful, and it
+        is asserted here rather than assumed.
+        """
+        import errno as _errno
+        assert isinstance(OSError(_errno.EACCES, "x"), OSError)
+        assert not isinstance(OSError(_errno.EROFS, "x"), PermissionError), (
+            "EROFS maps to PermissionError on this platform, so `other` would "
+            "never hold it and this test is measuring nothing"
+        )
+
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        seen = self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        monkeypatch.setattr(cc, "probe_writable", lambda _p: "error:EROFS")
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        assert rc == cc.RC_COULD_NOT_MEASURE, (
+            f"an unreadable store was folded into a verdict (rc={rc}) — the one "
+            f"outcome this file says must never happen"
+        )
+        assert not any("seed.sh" in " ".join(argv) for argv in seen), (
+            f"seed.sh was reached over a store nothing could measure: {seen}"
+        )
+
+    def test_the_USAGE_note_states_the_dry_run_refusal_and_the_run_dir_cost(self):
+        """🔴 THE BEHAVIOUR WAS PINNED AND THE DOCUMENTATION WAS NOT — deleting
+        the whole USAGE note SURVIVED the file. The note is the only place a
+        reader learns that the documented default command exits 19 on a
+        cut-over store, and that a dry run still writes a plaintext copy of the
+        served store to disk. Pin both claims, not the word 'dry run'."""
+        src = CUTOVER.read_text(encoding="utf-8")
+        usage = src[src.index("USAGE"):src.index("Exit codes are disjoint")]
+        assert "19" in usage and "P3 retired" in usage, (
+            f"USAGE no longer says a bare run exits 19 on a frozen store:\n{usage}"
+        )
+        for claim in ("plaintext copy", "deleting it"):
+            assert claim in usage, (
+                f"USAGE no longer records the run-dir cost ({claim!r}) — the "
+                f"earlier draft flatly said 'still changes nothing', which was "
+                f"false.\n{usage}"
+            )
+
     def test_a_BARE_DRY_RUN_on_a_frozen_store_refuses_and_changes_nothing(
         self, cc, tmp_path, monkeypatch
     ):
@@ -1549,10 +1654,23 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
         cc.set_entry_mode(root, 0o444)
         before = {p: p.stat().st_mode for p in root.rglob("*.md")}
 
-        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run")])
+        run_dir = tmp_path / "run"
+        rc = cc.main(["--store", str(root), "--run-dir", str(run_dir)])
         assert rc == cc.RC_CUTOVER_COMPLETE, f"a bare dry run returned {rc}"
         assert {p: p.stat().st_mode for p in root.rglob("*.md")} == before, (
-            "the dry run moved a mode bit"
+            "the dry run moved a mode bit in the STORE"
+        )
+        # 🔴 AND THE HALF THE FIRST DRAFT COULD NOT SEE. It asserted "changes
+        # nothing" by globbing the STORE only — while its own `cairn sync` stub
+        # wrote the served copy into the run dir, so the counter-evidence was
+        # produced inside the test and never looked at. P0 runs before P3, so a
+        # refused dry run still leaves a full plaintext copy on disk. Assert the
+        # true shape rather than the comfortable one; USAGE says the same.
+        assert run_dir.exists(), "P0 did not create the run dir — fixture drift"
+        copied = sorted(str(q.relative_to(run_dir)) for q in run_dir.rglob("*.md"))
+        assert copied, (
+            "the run dir holds no copy, so this test is no longer observing the "
+            "thing USAGE warns about"
         )
         assert not any("seed.sh" in " ".join(argv) for argv in seen), (
             f"a DRY RUN reached seed.sh: {seen}"

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1675,11 +1675,29 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
                       "--apply", "--push", "ns/dep"])
         assert rc == cc.RC_CUTOVER_COMPLETE, f"rc={rc}"
         text = "".join(capsys.readouterr())
-        first_create = text.index("cairn create")
-        freeze_at = text.index("--freeze --apply")
-        assert first_create < freeze_at, (
-            f"the freeze route is offered before the push — following it in that "
-            f"order strands local-only content behind a retired P3.\n{text}"
+        # 🔴 ANCHORED INSIDE THE MIXED CLAUSE, AND THE FIRST DRAFT WAS NOT.
+        # `str.index` returns the FIRST occurrence, and "cairn create" appears
+        # TWICE — once in the base sentence that precedes the whole suffix. So
+        # `first_create` always resolved to that one, which trivially precedes
+        # `--freeze --apply`, and the ordering WITHIN the clause — the thing this
+        # test's name and docstring claim to pin — was never measured. MEASURED:
+        # reverting the clause to the round-2 wording ("If P5 never finished,
+        # complete it with `--freeze --apply`. Afterwards get any local-only
+        # content onto the pod with `cairn create`") passed all 97 tests. That
+        # mutant IS the defect this test exists to stop recurring.
+        assert "still WRITABLE" in text, (
+            f"the MIXED suffix is absent, so there is no clause to order.\n{text}"
+        )
+        clause = text[text.index("still WRITABLE"):]
+        for token in ("cairn create", "--freeze --apply"):
+            assert token in clause, (
+                f"the MIXED clause no longer names {token!r}, so the ordering "
+                f"below is unmeasurable.\n{clause}"
+            )
+        assert clause.index("cairn create") < clause.index("--freeze --apply"), (
+            f"the freeze route is offered before the push WITHIN the mixed "
+            f"clause — following it in that order strands local-only content "
+            f"behind a retired P3.\n{clause}"
         )
         assert "pushes NOTHING" in text, (
             f"the message does not say the freeze route sends nothing.\n{text}"

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1617,6 +1617,116 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
             f"seed.sh was reached over a store nothing could measure: {seen}"
         )
 
+    def test_an_ORDINARY_dry_run_admits_the_run_dir_it_wrote(
+        self, cc, tmp_path, monkeypatch, capsys
+    ):
+        """🔴 THE PARTIAL SWEEP, ONE ROUND LATER — this is the site an operator
+        actually reads, and it was missed while USAGE and the frozen-store test
+        were fixed. On an UN-frozen store the run reaches the dry-run branch and
+        printed a flat "Nothing was changed." — while P0 had already synced a
+        full plaintext copy of the SERVED store into the run dir. The file's own
+        comment calls that out and notes the runbook prescribes several dry runs,
+        so they accumulate.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        self._past_p0(cc, monkeypatch, POD)
+        run_dir = tmp_path / "run"
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(run_dir)])
+        assert rc == cc.RC_OK, f"rc={rc}"
+        text = "".join(capsys.readouterr())
+        assert sorted(q.name for q in run_dir.rglob("*.md")), (
+            "the run dir holds no copy — this test no longer observes the thing"
+        )
+        assert "IN EITHER STORE" in text, (
+            f"the dry run still claims a flat 'Nothing was changed' while it "
+            f"wrote a plaintext copy of the served store.\n{text}"
+        )
+        assert "delete the run dir" in text, (
+            f"the dry run does not tell the operator how to roll back what it "
+            f"DID write.\n{text}"
+        )
+
+    def test_the_MIXED_advice_puts_the_PUSH_before_the_FREEZE_and_names_the_ledger(
+        self, cc, tmp_path, monkeypatch, capsys
+    ):
+        """🔴 TWO MEASURED HARMS FROM ONE SENTENCE OF ADVICE.
+
+        An earlier draft told a MIXED store to "complete it with `--freeze
+        --apply`". Reproduced end to end:
+          * on a never-cut-over store that FREEZES entries never pushed — the
+            `34d00d90`/#1254 shape, local-only content dark to every reader —
+            with P3 now retired over it;
+          * out of an interrupted freeze it writes a SECOND mode ledger holding
+            0444, and `--unfreeze` takes the NEWEST, so a 0600 entry is
+            "restored" to 0444 and the rollback exits 0.
+
+        So the advice must order the acts (push first) and carry the ledger
+        caveat with the route. Pinned on the ORDER, not on the words: `create`
+        must be recommended before `--freeze --apply` is mentioned.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        (root / "sc" / "later.md").write_text(_entry("sc", "later", "- 2026-01-02: y."))
+        assert cc.survey(root)["writable"] == 1, "fixture is not MIXED"
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        assert rc == cc.RC_CUTOVER_COMPLETE, f"rc={rc}"
+        text = "".join(capsys.readouterr())
+        first_create = text.index("cairn create")
+        freeze_at = text.index("--freeze --apply")
+        assert first_create < freeze_at, (
+            f"the freeze route is offered before the push — following it in that "
+            f"order strands local-only content behind a retired P3.\n{text}"
+        )
+        assert "pushes NOTHING" in text, (
+            f"the message does not say the freeze route sends nothing.\n{text}"
+        )
+        assert cc.MODE_LEDGER in text and "--mode-ledger" in text, (
+            f"the freeze route is named without the ledger caveat — a second "
+            f"freeze shadows the first and --unfreeze silently narrows a 0600 "
+            f"entry to 0444.\n{text}"
+        )
+
+    def test_the_UNMEASURABLE_branch_is_decided_BEFORE_the_retirement(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE ORDERING THE FIX IS DESCRIBED BY, AND IT WAS UNPINNED —
+        moving the `other` block below the `refused` block survived the file.
+
+        Both spellings refuse and neither pushes, so the behavioural stake is
+        which code an operator sees for a store that is BOTH partly frozen and
+        partly unreadable. That store is the one this builds, and it is the one
+        no other test constructs: the F1 test stubs `probe_writable` for EVERY
+        entry, so it can never produce a mixed bucket. 'Could not measure' must
+        win, because a store you cannot read is not a store you have classified.
+        """
+        root = _tree(tmp_path / "s", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+        })
+        seen = self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        real_probe = cc.probe_writable
+        monkeypatch.setattr(
+            cc, "probe_writable",
+            lambda q: "error:EROFS" if q.name == "b.md" else real_probe(q),
+        )
+        state = cc.survey(root)
+        assert state["refused"] == 1 and state["other"] == 1, (
+            f"fixture does not build the MIXED bucket: {state}"
+        )
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        assert rc == cc.RC_COULD_NOT_MEASURE, (
+            f"a store that is partly UNREADABLE was classified anyway (rc={rc}) "
+            f"— the unmeasurable branch must be decided first"
+        )
+        assert not any("seed.sh" in " ".join(argv) for argv in seen), seen
+
     def test_the_USAGE_note_states_the_dry_run_refusal_and_the_run_dir_cost(self):
         """🔴 THE BEHAVIOUR WAS PINNED AND THE DOCUMENTATION WAS NOT — deleting
         the whole USAGE note SURVIVED the file. The note is the only place a

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1457,7 +1457,8 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
         """🔴 THE CONTROL THAT KEEPS THE ONE ABOVE HONEST. A guard that refused
         unconditionally would satisfy every assertion in the previous test while
         breaking the one run P3 still exists for — a host that has NOT been cut
-        over. The ONLY difference between the two fixtures is the mode bits.
+        over. The ONLY difference between the two fixtures is the mode bits —
+        same argv, same pod, same store contents.
 
         ⚠ AN INVARIANT GUARD, NOT REGRESSION COVERAGE, and labelled so it is not
         counted as such: it passes at base too, by construction — before the
@@ -1467,14 +1468,94 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
         direction a future edit would break.
         """
         root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
-        self._past_p0(cc, monkeypatch, POD)
-        assert cc.survey(root)["writable"] == 1, "fixture is not actually writable"
+        seen = self._past_p0(cc, monkeypatch, POD)
+        assert cc.survey(root)["refused"] == 0, "fixture is not actually un-frozen"
 
+        # 🔴 THE SAME ARGV AS THE FROZEN CASE, DOWN TO --apply --push. The first
+        # draft passed neither here, so the pair differed in the mode bits AND in
+        # whether it could reach `seed.sh` at all — while the docstring claimed
+        # the mode bits were the only difference. A control whose fixture differs
+        # on two axes cannot say which one moved the result.
         rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
-])
+                      "--apply", "--push", "ns/dep"])
         assert rc != cc.RC_CUTOVER_COMPLETE, (
             "the retirement fired on a store that has NOT been cut over — P3 is "
             "retired post-freeze, not deleted"
+        )
+        # 🔴 AND IT MUST REACH THE PUSH. `rc != 19` alone is satisfied by ANY
+        # earlier refusal (RC_NO_STORE, RC_BACKUP, RC_UNRESOLVED_DIVERGENCE), so
+        # a future change that made P0 reject this fixture would leave this test
+        # green over zero coverage.
+        assert any("seed.sh" in " ".join(argv) for argv in seen), (
+            f"the un-frozen run never reached seed.sh, so this proves nothing "
+            f"about the retirement being CONDITIONAL: {seen}"
+        )
+
+    def test_a_NEW_entry_created_AFTER_the_freeze_does_not_disarm_the_guard(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE STATE THAT BROKE THE FIRST PREDICATE, AND IT IS A MEASURED ONE.
+
+        `set_entry_mode` freezes FILES and deliberately leaves scope DIRECTORIES
+        writable, so a genuinely new entry can still be created on local disk —
+        and `34d00d90`/#1254 records five entries that were created exactly that
+        way, existing on one host and dark to every reader. In that state
+        `writable >= 1`, so the original `writable == 0` predicate went SILENT on
+        a store that HAS been cut over, and P3 pushed. This is the situation that
+        makes someone reach for P3 in the first place, so it is the one the guard
+        must not miss.
+
+        `refused > 0` is what fixes it: the freeze leaves evidence that a later
+        creation cannot erase.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        seen = self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        # the post-freeze creation — a writable file in a still-writable scope dir
+        (root / "sc" / "brand-new.md").write_text(
+            _entry("sc", "brand-new", "- 2026-01-02: created after the freeze.")
+        )
+        state = cc.survey(root)
+        assert state["writable"] == 1 and state["refused"] == 1, (
+            f"fixture does not reproduce the mixed state: {state}"
+        )
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        assert rc == cc.RC_CUTOVER_COMPLETE, (
+            f"one writable file disarmed the retirement (rc={rc}) — this is the "
+            f"push the guard exists to stop, in the state that motivates it"
+        )
+        assert not any("seed.sh" in " ".join(argv) for argv in seen), (
+            f"seed.sh was reached from a cut-over store: {seen}"
+        )
+
+    def test_a_BARE_DRY_RUN_on_a_frozen_store_refuses_and_changes_nothing(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE DRY RUN IS THE DOCUMENTED DEFAULT, AND ITS BEHAVIOUR MOVED.
+
+        The guard sits ABOVE `if not args.apply:`, so a bare invocation on a
+        cut-over store now exits 19 instead of printing a plan. That is the
+        intended trade — a plan that can never be applied is not information —
+        but it is a change to the one command the USAGE block tells people to
+        run first, so it is pinned here and stated there. Nothing pinned it
+        before: moving the guard below the dry-run branch was caught by no test.
+
+        The 'changes nothing' half of the USAGE claim must still hold.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        seen = self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        before = {p: p.stat().st_mode for p in root.rglob("*.md")}
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run")])
+        assert rc == cc.RC_CUTOVER_COMPLETE, f"a bare dry run returned {rc}"
+        assert {p: p.stat().st_mode for p in root.rglob("*.md")} == before, (
+            "the dry run moved a mode bit"
+        )
+        assert not any("seed.sh" in " ".join(argv) for argv in seen), (
+            f"a DRY RUN reached seed.sh: {seen}"
         )
 
     def test_the_refusal_names_the_REMEDY_and_warns_off_allow_overwrite(
@@ -1486,13 +1567,25 @@ class TestP3IsRetiredOnceTheStoreIsFrozen:
         root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
         self._past_p0(cc, monkeypatch, POD)
         cc.set_entry_mode(root, 0o444)
-        cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
-                 "--apply", "--push", "ns/dep"])
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        # 🔴 ASSERT THE CODE TOO — the first draft discarded `main`'s return
+        # value, so it never checked the text it read belonged to THIS refusal.
+        assert rc == cc.RC_CUTOVER_COMPLETE, f"rc={rc}"
         out = capsys.readouterr()
         text = out.out + out.err
-        assert "cairn" in text and "append" in text, (
-            f"the refusal does not name the write route that replaced P3:\n{text}"
-        )
+        # 🔴 NOT `"cairn" in text` — THAT WAS VACUOUS AND A MUTANT SURVIVED IT.
+        # P0 logs `cairn sync -> rc …` on every run, so the word is present no
+        # matter what the refusal says: a message rewritten to "the `append` /
+        # `put` verb", with `cairn` nowhere in it, passed. Pin each VERB, and the
+        # ADD case that only `create` serves.
+        for verb in ("cairn create", "cairn append", "cairn put"):
+            assert verb in text, (
+                f"the refusal does not name `{verb}`. `append` and `put` both 404 "
+                f"on a ref that does not resolve, so a refusal omitting `create` "
+                f"sends the ADD case — the one most likely to have brought the "
+                f"operator here — to two verbs that cannot serve it.\n{text}"
+            )
         assert "--allow-overwrite" in text, (
             f"the refusal does not warn off the flag that would disarm it:\n{text}"
         )
@@ -1760,3 +1853,26 @@ class TestAcceptanceRefusalNamesWhatItActuallyHas:
         assert "1 scope(s) compared clean" in err, err
         assert "UNCOMPARED" in err, err
         assert f"REFUSED (rc {cc.RC_ACCEPTANCE})" in err, err
+
+
+class TestTheExitCodesAreActuallyDisjoint:
+    """🔴 THE SCRIPT ASSERTS IT AND NOTHING CHECKED IT. Its module docstring says
+    "Exit codes are disjoint and each names one refusal", and a mutant setting
+    `RC_CUTOVER_COMPLETE = 18` — colliding with `RC_COULD_NOT_MEASURE` — SURVIVED
+    the whole file. A collision makes two different refusals indistinguishable to
+    any caller that branches on the code, which is the entire point of having
+    them. Pre-existing gap; this change adds a code to the set, so it closes it.
+    """
+
+    def test_no_two_RC_constants_share_a_value(self, cc):
+        codes = {n: v for n, v in vars(cc).items()
+                 if n.startswith("RC_") and isinstance(v, int)}
+        assert len(codes) >= 12, f"the ledger found almost nothing: {codes}"
+        seen: dict[int, str] = {}
+        for name, value in sorted(codes.items()):
+            assert value not in seen, (
+                f"{name} and {seen[value]} are both {value} — the module "
+                f"docstring's 'exit codes are disjoint' is false, and a caller "
+                f"branching on {value} cannot tell the two refusals apart"
+            )
+            seen[value] = name

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1386,6 +1386,118 @@ class TestTheScriptRefusesRatherThanProceeds:
         assert set(payload["sc/a.md"]) == {"sha256", "aliases"}
 
 
+POD = {"sc/pod-only.md": _entry("sc", "pod-only", "- 2026-01-01: lives only on the pod.")}
+
+
+class TestP3IsRetiredOnceTheStoreIsFrozen:
+    """🔴 P3 pushes LOCAL -> POD, which is correct exactly ONCE and destructive
+    afterwards. These are the first tests in this file to drive P3 through the
+    REAL `main`: the previous suite only re-extracted `seed.sh`'s `find`
+    expression, so 85 green tests said nothing about whether this phase runs.
+
+    The trap this guards is that P3's failure mode LOOKS like a bug worth fixing.
+    `plan.shippable` is ADD + SUPERSEDES + MERGED, and SUPERSEDES/MERGED are by
+    definition entries whose pod bytes differ — exactly what `seed.sh`'s
+    pre-flight refuses — so post-cutover it exits 8 the moment anything
+    supersedes and reads as a shipped path that can never complete. The
+    one-line "fix" is `--allow-overwrite`, and that is the silent revert:
+    `seed.sh`'s tar adds and overwrites but never deletes, so a push from a
+    frozen mirror reverts every entry the pod has moved on and reports success.
+    """
+
+    def _past_p0(self, cc, monkeypatch, pod_entries: dict[str, str]):
+        """Stub ONLY the P0 gates (backup, sync, write-route), never P3 itself.
+
+        🔴 The phase under test is left entirely real. A stub reaching into P3
+        would be testing the stub. The `cairn sync` stub POPULATES the cache dir
+        the way the real one does — reading the destination out of the argv it
+        was handed — because P0 refuses when the served copy is empty, and a
+        stub that merely returned success would fail the run before P3.
+        """
+        monkeypatch.setattr(cc, "backup_precondition",
+                            lambda **kw: (True, "backup OK (stubbed)"))
+        monkeypatch.setattr(cc, "write_route_deployed",
+                            lambda **kw: (True, None, "write route OK (stubbed)"))
+        monkeypatch.setattr(cc, "_config", lambda: ("http://stub.invalid", "tok"))
+
+        real_run = cc.run
+        seen = []
+
+        def fake_run(argv, **kw):
+            argv = [str(a) for a in argv]
+            seen.append(argv)
+            if argv[-1] == "sync" and "--cache" in argv:
+                dest = Path(argv[argv.index("--cache") + 1])
+                _tree(dest, pod_entries)
+                return cc.Ran(0, "synced (stubbed)", "")
+            return real_run(argv, **kw)
+
+        monkeypatch.setattr(cc, "run", fake_run)
+        return seen
+
+    def test_a_FROZEN_store_refuses_P3_and_never_reaches_seed(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """The wiring, end to end: rc 19 out of the real `main`, and `seed.sh`
+        never invoked. Asserting only the rc would pass for a run that pushed
+        and then refused."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        seen = self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        assert cc.survey(root)["writable"] == 0, "fixture is not actually frozen"
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                      "--apply", "--push", "ns/dep"])
+        assert rc == cc.RC_CUTOVER_COMPLETE, f"rc={rc}"
+        assert not any("seed.sh" in " ".join(str(a) for a in argv) for argv in seen), (
+            f"seed.sh was invoked despite the retirement: {seen}"
+        )
+
+    def test_a_WRITABLE_store_is_NOT_refused(self, cc, tmp_path, monkeypatch):
+        """🔴 THE CONTROL THAT KEEPS THE ONE ABOVE HONEST. A guard that refused
+        unconditionally would satisfy every assertion in the previous test while
+        breaking the one run P3 still exists for — a host that has NOT been cut
+        over. The ONLY difference between the two fixtures is the mode bits.
+
+        ⚠ AN INVARIANT GUARD, NOT REGRESSION COVERAGE, and labelled so it is not
+        counted as such: it passes at base too, by construction — before the
+        retirement existed nothing could return RC_CUTOVER_COMPLETE. Measured:
+        deleting the guard reds the two tests either side of it and leaves this
+        one green. Its job is to pin the over-refusal direction, which is the
+        direction a future edit would break.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        self._past_p0(cc, monkeypatch, POD)
+        assert cc.survey(root)["writable"] == 1, "fixture is not actually writable"
+
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+])
+        assert rc != cc.RC_CUTOVER_COMPLETE, (
+            "the retirement fired on a store that has NOT been cut over — P3 is "
+            "retired post-freeze, not deleted"
+        )
+
+    def test_the_refusal_names_the_REMEDY_and_warns_off_allow_overwrite(
+        self, cc, tmp_path, monkeypatch, capsys
+    ):
+        """A refusal that does not say what to do instead gets routed around —
+        and here the obvious route around IS the data-loss bug. Pin both halves:
+        the correct write path, and the flag that must not be reached for."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        self._past_p0(cc, monkeypatch, POD)
+        cc.set_entry_mode(root, 0o444)
+        cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"),
+                 "--apply", "--push", "ns/dep"])
+        out = capsys.readouterr()
+        text = out.out + out.err
+        assert "cairn" in text and "append" in text, (
+            f"the refusal does not name the write route that replaced P3:\n{text}"
+        )
+        assert "--allow-overwrite" in text, (
+            f"the refusal does not warn off the flag that would disarm it:\n{text}"
+        )
+
+
 class TestTheDeltaTree:
     def test_materialise_copies_ONLY_the_shippable_entries(self, cc, tmp_path):
         text = _entry("sc", "same", "- 2026-01-01: unchanged.")


### PR DESCRIPTION
fix(cairn-cutover): retire P3 post-cutover — its exit-8 refusal is the last guard, not a bug

P3 pushes LOCAL -> POD. That is correct exactly once — while a host still holds
bytes the pod has never seen — and destructive afterwards. This script's own
header already states the post-condition: "After this cutover the hosts' stores
are caches of the pod."

What it LOOKED like: `plan.shippable` is ADD + SUPERSEDES + MERGED, and
SUPERSEDES/MERGED are by definition entries whose pod bytes differ, which is
exactly what `seed.sh`'s pre-flight refuses. So post-cutover P3 exits 8 the
moment anything supersedes, and reads as a shipped code path that can never
complete — one `--allow-overwrite` away from working.

🔴 IT IS NOT. That refusal is the LAST GUARD between a stale mirror and
authoritative content, and `--allow-overwrite` is the single change that would
disarm it. `seed.sh`'s tar adds and overwrites but never deletes, so a push from
a frozen mirror silently reverts every entry the pod has moved on and REPORTS
SUCCESS. Measured 2026-09-02/03: of 25 local-only bullet candidates, 5 were
POD-NEWER, two of them `OPEN:` -> `RESOLVED` closures carrying ~20 lines of
later corrections.

So P3 now refuses with RC_CUTOVER_COMPLETE (19) instead. Measured on the live
store 2026-09-08: 147 entry files, 0 writable (P5 freeze applied, cutover DONE)
against 218 entries in the pod cache — so a push today would ship a strict
subset and revert the difference.

🔴 THE SIGNAL IS THE FREEZE, NOT A FLAG OR A DATE. A store whose entries all
refuse a write has completed the cutover; one still writable has not. So a
genuine first cutover passes straight through and P3 stays live for it — this
is a retirement conditioned on state, not a deletion.

Tests — the FIRST in this file to drive P3 through the real `main`. The prior
suite only re-extracted `seed.sh`'s `find` expression, so its 85 green tests
said nothing about whether this phase runs:
  - a FROZEN store returns 19 AND `seed.sh` is never invoked (asserting the rc
    alone would pass for a run that pushed and then refused)
  - a WRITABLE store is NOT refused — the over-refusal direction, labelled an
    INVARIANT GUARD because it passes at base by construction
  - the refusal names the remedy (`cairn append`/`put`) and warns off
    `--allow-overwrite`, because a refusal that does not say what to do instead
    gets routed around, and here the obvious route around IS the data-loss bug

Red-at-base: deleting the guard reds 2 of the 3; the third is the labelled
invariant guard and stays green, as it should. File 85 -> 88 tests.

⚠ No `examined == 0` branch at P3, deliberately: P0 already refuses an empty
store with RC_NO_STORE and `survey` walks the same `read_store` population, so a
zero is unreachable there — and a guard that cannot execute reads as coverage
while providing none. P5 keeps its own check because `--freeze` reaches it
without passing P0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AwUQmUw99gqMug4T3ruFNC
Claude-Session-Id: 747b8a7d-0f55-4b5e-b364-625c1f0d6425


## Gating — read the tier split, it is not a clean green

Merged tree `77677af6` (base `origin/main` = `53c9f664`, unmoved at push).

- **sandbox `pytests`** — `RESULT: PASS (exit=0)`, 21332 collected / 21330 passed / **0 failed**
- **sandbox `nodetests`** — `RESULT: PASS (exit=0)`, 1449/1449
- **dev-host node** — `RESULT: PASS (exit=0)`, 1449/1449
- 🔴 **dev-host pytest — DID NOT COMPLETE.** `exit=124 (timeout after 3600s)`,
  `RESULT: FAIL (exit=143)` — SIGTERM at the wall clock, not an assertion. It was
  killed part-way through `scripts/browser-bridge/tests`.

**Why that is load and not this diff, by control rather than by theory:**

1. The killed target run STANDALONE on this exact tree: **915 passed, rc 0** in 422s.
2. The sandbox tier ran the whole suite on the same tree and passed.
3. This diff touches `scripts/cairn-cutover.py` and `scripts/tests/test_cairn_cutover.py`
   only — neither is reachable from browser-bridge.
4. Load average was **74–78 on 24 cores** throughout, all of it other sessions
   (checked for my own orphans: none).

⚠ **Not claimed:** a completed dev-host pytest run. One is owed when the box is
quieter. The repo's own rule is that a red above ~load 20 needs a control before
it means anything; the control above is what I have, and it is not the same
claim as a green full run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUQmUw99gqMug4T3ruFNC
