### PR TITLE
fix(tests): use write_exec for the ssh probe stubs — #1439 turned a guard red on main

### DIFF
--- a/scripts/tests/test_ship_ssh_fallback.py
+++ b/scripts/tests/test_ship_ssh_fallback.py
@@ -25,10 +25,19 @@ on a machine nobody named.
 
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# 🔴 write_exec owns the shebang. `#!/usr/bin/env bash` here is forbidden by
+# `test_runtime_shebangs.py` because `env` is absent from the nix build sandbox,
+# so a stub written that way cannot run in the tier the merge is gated on.
+from testlib.mockbin import write_exec  # noqa: E402
 
 LIB = Path(__file__).resolve().parents[1] / "lib" / "host-role.sh"
 
@@ -103,10 +112,8 @@ def test_LAPTOP_SSH_does_not_leak_into_the_laptops_own_candidates():
 
 def _probe_stub(tmp_path: Path, reachable: str) -> str:
     """A prober that succeeds only for `reachable` (empty = nothing answers)."""
-    p = tmp_path / "probe.sh"
-    p.write_text('#!/usr/bin/env bash\n[ "$1" = "%s" ]\n' % reachable)
-    p.chmod(0o755)
-    return str(p)
+    return str(write_exec(tmp_path / "probe.sh",
+                          '[ "$1" = "%s" ]\n' % reachable))
 
 
 def test_the_lan_address_wins_when_it_answers(tmp_path):

--- a/scripts/tests/test_ship_ssh_probe_wiring.py
+++ b/scripts/tests/test_ship_ssh_probe_wiring.py
@@ -27,9 +27,22 @@ argv the real line actually builds -- no network, no real host.
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# 🔴 write_exec OWNS THE SHEBANG, and that is the point. A call site that writes
+# its own `#!/usr/bin/env bash` is exactly what
+# `test_runtime_shebangs.py::test_no_test_writes_a_usr_bin_env_shebang_at_runtime`
+# forbids: `env` is not on PATH in the nix build sandbox, so a stub written that
+# way is unrunnable in the tier the merge is gated on. This file shipped with two
+# such stubs and turned that guard RED on main — caught by the sandbox tier,
+# which the dev-host subset structurally cannot see.
+from testlib.mockbin import write_exec  # noqa: E402
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 SHIP = SCRIPTS / "ship.sh"
@@ -41,14 +54,11 @@ LAPTOP_NEBULA = "zach@10.42.0.100"
 
 def _probe_stub(tmp_path: Path, reachable: str, log: Path | None = None) -> str:
     """A $SSH_PROBE_CMD that succeeds only for `reachable`, optionally logging."""
-    p = tmp_path / "probe.sh"
-    body = "#!/usr/bin/env bash\n"
+    body = ""
     if log:
         body += f'echo "$1" >> "{log}"\n'
     body += f'[ "$1" = "{reachable}" ]\n'
-    p.write_text(body)
-    p.chmod(0o755)
-    return str(p)
+    return str(write_exec(tmp_path / "probe.sh", body))
 
 
 def _ship_target(tmp_path: Path, env: dict) -> subprocess.CompletedProcess:
@@ -201,13 +211,11 @@ def _recording_ssh(tmp_path: Path, exit_code: int = 0) -> tuple[Path, Path]:
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     log = tmp_path / "argv.log"
-    stub = bindir / "ssh"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
+    write_exec(
+        bindir / "ssh",
         f'printf "%s\\n" "$*" >> "{log}"\n'
-        f"exit {exit_code}\n"
+        f"exit {exit_code}\n",
     )
-    stub.chmod(0o755)
     return bindir, log
 
 


### PR DESCRIPTION
## What

`tekton/devrc-pytests` is **red on `605b29ac`**: `test_no_test_writes_a_usr_bin_env_shebang_at_runtime`, 1 failure of 21,455. Both test modules #1439 added wrote stub scripts with a literal `#!/usr/bin/env bash`.

`scripts/tests/test_runtime_shebangs.py` forbids that because **`env` is not on PATH in the nix build sandbox** — a stub written that way is unrunnable in the tier the merge is gated on. Both now use `testlib.mockbin.write_exec`, which owns the shebang and refuses a body carrying its own.

**No allowlist entry was added.** The offenders are gone, not pinned.

## How it reached main

The dev-host subset I ran **structurally cannot see this** — it passes anywhere `/usr/bin/env` exists. The sandbox tier is where it fails, and that tier is `tekton/devrc-pytests`, which was still `pending` when I merged #1439 after reporting "no checks" minutes earlier. The two-tiers rule, biting exactly as documented.

## Verification

35 passed — `test_runtime_shebangs.py` (including the guard and its stale-pin accounting) plus both ship-ssh modules. Dev-host pytest tier, base `c68750f6`.