### PR TITLE
fix(oom-staged): a re-run whose rebuild fails restored a STALE backup over /etc/nixos

### DIFF
--- a/nix/system/apply-tmux-oom-protection.sh
+++ b/nix/system/apply-tmux-oom-protection.sh
@@ -149,8 +149,30 @@ fi
 # exists on the already-wired path, where there is nothing to restore. Printing
 # "restoring" while cp'ing a file that does not exist is a false statement at
 # exactly the moment an operator is reading under stress.
+#
+# 🔴 THE PREDICATE IS "DID *THIS RUN* TAKE THE BACKUP", NOT "DOES THE BACKUP
+# FILE EXIST" — and that distinction is the whole point, because $BACKUP is a
+# FIXED name that SURVIVES a successful run.
+#
+# The `-f "$BACKUP"` spelling this replaces was measured to destroy data:
+#   run 1  wires the import, writes $BACKUP, rebuild succeeds, $BACKUP remains;
+#   operator hand-edits $CFG (it is their system config; 18 sibling .bak files
+#     in that directory are evidence enough that it gets edited);
+#   run 2  takes the ALREADY-WIRED path, so it creates no backup — but the ERR
+#     trap still covers `nixos-rebuild switch` at the end. Any rebuild failure,
+#     for any unrelated reason, then found run 1's file and cp'd it over $CFG.
+# Measured result: the live, correctly-applied import GONE and the operator's
+# unrelated edit GONE, under a message that says "restoring" — and `cp -a`
+# restores the old mtime too, removing the obvious tell.
+#
+# A run that changed nothing must restore nothing. Do not "simplify" this back
+# to a file-existence test; scripts/tests/test_tmux_oom_protection_staged.py
+# pins the behaviour by EXECUTING the two-run scenario, not by grepping for a
+# spelling — the previous guard asserted `-f "$BACKUP"` was present and so read
+# as coverage while the defect was live.
+BACKUP_TAKEN_THIS_RUN=0
 restore() {
-  if [[ -f "$BACKUP" ]]; then
+  if [[ "$BACKUP_TAKEN_THIS_RUN" == "1" && -f "$BACKUP" ]]; then
     echo "FAILED — restoring $CFG from $BACKUP" >&2
     cp -a "$BACKUP" "$CFG"
   else
@@ -218,7 +240,6 @@ else
     echo "       to the top-level imports list manually, then re-run." >&2
     exit 1
   fi
-  cp -a "$CFG" "$BACKUP"
   awk '
     !ins && /^[[:space:]]*imports[[:space:]]*=/ { arm = 1 }
     arm && !ins && index($0, "[") > 0 {
@@ -234,6 +255,14 @@ else
     echo "       ./tmux-oom-protection.nix to its imports by hand, then rebuild." >&2
     exit 1
   fi
+  # 🔴 The backup is taken HERE — on the one branch that actually writes $CFG,
+  # immediately before the write — not up at the top of this block. Taken
+  # earlier, a refusal that modified NOTHING (the `imports =` guard above, or
+  # this awk finding no list) still deposited a `.bak.tmux-oom` into a directory
+  # already holding 18 of them, and left that file behind to arm the stale
+  # restore this script's `restore()` comment describes.
+  cp -a "$CFG" "$BACKUP"
+  BACKUP_TAKEN_THIS_RUN=1
   # Overwrite via cat (not mv) to preserve the file inode / 0644 root:root perms.
   cat "$CFG.new" > "$CFG"
   rm -f "$CFG.new"

--- a/scripts/tests/test_tmux_oom_protection_staged.py
+++ b/scripts/tests/test_tmux_oom_protection_staged.py
@@ -10,15 +10,31 @@ closely. That is precisely when a latent hazard costs something. These pin the
 two properties that would be expensive to get wrong and are invisible on a
 casual read, plus the honesty of the header.
 
-🔴 THESE ARE STRUCTURAL GUARDS ON A SHELL SCRIPT, NOT A TEST OF ITS BEHAVIOUR.
-Applying it requires root and a `nixos-rebuild`, so its runtime effect is not
-reachable from the suite. Stated here so nobody reads a green run as "the OOM
-protection works" — it means "the script does not contain the two mistakes we
-know to look for". The claim it CANNOT make is the whole reason the PR body
-labels this arm unverified.
+🔴 MOSTLY STRUCTURAL GUARDS — WITH ONE BEHAVIOURAL EXCEPTION, AND THE EXCEPTION
+IS THERE BECAUSE THE STRUCTURAL FORM MISSED A DATA-LOSS BUG.
+
+The privileged EFFECT of this script (lowering oom_score_adj, `nixos-rebuild`)
+is genuinely not reachable from the suite, so a green run still does NOT mean
+"the OOM protection works". But its CONTROL FLOW is reachable, and this file
+used to claim otherwise — a claim that cost something. `restore()` was pinned by
+a test asserting the literal `-f "$BACKUP"` appeared in its body; that spelling
+passed while the script destroyed `/etc/nixos/configuration.nix` on a re-run,
+because a fixed-name backup SURVIVES a successful run and `-f` then finds a
+STALE one. The guard read as coverage and provided none.
+
+So `test_a_rerun_whose_rebuild_fails_does_not_restore_a_STALE_backup` executes
+the script with only its environment couplings replaced (paths, the `$EUID`
+test, the selector pre-flight, `nixos-rebuild`), leaving the trap, the backup
+and the restore logic untouched. Every substitution is asserted to have applied,
+so a harness that silently patched nothing cannot report a pass.
+
+The lesson generalises past this file: when the artifact under test is a shell
+script, a guard on its SOURCE TEXT is walkable by any change that keeps the
+text. Execute it.
 """
 from __future__ import annotations
 
+import os
 import re
 import stat
 import subprocess
@@ -476,6 +492,146 @@ def test_restore_does_not_claim_to_restore_a_backup_that_does_not_exist(text: st
         "restore() must check the backup exists before claiming to use it")
     assert "nothing to restore" in restore, (
         "the no-backup branch must say plainly that nothing was rolled back")
+    # 🔴 EXISTENCE IS NOT ENOUGH, and this assertion is the scar from finding
+    # that out: $BACKUP is a FIXED name that outlives a successful run, so
+    # `-f` alone is TRUE on a re-run that backed up nothing. The behavioural
+    # test below is the real guard; this one keeps the structural half honest
+    # about what it does and does not prove.
+    assert "BACKUP_TAKEN_THIS_RUN" in restore, (
+        "restore() must gate on whether THIS RUN took the backup, not merely on "
+        "the backup file existing — see the behavioural test in this file")
+
+
+def _instrumented_script(tmp_path, script_text: str) -> tuple[Path, Path]:
+    """Copy the script with ONLY its environment couplings replaced.
+
+    Untouched: the ERR trap, `restore()`, the backup, and every branch. Each
+    substitution is asserted to have applied — a patcher that silently matched
+    nothing would run a script still pointed at the REAL /etc/nixos, or would
+    exit at the `$EUID` guard and report a vacuous pass.
+    """
+    etc = tmp_path / "etc"
+    etc.mkdir()
+    subs = [
+        ("CFG=/etc/nixos/configuration.nix", f"CFG={etc}/configuration.nix"),
+        ("MODULE=/etc/nixos/tmux-oom-protection.nix", f"MODULE={etc}/tmux-oom-protection.nix"),
+        ("if [[ $EUID -ne 0 ]]; then", "if false; then"),
+        ("if ! pgrep -u 1000 -x 'tmux: server' >/dev/null 2>&1; then", "if false; then"),
+        ('chown root:root "$MODULE"', "true"),
+        ("nixos-rebuild switch", "${FAKE_REBUILD:-true}"),
+    ]
+    body = script_text
+    for needle, repl in subs:
+        assert needle in body, (
+            f"instrumentation FAILED to find {needle!r} — the script changed shape, "
+            "and this harness would otherwise test a script it never patched")
+        body = body.replace(needle, repl)
+    path = tmp_path / "apply.sh"
+    path.write_text(body)
+    return path, etc / "configuration.nix"
+
+
+_CONFIG = """{ config, pkgs, ... }:
+{
+  imports =
+    [
+      ./hardware-configuration.nix
+    ];
+  networking.hostName = "nixos";
+}
+"""
+
+
+def _run_apply(script: Path, *, rebuild_ok: bool) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True,
+        env={"PATH": os.environ["PATH"], "FAKE_REBUILD": "true" if rebuild_ok else "false"})
+
+
+def test_a_rerun_whose_rebuild_fails_does_not_restore_a_STALE_backup(tmp_path, text: str):
+    """🔴 MEASURED DATA LOSS, not a hypothetical — the reason restore() gates on
+    a per-run flag rather than on the backup file existing.
+
+    $BACKUP has a FIXED name and survives a successful run. A re-run takes the
+    already-wired path and creates no backup, but the ERR trap still covers the
+    closing `nixos-rebuild switch`. With an existence test, ANY rebuild failure
+    — for any unrelated reason — restored the PREVIOUS run's file over the live
+    config, deleting both the correctly-applied import and whatever the operator
+    had edited since. `cp -a` restores the old mtime too, so there is no tell.
+    """
+    script, cfg = _instrumented_script(tmp_path, text)
+    cfg.write_text(_CONFIG)
+
+    first = _run_apply(script, rebuild_ok=True)
+    assert first.returncode == 0, f"run 1 should succeed:\n{first.stderr}"
+    assert "tmux-oom-protection.nix" in cfg.read_text(), "run 1 did not wire the import"
+
+    # The operator edits their own system config between runs. This line is the
+    # payload: it exists in NO backup, so restoring one silently deletes it.
+    cfg.write_text(cfg.read_text() + "  services.openssh.enable = true;  # OPERATOR EDIT\n")
+
+    second = _run_apply(script, rebuild_ok=False)
+    assert second.returncode != 0, "run 2's rebuild was supposed to fail"
+
+    after = cfg.read_text()
+    assert "OPERATOR EDIT" in after, (
+        "a failed re-run RESTORED A STALE BACKUP over the live config and "
+        "destroyed an unrelated operator edit — the exact measured defect")
+    assert "tmux-oom-protection.nix" in after, (
+        "a failed re-run removed the import that was already applied and live")
+    assert "nothing to restore" in second.stderr, (
+        "a run that took no backup must SAY it rolled nothing back")
+
+
+def test_a_FIRST_run_whose_rebuild_fails_still_rolls_the_config_back(tmp_path, text: str):
+    """🔴 THE POSITIVE CONTROL for the test above, and it is not optional.
+
+    Gating restore() on a per-run flag could be "passed" by a mutant that simply
+    never restores anything. This pins the other half: when THIS run did take
+    the backup and then failed, the config must go back — otherwise a half-wired
+    /etc/nixos survives a failed apply.
+    """
+    script, cfg = _instrumented_script(tmp_path, text)
+    cfg.write_text(_CONFIG)
+
+    proc = _run_apply(script, rebuild_ok=False)
+    assert proc.returncode != 0, "the rebuild was supposed to fail"
+    assert cfg.read_text() == _CONFIG, (
+        "a FAILED first run must restore the config it modified; it is still "
+        f"carrying this run's edit:\n{cfg.read_text()}")
+    assert "restoring" in proc.stderr, "the restoring branch must announce itself"
+
+
+def test_a_refusal_that_modifies_nothing_leaves_no_backup_behind(tmp_path, text: str):
+    """The backup belongs on the one branch that actually writes $CFG.
+
+    Taken earlier, a refusal that changed nothing still deposited a
+    `.bak.tmux-oom` beside the 18 already in /etc/nixos — and left that file
+    to arm the stale restore above on the next run.
+
+    🔴 THE FIXTURE HAS TO REACH THE RIGHT REFUSAL, and the obvious one does not.
+    A config with NO `imports =` at all exits at the `n_imports != 1` guard,
+    which sits ABOVE both the backup and the awk — so early-cp and late-cp
+    behave identically and a mutant moving the backup SURVIVES. Found exactly
+    that way: the first version of this test used that config and scored the
+    mutation as survived.
+
+    The branch that actually distinguishes them is the awk finding no list:
+    `imports =` present exactly ONCE (so the count guard passes) and no `[`
+    anywhere after it (so the awk arms and never inserts).
+    """
+    script, cfg = _instrumented_script(tmp_path, text)
+    cfg.write_text(
+        "{ config, pkgs, ... }:\n"
+        "{\n"
+        "  imports = myImportSet;\n"
+        '  networking.hostName = "nixos";\n'
+        "}\n")
+
+    proc = _run_apply(script, rebuild_ok=True)
+    assert proc.returncode != 0, "a config with no imports list must be REFUSED"
+    assert not (cfg.parent / "configuration.nix.bak.tmux-oom").exists(), (
+        "a refusal that modified nothing left a backup behind")
 
 
 def test_the_header_states_why_home_manager_cannot_do_this(text: str):


### PR DESCRIPTION
fix(oom-staged): a re-run whose rebuild fails restored a STALE backup over /etc/nixos

MEASURED DATA LOSS in the staged script #1415 merged. Found by the round-2
delta audit of that PR, reproduced by executing the script rather than reading
it, and it is a defect the round-1 fix pass INTRODUCED.

THE DEFECT

`BACKUP="${CFG}.bak.tmux-oom"` is a FIXED name (correctly — the timestamped
spelling it replaced added one file per run to a directory already holding 18).
But the backup is only taken on the branch that WIRES the import, while
`trap restore ERR` covers the whole script including the closing
`nixos-rebuild switch`. And `restore()` asked only whether the backup FILE
EXISTS.

So on a re-run — which takes the already-wired path and creates no backup — any
rebuild failure, for any unrelated reason, found the PREVIOUS run's file and
cp'd it over the live config:

  run 1  wires the import, writes $BACKUP, rebuild OK, $BACKUP survives
  operator hand-edits /etc/nixos/configuration.nix
  run 2  already wired -> no backup taken; rebuild fails -> ERR trap
         "FAILED - restoring ... from ...bak.tmux-oom"
         import present: 0      <- the live, correctly-applied import GONE
         operator edit present: 0  <- an unrelated edit GONE
         config byte-identical to the pre-wiring backup: YES

`cp -a` restores the old mtime as well, so there is no tell. The message says
"restoring", which reads as correct unwinding.

WHY THE EXISTING TEST COULD NOT SEE IT

`test_restore_does_not_claim_to_restore_a_backup_that_does_not_exist` asserted
the literal `-f "$BACKUP"` appeared inside `restore()`. That is a guard on the
SOURCE SPELLING, and the spelling it pinned is exactly what makes the bug fire:
`-f` is TRUE precisely because a stale backup exists. It read as coverage while
providing none.

THE FIX

  * `restore()` gates on BACKUP_TAKEN_THIS_RUN, not on file existence. A run
    that changed nothing restores nothing.
  * the backup moves to the one branch that actually writes $CFG, immediately
    before the write. Taken earlier, a refusal that modified nothing still
    deposited a .bak file — which then armed the stale restore on the next run.

TESTS: BEHAVIOURAL, because the structural form is what missed this

Three tests execute the real script with only its environment couplings
replaced (paths, the $EUID test, the selector pre-flight, nixos-rebuild); the
trap, the backup and every branch are untouched. Every substitution is asserted
to have applied, so a harness that patched nothing cannot report a pass.

  * a re-run whose rebuild fails must NOT restore a stale backup
  * POSITIVE CONTROL: a FIRST run whose rebuild fails MUST still roll back
  * a refusal that modifies nothing leaves no backup behind

MUTATION: 3 mutants, 3 killed, each by its own named assertion, control green.

  M1  restore() back to a bare `-f "$BACKUP"`   KILLED  ("RESTORED A STALE
      BACKUP ... destroyed an unrelated operator edit")
      and the positive control still PASSED under M1, so the new test
      discriminates rather than merely asserting restore never runs.
  M2  backup moved back above the awk           KILLED  ("a refusal that
      modified nothing left a backup behind")
  M3  BACKUP_TAKEN_THIS_RUN pinned to 0         KILLED  ("a FAILED first run
      must restore the config it modified")

M2 SURVIVED on the first sweep, and that was a real finding about the TEST, not
noise: the fixture used a config with no `imports =` at all, which exits at the
count guard ABOVE both the backup and the awk — so early-cp and late-cp behave
identically and the guarded branch never executes. The fixture now uses
`imports =` present exactly once with no `[` after it, which is the only shape
that reaches the awk-found-nothing refusal. Also recorded: an earlier M2 attempt
scored SURVIVED without running at all, because the mutating `python3` was not
on PATH and the failure was not read; the sweep now verifies the mutant differs
from the original before scoring it.

The module docstring claimed this script's behaviour "is not reachable from the
suite". Its privileged EFFECT is not; its CONTROL FLOW is, and that claim is
what let a spelled guard stand in for a real one. Corrected in the same commit.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jdbmhCKa6edhTmiADsziR
