### PR TITLE
fix(transcript-push): the caps were tuned to a server that is not deployed — push was 413-dead on both hosts

### DIFF
--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -98,6 +98,16 @@ def transcript(session_id: str, *lines: str) -> str:
 
 # --- the stub server ----------------------------------------------------------
 
+# 🔴 THE DEPLOYED SERVER'S SESSION CAP — MEASURED, NOT READ OFF A RELEASE NOTE.
+# 2026-09-10, from the running clawgate's own refusal:
+#     HTTP 413 {"error":"transcript: too many sessions in one push: 16 > 8"}
+#
+# It lives here so the stub server can REFUSE what production refuses. Raise it
+# only after re-measuring against the RUNNING server — `merged` is not
+# `deployed`, and treating a clawgate change as live is what made transcript push
+# 100% dead on both hosts for ~19 hours while this suite stayed green.
+DEPLOYED_MAX_SESSIONS_PER_PUSH = 8
+
 
 class _Recorder(HTTPServer):
     """An HTTPServer that records every request and serves a scripted digest."""
@@ -111,6 +121,11 @@ class _Recorder(HTTPServer):
         # What POST /api/transcripts answers with.
         self.push_status = 200
         self.push_body = b'{"ok":true}'
+        # The DEPLOYED clawgate's cap, measured 2026-09-10 from its own refusal:
+        # `transcript: too many sessions in one push: 16 > 8`. Set to None to
+        # model a server with no session cap — but do NOT make that the default
+        # again; see `_Handler.do_POST`.
+        self.max_sessions = DEPLOYED_MAX_SESSIONS_PER_PUSH
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -138,7 +153,27 @@ class _Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):  # noqa: N802
         length = int(self.headers.get("Content-Length") or 0)
-        self._record(self.rfile.read(length))
+        raw = self.rfile.read(length)
+        self._record(raw)
+        # 🔴 THE DOUBLE ENFORCES THE DEPLOYED SERVER'S SESSION CAP, AND THAT IS
+        # THE WHOLE POINT OF IT BEING HERE. Without this the double was strictly
+        # MORE PERMISSIVE than production: it accepted any number of sessions, so
+        # a client tuned above the real cap passed every test and then failed
+        # every single tick in the field. Measured 2026-09-10 — 228 consecutive
+        # 413s on the workbench, transcript push 100% dead on both hosts for ~19
+        # hours, against a suite that was green.
+        #
+        # A test double that accepts what production refuses is not a test.
+        if self.server.max_sessions is not None:
+            try:
+                n = len(json.loads(raw)["sessions"])
+            except (ValueError, KeyError, TypeError):
+                n = 0
+            if n > self.server.max_sessions:
+                self._reply(413, json.dumps({
+                    "error": f"transcript: too many sessions in one push: "
+                             f"{n} > {self.server.max_sessions}"}).encode())
+                return
         self._reply(self.server.push_status, self.server.push_body)
 
     def log_message(self, format, *args):  # noqa: A002
@@ -533,17 +568,33 @@ def test_a_truncated_tail_reports_the_WHOLE_file_size_not_the_tail_length(server
     )
 
 
-def test_coverage_is_not_capped_at_eight_sessions(server, projects, tmp_path):
-    """🔴 RED ON PRE-CHANGE CODE. The default was MAX_PER_PUSH=6 against a server
-    cap of 8, so a host with 21 changed sessions carried SIX of them per
-    five-minute tick — which is why most session cards had no conversation to
-    show at all (~93 live windows, measured 2026-09-07).
+def test_a_push_is_never_refused_for_carrying_more_sessions_than_the_server_takes(
+    server, projects, tmp_path
+):
+    """🔴 THE INVARIANT THAT ACTUALLY HOLDS, replacing a coverage assertion the
+    DEPLOYED server cannot satisfy.
 
-    21 is deliberately NOT a multiple of 8 or 6: a fixture of 8, 16 or 12 could be
-    passed by a mutant restoring the old cap by landing exactly on a boundary.
+    This test used to be `test_coverage_is_not_capped_at_eight_sessions` and
+    asserted that all 21 changed sessions ride in ONE push. That is a statement
+    about a server enforcing MaxSessionsPerPush=128 — which is not the server
+    that is running. #1408 raised the client to 48 to satisfy it, and four
+    minutes after that merged, every tick began failing:
+
+        HTTP 413 {"error":"transcript: too many sessions in one push: 16 > 8"}
+
+    228 consecutive failures on the workbench, transcript push dead on both hosts
+    for ~19 hours, suite green throughout — because the stub server accepted what
+    production refuses. It no longer does (see `DEPLOYED_MAX_SESSIONS_PER_PUSH`).
+
+    Coverage per tick is bounded by the SERVER, not by client preference. What the
+    client owes is that it never gets REFUSED. If coverage is the goal, raise the
+    server first and re-measure; the constant above is the single place to change.
+
+    21 is deliberately not a multiple of 8: a mutant landing exactly on a boundary
+    would otherwise pass.
     """
     n = 21
-    assert n % 8 != 0 and n % 6 != 0
+    assert n % DEPLOYED_MAX_SESSIONS_PER_PUSH != 0
     for i in range(n):
         projects(f"sess-{i:02d}", transcript(f"sess-{i:02d}", human_turn(f"turn {i}", f"sess-{i:02d}")))
 
@@ -552,10 +603,15 @@ def test_coverage_is_not_capped_at_eight_sessions(server, projects, tmp_path):
         tmp_path=tmp_path,
         env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
     )
-    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        "the push was REFUSED by a server enforcing the deployed session cap:\n"
+        + proc.stdout + proc.stderr)
     sent = json.loads(pushes(server)[0]["body"])["sessions"]
-    assert len(sent) == n, f"one push carried {len(sent)} of {n} changed sessions"
-    assert len({s["sessionId"] for s in sent}) == n
+    assert len(sent) <= DEPLOYED_MAX_SESSIONS_PER_PUSH, (
+        f"one push carried {len(sent)} sessions against a deployed cap of "
+        f"{DEPLOYED_MAX_SESSIONS_PER_PUSH} — this is refused in the field")
+    assert len({s["sessionId"] for s in sent}) == len(sent), "duplicate sessionIds in one push"
+    assert sent, "the push carried no sessions at all"
 
 
 def test_the_aggregate_byte_bound_stops_the_push_before_the_session_count_does(

--- a/scripts/transcript-push.sh
+++ b/scripts/transcript-push.sh
@@ -108,24 +108,50 @@ else
   fi
 fi
 
-# 🔴 THESE BOUNDS MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The server
-# enforces MaxTailBytes=262144, MaxSessionsPerPush=128 and MaxPushTailBytes=4 MiB
-# and REJECTS a push that exceeds any of them — a rejection changes nothing
-# server-side, so a client tuned exactly to a limit turns any rounding
-# disagreement into a feeder that fails every single tick while looking correctly
-# configured.
+# 🔴 THESE BOUNDS MUST STAY UNDER THE **DEPLOYED** SERVER'S OWN, AND "DEPLOYED"
+# IS THE WORD THAT COST US THE FEATURE. A rejection changes nothing server-side,
+# so a client tuned above a limit is a feeder that fails EVERY SINGLE TICK while
+# looking correctly configured.
 #
-# 🔴 MAX_PER_PUSH WAS 6 AGAINST A SERVER CAP OF 8, AND THAT PAIR WAS A COVERAGE
-# CAP, NOT A SAFETY BOUND. Measured 2026-09-07 against ~93 live windows: at most
-# six sessions could carry a transcript per tick, so most session cards had no
-# conversation to show at all. The server now bounds the AGGREGATE tail bytes
-# directly — which is the ceiling the count was only ever approximating — so the
-# count is free to rise to what coverage needs. 48 sessions x 192 KiB is 9 MiB in
-# the worst case, so MAX_PUSH_BYTES below is what actually holds, and the builder
-# stops adding sessions when it is reached.
-TAIL_BYTES="${TRANSCRIPT_PUSH_TAIL_BYTES:-196608}"     # 192 KiB; server cap 256 KiB
-MAX_PER_PUSH="${TRANSCRIPT_PUSH_MAX_SESSIONS:-48}"     # server cap 128
-MAX_PUSH_BYTES="${TRANSCRIPT_PUSH_MAX_BYTES:-3145728}" # 3 MiB; server cap 4 MiB
+# 🔴 THE PREVIOUS VALUES WERE TUNED TO A SERVER THAT IS NOT RUNNING, AND
+# TRANSCRIPT PUSH WAS 100% DEAD ON BOTH HOSTS FOR ~19 HOURS. The comment here
+# asserted "the server enforces MaxSessionsPerPush=128 and MaxPushTailBytes=4
+# MiB" and raised the client to 48/3 MiB to match. Measured 2026-09-10, from the
+# live server's own refusals:
+#
+#   workbench: HTTP 413 {"error":"transcript: too many sessions in one push:
+#              16 > 8"}          <- the APP's cap is 8, not 128
+#   laptop:    HTTP 413 <html>…413 Request Entity Too Large…nginx/1.29.4</html>
+#                                <- rejected by the INGRESS, before the app
+#
+# 228 consecutive failures on the workbench alone, beginning 2026-09-09
+# 19:38:52Z — four minutes after #1408 merged (19:34:12Z) and shipped.
+#
+# 🔴 TWO CEILINGS, NOT ONE, THEY FAIL DIFFERENTLY, AND THE TWO HOSTS DO NOT TAKE
+# THE SAME ROUTE — which is why the two hosts failed for two different reasons
+# and either one alone would have given a misleading diagnosis:
+#
+#   workbench -> http://192.168.50.250:30302   (NodePort; no proxy in front)
+#                so it reached the app and hit the APP's session cap.
+#   laptop    -> http://10.42.0.10:8109        (nebula; an nginx IS in this path)
+#                so an oversized body was refused by the PROXY and the app never
+#                saw it — the app's limits are irrelevant once that happens.
+#
+# ⚠ THE PROXY'S ACTUAL BYTE LIMIT IS UNMEASURED. No `client_max_body_size` /
+# `proxy-body-size` is set for clawgate in homelab-talos, which SUGGESTS nginx's
+# 1 MiB default, but that is an inference from an absent annotation and the route
+# above was not traced to the config that serves it. What IS measured: 3 MiB was
+# refused, and 817,481 B went through with HTTP 200 on 2026-09-10. MAX_PUSH_BYTES
+# is set below that observed-good size rather than at any believed ceiling.
+#
+# 🔴 BEFORE RAISING EITHER OF THESE, VERIFY THE RUNNING SERVER — do not raise
+# them because a clawgate PR or release note says the cap moved. `merged` is not
+# `deployed`, and that is exactly the distinction this block got wrong. The cheap
+# check is to run this script by hand and read the response body: the app names
+# its own cap in the refusal.
+TAIL_BYTES="${TRANSCRIPT_PUSH_TAIL_BYTES:-196608}"     # 192 KiB; server cap believed 256 KiB (UNVERIFIED)
+MAX_PER_PUSH="${TRANSCRIPT_PUSH_MAX_SESSIONS:-8}"      # deployed app cap 8, MEASURED from its refusal
+MAX_PUSH_BYTES="${TRANSCRIPT_PUSH_MAX_BYTES:-900000}"  # ~879 KiB, under the ingress's inferred 1 MiB
 # How far back to consider a transcript at all. 24h keeps a session readable the
 # morning after; older ones are past the server's retention anyway.
 MAX_AGE_HOURS="${TRANSCRIPT_PUSH_MAX_AGE_HOURS:-24}"


### PR DESCRIPTION
fix(transcript-push): the caps were tuned to a server that is not deployed — push was 413-dead on both hosts

MEASURED 2026-09-10. Transcript push had been failing 100% of ticks on BOTH
hosts for ~19 hours, with a green suite throughout.

WHAT HAPPENED

#1408 ("lift the coverage cap") raised MAX_PER_PUSH from 6 to 48 and
MAX_PUSH_BYTES to 3 MiB, on the stated belief that "the server enforces
MaxSessionsPerPush=128 and MaxPushTailBytes=4 MiB" and "now bounds the AGGREGATE
tail bytes directly". The running server does not. It enforces 8.

  #1408 merged   2026-09-09T19:34:12Z
  first failure  2026-09-09T19:38:52Z   — four minutes later
  failures since 228 consecutive, on the workbench alone

TWO CEILINGS, TWO ROUTES, TWO DIFFERENT ERRORS — and either host alone gives a
misleading diagnosis:

  workbench -> http://192.168.50.250:30302  (NodePort, no proxy)
      HTTP 413 {"error":"transcript: too many sessions in one push: 16 > 8"}
      i.e. it reached the app and hit the APP's session cap.

  laptop    -> http://10.42.0.10:8109       (nebula; an nginx is in this path)
      HTTP 413 <html>…413 Request Entity Too Large…nginx/1.29.4</html>
      i.e. the PROXY refused the body and the app never saw it.

THE FIX

  MAX_PER_PUSH   48      -> 8        the deployed app cap, MEASURED from its own
                                     refusal message
  MAX_PUSH_BYTES 3 MiB   -> 900000   below the largest body OBSERVED to succeed

⚠ Stated rather than implied: the proxy's actual byte limit is UNMEASURED. No
`client_max_body_size`/`proxy-body-size` is set for clawgate in homelab-talos,
which SUGGESTS nginx's 1 MiB default, but that is an inference from an absent
annotation and I did not trace the route to the config serving it. What is
measured: 3 MiB refused, 817,481 B accepted.

VERIFIED LIVE, ON BOTH HOSTS, BY RUNNING THE REAL PUSH

  workbench: pushed 775492B (HTTP 200) {"ok":true,"sessions":[4 ids]}
  laptop:    pushed 817481B (HTTP 200) {"ok":true,"sessions":[4 ids]}

THE REASON A GREEN SUITE MISSED THIS, AND THE STRUCTURAL FIX

The stub server accepted ANY number of sessions — strictly more permissive than
production. A client tuned above the real cap therefore passed every test and
failed every tick in the field. A test double that accepts what production
refuses is not a test.

`_Handler.do_POST` now enforces `DEPLOYED_MAX_SESSIONS_PER_PUSH = 8` and returns
production's own 413 JSON. The constant is the single place to change, and its
comment says to re-measure against the RUNNING server before raising it.

MUTATION: restoring #1408's value of 48 is KILLED by the double with
production's exact message — `too many sessions in one push: 21 > 8`. So this
guard would have caught #1408 before it shipped. Control green (87 passed);
mutant verified to differ from the original before scoring, and the source
restored byte-identical afterwards.

`test_coverage_is_not_capped_at_eight_sessions` is replaced by
`test_a_push_is_never_refused_for_carrying_more_sessions_than_the_server_takes`.
The old one asserted a coverage property the deployed server cannot satisfy —
all 21 sessions in one push — which is what motivated the raise. Coverage per
tick is bounded by the SERVER; what the client owes is never being refused. If
coverage is the goal, raise the server first and re-measure.

NOT DONE HERE, deliberately: raising the clawgate app cap or the ingress body
limit both live in other repos. This restores the feature against the server that
is actually running.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jdbmhCKa6edhTmiADsziR
