### PR TITLE
docs(home.nix): the laptop leg does not work for the reason this comment gave

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3629,12 +3629,33 @@ in
         #     prevent. The two agree today; they are not the same mechanism.
         #   * the LAPTOP leg gets no such guard — session-manager reaches it over
         #     ssh through the remote login shell, which sources .zshenv only, and
-        #     nothing in devrc sets TMUX_TMPDIR there. It works because the
-        #     laptop's socket is in /tmp. If the laptop ever acquires this host's
-        #     arrangement it silently reports zero windows — and `tmux` says "no
-        #     server running", which session-manager maps to reachable:true AND
-        #     windows_measured:TRUE, so the torn-collection gate in the pusher
-        #     cannot catch it either. Only an env pin on that side would.
+        #     nothing in devrc sets TMUX_TMPDIR there. The failure shape stands:
+        #     if that leg cannot find the socket it silently reports zero
+        #     windows — `tmux` says "no server running", which session-manager
+        #     maps to reachable:true AND windows_measured:TRUE, so the
+        #     torn-collection gate in the pusher cannot catch it either. Only an
+        #     env pin on that side would.
+        #
+        #     🔴 BUT THE REASON IT WORKS TODAY IS NOT THE ONE THIS COMMENT USED
+        #     TO GIVE, AND THE OLD REASON WAS MEASURED FALSE 2026-09-09. It said
+        #     "It works because the laptop's socket is in /tmp", and predicted
+        #     that acquiring this host's arrangement would break it. The laptop
+        #     HAS this host's arrangement: /tmp/tmux-1000 DOES NOT EXIST, the
+        #     socket is /run/user/1000/tmux-1000/default, and the server's own
+        #     environ carries TMUX_TMPDIR=/run/user/1000. By the old reasoning
+        #     the leg should therefore be reporting zero. It is not — measured
+        #     over the exact path session-manager uses (non-interactive ssh):
+        #     TMUX_TMPDIR=/run/user/1000 is present and `tmux list-windows -a`
+        #     returned 29 windows.
+        #
+        #     It works because TMUX_TMPDIR is in the ssh session environment —
+        #     and `grep -c TMUX_TMPDIR ~/.zshenv` on the laptop is 0, so devrc
+        #     is still not what sets it. That is the SAME undeclared runtime
+        #     state this comment flags two paragraphs up: a fact about this
+        #     boot, not a property of the configuration. So the laptop leg is
+        #     unguarded for the reason stated, but the hazard is currently
+        #     masked rather than absent — do not read "it works" as "it is
+        #     pinned", and do not restore the /tmp explanation.
         # `%t` is the user runtime dir (/run/user/UID).
         # Pinned by `test_the_unit_gives_tmux_its_SOCKET_directory`.
         "TMUX_TMPDIR=%t"


### PR DESCRIPTION
docs(home.nix): the laptop leg does not work for the reason this comment gave

MEASURED 2026-09-09, while verifying that the tmux restore stack operates on the
laptop host after #1415/#1376 shipped.

The comment on the tmux-snapshot-push unit's TMUX_TMPDIR pin said:

    the LAPTOP leg gets no such guard ... It works because the laptop's socket
    is in /tmp. If the laptop ever acquires this host's arrangement it silently
    reports zero windows

Both halves are wrong, in opposite directions, and a reader reasoning from
either lands somewhere false.

THE PREMISE IS FALSE. The laptop already HAS this host's arrangement:

    /tmp/tmux-1000                        does not exist
    /run/user/1000/tmux-1000/default      is the socket
    the server's own /proc/<pid>/environ  carries TMUX_TMPDIR=/run/user/1000

THE PREDICTION IS ALSO FALSE. By the old reasoning that leg should now be
reporting zero windows. It is not. Measured over the exact path session-manager
uses — a NON-INTERACTIVE ssh, which sources .zshenv only:

    TMUX_TMPDIR=[/run/user/1000]
    tmux list-windows -a  ->  29 windows
    grep -c TMUX_TMPDIR ~/.zshenv  ->  0

So devrc still does not set it, exactly as the comment says — but the value is
in the ssh session environment anyway. That is the SAME "undeclared runtime
state" this comment already flags two paragraphs earlier for the workbench: a
fact about this boot, not a property of the configuration.

WHAT THE CORRECTION KEEPS. The failure SHAPE is untouched and still worth
knowing: if that leg cannot find the socket it reports zero windows while
session-manager records reachable:true and windows_measured:TRUE, so the
pusher's torn-collection gate cannot catch it. Only an env pin on that side
would. The hazard is MASKED, not absent — the correction says so explicitly, so
nobody reads "it works" as "it is pinned", and says not to restore the /tmp
explanation.

This is the shape claude/RULES.md names: a comment is a claim too, and this one
would have led a maintainer to the wrong conclusion in either direction — either
"the laptop is fine because /tmp" or, on seeing the socket move, "the laptop
must be broken now".

Verified: `nix-instantiate --parse nix/home.nix` OK; test_tmux_snapshot_push.py
37 passed; the test this comment names,
test_the_unit_gives_tmux_its_SOCKET_directory, 2 passed. Comment-only change —
no evaluated Nix expression is touched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jdbmhCKa6edhTmiADsziR
