### PR TITLE
fix(ship): fall back to the nebula address when the LAN one is silent

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3308,7 +3308,15 @@ in
       # At today's N=2 that is 120s of new worst case, which 180 could not
       # absorb: the cgroup would be killed mid-run and the deadman would report
       # NOTHING, on a schedule, looking like a unit that merely takes a while.
-      # 420 leaves headroom for one more source repo without another edit.
+      # 🔴 420 does NOT leave headroom for another source repo — this line said
+      # it did, and that was already false when written. Re-derived from the
+      # pinned test's own model: needed was 400 against 420 (20s slack) at the
+      # merge-base, and the address probe added in #1439 took it to 410, so the
+      # slack is 10s. One more source repo costs 2 hosts x 30s = 60s and would
+      # need the ceiling raised to at least 470. The guard catches that LOUDLY
+      # (the test recomputes and fails), so the cost of the stale sentence was a
+      # reader skipping the edit, not a silent overflow — but do not read this
+      # block as permission to add a repo without touching the number.
       #
       # This is a SEAM — the tunable lives in the script, the ceiling lives here,
       # and neither file's tests owned their product. Pinned by
@@ -3320,9 +3328,14 @@ in
       # probe's `$SSH_PROBE_TIMEOUT` (default 5s, per candidate address). Each
       # source fetch is capped individually too, so this ceiling only ever fires
       # on several wedges at once; the cgroup is killed and the timer re-arms on
-      # the next OnUnitActiveSec. The test named above counts both — it was
-      # extended when the probe landed, because a network call added with no room
-      # made for it is precisely what it exists to catch.
+      # the next OnUnitActiveSec.
+      #
+      # ⚠ The test named above counts the PROBE derivedly (it reads
+      # SSH_PROBE_TIMEOUT from the lib and runs remote_ssh_candidates_of for the
+      # count) but NOT the remote leg's 10s, which sits inside an
+      # undifferentiated `+ 60` literal — raising that 10s to 120s moves nothing
+      # in the test. An earlier version of this comment said it "counts both",
+      # which described coverage one term wider than the implementation.
       TimeoutStartSec = 420;
       Environment = [
         # iproute2 is load-bearing, not incidental: `ip -4 -o addr show` is how

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3316,10 +3316,13 @@ in
       # _repo_fetch`, which recomputes it from both files and fails if either
       # moves out from under the other.
       #
-      # The ConnectTimeout inside the script is 10s and each source fetch is
-      # capped individually, so this ceiling only ever fires on several wedges at
-      # once; the cgroup is killed and the timer re-arms on the next
-      # OnUnitActiveSec.
+      # There are now TWO ConnectTimeouts: the remote leg's 10s, and the address
+      # probe's `$SSH_PROBE_TIMEOUT` (default 5s, per candidate address). Each
+      # source fetch is capped individually too, so this ceiling only ever fires
+      # on several wedges at once; the cgroup is killed and the timer re-arms on
+      # the next OnUnitActiveSec. The test named above counts both — it was
+      # extended when the probe landed, because a network call added with no room
+      # made for it is precisely what it exists to catch.
       TimeoutStartSec = 420;
       Environment = [
         # iproute2 is load-bearing, not incidental: `ip -4 -o addr show` is how

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2224,9 +2224,13 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   ⚠ It was UNVERIFIED when the pin moved, and the reason is worth keeping: the
   laptop was unreachable at its **LAN** address, and the note recorded that as
   "unreachable" full stop. It answers on **nebula** (`zach@10.42.0.100`), which
-  is how this check was run. A host being off-LAN is not a host being down —
-  `ship.sh` has the same blind spot (`LAPTOP_SSH_DEFAULT` is the LAN address,
-  overridable with `LAPTOP_SSH`).
+  is how this check was run. A host being off-LAN is not a host being down.
+  ⚠ `ship.sh` and `drift-check.sh` **had** the same blind spot; both now try the
+  LAN address and then nebula (`lib/host-role.sh` → `remote_ssh_candidates_of`
+  / `first_reachable_ssh`). Note the fix is only reached for the DERIVED
+  defaults: setting `LAPTOP_SSH` or `REMOTE_SSH` by hand pins one address and
+  deliberately DISABLES the fallback, so the old workaround is now the thing
+  that reintroduces the old failure.
   🔴 **The browser-only RESOLUTION on the laptop is STILL UNVERIFIED** — that is
   a separate claim from the version, and closing the easy half must not be read
   as closing both. It needs `opencode debug agent` run on the laptop; only the

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -747,12 +747,16 @@
 #                    as UNREACHABLE and escalates rc 13 after
 #                    $DRIFT_UNREACHABLE_ESCALATE runs. It never runs under
 #                    --no-remote, and never when an explicit $REMOTE_SSH names
-#                    one target. Those two conditions stop 271 of 279 probing
-#                    runs; the remaining 8 were stopped by the FIXTURE'S OWN
-#                    stub ssh, not by them — so "0 unstubbed attempts" is a
-#                    joint result, and crediting it to the gate alone (as an
-#                    earlier version of this line did) would mislead anyone
-#                    deciding the stub is removable. The fixture ALSO defaults
+#                    one target. MEASURED over the suite, twice: 333 runs reach
+#                    address selection — 279 stopped by --no-remote, 46 by the
+#                    one-candidate rule, and 8 probe. So the two conditions stop
+#                    325 of 333, and the 8 that probe are a DISJOINT cohort, not
+#                    a leak out of the 279. Their ssh calls landed on the
+#                    fixture's own stub, so "0 unstubbed attempts" is a joint
+#                    result of the conditions and the stub. ⚠ Two earlier
+#                    versions of this line got the mechanism wrong in opposite
+#                    directions — one credited the zero to the gate alone, the
+#                    next read it as an 8-in-279 gate leak. It is neither. The fixture ALSO defaults
 #                    this to 1, for determinism rather than containment, so a
 #                    future test that forgets a stub is not the first to notice.
 #                    NOT forwarded over ssh — the remote leg does no probing of

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -1004,7 +1004,47 @@ if [ "$LOCAL_ROLE" != workbench ] && [ "$LOCAL_ROLE" != laptop ]; then
   exit 6
 fi
 REMOTE_ROLE="$(remote_role_of "$LOCAL_ROLE")"
+# 🔴 CANDIDATES FIRST — same load-bearing order as ship.sh, and for the same
+# reason: `remote_ssh_candidates_of` reads $REMOTE_SSH to detect an OPERATOR
+# override, so computing it after the derived assignment below makes it mistake
+# this script's own default for one, return a single candidate, and skip the
+# probe entirely. Measured in ship.sh, where that ordering left the fallback
+# dead while every lib-level test passed.
+_dc_cands_raw="$(remote_ssh_candidates_of "$LOCAL_ROLE" 2>/dev/null || true)"
 REMOTE_SSH="$(remote_ssh_of "$LOCAL_ROLE")"
+
+# --- Address selection: LAN first, then nebula --------------------------------
+# 🔴 THIS DEADMAN IS THE ONE THAT MOST NEEDS THE FALLBACK, and it was the last
+# to get it. Its whole job is noticing a host that has silently fallen behind —
+# so reaching the host by only ONE of its two addresses turns "the laptop is on
+# a different network" into rc 13 UNREACHABLE, which after
+# $DRIFT_UNREACHABLE_ESCALATE consecutive runs (~24h) escalates and fails the
+# unit for a machine that was answering the whole time. The block below already
+# says a host that is "off, asleep or off-LAN … must not look like drift"; only
+# trying both addresses makes that true.
+#
+# Probing costs one bounded ssh, and ONLY when there is a real choice: an
+# explicit $REMOTE_SSH is a one-element list, so an operator-addressed run is
+# never redirected and makes exactly the connections it used to.
+if [ "${DRIFT_SKIP_SSH_PROBE:-0}" != 1 ] && command -v first_reachable_ssh >/dev/null; then
+  mapfile -t _dc_cands <<<"$_dc_cands_raw"   # captured ABOVE, before REMOTE_SSH was derived
+  # 🔴 The probe's own diagnostics must carry THIS script's prefix: the journal
+  # accepts only `[`, `===`, `drift-check: ` and indented lines, and an
+  # unprefixed line fails its hygiene guard.
+  SSH_PROBE_LOG_PREFIX=drift-check
+  if [ "${#_dc_cands[@]}" -gt 1 ]; then
+    _dc_chosen="$(first_reachable_ssh "${_dc_cands[@]}")" || _dc_chosen=""
+    if [ -n "$_dc_chosen" ]; then
+      [ "$_dc_chosen" = "$REMOTE_SSH" ] || \
+        echo "drift-check: $REMOTE_SSH did not answer — using $_dc_chosen for $REMOTE_ROLE." >&2
+      REMOTE_SSH="$_dc_chosen"
+    fi
+    # Nothing answered: leave REMOTE_SSH at its default and let the existing
+    # UNREACHABLE path report it. That path already distinguishes an absent host
+    # from drift, and it owns the streak/escalation ledger — short-circuiting
+    # here would bypass both.
+  fi
+fi
 
 # severity <rc> -> a comparable number; higher = worse. Unknown codes rank above
 # every known one so a NEW failure mode can never be silently outranked into

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -741,6 +741,20 @@
 #                    host. Deliberately NOT forwarded over ssh — the comparison
 #                    happens in the driver, and every value sent across that hop
 #                    is one that has to be proved safe.
+#   DRIFT_SKIP_SSH_PROBE=1  do not probe the remote host's addresses; use the
+#                    first derived candidate as-is. The probe (LAN, then nebula)
+#                    exists because a host that is merely off-LAN otherwise reads
+#                    as UNREACHABLE and escalates rc 13 after
+#                    $DRIFT_UNREACHABLE_ESCALATE runs. It never runs under
+#                    --no-remote, and never when an explicit $REMOTE_SSH names
+#                    one target. Defaulted to 1 by the test fixture: the probe
+#                    reaches a REAL host, and a read-only breach is still a
+#                    breach. NOT forwarded over ssh — the remote leg does no
+#                    probing of its own.
+#   SSH_PROBE_TIMEOUT / SSH_PROBE_CMD / SSH_PROBE_LOG_PREFIX
+#                    shared with ship.sh via lib/host-role.sh and documented in
+#                    that script's header; the prefix is set here so the probe's
+#                    diagnostics satisfy this script's journal hygiene.
 set -uo pipefail
 
 # --- Host identity: SOURCED, never copied (see header) ------------------------
@@ -1023,10 +1037,23 @@ REMOTE_SSH="$(remote_ssh_of "$LOCAL_ROLE")"
 # says a host that is "off, asleep or off-LAN … must not look like drift"; only
 # trying both addresses makes that true.
 #
-# Probing costs one bounded ssh, and ONLY when there is a real choice: an
+# Probing costs up to ONE BOUNDED ssh PER CANDIDATE (two today, at
+# $SSH_PROBE_TIMEOUT each — counted in the unit's TimeoutStartSec model), and
+# only when there is a real choice: an
 # explicit $REMOTE_SSH is a one-element list, so an operator-addressed run is
 # never redirected and makes exactly the connections it used to.
-if [ "${DRIFT_SKIP_SSH_PROBE:-0}" != 1 ] && command -v first_reachable_ssh >/dev/null; then
+# 🔴 `[ "$DO_REMOTE" = 1 ]` IS THE FIRST CONDITION, not an afterthought. Line 654
+# documents `--no-remote` as "this host only (no ssh)", and without this gate the
+# probe fires anyway: MEASURED at b280162a, `--no-remote` made two outbound
+# connections to the operator's laptop. `ship.sh` had the gate from the start and
+# this script did not — the same wiring applied asymmetrically to its two
+# callers. The second-order cost was larger than the contract breach:
+# `test_drift_check.py` issues one probe pair per `--no-remote` test, so the
+# suite made 568 real ssh attempts to a live host, and with the laptop off-LAN
+# each LAN probe burns the full ConnectTimeout — turning a hermetic 7.5-minute
+# module into a half-hour one whose verdict depends on the operator's network.
+if [ "$DO_REMOTE" = 1 ] && [ "${DRIFT_SKIP_SSH_PROBE:-0}" != 1 ] \
+   && command -v first_reachable_ssh >/dev/null; then
   mapfile -t _dc_cands <<<"$_dc_cands_raw"   # captured ABOVE, before REMOTE_SSH was derived
   # 🔴 The probe's own diagnostics must carry THIS script's prefix: the journal
   # accepts only `[`, `===`, `drift-check: ` and indented lines, and an

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -747,10 +747,13 @@
 #                    as UNREACHABLE and escalates rc 13 after
 #                    $DRIFT_UNREACHABLE_ESCALATE runs. It never runs under
 #                    --no-remote, and never when an explicit $REMOTE_SSH names
-#                    one target. Defaulted to 1 by the test fixture: the probe
-#                    reaches a REAL host, and a read-only breach is still a
-#                    breach. NOT forwarded over ssh — the remote leg does no
-#                    probing of its own.
+#                    one target — those two conditions are what stop the suite
+#                    reaching a real host (measured: 0 unstubbed ssh attempts).
+#                    The fixture ALSO defaults it to 1, for determinism rather
+#                    than containment: 8 stubbed probes still ran, and a future
+#                    test that forgets a stub should not be the first to notice.
+#                    NOT forwarded over ssh — the remote leg does no probing of
+#                    its own.
 #   SSH_PROBE_TIMEOUT / SSH_PROBE_CMD / SSH_PROBE_LOG_PREFIX
 #                    shared with ship.sh via lib/host-role.sh and documented in
 #                    that script's header; the prefix is set here so the probe's
@@ -1049,7 +1052,9 @@ REMOTE_SSH="$(remote_ssh_of "$LOCAL_ROLE")"
 # this script did not — the same wiring applied asymmetrically to its two
 # callers. The second-order cost was larger than the contract breach:
 # `test_drift_check.py` issues one probe pair per `--no-remote` test, so the
-# suite made 568 real ssh attempts to a live host, and with the laptop off-LAN
+# suite made 558 real ssh attempts to a live host (279 per address; an earlier
+# note in this file said 568 — that figure was never reproduced), and with the
+# laptop off-LAN
 # each LAN probe burns the full ConnectTimeout — turning a hermetic 7.5-minute
 # module into a half-hour one whose verdict depends on the operator's network.
 if [ "$DO_REMOTE" = 1 ] && [ "${DRIFT_SKIP_SSH_PROBE:-0}" != 1 ] \

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -747,11 +747,14 @@
 #                    as UNREACHABLE and escalates rc 13 after
 #                    $DRIFT_UNREACHABLE_ESCALATE runs. It never runs under
 #                    --no-remote, and never when an explicit $REMOTE_SSH names
-#                    one target — those two conditions are what stop the suite
-#                    reaching a real host (measured: 0 unstubbed ssh attempts).
-#                    The fixture ALSO defaults it to 1, for determinism rather
-#                    than containment: 8 stubbed probes still ran, and a future
-#                    test that forgets a stub should not be the first to notice.
+#                    one target. Those two conditions stop 271 of 279 probing
+#                    runs; the remaining 8 were stopped by the FIXTURE'S OWN
+#                    stub ssh, not by them — so "0 unstubbed attempts" is a
+#                    joint result, and crediting it to the gate alone (as an
+#                    earlier version of this line did) would mislead anyone
+#                    deciding the stub is removable. The fixture ALSO defaults
+#                    this to 1, for determinism rather than containment, so a
+#                    future test that forgets a stub is not the first to notice.
 #                    NOT forwarded over ssh — the remote leg does no probing of
 #                    its own.
 #   SSH_PROBE_TIMEOUT / SSH_PROBE_CMD / SSH_PROBE_LOG_PREFIX

--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -147,10 +147,32 @@ first_reachable_ssh() {
     # makes it see the continuation's leading word (`target`) as a program and
     # report it as unaccounted-for on the unit PATH. Keeping it on one line lets
     # it see `ssh`, which the table already carries as pkgs.openssh.
-    elif ssh -o BatchMode=yes -o ConnectTimeout="$timeout" -o StrictHostKeyChecking=accept-new "$target" true >/dev/null 2>&1; then
+    #
+    # `-n` redirects stdin from /dev/null: without it `ssh host true` EATS the
+    # caller's stdin, so an operator looping `while read h; do ship.sh; done`
+    # loses lines to the probe. No in-repo consumer pipes into these scripts
+    # today; this keeps that a non-issue rather than a latent one.
+    #
+    # 🔴 `StrictHostKeyChecking=accept-new` is a DELIBERATE and DECLARED trust
+    # change, looser than the effective default (`ssh -G` reports `ask` on this
+    # host) and looser than the real legs, which set nothing. It is required for
+    # the probe to work at all: with BatchMode and `ask`, an unknown host is
+    # refused, so a FIRST connection to a reinstalled machine could never
+    # succeed and the fallback would be inert exactly when it is needed. What it
+    # does NOT do is accept a CHANGED key — a reinstalled host or a squatter on
+    # the LAN address still fails the probe, and the run falls back rather than
+    # trusting it. The cost is that a first-ever address is TOFU-adopted without
+    # the operator being asked.
+    elif ssh -n -o BatchMode=yes -o ConnectTimeout="$timeout" -o StrictHostKeyChecking=accept-new "$target" true >/dev/null 2>&1; then
       echo "$target"; return 0
     fi
-    echo "ship: $target did not answer" >&2
+    # 🔴 The prefix is the CALLER's, not a hardcoded "ship:". This lib is shared,
+    # and `drift-check.sh` writes a JOURNAL whose every line must start with
+    # `[`, `===`, `drift-check: ` or two spaces — a stray `ship: …` from here
+    # fails its hygiene guard (measured:
+    # test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written) and, worse,
+    # attributes the message to the wrong program in the operator's log.
+    echo "${SSH_PROBE_LOG_PREFIX:-ship}: $target did not answer" >&2
   done
   return 1
 }

--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -33,8 +33,19 @@ WORKBENCH_IP_PRIMARY="192.168.50.250"
 WORKBENCH_IP_SECONDARY="10.42.0.30"
 LAPTOP_IP_PRIMARY="192.168.50.155"
 LAPTOP_IP_SECONDARY="10.42.0.100"
-WORKBENCH_SSH_DEFAULT="zach@192.168.50.250"
-LAPTOP_SSH_DEFAULT="zach@192.168.50.155"
+SSH_USER_DEFAULT="zach"
+WORKBENCH_SSH_DEFAULT="${SSH_USER_DEFAULT}@${WORKBENCH_IP_PRIMARY}"
+LAPTOP_SSH_DEFAULT="${SSH_USER_DEFAULT}@${LAPTOP_IP_PRIMARY}"
+# 🔴 The SECONDARY (nebula) targets exist because the LAN address is only
+# reachable from the same network, and the laptop is routinely NOT on it.
+# MEASURED 2026-09-09: `ship.sh` reached for 192.168.50.155, ssh timed out, the
+# laptop leg exited 255 and the run reported `converge exited 255` — while the
+# host was up and answering on 10.42.0.100 the whole time. A timed-out leg reads
+# as a DEAD HOST, so the laptop silently stopped receiving deploys while looking
+# merely unreachable. Derived from the IP constants above rather than spelled
+# again: one address, one place.
+WORKBENCH_SSH_SECONDARY="${SSH_USER_DEFAULT}@${WORKBENCH_IP_SECONDARY}"
+LAPTOP_SSH_SECONDARY="${SSH_USER_DEFAULT}@${LAPTOP_IP_SECONDARY}"
 
 # detect_role <space-or-comma-separated ipv4 list> -> workbench|laptop|unknown
 # Pure + testable: takes an IP list as input (no live-machine calls), so it can
@@ -88,6 +99,60 @@ remote_ssh_of() {
     laptop)    echo "$WORKBENCH_SSH_DEFAULT" ;;
     *)         echo "" ;;
   esac
+}
+
+# remote_ssh_candidates_of <local-role> -> ssh targets to TRY, one per line,
+# most-preferred first: the LAN address, then the nebula one.
+#
+# 🔴 AN EXPLICIT TARGET IS NEVER SECOND-GUESSED. When $REMOTE_SSH or (for the
+# laptop) $LAPTOP_SSH is set, that ONE target is the whole list: an operator who
+# names a host means that host, and silently trying a different machine after it
+# fails to answer is how a converge lands somewhere nobody asked for. Only the
+# DERIVED defaults get a fallback.
+#
+# Pure: prints candidates, contacts nothing. The probing lives in
+# first_reachable_ssh so this stays unit-testable with no network.
+remote_ssh_candidates_of() {
+  if [ -n "${REMOTE_SSH:-}" ]; then echo "$REMOTE_SSH"; return 0; fi
+  case "${1:-}" in
+    workbench)
+      if [ -n "${LAPTOP_SSH:-}" ]; then echo "$LAPTOP_SSH"; return 0; fi
+      echo "$LAPTOP_SSH_DEFAULT"; echo "$LAPTOP_SSH_SECONDARY" ;;
+    laptop)
+      echo "$WORKBENCH_SSH_DEFAULT"; echo "$WORKBENCH_SSH_SECONDARY" ;;
+    *) echo "" ;;
+  esac
+}
+
+# first_reachable_ssh <target>... -> the first target that answers, or empty.
+#
+# Probes with BatchMode (never prompts) and a bounded ConnectTimeout, running
+# `true` rather than anything that could change state. Prints the winner on
+# stdout; every diagnostic goes to stderr so callers can capture the target
+# cleanly. Returns 1 when NOTHING answered — the caller must treat that as a
+# genuinely unreachable host, not as "use the first one anyway".
+#
+# 🔴 $SSH_PROBE_CMD replaces the probe wholesale (it receives the target as $1
+# and signals reachability by exit status). It exists so the selection logic can
+# be tested without a network — a probe that always fails, or one that answers
+# only for a named address, is how the fallback is driven red.
+first_reachable_ssh() {
+  local timeout="${SSH_PROBE_TIMEOUT:-5}" target
+  for target in "$@"; do
+    [ -n "$target" ] || continue
+    if [ -n "${SSH_PROBE_CMD:-}" ]; then
+      if "$SSH_PROBE_CMD" "$target"; then echo "$target"; return 0; fi
+    # 🔴 ONE LINE, not a continuation. `test_drift_check.py`'s command extractor
+    # reads the first token of each line as a command, so a wrapped invocation
+    # makes it see the continuation's leading word (`target`) as a program and
+    # report it as unaccounted-for on the unit PATH. Keeping it on one line lets
+    # it see `ssh`, which the table already carries as pkgs.openssh.
+    elif ssh -o BatchMode=yes -o ConnectTimeout="$timeout" -o StrictHostKeyChecking=accept-new "$target" true >/dev/null 2>&1; then
+      echo "$target"; return 0
+    fi
+    echo "ship: $target did not answer" >&2
+  done
+  return 1
 }
 
 # Standalone probe mode — only when EXECUTED, never when sourced.

--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -169,9 +169,18 @@ first_reachable_ssh() {
     # 🔴 The prefix is the CALLER's, not a hardcoded "ship:". This lib is shared,
     # and `drift-check.sh` writes a JOURNAL whose every line must start with
     # `[`, `===`, `drift-check: ` or two spaces — a stray `ship: …` from here
-    # fails its hygiene guard (measured:
-    # test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written) and, worse,
-    # attributes the message to the wrong program in the operator's log.
+    # fails its hygiene guard and, worse, attributes the message to the wrong
+    # program in the operator's log.
+    #
+    # Guarded by `test_ship_ssh_probe_wiring.py::test_drift_checks_probe_output_
+    # is_journal_clean`, which drives the probe deliberately and asserts the
+    # prefix. ⚠ An earlier version of this comment cited
+    # `test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written` instead;
+    # that test could see a probe line when the citation was written and cannot
+    # now — the same change that added this default also stopped `--no-remote`
+    # probing and defaulted DRIFT_SKIP_SSH_PROBE=1 in the fixture. Deleting the
+    # default scored 594 passed against it. Cited here so nobody restores the
+    # dead pointer.
     echo "${SSH_PROBE_LOG_PREFIX:-ship}: $target did not answer" >&2
   done
   return 1

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -289,6 +289,11 @@
 #   scripts/ship.sh --no-local   # remote host only
 #   scripts/ship.sh --no-switch  # land on main + verify git state, SKIP home-manager (test/dry-run)
 #   scripts/ship.sh --detect-role # print detected local role (workbench|laptop|unknown) and exit
+#   scripts/ship.sh --print-remote-target
+#                                # resolve the remote host's address (LAN, then
+#                                # nebula) and print it, then exit. Converges
+#                                # nothing. The fallback announcement goes to
+#                                # stderr; read both, not the exit status.
 #
 # Env overrides:
 #   SHIP_ROLE     force the local role (workbench|laptop) when detection fails/differs

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -467,6 +467,48 @@ if [ "$DO_REMOTE" = 1 ] && [ -z "$REMOTE_SSH" ]; then
   exit 6
 fi
 
+# --- Address selection: LAN first, then nebula --------------------------------
+# 🔴 The LAN address is only reachable from the same network and the laptop is
+# routinely elsewhere. MEASURED 2026-09-09: this script reached for
+# 192.168.50.155, ssh timed out, the leg exited 255 — while the host answered on
+# 10.42.0.100 throughout. The failure reads as a DEAD HOST, so the laptop stops
+# receiving deploys while merely looking unreachable, and nothing says which of
+# the two it was.
+#
+# Only DERIVED defaults are probed. An explicit $REMOTE_SSH/$LAPTOP_SSH is a
+# one-element list by construction (see remote_ssh_candidates_of), so this never
+# redirects a run the operator addressed by hand.
+_cands="$(remote_ssh_candidates_of "$SHIP_ROLE")"
+mapfile -t _cand_arr <<<"$_cands"
+# 🔴 PROBE ONLY WHEN THERE IS SOMETHING TO CHOOSE BETWEEN. With one candidate
+# there is no alternative to fall back to, so a probe buys nothing and COSTS: it
+# is an extra ssh connection before the legs run, and anything downstream that
+# counts connections or orders events sees a different sequence. MEASURED: with
+# the probe unconditional, `test_a_merge_landing_between_the_two_fetches_is_not_
+# convergence` stopped seeing its injected mid-run merge and returned rc 0 where
+# it must return rc 19 (hosts disagree) — the extra connection moved the very
+# window that test exists to detect. An explicit $REMOTE_SSH/$LAPTOP_SSH is
+# always a one-element list, so this also means an operator-addressed run makes
+# exactly the connections it used to.
+if [ "$DO_REMOTE" = 1 ] && [ "${#_cand_arr[@]}" -gt 1 ] \
+   && [ "${SHIP_SKIP_SSH_PROBE:-0}" != 1 ]; then
+  _chosen="$(first_reachable_ssh "${_cand_arr[@]}")" || _chosen=""
+  if [ -n "$_chosen" ]; then
+    if [ "$_chosen" != "$REMOTE_SSH" ]; then
+      echo "ship: $REMOTE_SSH did not answer — falling back to $_chosen for $REMOTE_ROLE." >&2
+    fi
+    REMOTE_SSH="$_chosen"
+  else
+    # Every candidate was tried and none answered. Say so explicitly rather than
+    # proceeding into a 255 that reads as a broken converge: this is a
+    # reachability fact about the host, and the run below will report it as one.
+    echo "ship: NO candidate address answered for $REMOTE_ROLE — tried:" >&2
+    printf '  %s\n' $_cands >&2
+    echo "  the remote leg will fail; pass REMOTE_SSH=user@host if it lives elsewhere," >&2
+    echo "  or --no-remote to converge this host alone (which compares NO cross-host agreement)." >&2
+  fi
+fi
+
 # --- Self-supersession fingerprint --------------------------------------------
 # See SELF-SUPERSESSION in the header. Watched: this script, and the lib it
 # sources. Both live inside the repo a local converge fast-forwards, so both can

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -443,15 +443,23 @@ SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 SHIP_LIST_MAX="${SHIP_LIST_MAX:-10}"
 DO_LOCAL=1
 DO_REMOTE=1
-# Hidden test seam — see the block after address selection. Defaulted here (not
-# read bare) because this script runs under `set -u`.
-SHIP_PRINT_REMOTE_TARGET="${SHIP_PRINT_REMOTE_TARGET:-0}"
+# Set by --print-remote-target; NOT read from the environment, so it cannot be
+# inherited by an unrelated run. See the flag's own note in the arg loop.
+SHIP_PRINT_REMOTE_TARGET=0
 for a in "$@"; do
   case "$a" in
     --no-remote|--no-laptop) DO_REMOTE=0 ;;   # skip the OTHER (remote) host
     --no-local)  DO_LOCAL=0 ;;                # skip THIS (local) host
     --no-switch) SHIP_NO_SWITCH=1 ;;
     --detect-role) : ;;                        # handled above
+    # 🔴 ARGV, NOT AN ENV VAR — and that difference is the whole point. As
+    # $SHIP_PRINT_REMOTE_TARGET this was INHERITABLE: an operator who exported it
+    # while debugging would have every later `ship.sh` in that shell print an
+    # address and exit 0 having converged NOTHING — the vacuous green the rc 21
+    # refusal below exists to prevent, arriving by a route that refusal cannot
+    # see. As a flag it cannot be inherited, a typo lands in the `unknown arg`
+    # arm, and it appears in --help like every other option.
+    --print-remote-target) SHIP_PRINT_REMOTE_TARGET=1 ;;
     # Print the contiguous comment block after the shebang. Range-proof: no
     # hardcoded line numbers to drift as the header grows.
     -h|--help)   awk 'NR>1 { if (/^#/) print; else exit }' "$0"; exit 0 ;;
@@ -546,9 +554,15 @@ if [ "$DO_REMOTE" = 1 ] && [ "${#_cand_arr[@]}" -gt 1 ] \
   fi
 fi
 
-# Hidden mode: print the remote target this run WOULD use, then exit. Mirrors
-# `--detect-role` above, and exists for the same reason — a decision made inside
-# this script was otherwise unreachable from a test.
+# `--print-remote-target`: print the remote target this run WOULD use, then exit.
+# Mirrors `--detect-role` above — including in being ARGV, which is the property
+# that matters: an env-var version of this is inheritable, and an inherited copy
+# turns an ordinary `ship.sh` into a run that prints an address and exits 0
+# having converged nothing.
+#
+# ⚠ It exits 0 even when NO address answered, because the resolved target is
+# still a fact about what the run would use; the "NO candidate address answered"
+# diagnosis has already gone to stderr. Read both, not the status alone.
 #
 # 🔴 IT EXISTS BECAUSE THE SELECTION ABOVE WAS PROVABLY UNGUARDED. Measured
 # during this PR's round-1 audit: deleting the whole address-selection block

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -294,6 +294,21 @@
 #   SHIP_ROLE     force the local role (workbench|laptop) when detection fails/differs
 #   REMOTE_SSH    ssh target for the OTHER host (default derived from role)
 #   LAPTOP_SSH    back-compat: ssh target used ONLY when the remote host is the laptop
+#   SHIP_SKIP_SSH_PROBE=1  do not probe addresses; use the first derived candidate
+#                  as-is. The escape hatch for a harness the probe's extra
+#                  connection perturbs — one such was measured (it shifted the
+#                  window a convergence test detects), which is why the probe
+#                  only runs when there is more than one candidate at all.
+#   SSH_PROBE_TIMEOUT  ssh ConnectTimeout for the probe, seconds (default 5).
+#                  NOT validated: a non-numeric value makes ssh error out
+#                  instantly, so every address reports "did not answer" and the
+#                  run proceeds on its default target.
+#   SSH_PROBE_CMD  replace the probe wholesale; receives the target as $1 and
+#                  signals reachability by exit status. A TEST SEAM — it is how
+#                  the fallback is driven without a network. Unprefixed and
+#                  ungated by design so `lib/host-role.sh` can be sourced and
+#                  probed standalone; setting it in production replaces the
+#                  reachability check entirely.
 #   SHIP_REPO     repo path the CONVERGE routine operates on (default $HOME/workspace/devrc)
 #   SHIP_NO_SWITCH=1  same as --no-switch: run full git-landing logic, skip home-manager switch
 #   SHIP_LIST_MAX  max paths ENUMERATED per dirty-classification bucket
@@ -362,6 +377,15 @@ else
   resolve_local_role() { echo "${SHIP_ROLE:-unknown}"; }
   remote_role_of()   { case "${1:-}" in workbench) echo laptop ;; laptop) echo workbench ;; *) echo "" ;; esac; }
   remote_ssh_of()    { echo "${REMOTE_SSH:-}"; }
+  # 🔴 Defined here for the same reason as the four above: the address-selection
+  # block calls it unconditionally, and an undefined function in DEGRADED mode
+  # prints `command not found` into the middle of a recovery — the tool you
+  # reach for when a host is ALREADY broken. This file rejected that shape once
+  # before (see the detect_role note below: "said out loud rather than crashing
+  # on an undefined function"); this keeps it rejected.
+  # One element, always: degraded mode has no defaults to fall back to, so the
+  # probe is skipped and an explicit $REMOTE_SSH passes through untouched.
+  remote_ssh_candidates_of() { echo "${REMOTE_SSH:-}"; }
   WORKBENCH_IP_PRIMARY="<lib unavailable>"
   LAPTOP_IP_PRIMARY="<lib unavailable>"
 fi
@@ -419,6 +443,9 @@ SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 SHIP_LIST_MAX="${SHIP_LIST_MAX:-10}"
 DO_LOCAL=1
 DO_REMOTE=1
+# Hidden test seam — see the block after address selection. Defaulted here (not
+# read bare) because this script runs under `set -u`.
+SHIP_PRINT_REMOTE_TARGET="${SHIP_PRINT_REMOTE_TARGET:-0}"
 for a in "$@"; do
   case "$a" in
     --no-remote|--no-laptop) DO_REMOTE=0 ;;   # skip the OTHER (remote) host
@@ -457,6 +484,17 @@ fi
 # applies $REMOTE_SSH unconditionally and the back-compat $LAPTOP_SSH ONLY when
 # the remote host really is the laptop (from the laptop it would point at itself).
 REMOTE_ROLE="$(remote_role_of "$SHIP_ROLE")"
+# 🔴 CANDIDATES FIRST — this order is load-bearing. `remote_ssh_candidates_of`
+# reads $REMOTE_SSH to detect an OPERATOR-SUPPLIED target, and the assignment
+# below fills that same variable with a DERIVED default. Computed after it, the
+# function sees the script's own default, mistakes it for an explicit override,
+# and returns a one-element list — so the probe is skipped and the fallback
+# NEVER RUNS. Measured: with the two lines in the other order, `ship.sh` on a
+# workbench with the laptop off-LAN resolved zach@192.168.50.155 and exited
+# without ever trying nebula, while every lib-level test and a live probe of
+# `first_reachable_ssh` passed. That is the isolation seam: both halves correct
+# alone, broken together, and only a test that runs THIS FILE can see it.
+_cands="$(remote_ssh_candidates_of "$SHIP_ROLE")"
 REMOTE_SSH="$(remote_ssh_of "$SHIP_ROLE")"
 
 # In degraded recovery mode the SSH defaults are deliberately absent (see above),
@@ -478,8 +516,7 @@ fi
 # Only DERIVED defaults are probed. An explicit $REMOTE_SSH/$LAPTOP_SSH is a
 # one-element list by construction (see remote_ssh_candidates_of), so this never
 # redirects a run the operator addressed by hand.
-_cands="$(remote_ssh_candidates_of "$SHIP_ROLE")"
-mapfile -t _cand_arr <<<"$_cands"
+mapfile -t _cand_arr <<<"$_cands"   # $_cands was captured ABOVE, before REMOTE_SSH was derived
 # 🔴 PROBE ONLY WHEN THERE IS SOMETHING TO CHOOSE BETWEEN. With one candidate
 # there is no alternative to fall back to, so a probe buys nothing and COSTS: it
 # is an extra ssh connection before the legs run, and anything downstream that
@@ -507,6 +544,27 @@ if [ "$DO_REMOTE" = 1 ] && [ "${#_cand_arr[@]}" -gt 1 ] \
     echo "  the remote leg will fail; pass REMOTE_SSH=user@host if it lives elsewhere," >&2
     echo "  or --no-remote to converge this host alone (which compares NO cross-host agreement)." >&2
   fi
+fi
+
+# Hidden mode: print the remote target this run WOULD use, then exit. Mirrors
+# `--detect-role` above, and exists for the same reason — a decision made inside
+# this script was otherwise unreachable from a test.
+#
+# 🔴 IT EXISTS BECAUSE THE SELECTION ABOVE WAS PROVABLY UNGUARDED. Measured
+# during this PR's round-1 audit: deleting the whole address-selection block
+# left the ENTIRE suite green (98/98 in test_ship_converge.py), because every
+# ship.sh fixture that reaches an ssh shim sets $REMOTE_SSH — which is a
+# one-element candidate list, which skips the probe. So the bug this PR fixes
+# could be reintroduced wholesale without a single test going red. The lib-level
+# tests could not see it either: they source host-role.sh and never load this
+# file. This seam is what makes the fallback, the announcement and the
+# no-candidate diagnosis observable from outside.
+#
+# Prints the resolved target on stdout; the announcements above have already
+# gone to stderr, so a test can assert on both separately.
+if [ "$SHIP_PRINT_REMOTE_TARGET" = 1 ]; then
+  printf '%s\n' "$REMOTE_SSH"
+  exit 0
 fi
 
 # --- Self-supersession fingerprint --------------------------------------------

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -307,9 +307,13 @@ class Fleet:
             # 🔴 But the `[ "$DO_REMOTE" = 1 ]` gate in the script closed ALL of
             # that on its own. MEASURED with the gate and without this seam:
             # 8 probe executions, of which 0 reached an unstubbed ssh — every one
-            # landed on a fixture `stub_ssh` — across 11 static call sites that
-            # pass neither `--no-remote` nor an explicit REMOTE_SSH. (Positive
-            # control for the instrument: 558 on the ungated tree.)
+            # landed on a fixture `stub_ssh`. (Positive control for the
+            # instrument: 558 on the ungated tree.) ⚠ An earlier version added
+            # "across 11 static call sites"; that number is NOT mechanically
+            # reproducible — an AST sweep of the 203 `.check(` sites finds 4
+            # passing neither `--no-remote` nor REMOTE_SSH, three of them
+            # `*args` helper wrappers. The DYNAMIC count is the one that means
+            # anything, and it reproduces exactly.
             #
             # So this exists to stop 8 stubbed probes perturbing timing and
             # output, and as defence in depth if a future test forgets a stub —

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1791,6 +1791,23 @@ _SHELL_BUILTINS = frozenset("""
 # reviewer can check, whereas a heuristic filter would swallow a real command.
 _PROSE_NOT_COMMANDS = frozenset({
     "a", "f", "n", "prev", "more", "see", "the", "laptop", "workbench",
+    # 🔴 `target` is a LOOP VARIABLE and a `local` declaration in
+    # lib/host-role.sh's first_reachable_ssh, not a program. It is here because
+    # of a MEASURED blind spot in `_command_tokens`, not because the word is
+    # prose: `for` and `local` are both in _TRANSPARENT, so stripping them
+    # leaves the VARIABLE NAME as tokens[0]. Two lines produce it:
+    #     local timeout="${SSH_PROBE_TIMEOUT:-5}" target
+    #     for target in "$@"; do
+    # ⚠ The blind spot is older than this entry and nothing surfaced it,
+    # because the only other loop variable in that file is `ip` — which passes
+    # solely by COINCIDENCE, `ip` being a real command already in
+    # UNIT_PATH_REQUIREMENTS (iproute2). Rename that variable and this guard
+    # would have reported it too. Widening `_command_tokens` to skip `for X in`
+    # and `local` declarations is the structural fix; it is deliberately NOT
+    # done here, because it may unmask other words across drift-check.sh and
+    # that belongs in its own change rather than riding along with an ssh
+    # fallback.
+    "target",
 })
 
 

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -293,6 +293,21 @@ class Fleet:
             # write to the operator's real state dir and inherit a streak from
             # whatever ran before them.
             DRIFT_STATE_DIR=str(self.state),
+            # 🔴 THE SIXTH HERMETICITY SEAM, and it was paid for the same way as
+            # the fifth. The address probe added in #1439 runs before the remote
+            # leg and reaches the OPERATOR'S REAL LAPTOP. MEASURED at b280162a:
+            # this module made 568 outbound ssh attempts (284 per address), one
+            # pair per test, to a live host — a read-only breach is still a
+            # breach, and with the laptop off-LAN each LAN probe burns the full
+            # ConnectTimeout, so the module's runtime and its VERDICT started
+            # depending on the operator's network.
+            #
+            # `--no-remote` is now gated in the script itself, which removes most
+            # of them; this closes the rest, including the sites that pass
+            # neither `--no-remote` nor an explicit REMOTE_SSH. A test that wants
+            # the probe to run opts out with `envextra={"DRIFT_SKIP_SSH_PROBE": "0"}`
+            # and installs a stub ssh — never the real one.
+            DRIFT_SKIP_SSH_PROBE="1",
         )
         env.update(envextra)   # per-test overrides win (e.g. a blocked state dir)
         # `script` runs a COPY of the checker whose `lib/` a test controls. The
@@ -4151,13 +4166,38 @@ def test_the_unit_start_timeout_can_absorb_every_source_repo_fetch():
     sites, in_loop, GH_CALLS = _derive_gh_calls(DRIFT.read_text())
     assert sites >= 3, f"the gh call sites cannot be counted: {sites}"
     assert in_loop >= 1, "no gh call found inside the ruleset loop"
-    needed = 2 * len(EXPECTED_SOURCE_REPOS) * cap + phase2 + GH_CALLS * gh + 60
+
+    # 🔴 THE ADDRESS PROBE IS A NETWORK CALL AND MUST BE IN THIS MODEL. #1439
+    # added it to this script and did NOT extend the budget — the exact omission
+    # this test's docstring says it exists to catch, arriving in the commit that
+    # quoted the docstring. It is bounded by `ConnectTimeout=$SSH_PROBE_TIMEOUT`
+    # per address, over the candidate list, so the worst case is
+    # len(candidates) x that default. DERIVED from the lib for the same reason
+    # everything else here is: a literal beside the thing it counts drifts.
+    #
+    # ⚠ ConnectTimeout bounds the TCP CONNECT only. A peer that accepts :22 and
+    # then stalls in key exchange is NOT bounded by it, and nothing wraps the
+    # probe in `timeout`. That residue is stated rather than modelled — this
+    # budget covers the failure mode that actually happens (an address that does
+    # not answer), not a malicious half-open peer.
+    lib_src = (DRIFT.parent / "lib" / "host-role.sh").read_text()
+    m5 = re.search(r"SSH_PROBE_TIMEOUT:-(\d+)", lib_src)
+    assert m5, "no SSH_PROBE_TIMEOUT default in lib/host-role.sh"
+    probe_cap = int(m5.group(1))
+    n_candidates = max(
+        2, len(re.findall(r"^\s*echo \"\$(?:WORKBENCH|LAPTOP)_SSH_SECONDARY\"",
+                          lib_src, re.M)) + 1)
+    probe = n_candidates * probe_cap
+
+    needed = (2 * len(EXPECTED_SOURCE_REPOS) * cap + phase2
+              + GH_CALLS * gh + probe + 60)
     assert ceiling >= needed, (
         "TimeoutStartSec=%d cannot absorb the worst case: %d source fetches at "
-        "%ds + a %ds phase-2 scan + %d branch-protection probes at %ds + 60s of "
-        "devrc fetch/ssh = %ds. systemd would kill the run and the deadman would "
-        "report nothing, on a schedule."
-        % (ceiling, 2 * len(EXPECTED_SOURCE_REPOS), cap, phase2, GH_CALLS, gh, needed)
+        "%ds + a %ds phase-2 scan + %d branch-protection probes at %ds + %ds of "
+        "address probing + 60s of devrc fetch/ssh = %ds. systemd would kill the "
+        "run and the deadman would report nothing, on a schedule."
+        % (ceiling, 2 * len(EXPECTED_SOURCE_REPOS), cap, phase2, GH_CALLS, gh,
+           probe, needed)
     )
 
 

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -293,20 +293,29 @@ class Fleet:
             # write to the operator's real state dir and inherit a streak from
             # whatever ran before them.
             DRIFT_STATE_DIR=str(self.state),
-            # 🔴 THE SIXTH HERMETICITY SEAM, and it was paid for the same way as
-            # the fifth. The address probe added in #1439 runs before the remote
-            # leg and reaches the OPERATOR'S REAL LAPTOP. MEASURED at b280162a:
-            # this module made 568 outbound ssh attempts (284 per address), one
-            # pair per test, to a live host — a read-only breach is still a
-            # breach, and with the laptop off-LAN each LAN probe burns the full
-            # ConnectTimeout, so the module's runtime and its VERDICT started
-            # depending on the operator's network.
+            # 🔴 THE SIXTH SEAM — and it is a DETERMINISM seam, not an outbound
+            # one. Say that precisely, because the first version of this comment
+            # did not and would have misled anyone deciding to remove it.
             #
-            # `--no-remote` is now gated in the script itself, which removes most
-            # of them; this closes the rest, including the sites that pass
-            # neither `--no-remote` nor an explicit REMOTE_SSH. A test that wants
-            # the probe to run opts out with `envextra={"DRIFT_SKIP_SSH_PROBE": "0"}`
-            # and installs a stub ssh — never the real one.
+            # What happened: the address probe added in #1439 ran before the
+            # remote leg, and at the PR head before any gate this module made
+            # 558 outbound ssh attempts (279 per address) to the operator's real
+            # laptop — a read-only breach is still a breach, and with the host
+            # off-LAN each probe burned the full ConnectTimeout, so the module's
+            # runtime and its VERDICT depended on the operator's network.
+            #
+            # 🔴 But the `[ "$DO_REMOTE" = 1 ]` gate in the script closed ALL of
+            # that on its own. MEASURED with the gate and without this seam:
+            # 8 probe executions, of which 0 reached an unstubbed ssh — every one
+            # landed on a fixture `stub_ssh` — across 11 static call sites that
+            # pass neither `--no-remote` nor an explicit REMOTE_SSH. (Positive
+            # control for the instrument: 558 on the ungated tree.)
+            #
+            # So this exists to stop 8 stubbed probes perturbing timing and
+            # output, and as defence in depth if a future test forgets a stub —
+            # NOT because tests still reach a live host. A test that wants the
+            # probe opts out with `envextra={"DRIFT_SKIP_SSH_PROBE": "0"}` and
+            # installs a stub ssh, never the real one.
             DRIFT_SKIP_SSH_PROBE="1",
         )
         env.update(envextra)   # per-test overrides win (e.g. a blocked state dir)
@@ -4180,13 +4189,37 @@ def test_the_unit_start_timeout_can_absorb_every_source_repo_fetch():
     # probe in `timeout`. That residue is stated rather than modelled — this
     # budget covers the failure mode that actually happens (an address that does
     # not answer), not a malicious half-open peer.
-    lib_src = (DRIFT.parent / "lib" / "host-role.sh").read_text()
+    lib = DRIFT.parent / "lib" / "host-role.sh"
+    lib_src = lib.read_text()
     m5 = re.search(r"SSH_PROBE_TIMEOUT:-(\d+)", lib_src)
     assert m5, "no SSH_PROBE_TIMEOUT default in lib/host-role.sh"
     probe_cap = int(m5.group(1))
-    n_candidates = max(
-        2, len(re.findall(r"^\s*echo \"\$(?:WORKBENCH|LAPTOP)_SSH_SECONDARY\"",
-                          lib_src, re.M)) + 1)
+
+    # 🔴 ASK THE LIB, do not pattern-match it. A first version counted
+    # `^\s*echo "\$..._SSH_SECONDARY"` lines and floored the result at 2 — but
+    # the lib emits both candidates on ONE line (`echo "$X_DEFAULT"; echo
+    # "$X_SECONDARY"`), so the regex matched 0 and the whole value came from the
+    # floor: a literal wearing a derivation's costume, in a block whose own
+    # comment says a literal beside the thing it counts drifts. Proved by adding
+    # a genuine third address: the count stayed 2 and this test stayed GREEN,
+    # which is the "a network call added with no room for it" shape it exists to
+    # catch. Running the function is the only derivation that tracks the lib.
+    probed_roles = ("workbench", "laptop")
+    counts = []
+    for role in probed_roles:
+        out = subprocess.run(
+            ["bash", "-c",
+             f'set -euo pipefail; unset REMOTE_SSH LAPTOP_SSH; '
+             f'source "{lib}"; remote_ssh_candidates_of {role}'],
+            capture_output=True, text=True, check=True,
+        )
+        counts.append(len([ln for ln in out.stdout.splitlines() if ln.strip()]))
+    n_candidates = max(counts)
+    assert n_candidates >= 2, (
+        f"the candidate lists collapsed to {counts}; with fewer than two "
+        "addresses there is no fallback to budget for, which means the probe "
+        "was removed and this term should go with it"
+    )
     probe = n_candidates * probe_cap
 
     needed = (2 * len(EXPECTED_SOURCE_REPOS) * cap + phase2

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -83,10 +83,35 @@ SANDBOX_REFUSAL_RC = 97
 
 
 def _host_role_constant(name):
-    """Read a `NAME="value"` constant straight out of lib/host-role.sh."""
-    m = re.search(rf'^{name}="([^"]*)"', HOST_ROLE_LIB.read_text(), re.M)
-    assert m, f"{name} is no longer defined in {HOST_ROLE_LIB}"
-    return m.group(1)
+    """The VALUE of a constant in lib/host-role.sh, evaluated by bash.
+
+    🔴 EVALUATED, NOT SCRAPED. This read a `NAME="value"` literal with a regex
+    until 2026-09-09, when the ssh defaults became DERIVED
+    (`"${SSH_USER_DEFAULT}@${LAPTOP_IP_PRIMARY}"`, so one address lives in one
+    place). The regex then returned the literal string
+    `${SSH_USER_DEFAULT}@${LAPTOP_IP_PRIMARY}` and the caller asserted the ssh
+    shim had been handed THAT — a failure that reads as "the fallback target
+    moved" when nothing about the target had moved at all.
+
+    A helper that can only read constants nobody ever derives is a tripwire on
+    an ordinary refactor. Sourcing the lib is hermetic: it defines variables and
+    functions and does nothing else (see its SOURCE-ONLY note), so this touches
+    no network and starts no host.
+    """
+    out = subprocess.run(
+        ["bash", "-c", f'set -euo pipefail; source "{HOST_ROLE_LIB}"; printf %s "${{{name}-}}"'],
+        capture_output=True, text=True, check=True,
+    )
+    value = out.stdout.strip()
+    assert value, (
+        f"{name} is empty or no longer defined in {HOST_ROLE_LIB} "
+        f"(stderr: {out.stderr.strip()!r})"
+    )
+    assert "$" not in value, (
+        f"{name} evaluated to {value!r}, which still contains an unexpanded "
+        "variable — the lib defines it before its inputs are set."
+    )
+    return value
 
 
 def _write_sandbox_bin(d):

--- a/scripts/tests/test_ship_ssh_fallback.py
+++ b/scripts/tests/test_ship_ssh_fallback.py
@@ -1,0 +1,202 @@
+"""Unit tests for ship.sh's remote-address selection (LAN -> nebula fallback).
+
+WHY THIS EXISTS, measured 2026-09-09: `ship.sh` reached for the laptop's LAN
+address `192.168.50.155`, ssh timed out after the connect timeout, and the leg
+exited 255 with `converge exited 255`. The laptop was UP and answering on its
+nebula address `10.42.0.100` the entire time. Two things were wrong and only one
+of them is cosmetic:
+
+  * the deploy did not happen -- the laptop silently stopped receiving every
+    future change while the run merely looked like it had hit a dead host;
+  * nothing in the output distinguished "this host is off" from "this host is
+    not on that network", so the fix is not discoverable from the failure.
+
+The selection is split so it can be tested without a network:
+`remote_ssh_candidates_of` is PURE (prints the targets to try, contacts
+nothing), and `first_reachable_ssh` does the probing behind `$SSH_PROBE_CMD`,
+which these tests replace with a stub.
+
+🔴 The contract that matters most is the NEGATIVE one: an explicit
+`$REMOTE_SSH` / `$LAPTOP_SSH` must be a ONE-ELEMENT list, so a run an operator
+addressed by hand can never be silently redirected to the other address. A
+fallback that also "helpfully" retries an explicit target is a converge landing
+on a machine nobody named.
+"""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1] / "lib" / "host-role.sh"
+
+# The canonical addresses, restated here ON PURPOSE: if someone renumbers a host
+# in the lib, these tests must FAIL rather than silently re-derive the new value
+# and keep passing. A test that reads its expectation from the code under test
+# asserts nothing.
+LAPTOP_LAN = "zach@192.168.50.155"
+LAPTOP_NEBULA = "zach@10.42.0.100"
+WORKBENCH_LAN = "zach@192.168.50.250"
+WORKBENCH_NEBULA = "zach@10.42.0.30"
+
+
+def _run(snippet: str, env: dict | None = None) -> str:
+    """Source the lib and run a snippet, returning stdout (stderr dropped)."""
+    script = f'set -euo pipefail\nsource "{LIB}"\n{textwrap.dedent(snippet)}'
+    full_env = {**os.environ, **(env or {})}
+    # Unset the real overrides unless the case sets them, so a developer with
+    # REMOTE_SSH exported in their shell cannot turn these green by accident.
+    for var in ("REMOTE_SSH", "LAPTOP_SSH"):
+        if not (env or {}).get(var):
+            full_env.pop(var, None)
+    out = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True, text=True, check=True, env=full_env,
+    )
+    return out.stdout.strip()
+
+
+def candidates(role: str, env: dict | None = None) -> list[str]:
+    raw = _run(f'remote_ssh_candidates_of {role}', env)
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# The candidate list -- pure, no network
+# --------------------------------------------------------------------------- #
+
+def test_from_the_workbench_the_laptops_lan_address_comes_first():
+    assert candidates("workbench") == [LAPTOP_LAN, LAPTOP_NEBULA]
+
+
+def test_from_the_laptop_the_workbenchs_lan_address_comes_first():
+    assert candidates("laptop") == [WORKBENCH_LAN, WORKBENCH_NEBULA]
+
+
+def test_an_unknown_role_offers_nothing():
+    assert candidates("unknown") == []
+
+
+@pytest.mark.parametrize("override", ["REMOTE_SSH", "LAPTOP_SSH"])
+def test_an_explicit_target_is_the_WHOLE_list(override):
+    """🔴 The negative contract: no fallback behind an operator's own address.
+
+    A second candidate here would let a run addressed at one machine converge a
+    DIFFERENT one whenever the named host happened not to answer.
+    """
+    assert candidates("workbench", {override: "zach@10.0.0.9"}) == ["zach@10.0.0.9"]
+
+
+def test_LAPTOP_SSH_does_not_leak_into_the_laptops_own_candidates():
+    """From the laptop, the remote is the WORKBENCH -- LAPTOP_SSH would be self."""
+    assert candidates("laptop", {"LAPTOP_SSH": "zach@10.0.0.9"}) == [
+        WORKBENCH_LAN,
+        WORKBENCH_NEBULA,
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# The probe -- selection driven with a stubbed prober
+# --------------------------------------------------------------------------- #
+
+def _probe_stub(tmp_path: Path, reachable: str) -> str:
+    """A prober that succeeds only for `reachable` (empty = nothing answers)."""
+    p = tmp_path / "probe.sh"
+    p.write_text('#!/usr/bin/env bash\n[ "$1" = "%s" ]\n' % reachable)
+    p.chmod(0o755)
+    return str(p)
+
+
+def test_the_lan_address_wins_when_it_answers(tmp_path):
+    stub = _probe_stub(tmp_path, LAPTOP_LAN)
+    got = _run(
+        f'first_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA}',
+        {"SSH_PROBE_CMD": stub},
+    )
+    assert got == LAPTOP_LAN
+
+
+def test_it_falls_back_to_nebula_when_the_lan_address_is_silent(tmp_path):
+    """THE MEASURED CASE: laptop off-LAN, up on nebula."""
+    stub = _probe_stub(tmp_path, LAPTOP_NEBULA)
+    got = _run(
+        f'first_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA}',
+        {"SSH_PROBE_CMD": stub},
+    )
+    assert got == LAPTOP_NEBULA
+
+
+def test_nothing_reachable_yields_nothing_and_a_nonzero_status(tmp_path):
+    """🔴 It must NOT fall through to the first candidate.
+
+    Returning a target nobody could reach would turn a reachability fact into a
+    converge failure 200 lines later, which is the failure this whole change
+    exists to make legible.
+    """
+    stub = _probe_stub(tmp_path, "zach@nothing-answers")
+    script = (
+        f'set -uo pipefail\nsource "{LIB}"\n'
+        f'out="$(first_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA})" && rc=0 || rc=$?\n'
+        'echo "rc=$rc out=[$out]"\n'
+    )
+    env = {**os.environ, "SSH_PROBE_CMD": stub}
+    env.pop("REMOTE_SSH", None)
+    res = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True, env=env
+    )
+    assert res.stdout.strip() == "rc=1 out=[]"
+
+
+def test_the_probe_reports_each_address_that_did_not_answer(tmp_path):
+    """The operator has to be able to see WHICH addresses were tried."""
+    stub = _probe_stub(tmp_path, LAPTOP_NEBULA)
+    env = {**os.environ, "SSH_PROBE_CMD": stub}
+    env.pop("REMOTE_SSH", None)
+    res = subprocess.run(
+        ["bash", "-c",
+         f'set -uo pipefail\nsource "{LIB}"\nfirst_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA}'],
+        capture_output=True, text=True, check=True, env=env,
+    )
+    assert LAPTOP_LAN in res.stderr
+    assert "did not answer" in res.stderr
+    # ...and the one that DID answer is not reported as silent.
+    assert f"{LAPTOP_NEBULA} did not answer" not in res.stderr
+
+
+def test_the_secondary_targets_are_derived_from_the_ip_constants(tmp_path):
+    """One address, one place -- the nebula targets must not be a second copy.
+
+    Renumbering `LAPTOP_IP_SECONDARY` alone must move the ssh target with it; if
+    someone re-spells the address in a `*_SSH_SECONDARY` literal, this fails.
+
+    ⚠ The renumber is done in a COPY of the lib, not by exporting the variable:
+    the lib assigns its constants unconditionally, so an injected value is
+    overwritten the moment it is sourced. A first draft of this test did exactly
+    that and asserted nothing -- it read the unmodified default back and failed,
+    which at least failed LOUDLY rather than passing vacuously.
+    """
+    copy = tmp_path / "host-role.sh"
+    src = LIB.read_text()
+    old = 'LAPTOP_IP_SECONDARY="10.42.0.100"'
+    assert old in src, (
+        f"expected {old!r} in {LIB}; if the constant was renamed or respelled, "
+        "re-point this test -- it cannot prove derivation without it."
+    )
+    copy.write_text(src.replace(old, 'LAPTOP_IP_SECONDARY="10.99.99.99"'))
+
+    out = subprocess.run(
+        ["bash", "-c", f'set -euo pipefail\nsource "{copy}"\nremote_ssh_candidates_of workbench'],
+        capture_output=True, text=True, check=True,
+        env={k: v for k, v in os.environ.items() if k not in ("REMOTE_SSH", "LAPTOP_SSH")},
+    )
+    lines = out.stdout.split()
+    assert "zach@10.99.99.99" in lines, (
+        f"renumbering LAPTOP_IP_SECONDARY did not move the ssh target: {lines}. "
+        "The nebula target is a duplicated literal rather than derived."
+    )
+    assert LAPTOP_NEBULA not in lines, (
+        "the ORIGINAL nebula address survived a renumber, so it is spelled "
+        f"somewhere else too: {lines}"
+    )

--- a/scripts/tests/test_ship_ssh_probe_wiring.py
+++ b/scripts/tests/test_ship_ssh_probe_wiring.py
@@ -152,6 +152,33 @@ def test_the_seam_cannot_be_reached_through_the_ENVIRONMENT(tmp_path):
     )
 
 
+def test_the_flag_is_listed_in_help(tmp_path):
+    """The Usage block is what `--help` prints, and nothing read it.
+
+    `ship.sh` asserts in a comment that this flag "appears in --help like every
+    other option". It did not, for one commit: the flag was added to the arg
+    loop and not to the header. Deleting the Usage lines again is otherwise
+    undetectable -- and this round treated exactly that shape (an unguarded
+    fix) as a defect worth closing, so it should not leave one behind.
+
+    The positive control matters: `--help` prints a comment block by an awk
+    range, so a header edit can silently truncate the whole listing. Asserting
+    only the new flag would then pass while every other option vanished.
+    """
+    res = subprocess.run(["bash", str(SHIP), "--help"], capture_output=True,
+                         text=True, timeout=60)
+    assert res.returncode == 0, res.stderr
+    assert "--print-remote-target" in res.stdout, (
+        "the flag is not in the Usage block that --help prints, so a reader "
+        "sent there by ship.sh's own comment will not find it"
+    )
+    for control in ("--detect-role", "--no-remote", "--no-switch"):
+        assert control in res.stdout, (
+            f"{control} is missing too -- the header listing is truncated, so "
+            "the assertion above proves nothing about the flag specifically"
+        )
+
+
 def test_the_skip_switch_turns_the_probe_off(tmp_path):
     """`SHIP_SKIP_SSH_PROBE` is the documented escape hatch -- unexercised until now."""
     log = tmp_path / "probed.log"
@@ -234,10 +261,8 @@ def test_the_probes_diagnostic_carries_the_CALLERS_prefix(tmp_path):
 
     `drift-check.sh` accepts only lines starting with `[`, `===`,
     `drift-check: ` or two spaces. A hardcoded `ship:` here fails that hygiene
-    guard -- measured, as
-    `test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written` -- and
-    independently misattributes the message to the wrong program in the
-    operator's log.
+    guard and independently misattributes the message to the wrong program in
+    the operator's log.
 
     ⚠ SCOPE: this asserts the LIB under both prefix values. The drift-check
     side is asserted by
@@ -342,6 +367,18 @@ def test_drift_check_makes_no_ssh_connection_under_no_remote(tmp_path):
     env["DRIFT_REPO"] = str(tmp_path / "norepo")
     env["DRIFT_STATE_DIR"] = str(tmp_path / "state")
     env["DRIFT_GH"] = str(tmp_path / "no-gh")   # absent -> the arm takes its no-gh branch
+    # 🔴 AND THE OTHER TWO. Pinning the three above was measured INSUFFICIENT:
+    # `DRIFT_SESSION_MANAGER` defaults to the real 352 KB program, which the
+    # phase-2 gate execs to scan the operator's LIVE tmux (57 rows, measured) --
+    # `drift-check.sh` says of that scan "which no test may do", and
+    # `test_drift_check.py` pins it as its FOURTH hermeticity seam for the same
+    # reason. `$HOME` is the other: unredirected, each run walks the real
+    # ~/.claude and ~/.config/opencode (344 managed symlinks) and reads
+    # settings.json. Read-only, but the verdict then depends on the operator's
+    # live session state -- and pinning both is FASTER: 3 session-manager execs
+    # to 0, these tests 8.28s to 0.84s.
+    env["DRIFT_SESSION_MANAGER"] = str(tmp_path / "no-session-manager")
+    env["HOME"] = str(tmp_path / "home")
 
     subprocess.run(["bash", str(drift), "--no-remote"], capture_output=True,
                    text=True, env=env, timeout=300)
@@ -385,7 +422,12 @@ def test_drift_checks_probe_output_is_journal_clean(tmp_path):
            "DRIFT_SKIP_SSH_PROBE": "0",
            "DRIFT_REPO": str(tmp_path / "norepo"),
            "DRIFT_STATE_DIR": str(tmp_path / "state2"),
-           "DRIFT_GH": str(tmp_path / "no-gh")}
+           "DRIFT_GH": str(tmp_path / "no-gh"),
+           # Same five seams as the test above -- see its note. The real
+           # session-manager scans live tmux; an unredirected HOME walks the
+           # operator's ~/.claude.
+           "DRIFT_SESSION_MANAGER": str(tmp_path / "no-session-manager"),
+           "HOME": str(tmp_path / "home2")}
     for var in ("REMOTE_SSH", "LAPTOP_SSH"):
         env.pop(var, None)
 

--- a/scripts/tests/test_ship_ssh_probe_wiring.py
+++ b/scripts/tests/test_ship_ssh_probe_wiring.py
@@ -1,0 +1,236 @@
+"""ship.sh's address SELECTION, and the real `ssh` probe line.
+
+WHY THIS EXISTS. PR #1439's round-1 audit measured two holes that its own new
+tests could not see, because those tests source `lib/host-role.sh` directly and
+never load `ship.sh`:
+
+  1. Deleting ship.sh's ENTIRE address-selection block (42 lines) left the suite
+     green -- 98/98 in `test_ship_converge.py`. Every ship.sh fixture that
+     reaches an ssh shim sets `$REMOTE_SSH`, which is a one-element candidate
+     list, which skips the probe. So the bug the PR fixes could be reintroduced
+     wholesale with nothing going red.
+  2. The production probe line was never executed by any test: every probe test
+     sets `$SSH_PROBE_CMD`, taking the OTHER branch. Mutating the real line --
+     `StrictHostKeyChecking=accept-new` -> `=no`, `ConnectTimeout` -> `99999`,
+     and the remote command `true` -> `/bin/false` -- SURVIVED all three at
+     once. The `/bin/false` mutant alone makes every probe report "did not
+     answer", i.e. renders the whole fallback inert while the suite stays green.
+
+The first is closed via `SHIP_PRINT_REMOTE_TARGET=1`, a hidden mode that runs
+role resolution + address selection and prints the target it would use. The
+second is closed by putting a recording `ssh` FIRST ON PATH and asserting on the
+argv the real line actually builds -- no network, no real host.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SHIP = SCRIPTS / "ship.sh"
+LIB = SCRIPTS / "lib" / "host-role.sh"
+
+LAPTOP_LAN = "zach@192.168.50.155"
+LAPTOP_NEBULA = "zach@10.42.0.100"
+
+
+def _probe_stub(tmp_path: Path, reachable: str, log: Path | None = None) -> str:
+    """A $SSH_PROBE_CMD that succeeds only for `reachable`, optionally logging."""
+    p = tmp_path / "probe.sh"
+    body = "#!/usr/bin/env bash\n"
+    if log:
+        body += f'echo "$1" >> "{log}"\n'
+    body += f'[ "$1" = "{reachable}" ]\n'
+    p.write_text(body)
+    p.chmod(0o755)
+    return str(p)
+
+
+def _ship_target(tmp_path: Path, env: dict) -> subprocess.CompletedProcess:
+    """Run ship.sh's hidden target-resolution mode with a forced role."""
+    full = {**os.environ, "SHIP_ROLE": "workbench",
+            "SHIP_PRINT_REMOTE_TARGET": "1", **env}
+    for var in ("REMOTE_SSH", "LAPTOP_SSH"):
+        if var not in env:
+            full.pop(var, None)
+    return subprocess.run(
+        ["bash", str(SHIP)], capture_output=True, text=True, env=full, timeout=120
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ship.sh's selection block -- the 42 lines that were provably unguarded
+# --------------------------------------------------------------------------- #
+
+def test_ship_falls_back_to_nebula_and_SAYS_SO(tmp_path):
+    """THE MEASURED BUG, at the ship.sh level rather than the lib's."""
+    res = _ship_target(tmp_path, {"SSH_PROBE_CMD": _probe_stub(tmp_path, LAPTOP_NEBULA)})
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == LAPTOP_NEBULA, (
+        f"ship.sh resolved {res.stdout.strip()!r}; the whole point of the change "
+        "is that a silent LAN address does not end the run"
+    )
+    assert "falling back to" in res.stderr, (
+        "the fallback was taken SILENTLY -- an operator reading the log cannot "
+        f"tell which address was used:\n{res.stderr}"
+    )
+
+
+def test_ship_prefers_the_lan_address_and_stays_quiet_about_it(tmp_path):
+    res = _ship_target(tmp_path, {"SSH_PROBE_CMD": _probe_stub(tmp_path, LAPTOP_LAN)})
+    assert res.stdout.strip() == LAPTOP_LAN
+    assert "falling back" not in res.stderr, (
+        f"announced a fallback that did not happen:\n{res.stderr}"
+    )
+
+
+def test_ship_names_every_address_when_none_answers(tmp_path):
+    """🔴 The diagnosis is the whole point: 'off' must not read like 'wrong network'."""
+    res = _ship_target(
+        tmp_path, {"SSH_PROBE_CMD": _probe_stub(tmp_path, "zach@nothing-answers")}
+    )
+    assert "NO candidate address answered" in res.stderr, res.stderr
+    for addr in (LAPTOP_LAN, LAPTOP_NEBULA):
+        assert addr in res.stderr, f"{addr} was tried but not named:\n{res.stderr}"
+    assert res.stdout.strip() == LAPTOP_LAN, (
+        "with nothing reachable the run must keep its DERIVED default and let "
+        "the remote leg report the failure, not invent a target"
+    )
+
+
+@pytest.mark.parametrize("override", ["REMOTE_SSH", "LAPTOP_SSH"])
+def test_an_explicit_target_is_never_probed_or_redirected(tmp_path, override):
+    """🔴 The negative contract, at the ship.sh level.
+
+    Asserts the stronger thing: the probe is not merely ignored, it never RUNS.
+    A probe that executed and was then discarded would still make a connection
+    the operator did not ask for -- which is what perturbed a convergence test
+    once already.
+    """
+    log = tmp_path / "probed.log"
+    res = _ship_target(tmp_path, {
+        override: "zach@10.0.0.9",
+        "SSH_PROBE_CMD": _probe_stub(tmp_path, "zach@10.0.0.9", log=log),
+    })
+    assert res.stdout.strip() == "zach@10.0.0.9"
+    assert not log.exists(), (
+        f"the probe RAN for an explicitly addressed host: {log.read_text()!r}"
+    )
+
+
+def test_the_skip_switch_turns_the_probe_off(tmp_path):
+    """`SHIP_SKIP_SSH_PROBE` is the documented escape hatch -- unexercised until now."""
+    log = tmp_path / "probed.log"
+    res = _ship_target(tmp_path, {
+        "SHIP_SKIP_SSH_PROBE": "1",
+        "SSH_PROBE_CMD": _probe_stub(tmp_path, LAPTOP_NEBULA, log=log),
+    })
+    assert res.stdout.strip() == LAPTOP_LAN, (
+        "with the probe skipped the first derived candidate must be used as-is"
+    )
+    assert not log.exists(), "SHIP_SKIP_SSH_PROBE=1 still probed"
+
+
+# --------------------------------------------------------------------------- #
+# The REAL ssh line -- executed via a recording stub first on PATH
+# --------------------------------------------------------------------------- #
+
+def _recording_ssh(tmp_path: Path, exit_code: int = 0) -> tuple[Path, Path]:
+    """An `ssh` on PATH that records its argv and exits `exit_code`."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "argv.log"
+    stub = bindir / "ssh"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> "{log}"\n'
+        f"exit {exit_code}\n"
+    )
+    stub.chmod(0o755)
+    return bindir, log
+
+
+def _run_probe_with_real_branch(tmp_path, bindir, extra_env=None):
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"}
+    env.pop("SSH_PROBE_CMD", None)          # force the REAL branch
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["bash", "-c",
+         f'set -uo pipefail; source "{LIB}"; first_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA}'],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+
+
+def test_the_real_probe_line_builds_the_argv_it_claims(tmp_path):
+    """🔴 Kills three mutants that SURVIVED a fully green suite.
+
+    Each assertion below corresponds to one: dropping `-n` (stdin theft),
+    loosening `StrictHostKeyChecking`, unbounding `ConnectTimeout`, and running
+    something other than the harmless `true` on the remote host.
+    """
+    bindir, log = _recording_ssh(tmp_path)
+    res = _run_probe_with_real_branch(tmp_path, bindir)
+    assert res.stdout.strip() == LAPTOP_LAN, res.stderr
+    argv = log.read_text().splitlines()[0]
+
+    assert "-n" in argv.split(), f"probe lost -n, so it eats the caller's stdin: {argv}"
+    assert "BatchMode=yes" in argv, f"probe may now prompt: {argv}"
+    assert "StrictHostKeyChecking=accept-new" in argv, (
+        f"host-key policy changed; `=no` would trust a CHANGED key, which is "
+        f"exactly what the fallback must refuse: {argv}"
+    )
+    assert "ConnectTimeout=5" in argv, (
+        f"the default bound moved -- an unbounded probe hangs the run it was "
+        f"added to speed up: {argv}"
+    )
+    assert argv.rstrip().endswith(" true"), (
+        f"the probe runs something other than `true` on the remote host: {argv}"
+    )
+
+
+def test_the_probe_timeout_is_actually_applied(tmp_path):
+    """$SSH_PROBE_TIMEOUT reaches ssh -- otherwise the knob is decorative."""
+    bindir, log = _recording_ssh(tmp_path)
+    _run_probe_with_real_branch(tmp_path, bindir, {"SSH_PROBE_TIMEOUT": "11"})
+    assert "ConnectTimeout=11" in log.read_text()
+
+
+def test_the_probes_diagnostic_carries_the_CALLERS_prefix(tmp_path):
+    """🔴 SEAM: the lib is shared, and its other caller writes a checked journal.
+
+    `drift-check.sh` accepts only lines starting with `[`, `===`,
+    `drift-check: ` or two spaces. A hardcoded `ship:` here fails that hygiene
+    guard -- measured, as
+    `test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written` -- and
+    independently misattributes the message to the wrong program in the
+    operator's log. Both callers are asserted so neither can regress alone.
+    """
+    stub = _probe_stub(tmp_path, "zach@nothing-answers")
+    for prefix, expected in (("", "ship: "), ("drift-check", "drift-check: ")):
+        env = {**os.environ, "SSH_PROBE_CMD": stub}
+        env.pop("REMOTE_SSH", None)
+        if prefix:
+            env["SSH_PROBE_LOG_PREFIX"] = prefix
+        else:
+            env.pop("SSH_PROBE_LOG_PREFIX", None)
+        res = subprocess.run(
+            ["bash", "-c",
+             f'set -uo pipefail; source "{LIB}"; first_reachable_ssh {LAPTOP_LAN}'],
+            capture_output=True, text=True, env=env, timeout=60,
+        )
+        assert res.stderr.startswith(expected), (
+            f"with SSH_PROBE_LOG_PREFIX={prefix!r} the diagnostic must start "
+            f"{expected!r}; got {res.stderr!r}"
+        )
+
+
+def test_a_failing_real_probe_moves_to_the_next_address(tmp_path):
+    """The `/bin/false` mutant made every probe fail; this pins the consequence."""
+    bindir, log = _recording_ssh(tmp_path, exit_code=255)
+    res = _run_probe_with_real_branch(tmp_path, bindir)
+    assert res.returncode != 0, "every address failed, yet a target was returned"
+    assert res.stdout.strip() == ""
+    tried = log.read_text().splitlines()
+    assert len(tried) == 2, f"both addresses should have been tried: {tried}"

--- a/scripts/tests/test_ship_ssh_probe_wiring.py
+++ b/scripts/tests/test_ship_ssh_probe_wiring.py
@@ -16,8 +16,11 @@ never load `ship.sh`:
      once. The `/bin/false` mutant alone makes every probe report "did not
      answer", i.e. renders the whole fallback inert while the suite stays green.
 
-The first is closed via `SHIP_PRINT_REMOTE_TARGET=1`, a hidden mode that runs
-role resolution + address selection and prints the target it would use. The
+The first is closed via `--print-remote-target`, a flag that runs role
+resolution + address selection and prints the target it would use. (It began as
+an env var and was changed to argv in round 2: an env seam is INHERITABLE, and an
+inherited copy makes an ordinary `ship.sh` print an address and exit 0 having
+converged nothing.) The
 second is closed by putting a recording `ssh` FIRST ON PATH and asserting on the
 argv the real line actually builds -- no network, no real host.
 """
@@ -50,13 +53,13 @@ def _probe_stub(tmp_path: Path, reachable: str, log: Path | None = None) -> str:
 
 def _ship_target(tmp_path: Path, env: dict) -> subprocess.CompletedProcess:
     """Run ship.sh's hidden target-resolution mode with a forced role."""
-    full = {**os.environ, "SHIP_ROLE": "workbench",
-            "SHIP_PRINT_REMOTE_TARGET": "1", **env}
+    full = {**os.environ, "SHIP_ROLE": "workbench", **env}
     for var in ("REMOTE_SSH", "LAPTOP_SSH"):
         if var not in env:
             full.pop(var, None)
     return subprocess.run(
-        ["bash", str(SHIP)], capture_output=True, text=True, env=full, timeout=120
+        ["bash", str(SHIP), "--print-remote-target"],
+        capture_output=True, text=True, env=full, timeout=120,
     )
 
 
@@ -205,7 +208,13 @@ def test_the_probes_diagnostic_carries_the_CALLERS_prefix(tmp_path):
     guard -- measured, as
     `test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written` -- and
     independently misattributes the message to the wrong program in the
-    operator's log. Both callers are asserted so neither can regress alone.
+    operator's log.
+
+    ⚠ SCOPE: this asserts the LIB under both prefix values. It does not load
+    `drift-check.sh`; that side is covered by the test named above, in
+    `test_drift_check.py`. An earlier draft of this docstring claimed "both
+    callers are asserted so neither can regress alone", which was wrong about
+    THIS file -- the coverage exists, in another module.
     """
     stub = _probe_stub(tmp_path, "zach@nothing-answers")
     for prefix, expected in (("", "ship: "), ("drift-check", "drift-check: ")):
@@ -224,6 +233,80 @@ def test_the_probes_diagnostic_carries_the_CALLERS_prefix(tmp_path):
             f"with SSH_PROBE_LOG_PREFIX={prefix!r} the diagnostic must start "
             f"{expected!r}; got {res.stderr!r}"
         )
+
+
+def test_the_degraded_block_defines_the_function_the_selection_calls(tmp_path):
+    """🔴 The lib-less recovery path, which had NO test and reproduced its bug.
+
+    `ship.sh` runs in "degraded recovery mode" when `lib/host-role.sh` is
+    missing -- the state you are in when a host is already broken, and the one
+    the script's own recovery instructions tell you to use. The selection block
+    calls `remote_ssh_candidates_of` unconditionally, so if the degraded block
+    does not define it the run prints `command not found` into the middle of a
+    recovery. Measured: deleting that one line reproduced the symptom while
+    `pytest -k "without_the_lib or through_a_symlink"` stayed green, 4 passed.
+    """
+    lonely = tmp_path / "scripts"
+    lonely.mkdir()
+    (lonely / "ship.sh").write_text(SHIP.read_text())
+    env = {**os.environ, "SHIP_ROLE": "workbench", "REMOTE_SSH": "zach@10.0.0.9"}
+    env.pop("LAPTOP_SSH", None)
+    res = subprocess.run(
+        ["bash", str(lonely / "ship.sh"), "--print-remote-target"],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+    assert "degraded recovery mode" in res.stderr, (
+        f"expected the lib-less path; got:\n{res.stderr}"
+    )
+    assert "command not found" not in res.stderr, (
+        "an undefined function crashed into the middle of a RECOVERY run -- the "
+        f"exact shape this file rejects elsewhere:\n{res.stderr}"
+    )
+    assert res.stdout.strip() == "zach@10.0.0.9", (
+        f"degraded mode must still honour an explicit target; got {res.stdout!r}"
+    )
+
+
+def test_drift_check_makes_no_ssh_connection_under_no_remote(tmp_path):
+    """🔴 `--no-remote` is documented as "this host only (no ssh)".
+
+    MEASURED before the fix: it made two outbound probe connections to the
+    operator's real laptop, and `test_drift_check.py` -- which passes
+    `--no-remote` throughout -- issued 568 of them across the module. A
+    read-only breach is still a breach, and with the laptop off-LAN each probe
+    burns the full ConnectTimeout, so the suite's runtime and verdict began
+    depending on the operator's network.
+
+    The positive control below is the point: it proves this test can SEE a
+    probe, so the zero above is a measurement rather than a wiring accident.
+    """
+    drift = SCRIPTS / "drift-check.sh"
+    bindir, log = _recording_ssh(tmp_path, exit_code=255)
+    env = {**os.environ, "SHIP_ROLE": "workbench",
+           "PATH": f"{bindir}:{os.environ['PATH']}"}
+    for var in ("REMOTE_SSH", "LAPTOP_SSH", "DRIFT_SKIP_SSH_PROBE"):
+        env.pop(var, None)
+
+    subprocess.run(["bash", str(drift), "--no-remote"], capture_output=True,
+                   text=True, env=env, timeout=300)
+    probes = [ln for ln in (log.read_text().splitlines() if log.exists() else [])
+              if "BatchMode=yes" in ln and " true" in ln]
+    assert probes == [], (
+        "--no-remote is documented as making no ssh connection, but the address "
+        f"probe fired: {probes}"
+    )
+
+    # POSITIVE CONTROL — the same harness WITH the remote leg in scope must see
+    # probes, or the empty list above proves nothing about the gate.
+    log.unlink(missing_ok=True)
+    subprocess.run(["bash", str(drift)], capture_output=True, text=True,
+                   env=env, timeout=300)
+    seen = [ln for ln in (log.read_text().splitlines() if log.exists() else [])
+            if "BatchMode=yes" in ln and " true" in ln]
+    assert seen, (
+        "the control saw NO probe even with the remote leg in scope, so this "
+        "test cannot distinguish a working gate from a probe that never runs"
+    )
 
 
 def test_a_failing_real_probe_moves_to_the_next_address(tmp_path):

--- a/scripts/tests/test_ship_ssh_probe_wiring.py
+++ b/scripts/tests/test_ship_ssh_probe_wiring.py
@@ -123,6 +123,35 @@ def test_an_explicit_target_is_never_probed_or_redirected(tmp_path, override):
     )
 
 
+def test_the_seam_cannot_be_reached_through_the_ENVIRONMENT(tmp_path):
+    """🔴 The env->flag change, guarded — it was not, by this file's own standard.
+
+    As `$SHIP_PRINT_REMOTE_TARGET` this seam was INHERITABLE: an operator who
+    exported it while debugging would get, from every later `ship.sh` in that
+    shell, an address printed and rc 0 having converged NOTHING. Reverting the
+    initialiser to `${SHIP_PRINT_REMOTE_TARGET:-0}` is otherwise undetectable,
+    because after the change no test sets the variable at all.
+
+    So: export it, pass NO flag, and require a real run — which here means it
+    must NOT print a bare address and exit 0.
+    """
+    env = {**os.environ, "SHIP_ROLE": "workbench",
+           "SHIP_PRINT_REMOTE_TARGET": "1",
+           "SSH_PROBE_CMD": _probe_stub(tmp_path, LAPTOP_NEBULA),
+           "SHIP_REPO": str(tmp_path / "norepo"),
+           "SHIP_NO_SWITCH": "1"}
+    for var in ("REMOTE_SSH", "LAPTOP_SSH"):
+        env.pop(var, None)
+    res = subprocess.run(["bash", str(SHIP), "--no-remote"], capture_output=True,
+                         text=True, env=env, timeout=300)
+    printed = res.stdout.strip().splitlines()
+    assert printed[:1] != [LAPTOP_NEBULA] and printed[:1] != [LAPTOP_LAN], (
+        "an EXPORTED SHIP_PRINT_REMOTE_TARGET still triggered the seam: the run "
+        f"printed {printed[:1]!r} instead of converging. That is the inheritable "
+        "vacuous green the flag exists to make impossible."
+    )
+
+
 def test_the_skip_switch_turns_the_probe_off(tmp_path):
     """`SHIP_SKIP_SSH_PROBE` is the documented escape hatch -- unexercised until now."""
     log = tmp_path / "probed.log"
@@ -210,11 +239,20 @@ def test_the_probes_diagnostic_carries_the_CALLERS_prefix(tmp_path):
     independently misattributes the message to the wrong program in the
     operator's log.
 
-    ⚠ SCOPE: this asserts the LIB under both prefix values. It does not load
-    `drift-check.sh`; that side is covered by the test named above, in
-    `test_drift_check.py`. An earlier draft of this docstring claimed "both
-    callers are asserted so neither can regress alone", which was wrong about
-    THIS file -- the coverage exists, in another module.
+    ⚠ SCOPE: this asserts the LIB under both prefix values. The drift-check
+    side is asserted by
+    `test_drift_checks_probe_output_is_journal_clean` below, IN THIS FILE.
+
+    🔴 That test exists because this docstring has now been wrong twice. Draft 1
+    said "both callers are asserted so neither can regress alone" -- false, this
+    module loaded one. Draft 2 pointed at
+    `test_the_ladder_escalates_when_the_streak_FILE_cannot_be_written` in
+    `test_drift_check.py` -- true when written, and FALSE BY THE TIME IT WAS
+    WRITTEN: the same commit stopped `--no-remote` from probing and defaulted
+    `DRIFT_SKIP_SSH_PROBE=1` module-wide, so that test can no longer emit a
+    probe line at all. Measured: deleting `SSH_PROBE_LOG_PREFIX=drift-check`
+    scored 594 passed. A correction that pointed at coverage its own commit had
+    just removed.
     """
     stub = _probe_stub(tmp_path, "zach@nothing-answers")
     for prefix, expected in (("", "ship: "), ("drift-check", "drift-check: ")):
@@ -272,7 +310,8 @@ def test_drift_check_makes_no_ssh_connection_under_no_remote(tmp_path):
 
     MEASURED before the fix: it made two outbound probe connections to the
     operator's real laptop, and `test_drift_check.py` -- which passes
-    `--no-remote` throughout -- issued 568 of them across the module. A
+    `--no-remote` throughout -- issued 558 of them across the module (279 per
+    address; an earlier note said 568, which was my own count and was wrong). A
     read-only breach is still a breach, and with the laptop off-LAN each probe
     burns the full ConnectTimeout, so the suite's runtime and verdict began
     depending on the operator's network.
@@ -286,6 +325,23 @@ def test_drift_check_makes_no_ssh_connection_under_no_remote(tmp_path):
            "PATH": f"{bindir}:{os.environ['PATH']}"}
     for var in ("REMOTE_SSH", "LAPTOP_SSH", "DRIFT_SKIP_SSH_PROBE"):
         env.pop(var, None)
+    # 🔴 THIS TEST RUNS THE PRODUCTION DEADMAN, so every default it does not
+    # override reaches the OPERATOR'S REAL MACHINE. Measured before these three
+    # keys existed: it fetched in `$HOME/workspace/{devrc,homelab-talos,
+    # tmux-fuzzyclaw}` (truncating FETCH_HEAD in three SHARED checkouts), made
+    # authenticated `gh api` calls as the real user, and — worst — incremented
+    # the real `unreachable-laptop` escalation streak by one PER RUN, because
+    # the stub ssh always fails. Four suite runs inside one 6h timer window
+    # would drive that counter to DRIFT_UNREACHABLE_ESCALATE and fire the
+    # DND-bypassing failure toast for a host whose true state never got there.
+    #
+    # That is the same breach this very test was written to close, one layer
+    # out: `test_drift_check.py`'s fixture pins these three for exactly this
+    # reason and calls it a hermeticity seam. A test that reaches a live host to
+    # prove nothing reaches a live host is not a test.
+    env["DRIFT_REPO"] = str(tmp_path / "norepo")
+    env["DRIFT_STATE_DIR"] = str(tmp_path / "state")
+    env["DRIFT_GH"] = str(tmp_path / "no-gh")   # absent -> the arm takes its no-gh branch
 
     subprocess.run(["bash", str(drift), "--no-remote"], capture_output=True,
                    text=True, env=env, timeout=300)
@@ -307,6 +363,46 @@ def test_drift_check_makes_no_ssh_connection_under_no_remote(tmp_path):
         "the control saw NO probe even with the remote leg in scope, so this "
         "test cannot distinguish a working gate from a probe that never runs"
     )
+
+
+def test_drift_checks_probe_output_is_journal_clean(tmp_path):
+    """🔴 The drift-check half of the prefix seam, asserted where it is claimed.
+
+    `drift-check.sh` writes a journal whose every line must begin with `[`,
+    `===`, `drift-check: ` or two spaces. The probe lives in a SHARED lib whose
+    other caller is `ship.sh`, so its diagnostic carries whichever prefix the
+    caller sets -- and an unset one says `ship:`, which both fails the hygiene
+    rule and misattributes the line to a program that is not running.
+
+    This drives the probe deliberately (`DRIFT_SKIP_SSH_PROBE=0`, remote leg in
+    scope) with an ssh that always fails, so both candidates report. Hermetic:
+    repo, state dir and gh are pinned into tmp_path, and ssh is a stub.
+    """
+    drift = SCRIPTS / "drift-check.sh"
+    bindir, _log = _recording_ssh(tmp_path, exit_code=255)
+    env = {**os.environ, "SHIP_ROLE": "workbench",
+           "PATH": f"{bindir}:{os.environ['PATH']}",
+           "DRIFT_SKIP_SSH_PROBE": "0",
+           "DRIFT_REPO": str(tmp_path / "norepo"),
+           "DRIFT_STATE_DIR": str(tmp_path / "state2"),
+           "DRIFT_GH": str(tmp_path / "no-gh")}
+    for var in ("REMOTE_SSH", "LAPTOP_SSH"):
+        env.pop(var, None)
+
+    res = subprocess.run(["bash", str(drift)], capture_output=True, text=True,
+                         env=env, timeout=300)
+    out = res.stdout + res.stderr
+    probe_lines = [ln for ln in out.splitlines() if "did not answer" in ln]
+    assert probe_lines, (
+        "the probe produced no diagnostic, so this test cannot see the prefix "
+        f"it exists to check:\n{out[-2000:]}"
+    )
+    for ln in probe_lines:
+        assert ln.startswith("drift-check: "), (
+            f"probe line {ln!r} does not carry drift-check's prefix. The shared "
+            "lib defaults to `ship:`, which fails this script's journal hygiene "
+            "rule and names the wrong program in the operator's log."
+        )
 
 
 def test_a_failing_real_probe_moves_to_the_next_address(tmp_path):


### PR DESCRIPTION
## The bug, measured

Shipping `7edcb1e0` earlier today: `ship.sh` reached for the laptop's LAN address `192.168.50.155`, ssh timed out, the leg exited 255, and the run printed `converge exited 255`. **The laptop was up and answering on `10.42.0.100` the entire time.**

Two failures, only one cosmetic:

- the deploy did not happen — the laptop silently stops receiving every future change while looking like a dead host;
- nothing distinguished *"this host is off"* from *"this host is not on that network"*, so the fix isn't discoverable from the failure.

The address pair was already in the lib (`LAPTOP_IP_SECONDARY` et al). Only the LAN one was ever tried.

## What changed

- `lib/host-role.sh` derives the ssh targets from the IP constants (one address, one place) and gains **`remote_ssh_candidates_of`** (pure — prints targets, contacts nothing) and **`first_reachable_ssh`** (BatchMode, bounded ConnectTimeout, runs `true`, never anything that changes state).
- `ship.sh` picks the first address that answers, **announces** a fallback rather than taking it silently, and when nothing answers names every address tried instead of dropping into a 255 that reads as a broken converge.
- `drift-check.sh` sources the same lib, so it inherits the fix.

🔴 **The negative contract:** an explicit `$REMOTE_SSH`/`$LAPTOP_SSH` is a **one-element list by construction**, so a run addressed by hand is never silently redirected to the other machine. Pinned by two tests.

## Two regressions this change caused

Both found by running the **existing** suite; neither was visible in the new tests.

| regression | fix |
|---|---|
| The probe was unconditional, adding an ssh connection before the legs and shifting the window `test_a_merge_landing_between_the_two_fetches_is_not_convergence` exists to detect — **rc 0 where it must be rc 19** | Probe only when there's more than one candidate (also correct on its own terms: one candidate has nothing to fall back to) |
| `test_drift_check.py`'s extractor read a wrapped ssh invocation's continuation as a program | Unwrapped to one line, so it sees `ssh` — already in the table as `pkgs.openssh` |

## Two pre-existing weaknesses surfaced

- **`_host_role_constant` scraped a `NAME="value"` literal.** Deriving the constants made it return the unexpanded `${SSH_USER_DEFAULT}@${LAPTOP_IP_PRIMARY}` and report *"the fallback target has moved"* when nothing had moved. It now **evaluates** by sourcing the lib (hermetic — the lib is SOURCE-ONLY), so it survives any ordinary refactor.
- **The extractor reads loop variables and `local` declarations as commands** — `for` and `local` are both in `_TRANSPARENT`, so stripping them leaves the *variable name* as token zero. `target` is allowlisted via the test's own documented hatch, with the blind spot recorded: it predates this change and went unnoticed only because the file's other loop variable is named `ip`, which passes **by coincidence** — `ip` being a real command already in the table. Widening the tokenizer is the structural fix and is deliberately **not** bundled here; it may unmask words across `drift-check.sh`.

## Verification

- **582 passed** across `test_ship_ssh_fallback`, `test_ship_detect_role`, `test_ship_converge`, `test_drift_check` — dev-host pytest subset, base `37fb0646`
- **11 new tests**, including the negative contract in both spellings and a nothing-answers case asserting it does **not** fall through to the first target
- **Original symptom reproduced live** with the real prober, LAN genuinely silent:

```
ship: zach@192.168.50.155 did not answer
  CHOSE: zach@10.42.0.100
```

## Not run

The full dev-host tier and both `nix build .#checks.x86_64-linux.*` derivations were **not** run on the merged tree — the box has been heavily loaded all session. Scope of my claim is exactly the four modules named above, at that base.