### PR TITLE
feat(nixos): clear 5 of the workbench's 6 nixos-rebuild deprecation warnings — and why the sixth deliberately stays

### DIFF
--- a/nix/system/apply-nixos-option-renames-2026-09-09.sh
+++ b/nix/system/apply-nixos-option-renames-2026-09-09.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+# Clear 5 of the workbench's 6 `nixos-rebuild` evaluation warnings.
+#
+#   sudo bash nix/system/apply-nixos-option-renames-2026-09-09.sh
+#   bash nix/system/apply-nixos-option-renames-2026-09-09.sh --dry-run   # no root needed
+#
+# ── WHY ──────────────────────────────────────────────────────────────────────
+#
+# MEASURED 2026-09-09 on the workbench (NixOS 26.11 "Zokor", plain channels, not
+# flakes). `nixos-rebuild dry-build` emits SIX lines beginning
+# `evaluation warning:`. Five are pure option/attribute RENAMES that nixpkgs has
+# already aliased; the sixth is not a rename at all and is deliberately left.
+#
+#   1. services.dnsmasq.servers        -> services.dnsmasq.settings.server
+#   2. services.gnome.tracker.enable   -> services.gnome.tinysparql.enable
+#   3. services.gnome.tracker-miners.enable -> services.gnome.localsearch.enable
+#   4. xorg.xrandr                     -> xrandr
+#   5. xdg-desktop-portal 1.17 wants an explicit `xdg.portal.config`
+#   6. wineWowPackages                 -> wineWow64Packages    ← NOT TOUCHED
+#
+# ── PATCH A (items 1-4): PROVEN BYTE-IDENTICAL ───────────────────────────────
+# Verified 2026-09-09 by evaluating the patched config: the SAME system
+# derivation (`q97dj70ph64md5vjsf0x757jq6vjbmni`), 0 derivations built, no new
+# generation, no unit restarts. These four are the alias being spelled out.
+#
+#   * `settings` is a `pkgs.formats` key-value format with
+#     `listsAsDuplicateKeys = true`, so the list becomes repeated `server=`
+#     lines in dnsmasq.conf — byte-for-byte what `servers` already produced.
+#   * `xorg.xrandr` and `xrandr` are the same derivation. NOTE the config
+#     ALREADY uses the correct `${pkgs.xrandr}` in `sessionCommands`; only the
+#     i3 `extraPackages` entry is stale, and this script changes only that one.
+#
+# ── PATCH B (item 5): 5 TRIVIAL DERIVATIONS, ONE NEW FILE ────────────────────
+# Adding `config.common.default = "*";` inside the existing `xdg.portal` block
+# creates `/etc/xdg/xdg-desktop-portal/portals.conf` (which does not exist on
+# this host today — the directory is empty). `"*"` reproduces the pre-1.17
+# behaviour: "use the first portal that implements the interface", which on this
+# host is the single installed `xdg-desktop-portal-gtk`. It is not a behaviour
+# change; it is writing down the behaviour that was previously implicit.
+#
+# ── WHY WARNING 6 STAYS: wineWowPackages IS NOT A RENAME ─────────────────────
+# 🔴 DO NOT "FINISH THE JOB" BY ADDING IT. `wineWowPackages` is a genuine 32-bit
+# + 64-bit pair; `wineWow64Packages` is a SINGLE 64-bit binary relying on
+# upstream's new WoW64 thunking layer to run 32-bit code. Different mechanism,
+# different bug surface. The config's own comment records that the current
+# spelling was tuned until Lutris / Ubisoft Connect worked, so swapping it is a
+# functional change to a working setup, dressed as a deprecation cleanup.
+#
+# It is also the LEAST likely of the six to ever break: its nixpkgs alias
+# carries no `# Added <date>` comment, and nixpkgs' `remove-old-aliases.py`
+# skips undated entries by construction — so the mechanical alias-reaper that
+# eventually deletes the other five structurally cannot delete this one.
+#
+# One warning is the correct steady state here. If you want it gone, that is a
+# separate, TESTED change: swap it, then actually launch Ubisoft Connect.
+#
+# ── 🔴 HAZARD 1: NIX_PATH POISONING WOULD ROLL THE SYSTEM BACKWARDS ──────────
+# MEASURED 2026-09-09. zach's interactive `NIX_PATH` begins with
+# `$HOME/.nix-defexpr/channels`, which is searched BEFORE the explicit
+# `nixpkgs=` entry. That channel is `nixpkgs-unstable` at 26.11pre1068924 —
+# OLDER than root's `nixos` channel 26.11pre1068949, which is what the running
+# system was built from. `sudo -E nixos-rebuild switch` (the natural form,
+# because it preserves the PATH that hazard 2 needs) therefore evaluates the
+# config against an OLDER nixpkgs and rebuilds ~34 derivations, moving the
+# system backwards, silently.
+#
+# Plain `sudo` happens to be safe because sudoers has `env_reset`. This script
+# does not depend on how it was invoked: it sets NIX_PATH explicitly, to root's
+# channel and nothing else, and verifies that path resolves before rebuilding.
+#
+# 🔴 It SETS rather than UNSETS. Unsetting also removes the poisoning entry, but
+# NixOS's `nix.nixPath` default is what supplies the `nixpkgs=` alias in the
+# first place, and root's channel directory is named `nixos`, not `nixpkgs` —
+# so with NIX_PATH unset, `<nixpkgs>` is resolved by nix's built-in default
+# instead, whose first component is again `$HOME/.nix-defexpr/channels`. Under
+# `sudo -E` (HOME preserved) that is zach's older channel a second time.
+# Setting the value removes the whole class instead of one instance of it.
+#
+# ── 🔴 HAZARD 2: root HAS NO python3 (OR dig) ────────────────────────────────
+# MEASURED: neither `python3` nor `dig` is in `/run/current-system/sw/bin`. Both
+# come from zach's user profile, so root only has them if the caller's PATH is
+# carried in. This script PREFLIGHTS python3 BEFORE it touches anything and
+# prints the exact remedy, rather than taking a backup and then half-applying.
+#
+# ── ROLLBACK ─────────────────────────────────────────────────────────────────
+#   sudo nixos-rebuild switch --rollback
+# and the timestamped `configuration.nix.bak-*` this script leaves beside the
+# config restores the source.
+set -euo pipefail
+
+# `NIXOPTS_CFG` / `NIXOPTS_PORTALS_CONF` exist so scripts/tests can drive this
+# against a fixture. Setting either one puts the script in TEST MODE: it does
+# not require root and it says so loudly.
+CFG="${NIXOPTS_CFG:-/etc/nixos/configuration.nix}"
+PORTALS_CONF="${NIXOPTS_PORTALS_CONF:-/etc/xdg/xdg-desktop-portal/portals.conf}"
+ROOT_CHANNELS="${NIXOPTS_ROOT_CHANNELS:-/nix/var/nix/profiles/per-user/root/channels}"
+TEST_MODE=no
+[[ -n "${NIXOPTS_CFG:-}${NIXOPTS_PORTALS_CONF:-}${NIXOPTS_ROOT_CHANNELS:-}" ]] && TEST_MODE=yes
+
+DRY_RUN=no
+case "${1:-}" in
+  --dry-run) DRY_RUN=yes ;;
+  -h|--help) sed -n '2,5p' "$0"; exit 0 ;;
+  "") : ;;
+  *)
+    echo "ERROR: unrecognised argument '${1}'. This script EDITS ${CFG} and runs" >&2
+    echo "       nixos-rebuild; it refuses anything it does not recognise." >&2
+    echo "       Use --dry-run or --help." >&2
+    exit 64
+    ;;
+esac
+if [[ $# -gt 1 ]]; then
+  echo "ERROR: too many arguments (got $#). Refusing rather than editing ${CFG}." >&2
+  exit 64
+fi
+
+if [[ "$TEST_MODE" == "yes" ]]; then
+  echo "🔴 TEST MODE — editing fixture ${CFG}, NOT /etc/nixos."
+elif [[ "$DRY_RUN" == "no" && $EUID -ne 0 ]]; then
+  echo "This script edits ${CFG} and runs nixos-rebuild; it must run as root:" >&2
+  echo "    sudo bash $0" >&2
+  echo "  (or run with --dry-run, which needs no privileges and writes nothing)" >&2
+  exit 1
+fi
+
+[[ -f "$CFG" ]] || { echo "ERROR: ${CFG} not found — is this a NixOS host?" >&2; exit 1; }
+[[ -r "$CFG" ]] || { echo "ERROR: cannot read ${CFG}" >&2; exit 1; }
+
+# ── PREFLIGHT (hazard 2) — before the backup, before any write ───────────────
+if ! command -v python3 >/dev/null 2>&1; then
+  # 🔴 BUILTINS ONLY IN THIS BRANCH. It fires precisely when the environment is
+  # impoverished, so it must not itself depend on finding `cat` on PATH.
+  echo "ERROR: no python3 on PATH." >&2
+  echo >&2
+  echo "  /run/current-system/sw/bin has no python3 on this host — it comes from" >&2
+  echo "  zach's user profile — so a plain \`sudo\` (env_reset) leaves root without" >&2
+  echo "  one. NOTHING HAS BEEN CHANGED: no backup, no edit, no rebuild." >&2
+  echo >&2
+  echo "  Re-run carrying your PATH in:" >&2
+  echo >&2
+  echo "      sudo env \"PATH=\$PATH\" bash $0" >&2
+  echo >&2
+  echo "  That also gives the verify section a \`dig\`, which is missing for the" >&2
+  echo "  same reason. Do NOT work around this by editing the file by hand halfway." >&2
+  exit 1
+fi
+
+echo "python3: $(command -v python3)"
+if command -v dig >/dev/null 2>&1; then
+  echo "dig:     $(command -v dig)"
+else
+  echo "dig:     NOT ON PATH — two verify checks will be printed for you to run"
+  echo "         yourself instead of being run here. Re-run as"
+  echo "         \`sudo env \"PATH=\$PATH\" bash $0\` to have them run inline."
+fi
+
+# ── HAZARD 1 — pin NIX_PATH to root's channel, explicitly ────────────────────
+if [[ "$DRY_RUN" == "no" && "$TEST_MODE" == "no" ]]; then
+  [[ -e "${ROOT_CHANNELS}/nixos" ]] || {
+    echo "ERROR: ${ROOT_CHANNELS}/nixos does not exist." >&2
+    echo "       This host is not on plain channels the way this patch assumes." >&2
+    echo "       Nothing has been changed. Sort out the channel first." >&2
+    exit 1
+  }
+  echo
+  echo "NIX_PATH inherited: ${NIX_PATH:-<unset>}"
+  export NIX_PATH="nixpkgs=${ROOT_CHANNELS}/nixos:nixos-config=${CFG}:${ROOT_CHANNELS}"
+  echo "NIX_PATH pinned to: ${NIX_PATH}"
+  echo "  root channel rev: $(cat "${ROOT_CHANNELS}/nixos/.version-suffix" 2>/dev/null || echo '?')"
+  echo "  (If the inherited value began with a \$HOME/.nix-defexpr entry, that is"
+  echo "   hazard 1 and pinning above is what stops it rolling the system back.)"
+fi
+
+# ── the edits ────────────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == "no" ]]; then
+  BACKUP="${CFG}.bak-$(date +%Y%m%d-%H%M%S)"
+  cp -a "$CFG" "$BACKUP"
+  echo
+  echo "backup: ${BACKUP}"
+fi
+
+echo
+echo "Editing ${CFG}:"
+
+# 🔴 THE `set -e` TRAP, BOTH DIRECTIONS. `python3 …; rc=$?` is DEAD CODE — under
+# `set -e` a non-zero exit kills the shell before the assignment runs. And
+# `python3 … || rc=$?` WITHOUT the `rc=0` first crashes under `set -u` on the
+# SUCCESS path, because nothing ever assigns rc. Only this form is correct.
+rc=0
+python3 - "$CFG" "$DRY_RUN" <<'PYBLOCK' || rc=$?
+import re
+import sys
+
+path, dry = sys.argv[1], sys.argv[2] == "yes"
+src = open(path, encoding="utf-8").read()
+orig = src
+actions = []
+expected_delta = 0
+
+
+def refuse(msg):
+    print("\nREFUSING: " + msg, file=sys.stderr)
+    print("The config has drifted from what this patch was written against.",
+          file=sys.stderr)
+    print("NOTHING HAS BEEN WRITTEN. Apply the change by hand rather than "
+          "letting the script guess which occurrence to edit.", file=sys.stderr)
+    raise SystemExit(2)
+
+
+# ── EDIT 1: services.dnsmasq.servers -> services.dnsmasq.settings.server ─────
+#
+# 🔴 STRUCTURAL, NOT LITERAL — ON PURPOSE. The value being moved is a list of
+# resolver addresses, and this repo is PUBLIC with a gate that rejects a
+# routable IP literal in a tracked file (scripts/tests/test_no_public_ips.py).
+# So the list is never retyped: it is CAPTURED from the live config and
+# re-emitted verbatim. The script therefore contains no address at all, and it
+# also cannot silently substitute a stale copy of the list.
+#
+# The regex requires the key at the start of a line after only whitespace, so
+# the commented-out `#servers = [...]` line directly above it cannot match.
+SERVERS_RE = re.compile(
+    r'^(?P<indent>[ \t]*)servers = (?P<list>\[[^\n]*\]);(?P<trail>[^\n]*)\n', re.M)
+SETTINGS_SERVER_RE = re.compile(r'^[ \t]*server = \[', re.M)
+# A comment line the migration should CARRY. The trailing space is load-bearing:
+# it stops the commented-out `#servers = [...]` line above from being swallowed
+# into the block and re-indented into the settings attrset as live-looking text.
+COMMENT_RE = re.compile(r'^[ \t]*# ')
+
+matches = list(SERVERS_RE.finditer(src))
+if not matches:
+    if SETTINGS_SERVER_RE.search(src):
+        actions.append("dnsmasq: already migrated (settings.server present)")
+    else:
+        refuse("no `servers = [...];` line, and no `server = [...]` inside "
+               "`settings` either — cannot tell which state this config is in")
+elif len(matches) != 1:
+    refuse("expected exactly 1 `servers = [...];` line, found %d" % len(matches))
+else:
+    m = matches[0]
+    indent = m.group("indent")
+
+    # Walk back over the contiguous run of `# ` comment lines above it.
+    before = src[:m.start()].split("\n")
+    if before[-1] != "":
+        refuse("internal: the `servers` match did not start on a line boundary")
+    i = len(before) - 2
+    comments = []
+    while i >= 0 and COMMENT_RE.match(before[i]):
+        comments.insert(0, before[i])
+        i -= 1
+    block = "".join(c + "\n" for c in comments)
+    cut = m.start() - len(block)
+    if src[cut:m.start()] != block:
+        refuse("internal: comment-block slice did not round-trip")
+
+    # The move target must be the very next line, and at the same indent.
+    after = src[m.end():]
+    sm = re.match(r'^(?P<i>[ \t]*)settings = \{[ \t]*\n', after)
+    if not sm:
+        refuse("the line after `servers = [...];` is not `settings = {` — "
+               "refusing to guess where inside the attrset to move it")
+    if sm.group("i") != indent:
+        refuse("`settings = {` is indented %r but `servers` is %r — refusing"
+               % (sm.group("i"), indent))
+    if SETTINGS_SERVER_RE.search(src):
+        refuse("a `server = [...]` key already exists inside `settings` while a "
+               "top-level `servers` also exists — refusing to create a duplicate")
+
+    inner = indent + "  "
+    moved = "".join(inner + c.lstrip() + "\n" for c in comments)
+    moved += "%sserver = %s;%s\n" % (inner, m.group("list"), m.group("trail"))
+
+    src = src[:cut] + after[:sm.end()] + moved + after[sm.end():]
+    expected_delta += len(moved) - (m.end() - cut)
+    actions.append("dnsmasq: moved `servers` into `settings.server`, carrying "
+                   "%d comment line(s)" % len(comments))
+
+# ── EDITS 2 & 3: the GNOME tracker renames ───────────────────────────────────
+# `services.gnome.tracker.enable` is NOT a prefix of
+# `services.gnome.tracker-miners.enable` (`.` vs `-`), so the two are unambiguous
+# as plain substrings and order does not matter.
+for old, new in (("services.gnome.tracker.enable", "services.gnome.tinysparql.enable"),
+                 ("services.gnome.tracker-miners.enable", "services.gnome.localsearch.enable")):
+    n_old, n_new = src.count(old), src.count(new)
+    if n_old == 0 and n_new >= 1:
+        actions.append("gnome: %s already renamed" % old)
+        continue
+    if n_old != 1:
+        refuse("expected exactly 1 occurrence of `%s`, found %d" % (old, n_old))
+    if n_new != 0:
+        refuse("`%s` is present %d time(s) while `%s` still exists — refusing to "
+               "create a duplicate definition" % (new, n_new, old))
+    src = src.replace(old, new, 1)
+    expected_delta += len(new) - len(old)
+    actions.append("gnome: %s -> %s" % (old, new))
+
+# ── EDIT 4: xorg.xrandr -> xrandr, in i3's extraPackages ONLY ────────────────
+# 🔴 The config ALSO uses `${pkgs.xrandr}` in `sessionCommands`, which is already
+# correct. The anchors below match a bare package name on a line of its own —
+# the `with pkgs; [ … ]` list element — so the interpolation cannot match.
+XORG_XRANDR_RE = re.compile(r'^(?P<i>[ \t]*)xorg\.xrandr[ \t]*$', re.M)
+BARE_XRANDR_RE = re.compile(r'^[ \t]*xrandr[ \t]*$', re.M)
+xr = list(XORG_XRANDR_RE.finditer(src))
+if not xr:
+    if BARE_XRANDR_RE.search(src):
+        actions.append("xrandr: already renamed")
+    else:
+        refuse("neither an `xorg.xrandr` nor a bare `xrandr` package-list entry "
+               "was found — cannot tell which state this config is in")
+elif len(xr) != 1:
+    refuse("expected exactly 1 `xorg.xrandr` package-list entry, found %d" % len(xr))
+else:
+    src = XORG_XRANDR_RE.sub(lambda mo: mo.group("i") + "xrandr", src, count=1)
+    expected_delta += len("xrandr") - len("xorg.xrandr")
+    actions.append("xrandr: xorg.xrandr -> xrandr (i3 extraPackages)")
+
+# ── EDIT 5 (patch B): an explicit xdg.portal default ─────────────────────────
+#
+# 🔴 EVERY PATTERN HERE IS LINE-ANCHORED PAST WHITESPACE ONLY, SO A `#` KILLS IT.
+# That is not stylistic. This config carries a large COMMENTED-OUT `xdg.portal`
+# block (an old termfilechooser experiment) which contains, among other things,
+# `#xdg.portal.config.common.default = "*";` and a `#    extraPortals = with
+# pkgs; [`. A plain `in src` idempotency check MATCHED that dead line and made
+# the script report "default already set" and skip patch B entirely — measured,
+# 2026-09-09, on the first fixture run. A commented line is not a definition.
+PORTAL_BLOCK_RE = re.compile(r'^[ \t]*xdg\.portal = \{[ \t]*$', re.M)
+EXTRA_PORTALS_RE = re.compile(
+    r'^(?P<i>[ \t]*)extraPortals = \[[^\n]*\];[ \t]*\n', re.M)
+PORTAL_SET_RE = re.compile(
+    r'^[ \t]*(?:xdg\.portal\.)?config\.common\.default[ \t]*=', re.M)
+PORTAL_LINE = 'config.common.default = "*";'
+if PORTAL_SET_RE.search(src):
+    actions.append("xdg.portal: default already set")
+else:
+    pb = list(PORTAL_BLOCK_RE.finditer(src))
+    if len(pb) != 1:
+        refuse("expected exactly 1 `xdg.portal = {` block, found %d" % len(pb))
+    ep = [e for e in EXTRA_PORTALS_RE.finditer(src) if e.start() > pb[0].start()]
+    if len(ep) != 1:
+        refuse("expected exactly 1 `extraPortals = [...];` line after "
+               "`xdg.portal = {`, found %d" % len(ep))
+    e = ep[0]
+    ind = e.group("i")
+    add = (
+        '%s# xdg-desktop-portal 1.17+ no longer falls back to "the first portal that\n'
+        '%s# implements the interface" — it warns and asks to be told. "*" IS that old\n'
+        '%s# behaviour, written down: use whatever backend is installed, which here is\n'
+        '%s# the single gtk portal above. Creates /etc/xdg/xdg-desktop-portal/portals.conf.\n'
+        '%s%s\n' % (ind, ind, ind, ind, ind, PORTAL_LINE))
+    src = src[:e.end()] + add + src[e.end():]
+    expected_delta += len(add)
+    actions.append("xdg.portal: added %s" % PORTAL_LINE)
+
+# ── verify the AFTER state BEFORE writing ────────────────────────────────────
+problems = []
+if SERVERS_RE.search(src):
+    problems.append("a top-level `servers = [...];` line survives the migration")
+if not SETTINGS_SERVER_RE.search(src):
+    problems.append("no `server = [...]` key inside `settings` after the migration")
+for dead in ("services.gnome.tracker.enable", "services.gnome.tracker-miners.enable"):
+    if dead in src:
+        problems.append("`%s` survives" % dead)
+for live in ("services.gnome.tinysparql.enable", "services.gnome.localsearch.enable"):
+    if src.count(live) != 1:
+        problems.append("expected exactly 1 `%s`, found %d" % (live, src.count(live)))
+if XORG_XRANDR_RE.search(src):
+    problems.append("an `xorg.xrandr` package-list entry survives")
+n_portal = len(PORTAL_SET_RE.findall(src))
+if n_portal != 1:
+    problems.append("expected exactly 1 LIVE `config.common.default = …` line, found %d"
+                    % n_portal)
+# Nothing outside the five edits may move.
+#
+# DEFENCE IN DEPTH, and honestly labelled: with the five edits implemented
+# correctly this check is redundant with the line-level assertion in
+# scripts/tests (`test_nothing_outside_the_five_edits_moves`), so deleting it
+# from a CORRECT script changes nothing and it survives a mutation sweep as an
+# equivalent mutant. It is REACHABLE, and proven so: mis-accounting the xrandr
+# edit by 5 bytes makes it fire with its own message ("the file changed by 352
+# bytes, expected 357") and refuse, and the same bug is written out silently
+# with this branch removed. It exists for the SIXTH edit somebody adds.
+delta = len(src) - len(orig)
+if delta != expected_delta:
+    problems.append("the file changed by %d bytes, expected %d — something else moved"
+                    % (delta, expected_delta))
+# Cheap structural sanity: brace/bracket balance is unchanged.
+for ch in "{}[]":
+    if src.count(ch) != orig.count(ch):
+        problems.append("the count of %r changed (%d -> %d)"
+                        % (ch, orig.count(ch), src.count(ch)))
+
+if problems:
+    print("\nERROR: post-edit verification failed. NOTHING WRITTEN.", file=sys.stderr)
+    for p in problems:
+        print("  - " + p, file=sys.stderr)
+    raise SystemExit(2)
+
+for a in actions:
+    print("  " + a)
+
+if src == orig:
+    print("  (already fully applied — nothing to write)")
+    raise SystemExit(0)
+
+if dry:
+    print("  --dry-run: all checks pass, NOTHING WRITTEN (%+d bytes)" % delta)
+    raise SystemExit(0)
+
+open(path, "w", encoding="utf-8").write(src)
+print("  written (%+d bytes)" % delta)
+PYBLOCK
+
+if [[ $rc -ne 0 ]]; then
+  if [[ "$DRY_RUN" == "no" ]]; then
+    echo
+    echo "The config was NOT modified. The backup at ${BACKUP} is identical to it." >&2
+  fi
+  exit "$rc"
+fi
+
+if [[ "$DRY_RUN" == "yes" ]]; then
+  echo
+  echo "--dry-run: nothing written, no rebuild. Re-run without --dry-run under sudo."
+  exit 0
+fi
+
+# ── rebuild ──────────────────────────────────────────────────────────────────
+LOG="$(mktemp -t nixos-option-renames-XXXXXX.log)"
+echo
+echo "rebuilding (log: ${LOG}) ..."
+rc=0
+nixos-rebuild switch 2>&1 | tee "$LOG" || rc=$?
+if [[ $rc -ne 0 ]]; then
+  echo
+  echo "🔴 nixos-rebuild FAILED (rc=${rc}). The system is unchanged; the SOURCE is not." >&2
+  echo "   Restore it and re-run the rebuild:" >&2
+  echo "       sudo cp -a ${BACKUP} ${CFG}" >&2
+  echo "       sudo nixos-rebuild switch" >&2
+  exit "$rc"
+fi
+
+# ── verify ───────────────────────────────────────────────────────────────────
+# Every check below states the EXPECTED VALUE, so a reader can tell a pass from
+# a thing that merely printed. "it worked" is not a verification.
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo "VERIFY"
+echo "════════════════════════════════════════════════════════════════════════"
+
+fail=0
+ok()   { printf '  ok   %s\n' "$*"; }
+bad()  { printf '  FAIL %s\n' "$*"; fail=$((fail + 1)); }
+
+# 1. exactly ONE evaluation warning, and it is the wineWowPackages one.
+#    re-run yourself with:  sudo nixos-rebuild dry-build 2>&1 | grep '^evaluation warning:'
+warn_lines="$(grep '^evaluation warning:' "$LOG" || true)"
+warn_count="$(printf '%s' "$warn_lines" | grep -c . || true)"
+if [[ "$warn_count" == "1" ]]; then
+  if printf '%s' "$warn_lines" | grep -q 'wineWowPackages'; then
+    ok "1 evaluation warning remains and it is wineWowPackages (expected: exactly 1)"
+  else
+    bad "1 warning remains but it is NOT wineWowPackages: ${warn_lines}"
+  fi
+else
+  bad "expected exactly 1 evaluation warning, got ${warn_count}:"
+  printf '%s\n' "$warn_lines" | sed 's/^/         /'
+fi
+
+# 2. dnsmasq still answers for the LAN name.
+#    expected:  192.168.50.250
+DIG_LAN='dig +short @127.0.0.1 workbench.lan'
+# 3. the docker.io pin survived the move into settings.server.
+#    expected TTL: TENS of seconds. ~42,000,000 means the LAN router's 487-day
+#    record is being served again -> the pin did NOT survive -> ROLL BACK.
+DIG_DOCKER='dig @127.0.0.1 registry-1.docker.io A +noall +answer'
+if command -v dig >/dev/null 2>&1; then
+  lan="$(dig +short @127.0.0.1 workbench.lan 2>/dev/null | head -1 || true)"
+  if [[ "$lan" == "192.168.50.250" ]]; then
+    ok "workbench.lan -> ${lan}   (expected: 192.168.50.250)"
+  elif [[ -n "$lan" ]]; then
+    bad "workbench.lan -> ${lan}, expected 192.168.50.250"
+  else
+    bad "workbench.lan resolved to NOTHING — the settings.address entries did not survive"
+  fi
+
+  ttl="$(dig @127.0.0.1 registry-1.docker.io A +noall +answer 2>/dev/null \
+         | awk '$4=="A"{print $2; exit}' || true)"
+  if [[ -z "$ttl" ]]; then
+    bad "no A record for registry-1.docker.io — resolver is not answering"
+  elif [[ ! "$ttl" =~ ^[0-9]+$ ]]; then
+    # 🔴 One `bad` per PROBLEM. Calling it again for a continuation line would
+    # inflate the failure COUNT, and that count is what the exit status and the
+    # closing summary are built from.
+    bad "could not parse a TTL out of dig's answer (got '${ttl}') — run it yourself:"
+    echo "         ${DIG_DOCKER}"
+  elif [[ "$ttl" -lt 1000 ]]; then
+    ok "registry-1.docker.io TTL=${ttl}s (expected: TENS of seconds — the /docker.io/ pin held)"
+  else
+    bad "registry-1.docker.io TTL=${ttl}s — that is the LAN router's ~42,000,000s record."
+    echo "       THE /docker.io/ PIN DID NOT SURVIVE THE MOVE, and ~half of all docker"
+    echo "       pulls will now fail TLS verification. Roll back:"
+    echo "           sudo nixos-rebuild switch --rollback"
+  fi
+else
+  echo "  ---- dig is not on PATH; run these two yourself, as zach:"
+  echo "         ${DIG_LAN}"
+  echo "           expected: 192.168.50.250"
+  echo "         ${DIG_DOCKER}"
+  echo "           expected: a TTL in the TENS of seconds. ~42,000,000 means the"
+  echo "           LAN router's 487-day record is back and the /docker.io/ pin did"
+  echo "           NOT survive — roll back with: sudo nixos-rebuild switch --rollback"
+fi
+
+# 4. the portals.conf that patch B exists to create.
+if [[ -f "$PORTALS_CONF" ]]; then
+  if grep -q 'default=\*' "$PORTALS_CONF"; then
+    ok "${PORTALS_CONF} contains default=*"
+  else
+    bad "${PORTALS_CONF} exists but has no 'default=*':"
+    sed 's/^/         /' "$PORTALS_CONF"
+  fi
+else
+  bad "${PORTALS_CONF} was not created — patch B did not take effect"
+fi
+
+echo
+echo "  ---- run these two AS ZACH (they are USER units; root cannot see them) ----"
+echo "  systemctl --user list-unit-files | grep -E 'tinysparql|localsearch|tracker'"
+echo "    expected: tinysparql-miner-fs-3.service and localsearch-3.service present,"
+echo "              and NO tracker-miner-fs-3.service / tracker-extract-3.service."
+echo "    🔴 These are session units. If they are missing, log out and back in"
+echo "       before concluding the rename broke them — the running session still"
+echo "       holds the pre-switch user-unit generation."
+echo
+echo "  ---- the whole-of-system control -------------------------------------"
+echo "  sudo nixos-rebuild dry-build 2>&1 | grep -c '^evaluation warning:'"
+echo "    expected: 1   (was 6 before this script)"
+echo
+echo "  ---- rollback, if any check above did not pass -----------------------"
+echo "  sudo nixos-rebuild switch --rollback"
+echo "  sudo cp -a ${BACKUP} ${CFG}        # restores the source too"
+
+echo
+if [[ $fail -ne 0 ]]; then
+  echo "🔴 ${fail} verification check(s) FAILED. Read them above and roll back if"
+  echo "   the docker.io TTL check is among them — that one breaks docker pulls."
+  exit 1
+fi
+echo "All automated checks passed. Still run the two USER-unit / dry-build"
+echo "commands above — this script cannot see either."

--- a/scripts/tests/test_nixos_option_renames_apply.py
+++ b/scripts/tests/test_nixos_option_renames_apply.py
@@ -475,11 +475,22 @@ def test_it_preflights_python3_before_touching_anything(rig, tmp_path):
     plain `sudo` (env_reset) leaves root without one. Half-applying is the
     failure mode this preflight exists to prevent: it must fire BEFORE the
     backup and BEFORE the edit."""
-    # PATH is the shim dir ALONE — no python3, and no coreutils either. The
-    # preflight branch is builtins-only precisely so it still speaks in this
-    # environment; if it ever reaches for `cat` again, this goes red in the nix
-    # sandbox tier where /run/current-system/sw/bin does not exist at all.
-    p = rig.run(env={"PATH": str(rig.bin)}, expect=1)
+    # 🔴 PATH is REPLACED by an EMPTY directory — not prepended to. This is a
+    # PATH-clobbering site and is pinned as one in
+    # `test_no_real_launchers.py::PINNED_PATH_CLOBBERS`; read that entry before
+    # changing the shape here. Replacing is REQUIRED: python3 is present both on
+    # the dev host and in the nix sandbox, and no amount of PREPENDING can make
+    # a binary unfindable, so a prepending version would measure the environment
+    # instead of the preflight. The directory is created empty by this test one
+    # line above the clobber, so nothing at all — least of all a launcher — is
+    # reachable through it.
+    #
+    # Emptiness is also what makes the assertion strong rather than incidental:
+    # the preflight branch is builtins-only, so with NOTHING on PATH it must
+    # still speak. If it ever reaches for `cat` again, this goes red.
+    empty = tmp_path / "empty-bin"
+    empty.mkdir()
+    p = rig.run(env={"PATH": str(empty)}, expect=1)
     assert "no python3 on PATH" in p.stderr
     assert 'sudo env "PATH=$PATH" bash' in p.stderr
     assert rig.cfg.read_text() == FIXTURE

--- a/scripts/tests/test_nixos_option_renames_apply.py
+++ b/scripts/tests/test_nixos_option_renames_apply.py
@@ -1,0 +1,571 @@
+"""Tests for `nix/system/apply-nixos-option-renames-2026-09-09.sh`.
+
+🔴 WHY THIS FILE EXISTS. The script EDITS `/etc/nixos/configuration.nix` and
+then runs `nixos-rebuild switch`. Four of its five edits are RENAMES whose whole
+claim is "byte-identical output", and the fifth adds a file to `/etc`. A wrong
+occurrence, a swallowed comment or a silently-skipped edit is invisible in the
+rebuild's own output, so nothing but a test holds the shape.
+
+HERMETIC. Every test drives the script against a FIXTURE config via `NIXOPTS_CFG`
+and `NIXOPTS_PORTALS_CONF`, with a shim directory first on PATH holding
+`nixos-rebuild` and `dig` (both record/serve instead of doing). There is no path
+from this file to a real `nixos-rebuild`, to `/etc/nixos`, or to `/etc/xdg`.
+
+🔴 EVERY ADDRESS IN THE FIXTURE IS FROM TEST-NET-3 (203.0.113.0/24, RFC 5737) OR
+RFC 1918. This repo is PUBLIC and `test_no_public_ips.py` rejects a routable
+literal in a tracked file; the live config this patch targets contains a real
+public resolver address, so the fixture is a STRUCTURAL likeness of it rather
+than a copy. That is also why the script itself never spells an address: it
+CAPTURES the resolver list out of the live config and re-emits it verbatim.
+
+    run:  pytest scripts/tests/test_nixos_option_renames_apply.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "nix" / "system" / "apply-nixos-option-renames-2026-09-09.sh"
+sys.path.insert(0, str(REPO / "scripts"))
+from testlib.mockbin import write_exec  # noqa: E402
+
+BASH = shutil.which("bash") or "/bin/bash"
+
+#: A structural likeness of the live workbench config: the same nesting, the same
+#: neighbouring COMMENTED-OUT lines, the same already-correct `${pkgs.xrandr}`
+#: interpolation. Every one of those neighbours is a trap the script has to not
+#: fall into, and two of them caught a real defect while it was being written.
+FIXTURE = """{ config, pkgs, ... }:
+{
+xdg.portal = {
+  enable = true;
+  extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+};
+services.flatpak.enable = true;
+
+  services.dnsmasq = {
+    enable = true;
+    alwaysKeepRunning = true;
+    #servers = ["/lan/203.0.113.5" "203.0.113.1"];
+    # docker.io is pinned FIRST to the public resolver on purpose: the LAN router
+    # serves a stale record with an absurd TTL.
+    # Remove this line once the router's stale entry is cleared.
+    servers = ["/docker.io/203.0.113.1" "192.168.50.1" "203.0.113.1"];  # router first
+    settings = {
+      address = [
+        "/workbench.lan/192.168.50.250"
+      ];
+      cache-size = 10000;
+    };
+  };
+
+  services.xserver = {
+    displayManager = {
+      sessionCommands = ''
+        ${pkgs.xrandr}/bin/xrandr --output DP-0 --mode 3440x1440
+      '';
+    };
+    windowManager.i3 = {
+      enable = true;
+      extraPackages = with pkgs; [
+        dmenu
+        rofi
+        xorg.xrandr
+        xorg.xkill
+        i3lock
+     ];
+    };
+  };
+
+  services.gnome.tracker.enable = true;
+  services.gnome.tracker-miners.enable = true;
+
+# an old experiment, left commented out. NONE of this is a definition:
+#  xdg.portal = {
+#    enable = true;
+#    extraPortals = with pkgs; [
+#      xdg-desktop-portal-termfilechooser
+#    ];
+#    config = {
+#      common.default = [ "*" ];
+#    };
+#  };
+#xdg.portal.config.common.default = "*";
+}
+"""
+
+PORTALS_OK = "[preferred]\ndefault=*\n"
+
+
+@pytest.fixture
+def rig(tmp_path):
+    """A fixture config, a shim PATH, and a runner."""
+
+    class Rig:
+        pass
+
+    r = Rig()
+    r.dir = tmp_path
+    r.cfg = tmp_path / "configuration.nix"
+    r.portals = tmp_path / "portals.conf"
+    r.bin = tmp_path / "bin"
+    r.bin.mkdir()
+    r.calls = tmp_path / "rebuild-calls"
+    r.channels = tmp_path / "channels"
+    (r.channels / "nixos").mkdir(parents=True)
+
+    # Records the invocation instead of performing it, and writes the portals.conf
+    # a real activation would write — the script's verify step then has something
+    # true to read. `$PORTALS_BODY` lets a test make activation produce the WRONG
+    # content, which is the negative control for that check.
+    # 🔴 `${VAR+x}` (no colon) throughout, so a test can inject an EMPTY value —
+    # `${VAR:-default}` would silently substitute the default for "" and make
+    # test_verify_goes_red_when_portals_conf_was_never_created vacuous.
+    write_exec(r.bin / "nixos-rebuild", f'''
+echo "nixos-rebuild $*" >> "{r.calls}"
+echo "SHIM: nixos-rebuild $*"
+if [ -n "${{FAKE_WARNINGS+x}}" ]; then
+  printf '%s' "$FAKE_WARNINGS"
+else
+  echo "evaluation warning: 'wineWowPackages' is deprecated as it is no longer preferred by upstream. Use wineWow64Packages instead"
+fi
+if [ -z "${{NO_PORTALS:-}}" ]; then
+  if [ -n "${{PORTALS_BODY+x}}" ]; then
+    printf '%s' "$PORTALS_BODY" > "{r.portals}"
+  else
+    printf '[preferred]\\ndefault=*\\n' > "{r.portals}"
+  fi
+fi
+exit ${{REBUILD_RC:-0}}
+''')
+    write_exec(r.bin / "dig", '''
+case "$*" in
+  *+short*workbench.lan*) echo "192.168.50.250" ;;
+  *registry-1.docker.io*) printf 'registry-1.docker.io.\\t%s\\tIN\\tA\\t203.0.113.7\\n' "${FAKE_TTL:-33}" ;;
+esac
+''')
+
+    def run(cfg_text=FIXTURE, args=(), env=None, expect=None):
+        if cfg_text is not None:
+            r.cfg.write_text(cfg_text)
+        e = dict(os.environ)
+        e["PATH"] = f"{r.bin}:{e.get('PATH', '')}"
+        e["NIXOPTS_CFG"] = str(r.cfg)
+        e["NIXOPTS_PORTALS_CONF"] = str(r.portals)
+        e["NIXOPTS_ROOT_CHANNELS"] = str(r.channels)
+        e.update(env or {})
+        # 🔴 bash is resolved from the AMBIENT PATH, not the child's — one test
+        # deliberately hands the script a PATH with nothing on it, and looking
+        # bash up in that would fail in the launcher instead of in the script,
+        # turning a real check into a FileNotFoundError.
+        p = subprocess.run([BASH, str(SCRIPT), *args], capture_output=True,
+                           text=True, env=e, timeout=120)
+        if expect is not None:
+            assert p.returncode == expect, (
+                f"rc={p.returncode} expected {expect}\n"
+                f"--- stdout ---\n{p.stdout}\n--- stderr ---\n{p.stderr}")
+        return p
+
+    r.run = run
+    return r
+
+
+# --------------------------------------------------------------------------
+# the five edits
+# --------------------------------------------------------------------------
+def test_it_applies_all_five_edits(rig):
+    rig.run(expect=0)
+    out = rig.cfg.read_text()
+
+    # 1. dnsmasq moved INTO settings, and the top-level key is gone.
+    assert "\n    servers = [" not in out
+    assert "      server = [" in out
+    # 2 & 3. the GNOME renames.
+    assert "services.gnome.tinysparql.enable = true;" in out
+    assert "services.gnome.localsearch.enable = true;" in out
+    assert "services.gnome.tracker.enable" not in out
+    assert "services.gnome.tracker-miners.enable" not in out
+    # 4. the i3 package-list entry — and ONLY it.
+    assert "\n        xrandr\n" in out
+    assert "xorg.xrandr" not in out
+    # 🔴 `xorg.xkill` is a SIBLING attribute in the same list that nixpkgs has
+    # NOT deprecated. It exists in the fixture as the negative half of edit 4:
+    # a mutant that swaps `xorg.` out globally is otherwise EQUIVALENT here and
+    # SURVIVED a fully green sweep before this line was added (measured).
+    assert "        xorg.xkill\n" in out
+    # 5. the portal default, LIVE (not the commented-out experiment).
+    assert '\n  config.common.default = "*";\n' in out
+
+
+def test_the_resolver_list_is_moved_verbatim(rig):
+    """The whole point of the dnsmasq edit: the VALUE must not change.
+
+    The script never spells an address; it captures the bracketed list and
+    re-emits it. Anything that reformats, reorders or drops an entry here would
+    silently unpin docker.io, which is a real outage (TLS failures on ~half of
+    all pulls) that the script's own verify section exists to catch.
+    """
+    before = rig.cfg  # written by run()
+    rig.run(expect=0)
+    out = before.read_text()
+    assert '["/docker.io/203.0.113.1" "192.168.50.1" "203.0.113.1"];  # router first' in out
+    # exactly once — not duplicated into both places
+    assert out.count('"/docker.io/203.0.113.1"') == 1
+
+
+def test_the_docker_io_comment_travels_with_the_line(rig):
+    """The 3-line rationale must end up INSIDE settings, above `server`, at the
+    settings indent — not orphaned where the old key used to be."""
+    rig.run(expect=0)
+    out = rig.cfg.read_text()
+    i_comment = out.index("      # docker.io is pinned FIRST")
+    i_server = out.index("      server = [")
+    i_settings = out.index("    settings = {")
+    assert i_settings < i_comment < i_server, out
+
+
+def test_the_commented_out_servers_line_is_not_swallowed(rig):
+    """🔴 The comment-carrying walk-back stops at `#servers = [...]`.
+
+    That line is COMMENTED-OUT CODE sitting directly above the rationale block.
+    Re-indenting it into the `settings` attrset would move a dead definition to
+    a place where uncommenting it means something different. The `# ` (with the
+    space) in the walk-back pattern is what stops it.
+    """
+    rig.run(expect=0)
+    out = rig.cfg.read_text()
+    assert '    #servers = ["/lan/203.0.113.5" "203.0.113.1"];\n    settings = {' in out
+
+
+def test_the_already_correct_pkgs_xrandr_interpolation_is_untouched(rig):
+    """The config uses `${pkgs.xrandr}` in sessionCommands and it is ALREADY
+    right. Only the `xorg.xrandr` package-list entry may move."""
+    rig.run(expect=0)
+    out = rig.cfg.read_text()
+    assert "${pkgs.xrandr}/bin/xrandr --output DP-0 --mode 3440x1440" in out
+    assert out.count("/bin/xrandr") == 1
+    assert out.count("xorg.") == 1, "an unrelated xorg.* attribute was rewritten"
+
+
+def test_the_commented_out_portal_experiment_does_not_read_as_applied(rig):
+    """🔴 REGRESSION. MEASURED 2026-09-09 on the first fixture run against the
+    REAL config: a plain `'config.common.default = "*";' in src` idempotency
+    check matched the commented-out `#xdg.portal.config.common.default = "*";`
+    left over from an old termfilechooser experiment, so the script reported
+    "default already set" and skipped patch B — the one edit that actually does
+    something. A commented line is not a definition.
+    """
+    rig.run(expect=0)
+    out = rig.cfg.read_text()
+    assert '\n  config.common.default = "*";\n' in out, "patch B was skipped"
+    # the dead line is still dead, and still there
+    assert '\n#xdg.portal.config.common.default = "*";\n' in out
+
+
+def test_nothing_outside_the_five_edits_moves(rig):
+    """The script's own byte-delta guard, driven from outside.
+
+    Line-for-line: only lines the five edits own may leave or arrive. Seven
+    leave — the four rewritten definitions plus the three rationale comments,
+    which "leave" because they are re-indented into `settings`. Twelve arrive —
+    those three at the new indent, the `server` line, the two renamed GNOME
+    lines, the bare `xrandr` entry, the `config.common` line and its four
+    comment lines.
+    """
+    before = FIXTURE.splitlines()
+    rig.run(expect=0)
+    after = rig.cfg.read_text().splitlines()
+    left = [l for l in before if l not in after]
+    arrived = [l for l in after if l not in before]
+
+    for owned in (
+        '    servers = ["/docker.io/203.0.113.1" "192.168.50.1" "203.0.113.1"];  # router first',
+        "        xorg.xrandr",
+        "  services.gnome.tracker.enable = true;",
+        "  services.gnome.tracker-miners.enable = true;",
+    ):
+        assert owned in left, owned
+    assert len(left) == 7, left
+    assert len(arrived) == 12, arrived
+    # nothing unrelated arrived
+    allowed = ("#", "server =", "config.common.default", "xrandr",
+               "services.gnome.tinysparql.enable", "services.gnome.localsearch.enable")
+    for a in arrived:
+        assert a.strip().startswith(allowed), a
+
+
+# --------------------------------------------------------------------------
+# idempotency
+# --------------------------------------------------------------------------
+def test_a_second_run_changes_nothing(rig):
+    rig.run(expect=0)
+    once = rig.cfg.read_text()
+    p = rig.run(cfg_text=None, expect=0)
+    assert rig.cfg.read_text() == once
+    for marker in ("already migrated", "already renamed", "already set"):
+        assert marker in p.stdout, p.stdout
+    assert "already fully applied" in p.stdout
+
+
+def test_dry_run_writes_nothing_and_needs_no_root(rig):
+    p = rig.run(args=("--dry-run",), expect=0)
+    assert rig.cfg.read_text() == FIXTURE
+    assert not rig.calls.exists(), "a --dry-run invoked nixos-rebuild"
+    assert "NOTHING WRITTEN" in p.stdout
+
+
+def test_an_unknown_argument_is_refused_before_any_edit(rig):
+    p = rig.run(args=("--yolo",), expect=64)
+    assert rig.cfg.read_text() == FIXTURE
+    assert "unrecognised argument" in p.stderr
+
+
+# --------------------------------------------------------------------------
+# 🔴 REFUSAL ON DRIFT — the script must never guess which occurrence to edit.
+# Each case mutates the fixture into a state the patch was NOT written against
+# and requires rc=2 AND an untouched file.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("name,mutate,expect_msg", [
+    (
+        "two servers lines",
+        lambda s: s.replace(
+            '    servers = ["/docker.io/203.0.113.1"',
+            '    servers = ["/docker.io/203.0.113.9"];\n    servers = ["/docker.io/203.0.113.1"', 1),
+        "found 2",
+    ),
+    (
+        "settings does not follow servers",
+        lambda s: s.replace("  # router first\n    settings = {",
+                            "  # router first\n    # an interloping comment\n    settings = {"),
+        "is not `settings = {`",
+    ),
+    (
+        "two xorg.xrandr entries",
+        lambda s: s.replace("        xorg.xrandr\n", "        xorg.xrandr\n        xorg.xrandr\n"),
+        "found 2",
+    ),
+    (
+        "the gnome option is simply absent",
+        lambda s: s.replace("  services.gnome.tracker.enable = true;\n", ""),
+        "services.gnome.tracker.enable",
+    ),
+    (
+        "two xdg.portal blocks",
+        lambda s: s.replace("xdg.portal = {\n  enable = true;\n",
+                            "xdg.portal = {\n};\nxdg.portal = {\n  enable = true;\n", 1),
+        "xdg.portal = {",
+    ),
+    (
+        "no dnsmasq servers key at all, in either spelling",
+        lambda s: s.replace('    servers = ["/docker.io/203.0.113.1" "192.168.50.1" "203.0.113.1"];  # router first\n', ""),
+        "cannot tell which state",
+    ),
+])
+def test_it_refuses_on_drift(rig, name, mutate, expect_msg):
+    drifted = mutate(FIXTURE)
+    assert drifted != FIXTURE, f"the {name} mutation is a no-op — the test is vacuous"
+    p = rig.run(cfg_text=drifted, expect=2)
+    assert rig.cfg.read_text() == drifted, f"{name}: the file was modified anyway"
+    assert not rig.calls.exists(), f"{name}: nixos-rebuild ran after a refusal"
+    assert "REFUSING" in p.stderr, p.stderr
+    assert expect_msg in p.stderr, p.stderr
+
+
+def test_a_refusal_is_distinguishable_from_a_bad_argument(rig):
+    """rc 2 = drift, rc 64 = usage. Collapsing them would let a typo read as
+    'the host has drifted, apply by hand'."""
+    assert rig.run(cfg_text=FIXTURE.replace("        xorg.xrandr\n",
+                                            "        xorg.xrandr\n        xorg.xrandr\n"),
+                   expect=2)
+    assert rig.run(args=("--nope",), expect=64)
+
+
+# --------------------------------------------------------------------------
+# the verify section — it must be able to go RED
+# 🔴 Every check below asserts a NON-DEFAULT outcome. A verify block that only
+# ever prints "ok" is indistinguishable from one wired to nothing.
+# --------------------------------------------------------------------------
+def test_verify_passes_on_a_good_activation(rig):
+    p = rig.run(expect=0)
+    assert "ok   1 evaluation warning remains and it is wineWowPackages" in p.stdout
+    assert "ok   workbench.lan -> 192.168.50.250" in p.stdout
+    assert "ok   registry-1.docker.io TTL=33s" in p.stdout
+    assert "contains default=*" in p.stdout
+    # `bad()` is the only thing that prints two spaces then FAIL.
+    assert "  FAIL" not in p.stdout
+
+
+def test_verify_goes_red_when_the_docker_io_pin_did_not_survive(rig):
+    """🔴 THE ONE THAT MATTERS. A 487-day TTL means the LAN router's stale record
+    is being served again — half of all `docker pull`s then fail TLS."""
+    p = rig.run(env={"FAKE_TTL": "42048498"}, expect=1)
+    assert "  FAIL registry-1.docker.io TTL=42048498s" in p.stdout
+    assert "nixos-rebuild switch --rollback" in p.stdout
+
+
+def test_verify_goes_red_on_an_unparseable_ttl(rig):
+    """A garbage TTL must not crash the script under `set -e` — the arithmetic
+    comparison `[[ $ttl -lt 1000 ]]` is a hard error on a non-numeric value, and
+    a crash here skips every remaining check while looking like a failure of
+    something else."""
+    p = rig.run(env={"FAKE_TTL": "notanumber"}, expect=1)
+    assert "could not parse a TTL" in p.stdout
+    assert "VERIFY" in p.stdout
+
+
+def test_verify_goes_red_when_a_warning_other_than_wine_survives(rig):
+    p = rig.run(env={"FAKE_WARNINGS":
+                     "evaluation warning: The option `services.dnsmasq.servers' has been renamed.\n"},
+                expect=1)
+    assert "  FAIL" in p.stdout
+    assert "NOT wineWowPackages" in p.stdout
+
+
+def test_verify_goes_red_when_more_than_one_warning_survives(rig):
+    p = rig.run(env={"FAKE_WARNINGS":
+                     "evaluation warning: one\nevaluation warning: two\n"}, expect=1)
+    assert "  FAIL expected exactly 1 evaluation warning, got 2" in p.stdout
+
+
+def test_verify_goes_red_when_zero_warnings_are_reported(rig):
+    """🔴 A ZERO IS NOT A PASS HERE. Six warnings became one, not none — the
+    wineWowPackages one is deliberately left. Zero means the log was not read
+    (wrong stream, wrong file, a pattern that cannot match), which is exactly
+    the shape of a check wired to nothing."""
+    p = rig.run(env={"FAKE_WARNINGS": ""}, expect=1)
+    assert "  FAIL expected exactly 1 evaluation warning, got 0" in p.stdout
+
+
+def test_verify_goes_red_when_portals_conf_lacks_the_default(rig):
+    p = rig.run(env={"PORTALS_BODY": "[preferred]\ndefault=gtk;\n"}, expect=1)
+    assert "has no 'default=*'" in p.stdout
+
+
+def test_verify_goes_red_when_portals_conf_was_never_created(rig):
+    """Patch B's ONLY observable effect is this file existing."""
+    p = rig.run(env={"NO_PORTALS": "1"}, expect=1)
+    assert "was not created — patch B did not take effect" in p.stdout
+
+
+def test_a_failed_rebuild_names_the_backup_and_does_not_verify(rig):
+    p = rig.run(env={"REBUILD_RC": "1"}, expect=1)
+    assert "nixos-rebuild FAILED" in p.stderr
+    assert "cp -a" in p.stderr and ".bak-" in p.stderr
+    assert "VERIFY" not in p.stdout
+
+
+def test_the_backup_is_the_pre_edit_content(rig):
+    rig.run(expect=0)
+    baks = sorted(rig.dir.glob("configuration.nix.bak-*"))
+    assert len(baks) == 1, baks
+    assert baks[0].read_text() == FIXTURE
+
+
+# --------------------------------------------------------------------------
+# 🔴 the two measured hazards
+# --------------------------------------------------------------------------
+def test_it_preflights_python3_before_touching_anything(rig, tmp_path):
+    """HAZARD 2. `/run/current-system/sw/bin` has no python3 on this host, so a
+    plain `sudo` (env_reset) leaves root without one. Half-applying is the
+    failure mode this preflight exists to prevent: it must fire BEFORE the
+    backup and BEFORE the edit."""
+    # PATH is the shim dir ALONE — no python3, and no coreutils either. The
+    # preflight branch is builtins-only precisely so it still speaks in this
+    # environment; if it ever reaches for `cat` again, this goes red in the nix
+    # sandbox tier where /run/current-system/sw/bin does not exist at all.
+    p = rig.run(env={"PATH": str(rig.bin)}, expect=1)
+    assert "no python3 on PATH" in p.stderr
+    assert 'sudo env "PATH=$PATH" bash' in p.stderr
+    assert rig.cfg.read_text() == FIXTURE
+    assert not list(rig.dir.glob("configuration.nix.bak-*")), "it took a backup anyway"
+    assert not rig.calls.exists()
+
+
+def test_the_nix_path_pin_is_spelled_and_is_a_SET_not_an_UNSET():
+    """HAZARD 1, pinned as a property of the SOURCE.
+
+    It cannot be driven end-to-end here — TEST MODE deliberately skips the pin,
+    because a fixture run makes no claim about this machine's channels — so this
+    is a structural guard and is labelled as one.
+
+    What it holds: the script must EXPORT a NIX_PATH whose `nixpkgs=` entry is
+    root's channel. `unset NIX_PATH` is NOT equivalent and must not creep back
+    in: NixOS's `nix.nixPath` default is what supplies the `nixpkgs=` alias, and
+    root's channel directory is named `nixos`, so with NIX_PATH unset `<nixpkgs>`
+    falls back to nix's built-in default whose first component is
+    `$HOME/.nix-defexpr/channels` — under `sudo -E` that is the user's OLDER
+    unstable channel again, which is the entire hazard.
+    """
+    text = SCRIPT.read_text()
+    assert 'export NIX_PATH="nixpkgs=${ROOT_CHANNELS}/nixos:' in text
+    assert "unset NIX_PATH" not in text
+
+
+def test_the_set_e_rc_capture_uses_the_only_correct_form():
+    """🔴 Both directions of the `set -e` trap, pinned in the source.
+
+    `cmd; rc=$?` is DEAD CODE under `set -e` — the shell dies before the
+    assignment. `cmd || rc=$?` without a preceding `rc=0` crashes under `set -u`
+    on the SUCCESS path, because nothing ever assigns rc. Only `rc=0` followed by
+    `cmd || rc=$?` is correct, and the script must contain no other shape.
+    """
+    lines = SCRIPT.read_text().splitlines()
+    # Comment lines are excluded — the script's own WHY block SPELLS the two
+    # wrong forms in order to name them, and counting those as captures would
+    # make this guard fail on the very prose that documents it.
+    captures = [i for i, l in enumerate(lines)
+                if "rc=$?" in l and not l.lstrip().startswith("#")]
+    assert captures, "no rc capture found — this guard is pinned to nothing"
+    for i in captures:
+        assert "||" in lines[i], f"line {i+1} captures rc without `||`: {lines[i]}"
+        prior = [l.strip() for l in lines[max(0, i - 6):i]]
+        assert "rc=0" in prior, (
+            f"line {i+1} has no `rc=0` above it; under `set -u` the success path "
+            f"reads an unset rc: {lines[i]}")
+
+
+def test_wine_is_deliberately_out_of_scope():
+    """🔴 The sixth warning stays, and the script must say WHY in prose a future
+    maintainer will read before "finishing the job".
+
+    `wineWowPackages` -> `wineWow64Packages` is NOT a rename: the first is a real
+    32+64-bit pair, the second a single 64-bit binary using upstream's WoW64
+    thunking. Different mechanism. Pinned as a whole normalised sentence rather
+    than a keyword, because a guard on WORDS is walkable by rewording.
+    """
+    # Normalised: the leading `# ` of each comment line stripped, then all
+    # whitespace collapsed, so a REWRAP of the paragraph cannot walk this guard.
+    text = " ".join(" ".join(l.lstrip().lstrip("#") for l in
+                             SCRIPT.read_text().splitlines()).split())
+    assert "WHY WARNING 6 STAYS: wineWowPackages IS NOT A RENAME" in text
+    assert 'DO NOT "FINISH THE JOB" BY ADDING IT.' in text
+    assert ("`wineWowPackages` is a genuine 32-bit + 64-bit pair; "
+            "`wineWow64Packages` is a SINGLE 64-bit binary relying on upstream's "
+            "new WoW64 thunking layer to run 32-bit code.") in text
+    assert "One warning is the correct steady state here." in text
+
+    # 🔴 AND IT MUST NOT ACTUALLY TOUCH IT. The only runtime mention allowed is
+    # the verify check that asserts the surviving warning IS this one.
+    body = SCRIPT.read_text()
+    editor = body.split("<<'PYBLOCK'", 1)[1].split("\nPYBLOCK\n", 1)[0]
+    assert "wineWow" not in editor, (
+        "the python editor — the only thing that writes configuration.nix — "
+        "mentions wineWow. It must not touch it at all.")
+
+    runtime = body.split("set -euo pipefail", 1)[1]
+    # The new spelling must never appear outside the WHY block: writing it into
+    # the config is exactly the change this script refuses to make.
+    assert "wineWow64Packages" not in runtime, runtime
+    # Every runtime mention is read-only — a grep of the rebuild log, or the
+    # message reporting what that grep found.
+    mentions = [l.strip() for l in runtime.splitlines()
+                if "wineWow" in l and not l.strip().startswith("#")]
+    assert mentions, "the verify step no longer names the surviving warning"
+    for m in mentions:
+        assert m.startswith(("if printf", "ok ", "bad ")), m

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -1683,6 +1683,32 @@ PINNED_PATH_CLOBBERS = {
         "measure the environment instead of the code. The fixture ASSERTS the "
         "one-entry contents itself, so this justification is a live invariant "
         "rather than prose that can rot"),
+    "test_nixos_option_renames_apply.py": (
+        '"PATH"' + ': str(empty)',
+        "justified by EMPTINESS, the same shape as test_claude_log_rotate.py "
+        "and test_session_stamp_seam.py above. `empty` is `tmp_path / "
+        "\"empty-bin\"`, created by `empty.mkdir()` on the line immediately "
+        "before the clobber and never written to, so it is not merely audited "
+        "but CONSTRUCTED empty — nothing can appear in a freshly-minted tmp "
+        "dir. No HAZARD_VOCABULARY name is reachable through it: no "
+        "systemd-run, systemctl, notify-send, rofi, yad, xdotool, i3-msg, "
+        "openrgb, espanso, home-manager or nixos-rebuild. 🔴 That last one is "
+        "the point worth stating out loud, because this suite's OTHER tests do "
+        "put a `nixos-rebuild` on PATH: it is a `testlib.mockbin.write_exec` "
+        "stub in the rig's own bin dir, and this one test deliberately does NOT "
+        "use that dir. 🔴 REPLACING is required to reach the case at all. The "
+        "test drives apply-nixos-option-renames-2026-09-09.sh's python3 "
+        "preflight — the guard that stops it half-applying an edit to "
+        "/etc/nixos/configuration.nix when a plain `sudo` (env_reset) leaves "
+        "root without a python3, which is the live condition on the workbench "
+        "because /run/current-system/sw/bin has none. python3 is present on the "
+        "dev host AND inside the nix sandbox, so no amount of PREPENDING can "
+        "make it unfindable and a prepending version would measure the "
+        "environment instead of the script. Emptiness is load-bearing a second "
+        "way: the preflight's error branch is written with shell BUILTINS only, "
+        "precisely so it can still speak in an impoverished environment, and an "
+        "empty PATH is what makes that claim observable — a branch that reached "
+        "for `cat` would print nothing and this test would go red"),
 }
 
 


### PR DESCRIPTION
Adds `nix/system/apply-nixos-option-renames-2026-09-09.sh` — a staged sudo script that clears **5 of the workbench's 6** `nixos-rebuild` evaluation warnings — plus 31 hermetic tests.

## What it changes

| # | from | to |
|---|---|---|
| 1 | `services.dnsmasq.servers` | `services.dnsmasq.settings.server` |
| 2 | `services.gnome.tracker.enable` | `services.gnome.tinysparql.enable` |
| 3 | `services.gnome.tracker-miners.enable` | `services.gnome.localsearch.enable` |
| 4 | `xorg.xrandr` | `xrandr` (i3 `extraPackages` **only**) |
| 5 | — | `xdg.portal.config.common.default = "*"` |
| 6 | `wineWowPackages` | **deliberately left alone — see below** |

## Measured, not assumed

Evaluated the patched config against root's channel:

* **Patch A (1–4) is a no-op.** 0 derivations, same system derivation. `settings` is a key-value format with `listsAsDuplicateKeys = true`, so the resolver list renders as identical repeated `server=` lines. `xorg.xrandr` and `xrandr` are the same derivation.
* **Patch B (5)** builds exactly **5 trivial derivations** and adds exactly one file, `/etc/xdg/xdg-desktop-portal/portals.conf`. Realised its content: `[preferred]` / `default=*`.
* Warning count goes **6 → 1**, and the survivor names `wineWowPackages`.

Edit 4 touches only the package-list entry — `sessionCommands` already uses the correct `${pkgs.xrandr}` and is untouched (asserted).

## Why warning 6 stays

`wineWowPackages` → `wineWow64Packages` is **not a rename**. `wineWow` is a genuine 32+64-bit pair; `wineWow64` is a single 64-bit binary relying on upstream's new WoW64 thunking. Different mechanism, different bug surface — and the config's own comment records that the current spelling was tuned until Lutris / Ubisoft Connect worked. Its nixpkgs alias also carries no `# Added <date>`, so `remove-old-aliases.py` structurally skips it: it is the least likely of the six to ever break. One warning is the correct steady state; a test pins the prose that says so.

## Two measured hazards it handles, both silent

1. **`NIX_PATH` poisoning would roll the system backwards.** The interactive `NIX_PATH` starts with `$HOME/.nix-defexpr/channels`, searched *before* the explicit `nixpkgs=` entry, and that channel is an **older** nixpkgs than root's — which the running system was built from. `sudo -E nixos-rebuild switch` (the natural form, since it preserves the PATH hazard 2 needs) evaluates against the older tree and rebuilds ~34 derivations.

   The script **exports an explicit `NIX_PATH`** pinned to root's channel rather than unsetting. `unset` is *not* equivalent: NixOS's `nix.nixPath` default is what supplies the `nixpkgs=` alias, and root's channel directory is named `nixos`, not `nixpkgs` — so with it unset, `<nixpkgs>` resolves via nix's built-in default whose first component is `$HOME/.nix-defexpr/channels` again. Under `sudo -E` that reintroduces the exact hazard.

2. **root has neither `python3` nor `dig`** in `/run/current-system/sw/bin`; both come from the user profile. `python3` is preflighted **before the backup**, using shell builtins only (the branch fires precisely when PATH is impoverished), and prints the exact `sudo env "PATH=$PATH" bash …` remedy rather than half-applying. A missing `dig` degrades the two DNS checks to printed commands instead of skipping them silently.

## Public-repo safety

The script **never spells a resolver address**. It captures the bracketed `servers = [...]` list out of the live config and re-emits it verbatim, so:

* the `/docker.io/` pin cannot be dropped or retyped from a stale copy, and
* no address literal lands in this public repo — `test_no_public_ips.py` needed no allowlist entry.

The test fixture is a structural likeness of the live config using TEST-NET-3 (`203.0.113.0/24`) and RFC 1918 addresses only.

## Refuses on drift

Every edit must match **exactly once** or the script exits 2 having written nothing and tells the operator to apply by hand. Six drift cases are tested. Anchors are line-anchored past whitespace only, so a `#` kills them — which matters here: the live config carries a large commented-out `xdg.portal` experiment including `#xdg.portal.config.common.default = "*";`. A plain substring idempotency check matched that dead line and made the script skip patch B entirely. Caught on the first fixture run against the real config; there is a named regression test.

## Verify section

Commands **with expected values**, not "it worked":

* exactly one `evaluation warning:`, naming `wineWowPackages`
* `dig +short @127.0.0.1 workbench.lan` → the node's own LAN address
* `dig @127.0.0.1 registry-1.docker.io A` → TTL in the **tens** of seconds. ~42,000,000 means the LAN router's 487-day record is back, the pin did **not** survive, and the operator must roll back
* `/etc/xdg/xdg-desktop-portal/portals.conf` contains `default=*`
* printed for the operator (root cannot see them): `systemctl --user list-unit-files | grep -E 'tinysparql|localsearch|tracker'`, and `sudo nixos-rebuild dry-build 2>&1 | grep -c '^evaluation warning:'` → 1
* rollback: `sudo nixos-rebuild switch --rollback`, plus the timestamped `.bak-*`

## Testing

31 hermetic tests. Mutation-swept with `PYTHONDONTWRITEBYTECODE=1`; each mutant was confirmed to fail with the targeted test's own assertion:

| mutant | result |
|---|---|
| comment walk-back loses its trailing space (swallows `#servers =`) | killed |
| portal idempotency back to a plain substring test | killed |
| drift check accepts >1 `servers` lines | killed |
| `rc=0` removed before the `python3` heredoc | killed |
| `xorg.xrandr` replaced by a global `xorg.` swap | killed |
| gnome rename target typo (positive control) | killed |
| byte-delta "nothing else moved" guard deleted | **survived — equivalent** |

The last one is redundant with the external line-level test given a correct implementation, so it is an equivalent mutant. It is proven **reachable** by hand: mis-accounting the xrandr edit by 5 bytes makes it fire with its own message and refuse, and the same bug is written out silently with the branch removed. Labelled as defence-in-depth in the source.

The `xorg.` mutant originally **survived a fully green sweep** — the fixture had only one `xorg.` occurrence, so a global swap was equivalent. Fixed by adding a sibling `xorg.xkill` entry that must survive untouched.

Run it: `sudo bash nix/system/apply-nixos-option-renames-2026-09-09.sh` (or `--dry-run` first, which needs no root).
