### PR TITLE
fix(tests): the co-tenant flake is `git maintenance run --auto --detach`, not `gc --auto`

### DIFF
--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -231,6 +231,30 @@ _GIT_ENV = {
     "GIT_AUTHOR_EMAIL": "guard9@example.invalid",
     "GIT_COMMITTER_NAME": "guard nine",
     "GIT_COMMITTER_EMAIL": "guard9@example.invalid",
+    # 🔴 THE CO-TENANT FLAKE, DIAGNOSED FROM ITS OWN CAPTURE. `git commit` spawns
+    # `git maintenance run --auto --quiet --detach`. It is DETACHED, so
+    # `subprocess.run` returns when the commit exits while that process lives on
+    # with its cwd inside the just-created repo — and `live_cotenants` matches on
+    # exactly that. Observed in the sandbox tier 2026-09-09, cmdline and cwd
+    # captured by the diagnostic devrc#1340 added for this purpose:
+    #   127877:git cwd='…/test_live_cotenants_sees_anoth0/repo'
+    #   cmdline='…/git-core/git maintenance run --auto --quiet --detach'
+    #
+    # 🔴 THIS IS NOT `gc --auto`, AND THAT REFUTATION STANDS. The earlier theory
+    # was killed twice over — arithmetically (`_mkrepo` leaves 3 loose objects
+    # against a 6700 threshold) and empirically (0 hits in 80 iterations with
+    # `gc.auto=0` forced). Both were correct: `maintenance run --auto` is a
+    # DIFFERENT code path, reached from `git commit` regardless of `gc.auto`, and
+    # it decides per-task AFTER the process exists. So `gc.auto` is deliberately
+    # NOT set here — adding it would look like belt-and-braces and would quietly
+    # re-legitimise a theory the evidence disproved.
+    #
+    # Set through `GIT_CONFIG_*` rather than `-c` per call so it covers EVERY git
+    # invocation in this file, including ones added later; a `-c` on the three
+    # current call sites is one new call site away from the flake returning.
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "maintenance.auto",
+    "GIT_CONFIG_VALUE_0": "false",
 }
 
 
@@ -262,6 +286,66 @@ def _mkrepo(path: Path, branch: str = "main") -> Path:
 # --------------------------------------------------------------------------- #
 # 0. harness self-validation
 # --------------------------------------------------------------------------- #
+def test_mkrepo_spawns_no_detached_git_maintenance(tmp_path):
+    """🔴 THE CO-TENANT FLAKE, PINNED BY THE SPAWN RATHER THAN BY THE RACE.
+
+    `git commit` runs `git maintenance run --auto --quiet --detach`. Because it
+    is DETACHED, `subprocess.run` returns when the commit exits while that child
+    lives on with its cwd inside the repo just created — and `live_cotenants`
+    matches on cwd, so it reports a tenant in a repo microseconds old. That is
+    the whole mechanism, taken from the failure's own captured cmdline rather
+    than theorised.
+
+    Waiting for the race to recur is not a test: it went 0/80 in a deliberate
+    loop and then fired in the sandbox tier. `GIT_TRACE2_EVENT` makes it
+    DETERMINISTIC — git records every child it spawns, so the assertion is over
+    a spawn count, not over a timing window.
+
+    🔴 THE POSITIVE CONTROL IS THE HALF THAT MATTERS. A zero from a trace that
+    recorded nothing is indistinguishable from a zero from a suppressed spawn,
+    and this repo refuses that reading. So the same commit runs WITHOUT the
+    suppression first and must show the spawn.
+    """
+    def commit_and_trace(repo: Path, env: dict) -> tuple[int, str]:
+        trace = tmp_path / f"trace-{repo.name}.json"
+        repo.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(repo)],
+                       check=True, capture_output=True, env=env)
+        (repo / "f.txt").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "f.txt"],
+                       check=True, capture_output=True, env=env)
+        subprocess.run(["git", "-C", str(repo), "commit", "-qm", "base"],
+                       check=True, capture_output=True,
+                       env={**env, "GIT_TRACE2_EVENT": str(trace)})
+        text = trace.read_text(encoding="utf-8") if trace.exists() else ""
+        return text.count('"maintenance"'), text
+
+    # POSITIVE CONTROL — the suppression removed, so the spawn must be visible.
+    bare = {k: v for k, v in _env().items() if not k.startswith("GIT_CONFIG_")}
+    control_hits, control_text = commit_and_trace(tmp_path / "control", bare)
+    assert control_text, (
+        "GIT_TRACE2_EVENT wrote nothing — the instrument is not recording, so a "
+        "zero below would mean nothing at all"
+    )
+    assert control_hits > 0, (
+        f"the control did not spawn `git maintenance`, so this test cannot see "
+        f"the thing it exists to pin. git may have changed the trigger; "
+        f"re-derive it before trusting the assertion below.\n{control_text[:800]}"
+    )
+    assert "--detach" in control_text, (
+        f"the spawn is no longer DETACHED, which is what makes it outlive the "
+        f"parent and become a co-tenant. Re-read the mechanism.\n{control_text[:800]}"
+    )
+
+    # UNDER TEST — the harness env every git call in this file uses.
+    hits, text = commit_and_trace(tmp_path / "under-test", _env())
+    assert hits == 0, (
+        f"`_mkrepo`'s environment still spawns `git maintenance`: the detached "
+        f"child outlives the commit with its cwd in the new repo, and "
+        f"`live_cotenants` reports it as a tenant.\n{text[:800]}"
+    )
+
+
 def test_every_file_the_ledgers_read_exists():
     """Every ledger assertion below reads one of these. If one moved, the
     assertion would parse an empty string and pass while measuring nothing."""


### PR DESCRIPTION
fix(tests): the co-tenant flake is `git maintenance run --auto --detach`, not `gc --auto`

RANK 1, and it was event-blocked by design: the handoff said "wait for the next
sandbox red and read the cwd=/cmdline= the assertion now prints". It fired on
2026-09-09 and the diagnostic devrc#1340 shipped for exactly this captured it:

  127877:git cwd='…/test_live_cotenants_sees_anoth0/repo'
  cmdline='…/git-core/git maintenance run --auto --quiet --detach'

MECHANISM: committing spawns `git maintenance run --auto --quiet --detach`.
Because it is DETACHED, `subprocess.run` returns when the parent exits while that
child lives on with its cwd inside the repo created microseconds earlier —
`live_cotenants` matches on cwd, so it reports a tenant in a brand-new repo.

THE `gc --auto` REFUTATION STANDS, AND THAT IS WHY THIS TOOK SO LONG. It was
killed twice — arithmetically (`_mkrepo` leaves 3 loose objects against a 6700
threshold) and empirically (0/80 with `gc.auto=0` forced). Both were RIGHT.
`maintenance run --auto` is a different code path, reached regardless of
`gc.auto`, deciding per-task only AFTER the process exists. So `gc.auto` is
deliberately NOT set here: adding it would read as belt-and-braces while quietly
re-legitimising a theory the evidence disproved.

FIX: `maintenance.auto=false` via `GIT_CONFIG_*` in `_GIT_ENV`, so it covers
EVERY git invocation in the file including ones added later. A `-c` on the three
current call sites is one new call site away from the flake returning.

TEST — pinned by the SPAWN, not by the race. Waiting for the race is not a test:
it went 0/80 in a deliberate loop and then fired in the sandbox tier.
`GIT_TRACE2_EVENT` makes it deterministic, because git records every child it
spawns, so the assertion is a spawn count.

  MEASURED, both directions:
    without the suppression -> argv ["git","maintenance","run","--auto",
                                    "--quiet","--detach"] present
    with it                 -> 0 spawns

  The positive control is the half that matters: a zero from a trace that
  recorded nothing is indistinguishable from a zero from a suppressed spawn. The
  test asserts the trace is non-empty, that the control DID spawn, and that the
  spawn carried `--detach` — the property that makes it outlive its parent.

  Mutation: removing the suppression KILLS it with its own message; control 116
  passed either side. One mutant run showed a SECOND failure whose name I did
  not capture, and a repeat run showed only one — consistent with the co-tenant
  race firing under the mutant, but not recorded, so not claimed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AwUQmUw99gqMug4T3ruFNC

---
## How this was found

Not by looking. The handoff ranked this #1 with `forcing: gate` and marked it
event-blocked: the mechanism was unknown, so devrc#1340 shipped a DIAGNOSTIC
instead of a guess — the assertion prints the intruder's cwd and cmdline, because
`/proc` for a transient process is gone by the time anyone reads a log. It fired
during an unrelated docs PR's gate and named its own cause in one line.

That is the whole argument for shipping the diagnostic rather than `gc.auto=0`:
the one-line "fix" would have looked like a resolution, and the real mechanism
would have stayed open behind it.

## Gating

Merged tree, sandbox tier — the tier a merge gates on. The dev-host tier has been
hitting its 3600s wall clock all session under ambient load from other sessions
(80-90 on 24 cores); where it could not complete, the discriminating control was
the killed target run standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUQmUw99gqMug4T3ruFNC
