### PR TITLE
test: two coverage guards whose description was wider than their implementation

### DIFF
--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -928,8 +928,16 @@ def guessed_note(subject: str, below: int = 0, rank: int = 1) -> str:
     🔴 IT NAMES THE CLICKED TEXT AND TWO COUNTS, NOTHING ELSE — never the
     repository, never the mapping. The candidate ROW already shows the repo,
     which is the whole point of asking; the note must not become a second place
-    a name can leak from, and `_every_sink`'s guards would not see this one (it
-    goes to rofi).
+    a name can leak from.
+
+    ⚠ AND THE TEST SUITE'S `_every_sink` HELPER CANNOT SEE THIS STRING. It folds
+    stdout, stderr and the `notify-send` argv — the sinks that outlive the click;
+    this line goes to the picker, which is a transient window on the operator's
+    own screen and is reached through `pick()`, which the tests replace. So the
+    rule above is enforced by the per-site guards on `mesg` instead —
+    `_no_universe_token_anywhere` for the mapping, and
+    `_no_guessed_repo_token_anywhere` for the pane's own repo, which the first
+    one is structurally blind to (a guess never comes from the mapping).
     """
     if below <= 0:
         return (f"{subject} names no repository — the GitHub row offered was "

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -1553,6 +1553,22 @@ FAKE_UNIVERSE_TOKENS = (
     | {v.split("/")[1] for v in FAKE_UNIVERSE.values()}
 )
 
+# 🔴 THE PANE-GUESSED REPO IS A SECOND NAME THE NOTES MUST NOT CARRY, AND IT IS
+# NOT IN THE UNIVERSE. That is the point of it — a guess comes from the tmux
+# pane, not from the mapping — and it is exactly why
+# `_no_universe_token_anywhere` is STRUCTURALLY BLIND to a leak of it: every
+# token that check knows comes from `FAKE_UNIVERSE`, which by construction does
+# not contain this. So a mutant that spliced the guessed repo into the note
+# ("Row 1 is a guess from the tmux pane (wrongorg/wrongrepo)" — a natural-looking
+# improvement) passed every assertion in this file, under docstrings that said
+# the note "must not name a repository".
+PANE_GUESS = "wrongorg/wrongrepo"
+PANE_GUESS_TOKENS = {
+    PANE_GUESS,
+    PANE_GUESS.split("/")[0],
+    PANE_GUESS.split("/")[1],
+}
+
 
 def test_the_fixtures_KEYS_and_VALUES_are_pairwise_distinct():
     """🔴 THE GUARD ON THE GUARDS. Every disclosure assertion below is only as
@@ -1572,6 +1588,53 @@ def test_the_fixtures_KEYS_and_VALUES_are_pairwise_distinct():
                 assert a not in b, (
                     f"{a!r} is a substring of {b!r} — a leak of the first would "
                     f"be indistinguishable from a leak of the second")
+
+
+def test_the_pane_guess_is_OUTSIDE_the_universe_and_spelled_distinctly():
+    """🔴 THE GUARD ON THE SECOND LEDGER, and it pins the very property that
+    makes the second ledger necessary.
+
+    If `PANE_GUESS` were in `FAKE_UNIVERSE`, `_no_universe_token_anywhere` would
+    already cover it and `_no_guessed_repo_token_anywhere` would be decoration
+    that no mutation could kill. It is out, deliberately — and the two token sets
+    must stay disjoint, or a leak of one becomes indistinguishable from a leak of
+    the other.
+    """
+    assert PANE_GUESS not in FAKE_UNIVERSE.values(), PANE_GUESS
+    assert PANE_GUESS not in FAKE_UNIVERSE, PANE_GUESS
+    assert not (PANE_GUESS_TOKENS & FAKE_UNIVERSE_TOKENS), (
+        PANE_GUESS_TOKENS & FAKE_UNIVERSE_TOKENS)
+    assert len(PANE_GUESS_TOKENS) == 3, PANE_GUESS_TOKENS
+    for a in PANE_GUESS_TOKENS:
+        for b in PANE_GUESS_TOKENS:
+            if a != b and "/" not in a and "/" not in b:
+                assert a not in b, (
+                    f"{a!r} is a substring of {b!r} — a leak of the first would "
+                    f"be indistinguishable from a leak of the second")
+    # ...and no token may be a word the note legitimately uses, or the guard
+    # would be red on correct output rather than on a leak.
+    for token in PANE_GUESS_TOKENS:
+        assert token not in MO.guessed_note("audit-pr 1291", below=3, rank=1)
+        assert token not in MO.guessed_note("audit-pr 1291")
+
+
+def _no_guessed_repo_token_anywhere(everywhere: str, label: str) -> None:
+    """🔴 THE NOTE MUST NOT NAME THE GUESSED REPOSITORY EITHER.
+
+    `guessed_note`'s own docstring says it "names the clicked text and two
+    counts, NOTHING ELSE — never the repository", and until 2026-09-09 the only
+    check behind that sentence was `_no_universe_token_anywhere`, which cannot
+    see this name at all (see `PANE_GUESS`). A guard reading as coverage while
+    providing none is worse than none: it stops anyone looking.
+
+    The disclosure argument is the same one as for the universe. The candidate
+    ROW already shows the repository — that is what the operator is being asked
+    about — so the note repeating it buys nothing and adds a second place a name
+    can escape from. It is also the wrong claim: the note explains why a choice
+    is being offered, and the pane's repo is not part of that explanation.
+    """
+    for token in sorted(PANE_GUESS_TOKENS):
+        assert token not in everywhere, f"{label}: {token}"
 
 
 def _no_universe_token_anywhere(everywhere: str, label: str) -> None:
@@ -1706,9 +1769,17 @@ def test_the_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
 
     The count is now pinned by
     `test_a_GUESSED_repo_is_offered_WITH_the_whole_universe_beneath_it`, which
-    is the regression for the report."""
+    is the regression for the report.
+
+    🔴 "IT MUST NOT NAME A REPOSITORY" IS NOW ACTUALLY CHECKED. The body used to
+    run `_no_universe_token_anywhere` alone, which knows only the tokens in
+    `FAKE_UNIVERSE` — and the repository this test is ABOUT is the pane guess,
+    which is deliberately NOT in it. So the sentence covered every repository
+    except the one at issue, and a mutant leaking the guess into the note passed
+    under a docstring claiming otherwise. Both ledgers are asserted now; see
+    `_no_guessed_repo_token_anywhere`."""
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
-    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: PANE_GUESS)
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(n=len(c), mesg=mesg) or "")
@@ -1718,6 +1789,7 @@ def test_the_picker_for_a_guessed_repo_SAYS_WHY(monkeypatch):
     assert "audit-pr 1291" in seen["mesg"], seen
     assert "tmux pane" in seen["mesg"], seen
     _no_universe_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
+    _no_guessed_repo_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
 
 
 def test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess(monkeypatch):
@@ -1754,6 +1826,7 @@ def test_the_bare_hash_N_picker_SAYS_the_github_row_is_a_guess(monkeypatch):
     assert "guess" in seen["mesg"].lower(), seen["mesg"]
     assert "nothing here knows" not in seen["mesg"], seen["mesg"]
     _no_universe_token_anywhere(seen["mesg"], "BARE-HASH-N GUESS NOTE")
+    _no_guessed_repo_token_anywhere(seen["mesg"], "BARE-HASH-N GUESS NOTE")
 
 
 @pytest.mark.parametrize("text,expected", [
@@ -1785,7 +1858,13 @@ def test_the_suppression_reads_mention_scans_OWN_source_constant():
     a hand-spelled `"default"` here would silently stop firing the day
     `mention_scan` renamed the constant — with every suite green, because the
     branch would simply never be taken."""
-    import mention_scan as MS  # noqa: PLC0415 — see `_load_handler`'s sys.path
+    # noqa: PLC0415 — deliberately local, and it binds the SAME module object
+    # the handler imported: `exec_module(MO)` at the top of this file already put
+    # `scripts/collector` on `sys.path` and left `mention_scan` in `sys.modules`.
+    # (This comment used to point at `_load_handler`, a function that does not
+    # exist in this file and, by `git log -S`, never has — the loader has always
+    # been the module-level block beside `MO`.)
+    import mention_scan as MS  # noqa: PLC0415
 
     assert MO.SOURCE_DEFAULT is MS.SOURCE_DEFAULT
     assert MO.SOURCE_DEFAULT == "default"
@@ -2343,20 +2422,41 @@ def test_every_flag_refusal_the_handler_can_produce_survives_notify_send(
             f"got no `--`, so the toast never appears: {argv}")
 
 
-# The universe rows may reach the operator's rofi window and NOWHERE else, so
-# every sink the handler can write to is enumerated here rather than left to
+# The universe rows may reach the operator's own PICKER WINDOW and nowhere else,
+# so every sink the handler can write to is enumerated here rather than left to
 # whichever one a test happened to think of. A sink missing from this list is a
 # hole; adding one to the module means adding it here.
 #
-# 🔴 THE THREE SINKS ARE STDOUT, STDERR AND THE `notify-send` ARGV — and that is
-# the WHOLE list, because those are the only places `mention-open.py` writes.
-# It has no log file and no spool: it is a detached one-shot click handler. The
-# guard below used to be named `..._a_LOG_a_SPOOL_or_stderr`, which promised
-# coverage of two sinks that do not exist and understated the one that does (a
-# desktop toast is more public than either). A guard whose NAME is wider than
-# its body reads as coverage while providing none, which is worse than none —
-# it stops anyone looking. The tailer is the module with a spool, and its own
-# disclosure guards are in `test_session_tailer.py`.
+# 🔴 THE THREE SINKS THIS FOLDS ARE STDOUT, STDERR AND THE `notify-send` ARGV,
+# AND THAT IS NOT EVERY PLACE THE MODULE WRITES. There is a FOURTH destination —
+# the interactive picker: its rows, and the `mesg` line above them. This helper
+# cannot see it and never will, because the picker is reached through `pick()`,
+# which every test here replaces with a spy.
+#
+# 🔴 THAT EXCLUSION IS THE DESIGN, NOT A GAP. The picker is the ONE surface the
+# universe is allowed to reach — offering those rows is the entire feature —
+# so folding it in would make every disclosure assertion below red on correct
+# behaviour. The distinction is not "three sinks vs four": it is
+# PUBLISHED-vs-PRIVATE. stdout, stderr and a desktop toast outlive the click and
+# can be read by something other than the person who clicked; the picker is a
+# transient window on the operator's own screen, drawn by this process, gone the
+# moment they choose or dismiss. The property is about the SINK, not about which
+# program draws it — swapping the picker implementation changes nothing here.
+#
+# 🔴 AND "MAY SHOW THE UNIVERSE" IS NOT "MAY SHOW ANYTHING". The picker's own
+# `mesg` is guarded separately, at each site that builds one, by
+# `_no_universe_token_anywhere` and `_no_guessed_repo_token_anywhere` — see
+# `guessed_note`'s docstring in the handler, which says outright that this
+# helper "would not see this one".
+#
+# ⚠ THE PARAGRAPH ABOVE REPLACES ONE THAT READ "that is the WHOLE list, because
+# those are the only places `mention-open.py` writes". That was false in the
+# same shape it was written to warn about: the handler's own module docstring
+# and `guessed_note` both name the picker, and a reader who believed the
+# sentence would conclude a `mesg` leak was already covered here. It also still
+# holds for what it WAS about — this module has no log file and no spool (the
+# tailer is the module with a spool; its disclosure guards live in
+# `test_session_tailer.py`) — and that half is kept.
 def _every_sink(capsys, notify_argv: list[list[str]]) -> str:
     captured = capsys.readouterr()
     return "\n".join([captured.out, captured.err,
@@ -2844,6 +2944,7 @@ def test_a_guessed_picker_is_NOT_described_as_nothing_here_knows(monkeypatch):
     # the old wording — is now false: neither is what the operator should do.
     assert "search" in seen["mesg"].lower(), seen["mesg"]
     _no_universe_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
+    _no_guessed_repo_token_anywhere(seen["mesg"], "GUESSED-NOTE DISCLOSURE")
 
 
 def test_the_ONE_ROW_wording_survives_for_an_EMPTY_universe(monkeypatch):

--- a/scripts/tests/test_regen_known_repos.py
+++ b/scripts/tests/test_regen_known_repos.py
@@ -30,18 +30,109 @@ _spec.loader.exec_module(RG)
 # --------------------------------------------------------------------------- #
 # 🔴 The disclosure guard
 # --------------------------------------------------------------------------- #
-_PAIR_RE = re.compile(
-    r"""["']([A-Za-z0-9][A-Za-z0-9._-]*)["']\s*:\s*["']([A-Za-z0-9-]+/[A-Za-z0-9._-]+)["']""")
+# What an `owner/repo` looks like. Shared by BOTH detectors below — the mapping
+# one asks it of a dict's VALUES, the universe one of a list's ELEMENTS — so the
+# two arms cannot drift on what a repository name is.
+_FULL_NAME_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 # A repo mapping is many DISTINCT names pointing at `owner/repo`. Counting
 # occurrences instead flagged a dl-router fixture that repeats ONE key 45 times
 # (`dupRelPath: "john-smith/75936.mov"`); the leaked file had 420 distinct keys.
+#
+# 🔴 THE NUMBER IS NOT THE GUARD — THE SHAPE IS, AND THAT IS WHY THIS ONE IS
+# SAFE TO LEAVE ALONE. `looks_like_a_repo_mapping` counts keys inside ONE dict
+# literal, so reaching 20 takes a single object mapping 20 distinct names at
+# `owner/repo` — which is a repo mapping, not a coincidence. MEASURED across all
+# 562 published `.json`/`.py` files on 2026-09-09: largest score **9**
+# (`scripts/check-clickup-addressed/check-completion.py`, a hand-curated
+# vocabulary), i.e. 11 keys of headroom in ONE literal. Under the text sweep this
+# replaced, the largest was **19** — one added fixture from reddening a
+# DISCLOSURE guard, because unrelated pairs anywhere in a 700-line file were
+# summed together.
+#
+# ⚠ NO RATCHET IS ASSERTED ON THAT HEADROOM, DELIBERATELY. A "largest ordinary
+# file must stay under N" test is a second fixed threshold, and the curated
+# vocabulary above is a legitimate mapping that may grow — the guard would go
+# red on an honest edit, which is the failure mode this change removed. The
+# measurement is recorded here; the enforcement is the shape.
 MAPPING_KEY_THRESHOLD = 20
 
 
+def _json_dicts(text: str):
+    """Every `dict` in `text` read as a JSON document, at any depth."""
+    try:
+        doc = json.loads(text.strip())
+    except ValueError:
+        return
+    stack = [doc]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            yield node
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
 def looks_like_a_repo_mapping(text: str) -> int:
-    """How many DISTINCT `name: "owner/repo"` keys `text` carries."""
-    return len({k for k, _ in _PAIR_RE.findall(text)})
+    """How many DISTINCT `name -> "owner/repo"` keys the BIGGEST single MAPPING
+    LITERAL in `text` carries.
+
+    🔴 ONE LITERAL, NOT THE WHOLE FILE — AND THAT IS THE FIX, NOT A RELAXATION.
+    This used to `re.findall` a `"key": "owner/repo"` pattern across the entire
+    text and count the distinct keys, which sums pairs that have nothing to do
+    with each other: unrelated fixtures, several small dicts, a docstring and a
+    parametrize list all added into one number. MEASURED 2026-09-09, this very
+    file scored **19** against a threshold of 20 — one added fixture from
+    reddening a DISCLOSURE guard, and the fixes that come to hand under pressure
+    (raise the number, exclude the file) are the ones that gut it. The number was
+    never the guard; the SHAPE is. `looks_like_a_repo_universe` had already
+    reached the same conclusion for the list shape and used `ast` for exactly
+    this reason — this is that argument applied to the dict shape.
+
+    🔴 BOTH INCIDENT SPELLINGS ARE STILL CAUGHT, and they are the whole point:
+      * a `.py` module holding `KNOWN_REPOS = {...}` — the ORIGINAL incident, a
+        generator writing its output into a module that was then committed. It
+        is an `ast.Dict` literal, counted here.
+      * a `.json` file of the same mapping — what the generator emits today. It
+        is a JSON object, counted here, at ANY depth, so wrapping it in
+        `{"repos": {...}}` does not hide it.
+    A dict-literal count on the artefact is if anything TIGHTER than the old
+    text sweep: 420 keys in one literal is 420 either way, and no ordinary file
+    reaches 20 by accident (measurement beside `MAPPING_KEY_THRESHOLD`).
+
+    ⚠ WHAT IT CANNOT SEE, stated rather than papered over:
+      * a mapping SPLIT across several smaller literals, or built by a
+        comprehension, a `dict(...)` call, or key-by-key assignment. That is the
+        same residual `looks_like_a_repo_universe` already documents, and it is
+        deliberate: this detects the DUMP, which is how this has gone wrong.
+      * a mapping embedded as an escaped JSON string inside another document.
+      * anything outside `.json`/`.py` — the sweep's file filter, unchanged.
+    """
+    best = 0
+    for node in _json_dicts(text):
+        best = max(best, len({k for k, v in node.items()
+                              if isinstance(v, str) and _FULL_NAME_RE.match(v)}))
+    # The Python-literal spelling. `ast` rather than a regex, so a dict is
+    # recognised as a dict rather than as "some quoted strings near a colon" —
+    # and a non-constant key (`'X'.lower()`, a variable) is skipped instead of
+    # being scraped out of the source text.
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return best
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = set()
+        for k, v in zip(node.keys, node.values):
+            if (isinstance(k, ast.Constant) and isinstance(k.value, str)
+                    and isinstance(v, ast.Constant) and isinstance(v.value, str)
+                    and _FULL_NAME_RE.match(v.value)):
+                keys.add(k.value)
+        best = max(best, len(keys))
+    return best
 
 
 # 🔴 A SECOND SHAPE, BECAUSE THE GENERATOR NOW EMITS A SECOND FILE — AND THE
@@ -51,9 +142,8 @@ def looks_like_a_repo_mapping(text: str) -> int:
 # that is a WIDER disclosure than the mapping (it is deliberately unfiltered, so
 # it names MORE private repositories). Committing one would have sailed past the
 # guard that exists precisely to stop that — the same structural blindness that
-# let the original incident through, in a new shape.
-_FULL_NAME_RE = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+# let the original incident through, in a new shape. (`_FULL_NAME_RE` is defined
+# above `looks_like_a_repo_mapping`, which now shares it.)
 
 
 def _owner_repo_count(items) -> int:
@@ -121,6 +211,55 @@ def test_the_mapping_detector_FIRES_on_a_realistic_mapping():
         "{'a': 'o/a', 'b': 'o/b', 'c': 'o/c'}") < MAPPING_KEY_THRESHOLD
 
 
+def test_the_mapping_detector_FIRES_on_the_JSON_the_generator_ACTUALLY_WRITES():
+    """🔴 THE SECOND POSITIVE CONTROL, AND IT IS THE ONE THAT MATTERS TODAY.
+
+    The `.py` control above is the ORIGINAL incident's shape — a generator's
+    output pasted into a module. What the generator emits NOW is a JSON object,
+    and a detector that only understood Python would score it 0 while the file
+    sat in the tree. Built by `write_mapping` itself rather than by hand, so
+    this cannot drift from the artefact it is about.
+
+    ⚠ AT DEPTH TOO. A committed copy is as likely to arrive wrapped
+    (`{"generated": …, "repos": {…}}`) as bare, and a top-level-only reader
+    would score that 0.
+    """
+    mapping = {f"{n}{i}": f"gardenersguild/{n}{i}"
+               for i, n in enumerate(["Trowelcast", "SledgeHorn",
+                                      "PloughShare"] * 9)}
+    bare = json.dumps(mapping, indent=1)
+    assert looks_like_a_repo_mapping(bare) >= MAPPING_KEY_THRESHOLD
+    wrapped = json.dumps({"generated": "2026-09-09T00:00:00Z", "repos": mapping})
+    assert looks_like_a_repo_mapping(wrapped) >= MAPPING_KEY_THRESHOLD, (
+        "a mapping nested one level down scored below the threshold — the JSON "
+        "reader is looking at the top level only")
+
+
+def test_the_mapping_detector_counts_ONE_LITERAL_not_the_whole_file():
+    """🔴 THE STRUCTURAL PROPERTY, ASSERTED — this is what replaced a threshold
+    the next fixture was going to trip.
+
+    Pairs scattered across many unrelated small dicts are not a repo mapping,
+    however many of them a long file happens to contain. Summing them is what
+    put THIS file at 19 of 20 on 2026-09-09; the arithmetic said "one fixture
+    from red" while nothing in the tree was anywhere near being a dump.
+
+    ⚠ THIS IS A DELIBERATE NARROWING AND IT IS NAMED IN
+    `looks_like_a_repo_mapping`'s docstring. What it gives up — a mapping split
+    across several literals — has never been how this went wrong; what it buys
+    is a guard that fires on the artefact and on nothing else, which is the only
+    kind anyone leaves switched on.
+    """
+    scattered = "\n".join(
+        f"CASE_{i} = {{'name{i}': 'gardenersguild/thing{i}'}}"
+        for i in range(3 * MAPPING_KEY_THRESHOLD)
+    )
+    # The old text sweep counted 60 distinct keys here.
+    assert len(re.findall(r"'name\d+':", scattered)) == 3 * MAPPING_KEY_THRESHOLD
+    assert looks_like_a_repo_mapping(scattered) == 1, (
+        "unrelated one-entry dicts are being summed into one score again")
+
+
 def test_the_UNIVERSE_detector_FIRES_and_the_mapping_one_is_BLIND_to_it():
     """🔴 THE NEGATIVE CONTROL FOR THE SECOND SHAPE — and it asserts the BLIND
     SPOT explicitly, because that is the finding rather than a side note.
@@ -180,16 +319,15 @@ def candidate_files(root: Path | None = None) -> tuple[str, list[Path]]:
     return "filesystem walk (no .git — sandbox tier)", found
 
 
-def test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo():
-    """🔴 THE INCIDENT GUARD. This repo is public and the mapping names private
-    repositories. Keyed on CONTENT rather than on a filename, so a copy under
-    any name or in any directory fails it: the claim is 'no published file IS
-    this mapping', not 'the old path is absent'.
+def disclosure_offenders(files, root: Path) -> list[str]:
+    """Every file in `files` that IS a repo mapping or a picker universe.
+
+    Lifted out of the guard below so the guard's own negative control can drive
+    the SAME loop over a planted tree. It used to be inline, which left the only
+    evidence that the sweep can go red as a synthetic call to
+    `looks_like_a_repo_mapping` — a claim about the detector, never about the
+    loop that reads files and assembles the verdict.
     """
-    how, files = candidate_files()
-    assert len(files) > 100, (
-        f"the sweep examined only {len(files)} file(s) via {how} — a zero from "
-        f"a sweep that walked nothing is the failure, not the all-clear")
     offenders = []
     for path in files:
         try:
@@ -198,7 +336,7 @@ def test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo():
             continue
         keys = looks_like_a_repo_mapping(text)
         if keys >= MAPPING_KEY_THRESHOLD:
-            offenders.append(f"{path.relative_to(ROOT)} ({keys} distinct repo keys)")
+            offenders.append(f"{path.relative_to(root)} ({keys} distinct repo keys)")
             continue
         # 🔴 THE UNIVERSE SHAPE, CHECKED ON THE SAME SWEEP RATHER THAN IN A
         # SECOND TEST — one walk, one `len(files) > 100` floor, one place for a
@@ -207,7 +345,59 @@ def test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo():
         fulls = looks_like_a_repo_universe(text)
         if fulls >= MAPPING_KEY_THRESHOLD:
             offenders.append(
-                f"{path.relative_to(ROOT)} ({fulls} distinct owner/repo names)")
+                f"{path.relative_to(root)} ({fulls} distinct owner/repo names)")
+    return offenders
+
+
+def test_the_incident_guard_CAN_GO_RED_on_both_incident_spellings(tmp_path):
+    """🔴 THE NEGATIVE CONTROL FOR THE GUARD BELOW, on a PLANTED tree.
+
+    The guard's passing verdict is an empty list, which is indistinguishable
+    from a loop wired to nothing — so this feeds it the two artefacts it exists
+    to catch and watches the number move. Both spellings, because the detector
+    was rewritten to be structural and "still catches the incident" is the claim
+    that rewrite has to keep:
+
+      * `.py` — a module holding `KNOWN_REPOS = {...}`. THE ORIGINAL INCIDENT: a
+        generator's output pasted into a committed module.
+      * `.json` — the mapping file the generator writes today, verbatim.
+
+    Both are built by `RG.write_mapping`/`json.dumps` from a realistic 27-entry
+    mapping rather than by hand, and an ordinary file sits beside them so the
+    result is a SELECTION and not "everything is an offender".
+    """
+    mapping = {f"{n}{i}": f"gardenersguild/{n}{i}"
+               for i, n in enumerate(["Trowelcast", "SledgeHorn",
+                                      "PloughShare"] * 9)}
+    (tmp_path / "leaked.json").write_text(json.dumps(mapping, indent=1))
+    (tmp_path / "pasted.py").write_text(
+        "KNOWN_REPOS = " + repr(mapping) + "\n")
+    (tmp_path / "ordinary.py").write_text(
+        "# mentions gardenersguild/trowelcast in passing\nX = {'a': 'o/a'}\n")
+
+    how, files = candidate_files(tmp_path)
+    assert len(files) == 3, sorted(f.name for f in files)
+    named = sorted(o.split(" ")[0] for o in disclosure_offenders(files, tmp_path))
+    assert named == ["leaked.json", "pasted.py"], (
+        f"the guard did not flag both incident spellings, and only them: "
+        f"{disclosure_offenders(files, tmp_path)}")
+
+
+def test_the_generated_mapping_is_NOT_published_anywhere_in_this_repo():
+    """🔴 THE INCIDENT GUARD. This repo is public and the mapping names private
+    repositories. Keyed on CONTENT rather than on a filename, so a copy under
+    any name or in any directory fails it: the claim is 'no published file IS
+    this mapping', not 'the old path is absent'.
+
+    ⚠ Its passing verdict is an EMPTY LIST, so the proof that it can go red is
+    `test_the_incident_guard_CAN_GO_RED_on_both_incident_spellings`, which
+    drives the same `disclosure_offenders` loop over a planted tree.
+    """
+    how, files = candidate_files()
+    assert len(files) > 100, (
+        f"the sweep examined only {len(files)} file(s) via {how} — a zero from "
+        f"a sweep that walked nothing is the failure, not the all-clear")
+    offenders = disclosure_offenders(files, ROOT)
     assert offenders == [], (
         f"file(s) look like a repo mapping or picker universe (via {how}): "
         f"{offenders}. Both name PRIVATE repositories and this repo is PUBLIC — "


### PR DESCRIPTION
Two independent coverage-claim defects — guards whose DESCRIPTION was wider than
their implementation, which `claude/RULES.md` records as worse than no guard
because it stops anyone looking.

They touch disjoint files and are separate commits. There was a third item in
this batch (`ship.sh`'s off-LAN blind spot); **#1439 got there first and is the
better implementation** — see the closing note.

---

## 1. The note's "never names a repository" was checked against every repo EXCEPT the guessed one

**Root cause.** `test_the_picker_for_a_guessed_repo_SAYS_WHY`'s docstring claims
the note "must not name a repository". The only check behind that sentence was
`_no_universe_token_anywhere`, which knows the tokens in `FAKE_UNIVERSE` — and
the repository the test is ABOUT is the tmux-pane guess, which is deliberately
**not** in `FAKE_UNIVERSE`, because a guess comes from the pane and not from the
mapping. The guard covered every repository except the one at issue.

**Mutation proof, both directions.** The mutant threads the guessed repo into
`guessed_note` — `Row 1 is a guess from the tmux pane (wrongorg/wrongrepo)`, a
natural-looking improvement — through the existing call site and parameter list,
so nothing else changes. (First attempt called `tmux_pane_repo()` inside the note
and killed three unrelated tests for the wrong reason; discarded, per the
isolate-the-mutation rule.)

| | mutant applied |
|---|---|
| `origin/main` test file | **3 passed** — all three token-only guards SURVIVED |
| this branch | **3 failed**, each on its own new assertion |

The killing message is this guard's own: `AssertionError: GUESSED-NOTE
DISCLOSURE: wrongorg`. It is *reached*, not short-circuited — every earlier
assertion in the test (`"audit-pr 1291" in mesg`, `"tmux pane" in mesg`,
`_no_universe_token_anywhere`) passes first.

**What was added.** `PANE_GUESS` / `PANE_GUESS_TOKENS` (three spellings) and
`_no_guessed_repo_token_anywhere`, applied at the three sites that checked
tokens only. `test_the_pane_guess_is_OUTSIDE_the_universe_and_spelled_distinctly`
is the guard on the new ledger: if `PANE_GUESS` were in `FAKE_UNIVERSE` the new
check would be decoration no mutation could kill, and the two token sets must
stay disjoint or a leak of one is indistinguishable from a leak of the other. It
also asserts no token is a word the CORRECT note uses, so the guard cannot go red
on right output.

**Deliberately not touched.** The two tests that pin the WHOLE normalised note
string were already immune to this mutant and are unchanged.

### …and the `_every_sink` comment reconciled with reality

It asserted three sinks were "the WHOLE list, because those are the only places
`mention-open.py` writes" — false in exactly the shape it was written to warn
about. `mention-open.py`'s module docstring and `guessed_note` both name a FOURTH
destination, the interactive picker, which `_every_sink` cannot see because
`pick()` is stubbed in every test.

Reconciled, not deleted. The exclusion is the design: the picker is the one
surface the universe is ALLOWED to reach, so folding it in would make every
disclosure assertion red on correct behaviour. The distinction is not
three-vs-four but **published vs private** — stdout, stderr and a desktop toast
outlive the click and can be read by someone other than the person who clicked;
the picker is a transient window on the operator's own screen.

Written about the **sink**, not the tool that draws it, because a concurrent
change from rofi to fzf was flagged as possible: swapping the picker
implementation changes nothing in that paragraph. (`git log origin/main --
scripts/mention-open.py` shows no such swap today; `fzf` currently appears only
as rofi's `-sorting-method`, from #1421.) And "may show the universe" is not "may
show anything" — the picker's `mesg` is guarded per-site, now by both ledgers.
The half that WAS true (no log file, no spool) is kept.

**Also stale.** A comment pointed at `` `_load_handler`'s sys.path``.
`git log -S _load_handler` says that name has never existed in this file — it
arrived already-stale in `8477789b`. It now points at the module-level loader
beside `MO`, which is what it always meant.

---

## 2. The disclosure guard sat one fixture from red

**Root cause.** `looks_like_a_repo_mapping` regex-swept the whole file text for
`"key": "owner/repo"` and counted distinct keys — summing pairs that have nothing
to do with each other: unrelated fixtures, several small dicts, a docstring, a
parametrize list. MEASURED 2026-09-09:
`scripts/tests/test_regen_known_repos.py` itself scored **19** against
`MAPPING_KEY_THRESHOLD = 20`. The next person adding a fixture reddens a
DISCLOSURE guard, and the fixes that come to hand under pressure — raise the
threshold, exclude the file — gut it.

**The number was never the guard; the SHAPE is.**
`looks_like_a_repo_universe` in the same file had already reached that conclusion
for the list shape and used `ast`. This is that argument applied to the dict
shape: it now counts the keys of the **biggest single mapping literal** —

* JSON objects at ANY depth, so a copy wrapped as
  `{"generated": …, "repos": {…}}` does not hide;
* `ast.Dict` literals, with non-constant keys (`'X'.lower()`, a variable) skipped
  rather than scraped out of the source text.

### What it can and cannot see

*Still caught — and these are the two incidents that motivated the guard:*
* a `.py` module holding `KNOWN_REPOS = {...}` — the ORIGINAL incident, a
  generator's output pasted into a committed module;
* a `.json` file of the same mapping — what the generator emits today, bare or
  nested.

On the artefact the new count is if anything **tighter**: 420 keys in one literal
is 420 either way.

*Not caught, stated in the docstring rather than papered over:*
* a mapping SPLIT across several literals, or built by a comprehension, a
  `dict(...)` call, or key-by-key assignment — the same residual
  `looks_like_a_repo_universe` already documents;
* a mapping embedded as an escaped JSON string inside another document;
* anything outside `.json`/`.py` — the sweep's pre-existing file filter.

This is a deliberate narrowing and it is labelled as one. What it gives up has
never been how this went wrong; what it buys is a guard that fires on the
artefact and on nothing else, which is the only kind anyone leaves switched on.

**Headroom, measured across all 562 published `.json`/`.py` files:** largest
score now **9** (a hand-curated 9-entry vocabulary in `check-clickup-addressed`)
against **19** before. Recorded in a comment beside the constant.

⚠ **No ratchet is asserted on that headroom, deliberately.** I wrote one, then
deleted it before pushing: "largest ordinary file must stay under N" is a
*second* fixed threshold, and that 9-entry vocabulary is a legitimate mapping
that may grow — the guard would go red on an honest edit, which is precisely the
failure mode being removed. The number is a measurement in a comment; the
enforcement is the shape.

### New controls

* `..._FIRES_on_the_JSON_the_generator_ACTUALLY_WRITES` — the `.py` control was
  the only positive one and the artefact is JSON now. Bare and nested.
* `..._counts_ONE_LITERAL_not_the_whole_file` — the structural property, asserted.
* `test_the_incident_guard_CAN_GO_RED_on_both_incident_spellings` — the incident
  guard's passing verdict is an EMPTY LIST, indistinguishable from a loop wired
  to nothing. Its loop is now `disclosure_offenders()` so this negative control
  drives **the same code** over a planted tree holding both spellings plus an
  ordinary file, asserting the result is a SELECTION and not "everything is an
  offender".

### Base-vs-head matrix

The detector lives in the test file, so "base" is the `origin/main` detector with
the new tests spliced in:

| test | old detector | new detector |
|---|---|---|
| `..._counts_ONE_LITERAL_not_the_whole_file` | **FAILED** (`60 != 1`) | passed |
| `..._FIRES_on_the_JSON_the_generator_ACTUALLY_WRITES` | passed | passed |
| `..._FIRES_on_a_realistic_mapping` | passed | passed |

The two `FIRES_*` are controls, not regressions, and are labelled as such in
their docstrings.

---

## Gate

**Merged tree** `37de31bd` = these two commits on `origin/main` `e2cf1925`
(this branch is cut from main, so the branch tree *is* the merged tree).

| tier | result |
|---|---|
| dev-host `scripts/gate.sh --tier both` | **node PASS** — 5 suites, 1449 tests, every suite over its floor. **pytest: 0 FAILED**, but the runner hit its 3600 s wall clock (`exit=124` -> SIGTERM 143) on the last target under load ~60 with six sibling gates running. Everything it ran was green — `scripts/tests` **13469 passed** (both files I touched live there), collector 869, dl-router 1020. The truncated target was then run alone: `scripts/browser-bridge/tests` **915 passed**. |
| sandbox `nix build .#checks.x86_64-linux.nodetests` | **RC 0** |
| sandbox `nix build .#checks.x86_64-linux.pytests` | **RC 1 — one failure, in a file this diff cannot reach.** See below. |

Built **one at a time**, never combined (a combined invocation produces false
failures), and with plain `nix build` (`--rebuild` does not re-run a failed
derivation and `nix log` then serves the old log).

### The sandbox pytests red — attributed, not waved away

`13561 passed, 1 failed`. The failure is
`scripts/tests/test_git_repo_isolation.py::test_live_cotenants_does_not_count_this_process`,
asserting `live_cotenants([git_dir]) == []` and getting `['126683:git']`.

I did **not** re-run it to green. Three independent pieces of evidence:

1. **Structurally unreachable from this diff.** `live_cotenants` matches only
   processes whose **cwd** resolves inside the probe's own throwaway repo
   (`/build/pytest-of-nixbld/…/popen-gw2/…/repo`), excluding our own lineage and
   sibling xdist workers. My new tests never `chdir` there; the one subprocess I
   added (`git -C <a different tmp dir> ls-files`, inside
   `test_the_incident_guard_CAN_GO_RED_…`) inherits the worker's cwd of
   `/build/src`, which is not under that root.
2. **The repo already documents this exact failure.** `6ae9fef9` (2026-09-06,
   #1340) — *"the co-tenant precondition flakes UNATTRIBUTABLY"* — records the
   same test, in the same sandbox tier, returning `['126220:git']` (mine:
   `['126683:git']`), with the dev-host tier green on the same tree and a
   **byte-identical re-run passing**. It refutes the `gc --auto` theory with
   0/80 iterations under a positive control, states the cause is **UNKNOWN**, and
   says plainly that the flake is **NOT FIXED**.
3. **Pristine control.** `nix build .#checks.x86_64-linux.pytests` on a
   `git archive` of untouched `origin/main` (`4e26ec9a`): **RC 0**. One sample,
   and at a sha 9 commits newer than my merge base — stated so the claim carries
   its own scope.

So the honest verdict: **node green in both tiers; pytest green everywhere it
ran, with one known-flaky, unreachable test red in the sandbox tier.** I am not
claiming the sandbox pytests derivation is green on this tree.

### A finding on the way past

#1340 added `_describe_cotenants` so *"the next occurrence will now say who the
intruder was"* — cwd and cmdline, with two tests behind it. **It does not cover
the assertion that actually fired.**
`test_live_cotenants_does_not_count_this_process`
(`test_git_repo_isolation.py:1609`) still asserts with a bare string, so my
failure printed `['126683:git']` and nothing else — the diagnostic built for
precisely this occurrence was not wired to it. Same class as the two defects this
PR fixes: a guard whose description is wider than its implementation. Not fixed
here — it is someone else's file and its own change.

---

## The third item: dropped in favour of #1439

This batch also covered `ship.sh`'s off-LAN blind spot. **#1439 opened 06:28Z;
my branch was not pushed until 06:52Z** — they were first, and theirs is the
better implementation. It is not in this PR and I am not opening a competing one.
Independently, both of us hit the same trap (`ship.sh` writing the DERIVED
primary back into `$REMOTE_SSH`, which the candidate function reads as the
operator's override, leaving the fallback inert) and both fixed it.

Three deltas from my discarded branch that look worth porting onto #1439, offered
as review notes rather than as a competing change:

1. **A distinct exit code.** #1439's no-candidate branch prints its diagnosis and
   then proceeds into the remote leg, which fails at ssh — so the run still exits
   **255**, the exact code its own description calls "a 255 that reads as a broken
   converge". A dedicated code (26 was free; both ladders' headers publish the
   next free number, and `drift-check.sh` carries the reciprocal
   `RESERVED-TO-SHIP` ledger) makes it distinguishable and lets the message say
   the far host was never asked to do anything.
2. **Announce the un-probed case.** #1439 is silent when the candidate list has
   one element, so an explicit `REMOTE_SSH` reads identically to a measured
   "this address is up". Naming it (`… comes from an explicit override; NOT
   probed`) keeps the three outcomes three different claims.
3. **Normalise a junk `SSH_PROBE_TIMEOUT`.** #1439 documents that a non-numeric
   value makes every address report "did not answer" and the run "proceeds on
   its default target" — a silent wrong answer in the reassuring direction. A
   two-line `case` normalising it to the default removes the hazard instead of
   recording it.

Conversely, #1439 has three things mine did not, which is most of why it should
be the one that lands: `ssh -n` (the probe would otherwise eat a caller's stdin),
a declared `StrictHostKeyChecking=accept-new` trust argument, and
`drift-check.sh` actually inheriting the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
