### PR TITLE
feat(nix): a check that EXECUTES the pinned cairn client, and bump the pin past the validate fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1788846344,
-        "narHash": "sha256-zcgGqHCayZwaYjqBRbS5rpxz6Uk495YAnB6POf3i+gs=",
+        "lastModified": 1788926377,
+        "narHash": "sha256-voZR/UA9CaqNgQEk1W6Sg1eOttA01n7k6+RdCleFlWs=",
         "owner": "ZacxDev",
         "repo": "cairn",
-        "rev": "921372635ff3240e4993b0db67032d61da83637e",
+        "rev": "c84c14292e9977d2675f9d0645b10c6d7453086d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -545,6 +545,111 @@
             fi
             touch "$out"
           '';
+
+        # 🔴 NOTHING INVOKES THIS YET — IT IS AN OUTPUT, NOT A GATE, AND SAYING
+        # SO IS THE POINT. `devrc-ci-pipeline.yaml` in the infra repo hardcodes
+        # exactly two legs (`LEG` ∈ {pytests, nodetests}, built as
+        # `.#checks.x86_64-linux.${LEG}`); there is no `nix flake check` and no
+        # loop, so a third output is never built by CI. Landing it silently
+        # would ship something that READS like a gate and can never fail —
+        # precisely the defect class this check exists to catch, committed by
+        # the check itself.
+        # Run it on demand: `nix build .#checks.x86_64-linux.cairn-client-runs`
+        # (~1.4 s; the cairn package is already in the home-manager closure, so
+        # it adds no build). Wiring a third leg is a separate change to a
+        # GitOps-reconciled repo and is deliberately not bundled here.
+        #
+        # 🔴 THE ONLY CHECK THAT *EXECUTES* THE PINNED CLIENT. Every other cairn
+        # guard in this repo reads `flake.nix` / `flake.lock` / `nix/home.nix` /
+        # `nix/sessionVariables.nix` as TEXT, so all of them stay green while the
+        # pinned client is thoroughly broken: they assert the WIRING, never that
+        # anything runs. A `nix flake lock --update-input cairn` to a revision
+        # where `packages.cairn` still builds but a VERB regressed would leave
+        # this repo's gate fully green and surface at the operator, mid-task.
+        # cairn's own `checks.client-resolves-its-lib` would catch some of that,
+        # and it lives in cairn's flake — which this repo's gate does not run.
+        #
+        # 🔴 IT ASSERTS OUTPUT CONTENT, NOT EXIT CODES, and the two verbs are
+        # asserted DIFFERENTLY on purpose:
+        #   `validate` — a fixture cache with exactly ONE parsable entry must
+        #     produce "1 of 1 entry file(s) parse". That string is the gate: a
+        #     client whose validate prints nothing fails here, which is this
+        #     check's whole reason to exist.
+        #   `doctor`   — asserted only to PRODUCE A REPORT. Its exit code is
+        #     deliberately NOT asserted: in a sandbox with no pod, no token and
+        #     no network, a non-zero doctor verdict is the CORRECT answer, and
+        #     demanding zero would either pin a wrong expectation or push the
+        #     check into faking an environment. Same reasoning cairn's own
+        #     packaging check records.
+        cairn-client-runs =
+        pkgs.runCommandLocal "devrc-cairn-client-runs"
+          {
+            nativeBuildInputs = [
+              cairn.packages.${system}.cairn
+              pkgs.coreutils
+              pkgs.gnugrep
+            ];
+          }
+          ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            F="$TMPDIR/cache"
+            mkdir -p "$F/demo"
+
+            # A stamp is REQUIRED, not decoration: the reader refuses a store
+            # that cannot date itself rather than serving it, so without this
+            # the run below fails as `store-unreachable` and would "fail" for a
+            # reason that says nothing about the client's verbs.
+            printf 'synced=1700000000\nrevision=fixture\nentries=1\ncoverage=ALL\n' \
+              > "$F/.sync-stamp"
+
+            cat > "$F/demo/widget.md" <<'ENTRY'
+            ---
+            service: widget
+            scope: demo
+            sensitivity: public
+            created_by: handoff
+            ---
+            # widget
+
+            ## What it is
+            A fixture entry, and the ONLY one — so "1 of 1" below is a real count.
+
+            ## Pointers
+            - `nowhere/real.py` — a pointer.
+
+            ## Nuance / work-history
+            - 2026-01-01: a bullet.
+            ENTRY
+            # The heredoc is indented to match this file; strip that leading
+            # whitespace or the front matter is not at column 0 and the entry
+            # parses as prose. (Measured: an indented `---` is not front matter.)
+            sed -i 's/^            //' "$F/demo/widget.md"
+
+            # --- validate: the verb this gate exists to police -------------
+            rc=0
+            cairn --cache "$F" validate --scope demo --no-sync > val.txt 2>&1 || rc=$?
+            if ! grep -q '1 of 1 entry file(s) parse' val.txt; then
+              echo "checks.cairn-client-runs: the pinned client's \`validate\` did not report" >&2
+              echo "  parsing the one fixture entry. rc=$rc, output follows:" >&2
+              sed 's/^/    /' val.txt >&2
+              exit 1
+            fi
+
+            # --- doctor: drives the deep import closure --------------------
+            # `--help` would NOT do: the hazard packaging introduces is the
+            # sibling-import mechanism, and only a verb that reaches the deep
+            # modules exercises it.
+            cairn --cache "$F" doctor --no-sync > doc.txt 2>&1 || true
+            if [ ! -s doc.txt ]; then
+              echo "checks.cairn-client-runs: \`doctor\` produced NO output at all." >&2
+              echo "  Its exit code is not asserted (no pod in a sandbox), but a" >&2
+              echo "  client that cannot even report is not a working client." >&2
+              exit 1
+            fi
+
+            touch "$out"
+          '';
       };
     };
 }


### PR DESCRIPTION
feat(nix): a check that EXECUTES the pinned cairn client, and bump the pin past the validate fix

Every cairn guard in this repo reads `flake.nix` / `flake.lock` / `nix/home.nix`
/ `nix/sessionVariables.nix` as TEXT. All of them assert the WIRING; none
asserts that anything RUNS. So a `nix flake lock --update-input cairn` to a
revision where `packages.cairn` still builds but a VERB regressed leaves this
repo's gate fully green and surfaces at the operator, mid-task.

That is not hypothetical. Building this check is what found it.

WHAT IT FOUND, FIRST RUN

The pinned client's `validate` printed NOTHING on a clean store and exited 0 —
byte-identical to a validate that parsed no files. `cairn validate` is the
post-write check the index-write protocol MANDATES after every store write, so
that silence was being read as "the entry I just wrote is fine".

🔴 cairn's OWN CI did not catch it: its full 1709-test suite was green while the
verb was inert, because the test covering it asserted only `rc == 0` and the
absence of an error string. So "upstream will catch a broken client" — the best
argument against needing this check — is empirically false for the one case we
have. Fixed upstream in ZacxDev/cairn#11 (`c84c1429`), which this bump takes.

THE BUMP

`9213726` -> `c84c1429`, which carries #6 (leakscan coverage derived from
bytes), #7 (the recall drill-down flags the digest's own footer prescribes), #9
(the client builds a focus window), #10 and #11 (validate reports what it
checked). ⚠ It reaches `~/.local/bin/cairn` only after a `home-manager switch`.

WHAT THE CHECK ASSERTS, AND WHY THE TWO VERBS DIFFER

  `validate` — a fixture cache holding exactly ONE parsable entry must produce
    "1 of 1 entry file(s) parse". That string IS the gate.
  `doctor`   — asserted only to PRODUCE A REPORT. Its exit code is deliberately
    NOT asserted: in a sandbox with no pod, token or network a non-zero verdict
    is the CORRECT answer, and demanding zero would either pin a wrong
    expectation or push the check into faking an environment.

CONTROLS, WATCHED IN BOTH DIRECTIONS

  green against the real pinned client at c84c1429
  RED with the client stubbed to `exit 0` (prints nothing) — failing with THIS
    check's own message, not a bystander's

That red arm is rank 16's closing condition, exercised rather than asserted. The
tree was restored byte-identical to pristine afterwards.

🔴 NOTHING INVOKES IT YET, AND THE COMMENT SAYS SO IN THE FILE

`devrc-ci-pipeline.yaml` hardcodes two legs (`LEG` in {pytests, nodetests},
built as `.#checks.x86_64-linux.${LEG}`); there is no `nix flake check` and no
loop, so a third output is never built by CI. Landing it as a silent "gate"
would ship something that reads like one and can never fail — the exact defect
class it exists to catch. Wiring a third leg touches a GitOps-reconciled repo
where committing is deploying, so it is deliberately NOT bundled here and is
filed as its own item.

Cost on demand: ~1.4 s. The cairn package is the same derivation home-manager
already builds to deploy the client, so it adds no build.

VERIFICATION SCOPE, STATED HONESTLY

Not the full 21k-test gate. The change is a lock rev plus a new checks output,
so the suites that READ those files were run: test_cairn_flake_pin,
test_cairn_cli, test_cairn_split, test_no_captured_markup,
test_devshell_satisfies_required_tools — 190 passed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCjWicwrMAwjGTh3uXsSNT