### PR TITLE
feat(audit-pr): round 0 asks whether the change should EXIST — the nine axes only ever asked whether it is correct

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -93,7 +93,7 @@ audit scoped to a diff will never raise it on its own: that is how a 145 KB webh
 nothing had ever run survived every round that read it. Round 0 is the only round that can
 conclude **close this PR, do not audit it**.
 
-The order is the mechanism, not a preference — steps 3–5 spent on something step 2 would have
+The order is the mechanism, not a preference — steps 3–4 spent on something step 2 would have
 deleted is the waste this exists to catch. Work them in order; do not skip ahead.
 
 1. **Question every requirement, and NAME its author.** For each behaviour the diff introduces,
@@ -104,20 +104,34 @@ deleted is the waste this exists to catch. Work them in order; do not skip ahead
    history, so re-opening it reads as ignoring evidence and nobody does — the "requirements from
    smart people are the most dangerous" case exactly. Then make it less dumb: name the requirement
    you would drop or weaken, not only the code that implements it.
-2. **Delete.** List what could go — from the diff AND from the code it touches. Decide each by the
-   **REVERT TEST already defined below** (revert this file's diff: does the PR's stated deliverable
-   still ship?); do not mint a second rule for it. Where the payload is prose the deletion
-   instruments already exist — `/prune-skill`, `/prune-memory` — name the one that applies rather
-   than hand-rolling a cut.
+2. **Delete.** List what could go — from the diff AND from the code it touches. For each
+   candidate ask: **(a) is it RUNNING** — configured, installed, reachable? **(b) has it ever
+   caught a real problem, or only fired falsely? (c) does something else already check this
+   property against reality?** A "no" to (a) retires it outright; `/adoption-scan` answers (a) and
+   (b) for anything already shipped. Where the payload is prose the deletion instruments already
+   exist — `/prune-skill`, `/prune-memory` — name the one that applies rather than hand-rolling a
+   cut.
+   🔴 **NOT the REVERT TEST below — that answers a DIFFERENT question and is wrong here in both
+   directions.** It decides whether a file is payload or scaffolding, not whether a thing should
+   exist: applied to a PR's own payload it always answers *keep* (reverting it is exactly what
+   stops the deliverable shipping), and applied to the surrounding code it always answers
+   *deletable* (the deliverable ships regardless). Round 0 is the only round that can conclude
+   *close this PR* and a borrowed predicate that can never say so is worse than none. Question (a)
+   is the one that did the work in the incident this section cites — the 145 KB listener had no
+   token configured on either host and had never run.
 3. **Simplify — only what survived step 2.** Owned by `/simplify` and `/code-review`: NAME them,
    do not restate them here. 🔴 Both of those MUTATE (`/simplify` applies its fixes; `/code-review`
    takes `--fix`), and you are dispatched READ-ONLY — so this is a recommendation for the OPERATOR
    to run afterwards, never something you invoke. 🔴 Do not reach for it before steps 1–2 have run;
    simplifying a part that should not exist is the failure this ordering prevents.
-4. **Accelerate.** The ladder's own cycle time is in scope — report it, do not act on it. The
-   attribution gate below is what acts.
-5. **Automate — last.** If the round proposes automation, say what it automates and confirm steps
-   1–4 ran on that thing first.
+4. **Do not accelerate or automate anything steps 1–2 have not cleared.** If this round proposes
+   either, name what it applies to and confirm the requirement was questioned and the deletion
+   considered FIRST. The ladder's own cycle time is in scope to REPORT; the attribution gate below
+   is what acts on it.
+   ⚠ This was two steps — *accelerate* then *automate* — and they were merged because nothing read
+   them: the ledger counts only steps 1–2, all four verdicts are step-1/2 outcomes, and step 4 said
+   "report, do not act" while pointing at a gate that already acts. What survives is the ORDERING
+   claim, which is the half that does work. Recorded so the pair is not re-derived as ceremony.
 
 🔴 **ROUND 0 REPORTS; IT DOES NOT MOVE THE LADDER.** Its verdict is one of `proceed to the
 checklist` / `requirement questioned — <which>` / `deletion candidate — <what>` / `close, do not

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -49,6 +49,12 @@ that is empty by construction and a finding-free pass over it reads as a clean r
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
+⚠ **Consider `--round 0` FIRST — the requirements & deletion pass (its own section below).** It
+asks whether the change should EXIST, which no item on the checklist asks; it is the only round
+that can conclude *close this PR, do not audit it*. It is ON TRIAL, so it is a judgement call, not
+a step — but it has to be reachable from here or the trial closes by attrition rather than by
+evidence. Whichever you run, record `ran: R · changed the outcome: C` on the PR.
+
 **Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. What each hid, and `GOPRIVATE`: reference file.
 
 **Brief the auditor on the environment, or it will report false findings** — a fresh worktree is
@@ -103,9 +109,11 @@ deleted is the waste this exists to catch. Work them in order; do not skip ahead
    still ship?); do not mint a second rule for it. Where the payload is prose the deletion
    instruments already exist — `/prune-skill`, `/prune-memory` — name the one that applies rather
    than hand-rolling a cut.
-3. **Simplify — only what survived step 2.** Owned by `/simplify` and `/code-review`: route there,
-   do not restate them here. 🔴 Do not route before steps 1–2 have run; simplifying a part that
-   should not exist is the failure this ordering prevents.
+3. **Simplify — only what survived step 2.** Owned by `/simplify` and `/code-review`: NAME them,
+   do not restate them here. 🔴 Both of those MUTATE (`/simplify` applies its fixes; `/code-review`
+   takes `--fix`), and you are dispatched READ-ONLY — so this is a recommendation for the OPERATOR
+   to run afterwards, never something you invoke. 🔴 Do not reach for it before steps 1–2 have run;
+   simplifying a part that should not exist is the failure this ordering prevents.
 4. **Accelerate.** The ladder's own cycle time is in scope — report it, do not act on it. The
    attribution gate below is what acts.
 5. **Automate — last.** If the round proposes automation, say what it automates and confirm steps
@@ -116,15 +124,38 @@ checklist` / `requirement questioned — <which>` / `deletion candidate — <wha
 audit`. It is **not** a finding for the findings-keyed stop rule, it cannot end a ladder, and it
 cannot license skipping a round. Every stop rule below is unchanged by it.
 
-**Ledger:** `round 0 · requirements: N (unattributed: U) · deletion candidates: D`. Once the ladder
-ends, add `deleted: X · re-added: Y (Y/X = Z%)`, both from the same `--numstat` command the
-attribution gate already runs. An add-back of 0% means the deletion pass was too timid; deleting
-nothing at all is reportable.
+**Ledger:** `round 0 · requirements: N (unattributed: U) · deletion candidates: D`. Deleting
+nothing at all is reportable — say what you examined to get there.
 
-🔴 **RETIREMENT CONDITION — this section is on trial.** Run it on the next 3–5 PRs and count the
-ones where its verdict CHANGED what happened. **If that count is zero, DELETE this section** — do
-not automate it further, and do not keep it because it reads well. Closed by that count reaching a
-decision, recorded on the PR that removes this section or on the one that promotes it out of trial.
+⚠ **There is deliberately NO add-back percentage here.** An earlier draft asked for `deleted: X ·
+re-added: Y (Y/X = Z%)` "from the same `--numstat` command the attribution gate already runs", and
+that was **false**: `--numstat` reports added and deleted counts per file and cannot tell you that
+an added line is one previously deleted, so `Y` is undefined by the instrument named. The 10%
+add-back heuristic needs a measurement nothing here performs — and the sentence that followed it
+("an add-back of 0% means the deletion pass was too timid") asserted a direction measured nowhere,
+which is the shape this skill tells you to delete rather than reverse. Recorded so nobody derives
+it again.
+
+🔴 **RETIREMENT CONDITION — this section is on trial.** Run it on the next 3–5 PRs and record, on
+each PR, its verdict and whether that verdict CHANGED what happened. **If it ran and changed
+nothing, DELETE this section** — do not automate it further, and do not keep it because it reads
+well.
+
+🔴 **REPORT THE PAIR — `ran: R · changed the outcome: C` — never `C` alone.** A bare zero cannot
+distinguish "it ran five times and was useless" from "nobody ever typed `--round 0`", and those
+have opposite conclusions: the first retires the section, the second says the trial never started.
+`--round` still DEFAULTS to 1, so the second is the likelier reading of a silent zero. `R = 0` is
+not evidence about this section at all — it is evidence about its routing, and the fix is to run it,
+not to delete it. Closed by that pair reaching a decision, recorded on the PR that removes this
+section or on the one that promotes it out of trial.
+
+<!-- 🔴 LOAD-BEARING HEADING, NOT NAVIGATION. `_read_round_zero` in
+     scripts/audit-dispatch.py captures the ROUND 0 section up to the next
+     `## `, and this is that heading. Delete or demote it and the next `## ` is
+     `## After the fixes`, so the round-0 brief silently gains the nine
+     correctness axes it exists to withhold — measured: 3,367 chars -> 4,057.
+     Pinned by test_the_round_zero_section_the_script_reads_is_the_one_the_
+     skill_ships. Reword it freely; keep it a `## `. -->
 
 ## THE CHECKLIST — the nine axes (runs AFTER round 0)
 

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -77,6 +77,57 @@ kill by **resolved PID**. Never let a pattern reach `pkill -f` — it matches yo
 one scratchpad path and the branch namespace, so two audit rounds that both pick `cgpg` or port
 55432 collide silently and one reports a green computed against the other's database.
 
+## ROUND 0 — QUESTION THE REQUIREMENT, THEN DELETE (runs BEFORE the checklist)
+
+⚠ **ON TRIAL, NOT A STANDING RULE — read the retirement condition at the end of this section
+before you run it.**
+
+Every axis below asks whether the change is CORRECT. None asks whether it should EXIST, and an
+audit scoped to a diff will never raise it on its own: that is how a 145 KB webhook listener
+nothing had ever run survived every round that read it. Round 0 is the only round that can
+conclude **close this PR, do not audit it**.
+
+The order is the mechanism, not a preference — steps 3–5 spent on something step 2 would have
+deleted is the waste this exists to catch. Work them in order; do not skip ahead.
+
+1. **Question every requirement, and NAME its author.** For each behaviour the diff introduces,
+   record the requirement and its **author of record**: Zach (quote the ask), a **prior audit
+   round** (`#N round R`), a `RULES.md`/`CLAUDE.md` bullet (quote it), or **unattributed** — which
+   is itself a finding. 🔴 **A requirement whose author is a PRIOR ROUND OF THIS LADDER is the
+   highest-scrutiny class, not the safest.** It arrives carrying a measured incident and a case
+   history, so re-opening it reads as ignoring evidence and nobody does — the "requirements from
+   smart people are the most dangerous" case exactly. Then make it less dumb: name the requirement
+   you would drop or weaken, not only the code that implements it.
+2. **Delete.** List what could go — from the diff AND from the code it touches. Decide each by the
+   **REVERT TEST already defined below** (revert this file's diff: does the PR's stated deliverable
+   still ship?); do not mint a second rule for it. Where the payload is prose the deletion
+   instruments already exist — `/prune-skill`, `/prune-memory` — name the one that applies rather
+   than hand-rolling a cut.
+3. **Simplify — only what survived step 2.** Owned by `/simplify` and `/code-review`: route there,
+   do not restate them here. 🔴 Do not route before steps 1–2 have run; simplifying a part that
+   should not exist is the failure this ordering prevents.
+4. **Accelerate.** The ladder's own cycle time is in scope — report it, do not act on it. The
+   attribution gate below is what acts.
+5. **Automate — last.** If the round proposes automation, say what it automates and confirm steps
+   1–4 ran on that thing first.
+
+🔴 **ROUND 0 REPORTS; IT DOES NOT MOVE THE LADDER.** Its verdict is one of `proceed to the
+checklist` / `requirement questioned — <which>` / `deletion candidate — <what>` / `close, do not
+audit`. It is **not** a finding for the findings-keyed stop rule, it cannot end a ladder, and it
+cannot license skipping a round. Every stop rule below is unchanged by it.
+
+**Ledger:** `round 0 · requirements: N (unattributed: U) · deletion candidates: D`. Once the ladder
+ends, add `deleted: X · re-added: Y (Y/X = Z%)`, both from the same `--numstat` command the
+attribution gate already runs. An add-back of 0% means the deletion pass was too timid; deleting
+nothing at all is reportable.
+
+🔴 **RETIREMENT CONDITION — this section is on trial.** Run it on the next 3–5 PRs and count the
+ones where its verdict CHANGED what happened. **If that count is zero, DELETE this section** — do
+not automate it further, and do not keep it because it reads well. Closed by that count reaching a
+decision, recorded on the PR that removes this section or on the one that promotes it out of trial.
+
+## THE CHECKLIST — the nine axes (runs AFTER round 0)
+
 **Audit for:**
 1. **Risks** — what breaks in production.
 2. **Regressions** — behaviour this silently alters or removes.

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -932,7 +932,12 @@ Facts = namedtuple(
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
     "worktree branch dirty prev_sha emit_from claims claims_round checklist "
     "ledger assembled_at claims_source head_check base_assumed "
-    "base_assumed_reason repo_unknown_reason",
+    "base_assumed_reason repo_unknown_reason round_zero",
+    # `round_zero` is appended LAST and defaulted so that every existing
+    # construction — including the suite's — keeps working unchanged. It is
+    # None for every round except 0, and None AT round 0 means the skill was
+    # not readable, which `render_checklist` reports rather than hiding.
+    defaults=(None,),
 )
 # 🔴 `repo_unknown_reason` — ROUND 13'S NINTH INSTANCE, AND THE THIRD IN THIS
 # EXACT FAMILY. `no_sha_reason` was `headRefOid`, `base_assumed_reason` was
@@ -3220,6 +3225,20 @@ def render_ledger(facts):
         ])
     led = facts.ledger
     if led is None:
+        # 🔴 ROUND 0 GETS ITS OWN SENTENCE. It reaches this branch for the same
+        # mechanical reason round 1 does (no previous round to attribute
+        # against), but "a first, full audit" is a false description of it —
+        # and round 0 carries a DIFFERENT ledger line, which the reader would
+        # otherwise never be told to write.
+        if facts.round_no == 0:
+            lines += [
+                "Not measured, and not measurable: round 0 runs before any fix "
+                "exists, so there is no payload to attribute. Carry the "
+                "round-0 ledger from the section above instead — `round 0 · "
+                "requirements: N (unattributed: U) · deletion candidates: D` — "
+                "and start THIS ledger at round 2.",
+            ]
+            return "\n".join(lines)
         lines += [
             "Not measured: a first, full audit has no previous round to "
             "attribute against. Start the ledger at your round 2.",
@@ -3341,6 +3360,32 @@ def render_checklist(facts):
     that has already been silently shaved once, with a commit message claiming
     the opposite. The paraphrase would have drifted with nothing watching.
     """
+    # 🔴 ROUND 0 IS A DIFFERENT PASS, NOT A LIGHTER ONE. It asks whether the
+    # change should exist; the nine axes ask whether it is correct. Emitting
+    # both would let the auditor answer the correctness question first, which
+    # is the exact ordering failure the section exists to prevent — so this
+    # returns the round-0 section INSTEAD of the checklist, not before it.
+    if facts.round_no == 0:
+        if not facts.round_zero:
+            return "\n".join([
+                "## ROUND 0 — QUESTION THE REQUIREMENT, THEN DELETE",
+                "",
+                "⚠ **COULD NOT INLINE the round-0 section** — "
+                "`~/.claude/skills/audit-pr/SKILL.md` was not readable from "
+                "here, so no instructions are printed rather than a guess at "
+                "them. Read its **ROUND 0** section and work its five steps in "
+                "order, or re-run this assembly where the skill is readable.",
+            ])
+        return "\n".join([
+            "## ROUND 0 — QUESTION THE REQUIREMENT, THEN DELETE",
+            "",
+            "This round works the section below **instead of** the nine axes, "
+            "which are not in this brief. Do not audit for correctness here: "
+            "that is round 1's job, and doing it first is the ordering failure "
+            "this round exists to prevent.",
+            "",
+            facts.round_zero,
+        ])
     lines = ["## AUDIT FOR", ""]
     if facts.round_no >= 2:
         lines += [
@@ -3372,10 +3417,12 @@ def render_output_contract(facts):
 
 
 def render_brief(facts):
-    kind = (
-        "FIRST, FULL adversarial audit" if facts.round_no < 2
-        else f"DELTA re-audit — ROUND {facts.round_no}"
-    )
+    if facts.round_no == 0:
+        kind = "ROUND 0 — REQUIREMENTS & DELETION pass (NOT a correctness audit)"
+    elif facts.round_no < 2:
+        kind = "FIRST, FULL adversarial audit"
+    else:
+        kind = f"DELTA re-audit — ROUND {facts.round_no}"
     head = "\n".join([
         f"# {kind} — PR #{facts.pr} in `{facts.repo}`",
         "",
@@ -3644,6 +3691,38 @@ def _read_checklist(repo_dir):
     return None
 
 
+ROUND_ZERO_HEADING = "## ROUND 0 — QUESTION THE REQUIREMENT, THEN DELETE"
+
+
+def _read_round_zero(repo_dir):
+    """The round-0 section, read from the skill rather than duplicated here.
+
+    Same seam and same reason as `_read_checklist`: a second copy of a block
+    that lives in SKILL.md is a second thing to keep in step, and this one
+    carries its OWN retirement condition — a paraphrase here would let the
+    section be deleted from the skill while the brief kept dispatching it.
+
+    Returns None when the skill is not readable from here, which the caller
+    reports rather than papering over: round 0 with no instructions is not a
+    round 0.
+    """
+    for cand in (
+        Path(repo_dir) / "claude" / "skills" / "audit-pr" / "SKILL.md",
+        Path.home() / ".claude" / "skills" / "audit-pr" / "SKILL.md",
+    ):
+        try:
+            body = cand.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = re.search(
+            r"^" + re.escape(ROUND_ZERO_HEADING) + r"[^\n]*\n(.*?)(?=\n## )",
+            body, re.M | re.S,
+        )
+        if m:
+            return m.group(1).strip()
+    return None
+
+
 def build_parser():
     ap = argparse.ArgumentParser(
         prog="audit-dispatch.py",
@@ -3655,7 +3734,9 @@ def build_parser():
     # `pr=None`.
     ap.add_argument("pr", type=int, nargs="?", help="the PR number")
     ap.add_argument("--round", dest="round_no", type=int, default=1,
-                    help="round number; >=2 assembles a DELTA re-audit brief")
+                    help="round number; 0 assembles the ROUND 0 requirements "
+                         "& deletion pass (the nine axes are NOT in that "
+                         "brief); >=2 assembles a DELTA re-audit brief")
     ap.add_argument("--repo", help="owner/name, when the PR is not in the cwd's repo")
     ap.add_argument("--out", help="write the brief to this file instead of stdout")
     ap.add_argument("--check", metavar="FILE",
@@ -3719,12 +3800,16 @@ def check_brief_file(path, out_stream, err_stream):
 
 
 def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
-         checklist_reader=None):
+         checklist_reader=None, round_zero_reader=None):
     # `checklist_reader` is injected by the test suite so no test depends on
     # whether THIS HOST happens to have the skill deployed under ~/.claude —
     # a suite that reads the ambient home is not hermetic, and the sandbox gate
-    # tier runs with a different one.
+    # tier runs with a different one. `round_zero_reader` is the same seam for
+    # the same reason, and is deliberately a SECOND reader rather than a
+    # round-aware first one: making `checklist_reader` take the round would
+    # change the signature every existing injection is written against.
     checklist_reader = checklist_reader or _read_checklist
+    round_zero_reader = round_zero_reader or _read_round_zero
     parser = build_parser()
     args = parser.parse_args(argv)
     out_stream = stdout or sys.stdout
@@ -3735,6 +3820,22 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         return check_brief_file(args.check, out_stream, err_stream)
     if args.pr is None:
         parser.error("the PR number is required (or use --check FILE)")
+
+    # 🔴 A NEGATIVE ROUND USED TO ASSEMBLE A ROUND-1 BRIEF IN SILENCE. Every
+    # gate in this module is spelled `>= 2` or `< 2`, so `--round -1` fell
+    # through the `< 2` side and printed "FIRST, FULL adversarial audit" at
+    # rc 0 — a brief whose header disagreed with the flag that asked for it.
+    # Harmless while 0 was also meaningless; not harmless now that 0 names a
+    # DIFFERENT pass, because -1 would silently get the correctness checklist
+    # from a run that asked for something else.
+    if args.round_no < 0:
+        print(
+            f"🔴 REFUSING: --round {args.round_no} is not a round. Rounds are "
+            "0 (the requirements & deletion pass), 1 (the first full "
+            "correctness audit), then 2+ (delta re-audits).",
+            file=err_stream,
+        )
+        return 4
 
     # 🔴 An EMPTY `--audited` is the fifth row of round 5's measured table: it
     # is falsy, so it falls straight through to `emit_anchor(newest)` and the
@@ -4066,7 +4167,25 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     emit_from = args.audited or emit_anchor(newest)
     claims = list(newest.items) if newest else []
     claims_round = newest.round_no if newest else None
-    if newest is not None and newest.round_no >= args.round_no:
+    # 🔴 BOTH WARNINGS BELOW ARE ABOUT ANCHORING A DELTA, AND ROUND 0 ANCHORS
+    # NOTHING. `render_claims` returns "" below round 2, the range comes from
+    # the base, and `prev_sha` is never read — so on a PR that already has a
+    # ladder, `--round 0` printed "Using it anyway" about a block it does not
+    # use, and told the operator to check they were "not re-auditing a round
+    # that already ran" for a pass that is not a re-audit. Measured on devrc
+    # #1427 (`round=5` block): both sentences, on every run.
+    #
+    # It fires on EVERY round 0 of any PR with a block, which is the shape
+    # `claude/RULES.md` calls a permanently-red gate — and the stream it
+    # trains the operator to ignore is the one carrying the missing-intermediate
+    # -block warning that the skill says is announced "on stderr, once, and
+    # nowhere in the brief".
+    #
+    # Round 1 deliberately keeps both: a round-1 run over a `round=3` block
+    # plausibly meant to be a delta, and there the nudge is correct.
+    if args.round_no == 0:
+        pass
+    elif newest is not None and newest.round_no >= args.round_no:
         print(
             f"⚠ the newest claims block says round={newest.round_no}, and you "
             f"asked for round {args.round_no}. Using it anyway — but check you "
@@ -4155,6 +4274,10 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         base_assumed=base_assumed,
         base_assumed_reason=base_assumed_reason,
         repo_unknown_reason=repo_unknown_reason,
+        # Read ONLY at round 0. Every other round would carry a section it
+        # never prints, and reading the skill twice per run to no effect is
+        # the kind of dead work round 0 itself exists to delete.
+        round_zero=round_zero_reader(repo_dir) if args.round_no == 0 else None,
     )
 
     # 🔴 THE REFUSAL'S SCOPE IS THE BRIEF, AND ONLY THE BRIEF. A refused run

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -933,8 +933,8 @@ Facts = namedtuple(
     "worktree branch dirty prev_sha emit_from claims claims_round checklist "
     "ledger assembled_at claims_source head_check base_assumed "
     "base_assumed_reason repo_unknown_reason round_zero",
-    # `round_zero` is appended LAST and defaulted so that every existing
-    # construction — including the suite's — keeps working unchanged. It is
+    # `round_zero` is appended LAST and defaulted so the two existing
+    # constructions — one here, one in the suite — keep working unchanged. It is
     # None for every round except 0, and None AT round 0 means the skill was
     # not readable, which `render_checklist` reports rather than hiding.
     defaults=(None,),
@@ -3705,6 +3705,22 @@ def _read_round_zero(repo_dir):
     Returns None when the skill is not readable from here, which the caller
     reports rather than papering over: round 0 with no instructions is not a
     round 0.
+
+    🔴 THE `## ` THAT TERMINATES THIS CAPTURE IS LOAD-BEARING, AND IN SKILL.md
+    IT IS THE HEADING `## THE CHECKLIST — the nine axes (runs AFTER round 0)`.
+    That heading reads like navigation and is not: delete it and the next `## `
+    is `## After the fixes`, so this returns the round-0 section PLUS the nine
+    correctness axes, and the assembler inlines the checklist into a brief
+    whose entire design is to withhold it. Measured on the shipped file at
+    `d16bfd7a`: 3,367 chars with the heading, 4,057 without, `**Audit for:**`
+    inside the capture.
+
+    It is silent, and the obvious guards do not see it — the round-0 render
+    tests inject a fixture reader on purpose, and a presence check for the five
+    steps stays green because they are all still there, at the head of an
+    over-long capture. `test_the_round_zero_section_the_script_reads_is_the_
+    one_the_skill_ships` therefore asserts the checklist is ABSENT from what
+    this returns, which is the only assertion that can fail for this cause.
     """
     for cand in (
         Path(repo_dir) / "claude" / "skills" / "audit-pr" / "SKILL.md",
@@ -3907,6 +3923,39 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     # everywhere else: `--audited` is written by `--emit-claims` and by nothing
     # else, so passing it to a plain assembly run is a no-op the operator would
     # otherwise read as "recorded".
+    # 🔴 ROUND 0 CANNOT EMIT A CLAIMS BLOCK, AND WITHOUT THIS THE SKILL'S
+    # 🔴 SENTENCE WAS A COMMENT RATHER THAN A GUARD. The section says "ROUND 0
+    # REPORTS; IT DOES NOT MOVE THE LADDER" — but `if args.emit_claims:` sits
+    # below every round gate and had none of its own, so
+    # `--round 0 --emit-claims` printed a well-formed ``audit-claims round=0``
+    # block. `newest_block` would then hand it to a later `--round 2`, whose
+    # `prev_sha = range_anchor(newest)` anchors the delta on round 0's tip:
+    # round 0 moving the ladder, in the one way the prose forbids.
+    #
+    # Measured on devrc #1440 at `d16bfd7a`: `--round 0 --emit-claims --audited
+    # d16bfd7a` emitted ``audit-claims round=0 audited=d16bfd7a..d16bfd7a`` at
+    # rc 0. `claude/RULES.md`: a field that exists is not a guard — only a
+    # BRANCH on it is.
+    #
+    # Refused rather than warned: round 0 runs BEFORE any fix exists, so it has
+    # no claims to record. There is no reading of the flag pair the operator
+    # meant.
+    if args.round_no == 0 and args.emit_claims:
+        print("\n".join([
+            f"{EMIT_REFUSAL_HEADER}: round 0 has no fixes to claim.",
+            "",
+            "  Round 0 runs BEFORE any fix exists — it reports requirements "
+            "and deletion candidates, and the skill says it does not move the "
+            "ladder. A `round=0` block is anchorable: the next delta round "
+            "would diff FROM the tip round 0 merely READ, attributing the "
+            "whole change to a round that fixed nothing.",
+            "",
+            "  Record round 0's verdict in the PR comment as prose. The claims "
+            "block starts at the round that first FIXES something — normally "
+            "`--round 1 --emit-claims --audited <the tip round 1 read>`.",
+        ]), file=err_stream)
+        return 4
+
     if args.audited and not args.emit_claims:
         print(
             "⚠ --audited names the tip this round's audit read and is only "

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -3373,7 +3373,7 @@ def render_checklist(facts):
                 "⚠ **COULD NOT INLINE the round-0 section** — "
                 "`~/.claude/skills/audit-pr/SKILL.md` was not readable from "
                 "here, so no instructions are printed rather than a guess at "
-                "them. Read its **ROUND 0** section and work its five steps in "
+                "them. Read its **ROUND 0** section and work its steps in "
                 "order, or re-run this assembly where the skill is readable.",
             ])
         return "\n".join([

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1025,6 +1025,22 @@ def fake_checklist(_repo_dir):
     return CHECKLIST
 
 
+# The round-0 section's stand-in. Deliberately NOT a copy of the real one: these
+# tests assert that the brief carries WHATEVER the skill said, and a fixture
+# quoting the shipped prose would pass just as well against a script that
+# restated the section internally. The two-way pin on the real file is
+# `test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships`.
+ROUND_ZERO_FIXTURE = (
+    "1. **Question every requirement, and NAME its author.** <fixture>\n"
+    "2. **Delete.** <fixture>\n"
+    "5. **Automate — last.** <fixture>"
+)
+
+
+def fake_round_zero(_repo_dir):
+    return ROUND_ZERO_FIXTURE
+
+
 # 🔴 THE FAKE'S OWN, INDEPENDENT READ of which repository each side names —
 # deliberately NOT `ad.pr_slug` / `ad._slug_from_remote`. A fake that asks the
 # code under test what the world looks like is a second sample of the thing in
@@ -1177,6 +1193,12 @@ def run_main(argv, **kw):
     `runner=` straight into `make_runner` and raised.
     """
     out, err = io.StringIO(), io.StringIO()
+    # 🔴 POPPED BEFORE `make_runner`, for the reason the docstring above gives
+    # about `runner`: anything left in `kw` is forwarded to `make_runner`,
+    # which does not take it. Defaulted to the fixture rather than to None so
+    # a round-0 test cannot silently fall through to the REAL `_read_round_zero`
+    # and read whatever this HOST happens to have deployed under `~/.claude`.
+    round_zero_reader = kw.pop("round_zero_reader", fake_round_zero)
     runner = kw.pop("runner", None) or make_runner(**kw)
     rc = ad.main(
         argv,
@@ -1184,6 +1206,7 @@ def run_main(argv, **kw):
         stdout=out,
         stderr=err,
         checklist_reader=fake_checklist,
+        round_zero_reader=round_zero_reader,
     )
     return rc, out.getvalue(), err.getvalue()
 
@@ -8022,6 +8045,189 @@ def test_a_gh_failure_is_reported_and_not_papered_over():
     assert "gh pr view 900" in err and "failed" in err
 
 
+# --------------------------------------------------------------------------- #
+# ROUND 0 — the requirements & deletion pass
+# --------------------------------------------------------------------------- #
+#
+# 🔴 ALL FOUR ARE INVARIANT GUARDS, NOT REGRESSION COVERAGE, and the module
+# docstring's rule is why: `--round 0` did not exist at any base in
+# RED_AT_BASE_REFS, so "watched red there" would only restate that the feature
+# was added. Their evidence is the mutation battery and the negative controls
+# each carries inline.
+
+
+def test_round_zero_emits_the_deletion_pass_INSTEAD_OF_the_nine_axes():
+    """🔴 THE ORDERING IS THE WHOLE MECHANISM, so it is asserted both ways.
+
+    The section exists because an audit scoped to a diff asks whether the
+    change is CORRECT and never whether it should EXIST. A brief carrying BOTH
+    lets the auditor answer the correctness question first, which is exactly
+    the failure the ordering prevents — so the absence of the checklist is as
+    load-bearing as the presence of the section, and a test asserting only the
+    presence would stay green against a brief that appended round 0 to the
+    nine axes.
+    """
+    rc, out, err = run_main(["900", "--round", "0"])
+    assert rc == 0, f"round 0 exited {rc}: {err}"
+
+    assert ROUND_ZERO_FIXTURE in out, (
+        "the round-0 section the reader returned is not in the brief, so the "
+        f"round dispatches with no instructions at all:\n{out[:2000]}"
+    )
+    assert "REQUIREMENTS & DELETION pass" in out, (
+        "the brief's own title does not say which pass this is; a round-0 "
+        "brief headed 'FIRST, FULL adversarial audit' is the state this "
+        "feature exists to end"
+    )
+    # The negative half. `CHECKLIST` is the fixture `fake_checklist` returns,
+    # so this is a claim about THIS run and not about the shipped skill.
+    assert CHECKLIST not in out and "## AUDIT FOR" not in out, (
+        "the nine correctness axes are in the round-0 brief. Round 0 must "
+        "replace them, not precede them: an auditor handed both will answer "
+        "'is it correct?' before 'should it exist?', and the answer to the "
+        "second is what makes the first worth asking."
+    )
+
+
+def test_round_zero_says_it_cannot_measure_a_ledger_rather_than_claiming_round_one():
+    """The `led is None` branch is shared with round 1 and its sentence was not.
+
+    Round 0 reaches that branch for a mechanically identical reason (no
+    previous round to attribute against) and a DIFFERENT real one (no fix
+    exists yet). Left on round 1's wording the brief tells a round-0 auditor
+    they ran 'a first, full audit' — and never tells them to carry the round-0
+    ledger line, which is the only ledger that round can produce.
+    """
+    rc, out, err = run_main(["900", "--round", "0"])
+    assert rc == 0, f"round 0 exited {rc}: {err}"
+
+    assert "a first, full audit has no previous round" not in out, (
+        "round 0's ledger section describes it as 'a first, full audit' — a "
+        "false description of a pass that deliberately is not one"
+    )
+    assert "requirements: N (unattributed: U) · deletion candidates: D" in out, (
+        "the round-0 ledger line is not in the brief, so the round is asked "
+        "for a ledger nobody told it the shape of"
+    )
+
+
+def test_round_zero_reports_an_unreadable_skill_instead_of_inventing_the_steps():
+    """None from the reader must not become a brief that looks complete.
+
+    🔴 The failure this refuses is the one `claude/RULES.md` calls a zero you
+    did not watch a command earn: a round-0 brief with the section silently
+    missing reads as an ordinary brief, and the auditor works the five steps
+    from memory — which is where the paraphrase this module keeps deleting
+    comes back.
+    """
+    rc, out, err = run_main(["900", "--round", "0"],
+                            round_zero_reader=lambda _d: None)
+    assert rc == 0, f"round 0 exited {rc}: {err}"
+    assert "COULD NOT INLINE the round-0 section" in out, (
+        "an unreadable skill produced a brief that does not say so:\n"
+        + out[:2000]
+    )
+    # Positive control for the assertion above: the SAME run with a readable
+    # section must NOT carry the banner, or the check is satisfied by every
+    # brief and asserts nothing.
+    _, ok_out, _ = run_main(["900", "--round", "0"])
+    assert "COULD NOT INLINE the round-0 section" not in ok_out, (
+        "the banner is in a brief whose section WAS readable, so its presence "
+        "above is not evidence of the unreadable path"
+    )
+
+
+def test_a_negative_round_is_refused_rather_than_assembled_as_round_one():
+    """Every gate in the script is `>= 2` or `< 2`, so -1 fell through as 1.
+
+    Harmless while 0 was merely meaningless; not harmless now that 0 names a
+    different pass, because `--round -1` would hand back the correctness
+    checklist under a header disagreeing with the flag that asked for it.
+    """
+    rc, out, err = run_main(["900", "--round", "-1"])
+    assert rc == 4, f"expected the refusal rc, got {rc}"
+    assert out.strip() == "", "a refused run must render no brief"
+    assert "is not a round" in err, err
+    # The refusal must name the rounds that DO exist, or the operator's next
+    # move is a second guess.
+    assert "0" in err and "2+" in err, err
+
+
+def test_round_zero_does_not_warn_about_a_claims_block_it_never_consults():
+    """🔴 FOUND BY A LIVE SMOKE TEST, not by this suite — devrc #1427.
+
+    Round 0 anchors nothing: `render_claims` returns "" below round 2, the
+    range comes from the base, and `prev_sha` is never read. The delta-anchor
+    warning fired anyway, saying "Using it anyway" about a block round 0 does
+    not use and telling the operator to check they were not "re-auditing a
+    round that already ran" — of a pass that is not a re-audit.
+
+    It fired on EVERY round 0 of any PR carrying a block, and stderr is where
+    the missing-intermediate-block warning lives — the one the skill says is
+    announced "on stderr, once, and nowhere in the brief". A stream with a
+    permanent false alarm on it is a stream nobody reads.
+    """
+    rc, out, err = run_main(["900", "--round", "0"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, f"round 0 exited {rc}: {err}"
+    assert "Using it anyway" not in err, (
+        "round 0 warns about a claims block it never consults:\n" + err
+    )
+    assert "re-auditing a round that already ran" not in err, err
+
+    # 🔴 POSITIVE CONTROL. Without it a zero here is indistinguishable from a
+    # fixture that carries no block at all, or from the warning having been
+    # deleted outright — the fix is a ROUND-0 suppression, not a removal, so
+    # round 1 over the same block must still say it.
+    rc1, _, err1 = run_main(["900", "--round", "1"], comments=[CLAIMS_BLOCK_R2])
+    assert rc1 == 0, f"round 1 exited {rc1}: {err1}"
+    assert "Using it anyway" in err1, (
+        "the warning is gone at round 1 as well, so this fix deleted it "
+        "rather than scoping it — and the round-0 assertion above is passing "
+        "for the wrong reason:\n" + err1
+    )
+
+
+def test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships():
+    """🔴 THE SEAM. Two hermetically-correct halves that do not meet.
+
+    `_read_round_zero` anchors on a heading LITERAL; the skill owns that
+    heading. Both sides can be edited independently and stay green — the
+    script's own tests inject a fixture reader (deliberately), and the skill's
+    tests pin prose the script never parses. So nothing else in either module
+    would notice a heading rename, and the observable failure is a round-0
+    brief that quietly says COULD NOT INLINE forever.
+
+    This reads the REAL file with the REAL reader. It is hermetic because the
+    file is in this repo: `_read_round_zero` tries `<repo>/claude/skills/...`
+    first and only falls back to `~/.claude` when that misses.
+    """
+    section = ad._read_round_zero(REPO)
+    assert section, (
+        f"`_read_round_zero` found no round-0 section under {REPO}. Either "
+        f"the heading {ad.ROUND_ZERO_HEADING!r} was renamed in "
+        "claude/skills/audit-pr/SKILL.md, or the section was deleted. If it "
+        "was deleted deliberately — the retirement condition says it may be — "
+        "delete `--round 0` and these tests in the SAME commit, rather than "
+        "leaving a flag that dispatches an empty pass."
+    )
+    # Not a spelling pin: assert the five steps are STRUCTURALLY present, so a
+    # reworded section stays green and a truncated one does not. A partial read
+    # is the dangerous shape here — the regex stops at the next `## `, so a
+    # heading inserted mid-section would silently return only its head.
+    for step in ("1.", "2.", "3.", "4.", "5."):
+        assert step in section, (
+            f"step {step} is missing from the section the script reads. The "
+            "regex stops at the next `## ` heading — if one was inserted into "
+            "the middle of the section, the brief now carries only its head "
+            f"while the skill still reads complete:\n{section[:600]}"
+        )
+    assert "RETIREMENT CONDITION" in section, (
+        "the retirement condition is not in the text the script inlines. It "
+        "is the only thing standing between a trial and a permanent rule, and "
+        "an auditor who never sees it cannot apply it."
+    )
+
+
 # The two ledgers the module docstring commits to.
 #
 # 🔴 RED_AT_BASE WAS EMPTY, AND IS NOT ANY MORE. It was empty because the script
@@ -8406,6 +8612,21 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
+    # 🔴 ROUND 0 — the requirements & deletion pass. All five are guards for
+    # the reason stated above their definitions: `--round 0` exists at no base
+    # in `RED_AT_BASE_REFS`, so a red there would be argparse accepting an
+    # integer and rendering a round-1 brief — a claim about the flag's absence,
+    # not about any behaviour. Their evidence is the in-test controls (the
+    # nine-axes NEGATIVE half, and the readable/unreadable pair) plus the
+    # battery. `..._is_the_one_the_skill_ships` is the SEAM guard: it is the
+    # only test in either module that reads the real skill with the real
+    # reader, and it is what goes red when a heading rename separates them.
+    "test_round_zero_emits_the_deletion_pass_INSTEAD_OF_the_nine_axes",
+    "test_round_zero_says_it_cannot_measure_a_ledger_rather_than_claiming_round_one",
+    "test_round_zero_reports_an_unreadable_skill_instead_of_inventing_the_steps",
+    "test_a_negative_round_is_refused_rather_than_assembled_as_round_one",
+    "test_round_zero_does_not_warn_about_a_claims_block_it_never_consults",
+    "test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships",
     # 🔴 An invariant guard, NOT regression coverage — `_flake_check_names`
     # does not exist at `9e23c379`, so its red there would be an
     # `AttributeError` about a missing symbol rather than a wrong answer. Its

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -8117,7 +8117,7 @@ def test_round_zero_reports_an_unreadable_skill_instead_of_inventing_the_steps()
 
     🔴 The failure this refuses is the one `claude/RULES.md` calls a zero you
     did not watch a command earn: a round-0 brief with the section silently
-    missing reads as an ordinary brief, and the auditor works the five steps
+    missing reads as an ordinary brief, and the auditor works the steps
     from memory — which is where the paraphrase this module keeps deleting
     comes back.
     """
@@ -8248,11 +8248,11 @@ def test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships():
         "delete `--round 0` and these tests in the SAME commit, rather than "
         "leaving a flag that dispatches an empty pass."
     )
-    # Not a spelling pin: assert the five steps are STRUCTURALLY present, so a
+    # Not a spelling pin: assert the steps are STRUCTURALLY present, so a
     # reworded section stays green and a truncated one does not. A partial read
     # is the dangerous shape here — the regex stops at the next `## `, so a
     # heading inserted mid-section would silently return only its head.
-    for step in ("1.", "2.", "3.", "4.", "5."):
+    for step in ("1.", "2.", "3.", "4."):
         assert step in section, (
             f"step {step} is missing from the section the script reads. The "
             "regex stops at the next `## ` heading — if one was inserted into "

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -8049,7 +8049,8 @@ def test_a_gh_failure_is_reported_and_not_papered_over():
 # ROUND 0 — the requirements & deletion pass
 # --------------------------------------------------------------------------- #
 #
-# 🔴 ALL FOUR ARE INVARIANT GUARDS, NOT REGRESSION COVERAGE, and the module
+# 🔴 EVERY TEST IN THIS SECTION IS AN INVARIANT GUARD, NOT REGRESSION
+# COVERAGE — the count is the ledger's to carry, not this comment's. The module
 # docstring's rule is why: `--round 0` did not exist at any base in
 # RED_AT_BASE_REFS, so "watched red there" would only restate that the feature
 # was added. Their evidence is the mutation battery and the negative controls
@@ -8187,6 +8188,43 @@ def test_round_zero_does_not_warn_about_a_claims_block_it_never_consults():
     )
 
 
+def test_round_zero_cannot_emit_a_claims_block_that_a_later_round_would_anchor_on():
+    """🔴 THE SKILL'S 🔴 SENTENCE WAS A COMMENT, NOT A GUARD.
+
+    The section says "ROUND 0 REPORTS; IT DOES NOT MOVE THE LADDER". But
+    `if args.emit_claims:` sits below every round gate and had none of its own,
+    so `--round 0 --emit-claims` printed a well-formed ``audit-claims round=0``
+    block. `newest_block` hands that to a later `--round 2`, whose
+    `prev_sha = range_anchor(newest)` anchors the delta on the tip round 0
+    merely READ — attributing the change to a round that fixed nothing, which
+    is exactly the movement the prose forbids.
+
+    Measured live on devrc #1440 at `d16bfd7a`, rc 0:
+    ``audit-claims round=0 audited=d16bfd7a..d16bfd7a``.
+
+    `claude/RULES.md`: a field that exists is not a guard — only a BRANCH on it
+    is. This is the branch.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "0", "--emit-claims", "--audited", "aaaa1111"])
+    assert rc == 4, f"expected the emit refusal rc, got {rc}"
+    assert "audit-claims" not in out, (
+        "round 0 still emitted a claims block:\n" + out[-1500:]
+    )
+    assert "no fixes to claim" in err, err
+
+    # 🔴 POSITIVE CONTROL. Without it a missing block is indistinguishable from
+    # `--emit-claims` being broken for every round. Round 1 over the same flags
+    # must still emit one — the fix is a round-0 gate, not a removal.
+    rc1, out1, err1 = run_main(
+        ["900", "--round", "1", "--emit-claims", "--audited", "aaaa1111"])
+    assert rc1 == 0, f"round 1 --emit-claims exited {rc1}: {err1}"
+    assert "audit-claims round=1" in out1, (
+        "round 1 no longer emits a claims block either, so this fix disabled "
+        "the feature rather than scoping it:\n" + out1[-1500:]
+    )
+
+
 def test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships():
     """🔴 THE SEAM. Two hermetically-correct halves that do not meet.
 
@@ -8225,6 +8263,35 @@ def test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships():
         "the retirement condition is not in the text the script inlines. It "
         "is the only thing standing between a trial and a permanent rule, and "
         "an auditor who never sees it cannot apply it."
+    )
+    # 🔴 THE HALF THAT WAS MISSING, AND THE ONLY ONE THAT CAN FAIL FOR THE
+    # CAUSE THAT MATTERS. Every assertion above is a PRESENCE check, and the
+    # capture's failure mode is being too WIDE: `_read_round_zero` stops at the
+    # next `## `, so deleting the `## THE CHECKLIST` heading — which reads like
+    # navigation — runs the capture on to `## After the fixes` and pulls the
+    # nine correctness axes into the round-0 section. Steps 1-5 and the
+    # retirement condition are all still present at the head of that longer
+    # capture, so every check above stays GREEN while the brief silently gains
+    # the checklist it exists to withhold.
+    #
+    # Measured on the shipped file: 3,367 chars with the heading, 4,057 without.
+    #
+    # The render tests cannot see this either — they inject `fake_round_zero`
+    # on purpose, so they never read the real file's structure at all. This is
+    # the guard for it.
+    assert "**Audit for:**" not in section, (
+        f"\n\nthe round-0 section the script reads is {len(section)} chars and "
+        "CONTAINS the nine correctness axes.\n"
+        "  `_read_round_zero` captures up to the next `## ` heading. Something "
+        "removed, demoted or reworded the `## THE CHECKLIST — the nine axes` "
+        "heading in claude/skills/audit-pr/SKILL.md, so the capture ran on "
+        "into the checklist.\n"
+        "  The effect is silent and defeats the whole design: `--round 0` "
+        "would inline the correctness checklist into a brief whose entire "
+        "purpose is to withhold it until round 1, and an auditor handed both "
+        "answers 'is it correct?' first.\n"
+        "  Restore a `## ` heading between the round-0 section and "
+        "`**Audit for:**`."
     )
 
 
@@ -8612,8 +8679,8 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
-    # 🔴 ROUND 0 — the requirements & deletion pass. All five are guards for
-    # the reason stated above their definitions: `--round 0` exists at no base
+    # 🔴 ROUND 0 — the requirements & deletion pass. Every entry below is a
+    # guard, for the reason stated above their definitions: `--round 0` exists at no base
     # in `RED_AT_BASE_REFS`, so a red there would be argparse accepting an
     # integer and rendering a round-1 brief — a claim about the flag's absence,
     # not about any behaviour. Their evidence is the in-test controls (the
@@ -8626,6 +8693,7 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_round_zero_reports_an_unreadable_skill_instead_of_inventing_the_steps",
     "test_a_negative_round_is_refused_rather_than_assembled_as_round_one",
     "test_round_zero_does_not_warn_about_a_claims_block_it_never_consults",
+    "test_round_zero_cannot_emit_a_claims_block_that_a_later_round_would_anchor_on",
     "test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships",
     # 🔴 An invariant guard, NOT regression coverage — `_flake_check_names`
     # does not exist at `9e23c379`, so its red there would be an


### PR DESCRIPTION
## What this is

`/audit-pr` audits for risks, regressions, assumptions, gaps, bugs, issues, behaviour changes, leaks and second-order consequences. **Every one of those asks whether the change is CORRECT. None asks whether it should EXIST** — and an audit scoped to a diff will not raise it on its own, which is how a 145 KB webhook listener nothing had ever run survived every round that read it.

This adds **ROUND 0**, a requirements & deletion pass, as a section of the skill and a `--round 0` mode of the assembler. It is the only round that can conclude *"close this PR, do not audit it."*

It is an integration of "the algorithm" (question the requirement → delete → simplify → accelerate → automate) into the existing ladder.

## Why it is a separate round and not checklist items 10–11

The ordering **is** the mechanism. Steps 3–5 spent on something step 2 would have deleted is the waste the pass exists to catch — so appending "can this be deleted?" after the nine correctness axes reproduces exactly the failure being prevented.

Round 0 therefore emits its section **instead of** the nine axes, not before them. An auditor handed both answers "is it correct?" first. Both halves are asserted, and the negative half (`CHECKLIST not in out`) is as load-bearing as the positive one.

## What it deliberately does NOT add

Steps 3–5 grow no machinery:

- step 3 routes to `/simplify` and `/code-review`
- step 2 routes to `/prune-skill` and `/prune-memory`
- step 2's tie-breaker is the **revert test the attribution gate already defines**

One rule, one place. Automation is step 5 for a reason.

## It cannot move the ladder

Stated explicitly in the section: round 0 is **not** a finding for the findings-keyed stop rule, it cannot end a ladder, and it cannot license skipping a round. A new pass that quietly becomes a stop condition is the *"wider on one axis, narrower on another"* shape this skill hunts for.

## It ships with its own retirement condition

> Run it on the next 3–5 PRs and count the ones where its verdict CHANGED what happened. **If that count is zero, DELETE this section.**

The assembler inlines that condition into the brief, so the auditor sees it. This PR is trial #1.

## Two defects fixed along the way

1. **Found by a live smoke test against #1427, not by the suite.** `--round 0` printed the delta-anchor warning (*"Using it anyway"*, *"check you are not re-auditing a round that already ran"*) over a claims block round 0 never consults — `render_claims` returns `""` below round 2 and the range comes from the base. It fired on **every** round 0 of any PR with a ladder, on the one stream carrying the missing-intermediate-block warning. Scoped to round 0 only; round 1 keeps both warnings and a positive control pins that.

2. **A negative round assembled a round-1 brief in silence.** Every gate is spelled `>= 2` or `< 2`, so negatives fell through the `< 2` side. Harmless while `0` was meaningless; not harmless now that `0` names a different pass. Refused, rc 4.

## Test evidence

6 **invariant guards**, not regression coverage — `--round 0` exists at no base in `RED_AT_BASE_REFS`, so a red there would only restate that the flag was added. Evidence is the mutation battery plus in-test controls:

| mutant | killed by |
|---|---|
| M1 guard-off (`== 99`) | `INSTEAD_OF_the_nine_axes`, unreadable-skill |
| M2 title → round 1 | `INSTEAD_OF_the_nine_axes` |
| M3 ledger branch off | `ledger_rather_than_claiming_round_one` |
| M4 negative bound loosened | `negative_round_is_refused` |
| M5 reader's answer unused | `INSTEAD_OF_the_nine_axes`, unreadable-skill |
| M6 heading renamed | `section_the_script_reads_is_the_one_the_skill_ships` |
| M7 suppression off | `does_not_warn_about_a_claims_block` |

- **negative control:** unmutated GREEN (133 passed)
- **positive control:** an *unrelated* pre-existing guard mutated → RED, proving the harness can go red at all

Run under `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, restored from a `cp -a` copy between mutants.

The **seam guard** is the one that matters most: `_read_round_zero` anchors on a heading literal and the skill owns that heading. Both sides are hermetically tested and neither notices a rename — the script's tests inject a fixture reader on purpose, the skill's tests pin prose the script never parses. So one test reads the real file with the real reader.

## 🔴 Gate status — INCOMPLETE, read before merging

Measured on the isolated worktree at each named sha, not on a shared checkout.

| tier | result |
|---|---|
| node (`scripts/gate.sh`) | **PASS** — 5 suites, 41 files, 1449 tests, 0 fail (run twice: `d16bfd7a`, `97b03d8a`) |
| pytest — targeted (`test_audit_dispatch.py` + `test_audit_ladder_stop_rule.py`) | **PASS** — 151 passed, at `dcd84c73` |
| pytest — FULL dev-host tier | 🔴 **NO VERDICT** — timed out at the 3600 s cap (`exit=124`, `RESULT: FAIL (exit=143)` = SIGTERM). Not an assertion failure |
| `nix build .#checks.x86_64-linux.pytests` | **NOT RUN** |
| `nix build .#checks.x86_64-linux.nodetests` | **NOT RUN** |

**Why the missing tiers are missing, stated plainly:** this box has been continuously saturated by other agent sessions for the whole life of this PR — load average 88–96 at the first attempt and still **60 with 36 concurrent `run-tests.sh` runs and another `nix build .#checks` in flight** nine hours later. A second concurrent check derivation is the store contention `CLAUDE.md` says yields *false* failures, so it was never started; a red from it would have been evidence about the box, not about this diff. The one full run that did start hit the hour cap.

**Do not merge on what is green above.** The node tier and a targeted pytest selection are not the gate. The sandbox tier is the one Tekton runs and the one the dev-host tier is structurally blind to (it builds from a `cp -r` store copy with no `.git`, so anything keyed on being a git checkout evaluates differently there).

**What remains:** `scripts/gate.sh --tier both` to completion, then the two `nix` check derivations **one at a time**, on a quiet box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBnXuHA2pzzqFUTc9gp61u
