### PR TITLE
refactor(browser-bridge): delete the hand-rolled shell lexer — measured to detect nothing the command-position anchor did not

### DIFF
--- a/claudedocs/browser-bridge-shell-masker-measurement.py
+++ b/claudedocs/browser-bridge-shell-masker-measurement.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Re-runnable evidence for deleting `mask_shell_noncode` from
+`scripts/browser-bridge/tests/test_surface_parity.py`.
+
+WHY THIS FILE EXISTS
+--------------------
+That module used to carry a 129-line hand-rolled shell lexer (CODE/SQ/DQ/BQ
+states, a `$(` suspend stack, a heredoc queue) whose only job was to answer "is
+this byte inside code?" before the `cmd_op <op>` dispatch regex ran. Successive
+audit rounds kept finding real over-strips in it; each fix added a branch and
+exposed another. The defect rate never fell, because the thing being patched was
+a hand-rolled shell lexer.
+
+It was deleted on MEASUREMENT. This script IS that measurement, so the next
+round that is tempted to reinstate quote/heredoc tracking can re-derive the
+numbers instead of re-litigating them.
+
+RUN IT
+------
+    nix develop ~/workspace/devrc -c \\
+      python3 claudedocs/browser-bridge-shell-masker-measurement.py
+
+Add `--base <ref>` to also load the PRE-DELETION module out of git and run the
+full 2x2 (masker x anchor). Any ref whose tree still contains
+`mask_shell_noncode` works; the numbers below were taken against `cdfd14ab`,
+the base this deletion branched from.
+
+WHAT IT PRINTS, AND WHAT WAS MEASURED 2026-09-10 at that ref
+------------------------------------------------------------
+Corpus: `scripts/browser-bridge/browser`, 144,273 bytes, 53 `cmd_op`
+occurrences of which 25 are prose (comments / strings / an embedded `python3 -c`
+program body).
+
+    masker  anchor    ops parsed
+    ------  ------    ----------
+    on      on        19   <- what shipped
+    OFF     on        19   IDENTICAL, same 19 names
+    on      OFF       19   IDENTICAL, same 19 names
+    OFF     OFF       27   8 junk words: OP, already, can, dispatches,
+                           in, inside, runs, splices
+
+So each defence was independently sufficient on this corpus, and the lexer
+detected NOTHING the command-position anchor had not already rejected. Its
+entire marginal contribution was ONE line -- `browser`'s own comment
+
+    # substitution (`resp="$(cmd_op nav …)"`), and a subshell cannot write the
+
+which the anchor accepts (a `$(` precedes the mention) and which is harmless
+only because `nav` happens to be a real op. That single case is now rejected by
+a whole-line comment filter, one regex with no state and no over-strip failure
+mode: a shell dispatch can never begin with `#`, so dropping such a line can
+remove a MENTION and never a call.
+
+CONSTRUCT CENSUS on the same corpus (why no replacement lexer was written)
+-------------------------------------------------------------------------
+    heredoc openers `<<WORD`            0
+    here-strings `<<<`                  1  (inside a single-quoted jq program)
+    process substitutions `<(` `>(`     0
+    `$( (` subshell-in-cmdsubst         0
+    ANSI-C quoting `$'…'`              12  (all `$'\\n'` inside `${…}` in a
+                                            double-quoted word -- never around a
+                                            `cmd_op` mention)
+    backticks, total                  980
+    backticks outside comments/strings  0
+
+TWO REPLACEMENTS WERE TRIED AND REFUTED, both by measurement
+------------------------------------------------------------
+1. **A real tokeniser.** stdlib `shlex` (posix=True, punctuation_chars, newline
+   as a separator) parsed only 11 of the 19 real dispatches: a double-quoted
+   span is ONE token to it, so it cannot see `resp="$(cmd_op screenshot …)"` at
+   all, which is how 8 of the 19 are spelled. `shfmt` and `shellcheck` -- the
+   only real shell parsers that would work -- are NOT in this repo's devShell,
+   so using one means a new input to the hermetic pre-merge check for one test.
+2. **A whole-line-shape whitelist** (dispatch must match `^cmd_op <op>` or
+   `^<var>="?$( cmd_op <op>`). Measured against the rig: it leaks exactly the
+   same 5 mentions as no masking at all (a prose line at column 0 inside a
+   multi-line quoted string or a heredoc body matches `^cmd_op <word>`), so it
+   buys nothing over the anchor while adding a second grammar to maintain.
+
+THE RESIDUAL BLIND SPOT, stated rather than implied
+---------------------------------------------------
+The surviving parser cannot see a `cmd_op <word>` mention (a) at the start of a
+line inside a multi-line quoted string or a heredoc body, or (b) in a TRAILING
+comment behind a `(`/`;`/`|`/`&`. Neither exists in `browser` today (measured
+above). If one appears, the result is a PHANTOM op, and
+`test_the_classification_matches_what_the_cli_actually_dispatches` and
+`test_the_dispatch_parser_did_not_over_tighten_on_the_real_cli` both report it
+loudly, by name, as `only-in-CLI=[<word>]`. It is a false RED, not a silent
+hole, and the remedy is to reword the mention -- `browser`'s own `classify()`
+docstring documents that discipline.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BB = REPO / "scripts" / "browser-bridge"
+CLI = BB / "browser"
+RIG = BB / "tests" / "fixtures" / "cmd_op_parse_rig.sh"
+REL = "scripts/browser-bridge/tests/test_surface_parity.py"
+
+
+def _load(name: str, path: Path):
+    sys.path.insert(0, str(BB))
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _census(src: str) -> list[tuple[str, int]]:
+    return [
+        ("heredoc openers  <<WORD    ",
+         len(re.findall(r"""<<-?\s*['"]?[A-Za-z_][A-Za-z0-9_]*""", src))),
+        ("here-strings     <<<       ", src.count("<<<")),
+        ("process subst    <( or >(  ", len(re.findall(r"[<>]\(", src))),
+        ("$( (  subshell-in-cmdsubst ", len(re.findall(r"\$\(\s*\(", src))),
+        ("ANSI-C quoting   $'        ", src.count("$" + "'")),
+        ("backticks, total           ", src.count("`")),
+        ("cmd_op occurrences         ", len(re.findall(r"cmd_op", src))),
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", help="git ref whose tree still has mask_shell_noncode")
+    args = ap.parse_args()
+
+    now = _load("tsp_now", BB / "tests" / "test_surface_parity.py")
+    src = CLI.read_text(encoding="utf-8")
+
+    anchored = now._CMD_OP_CALL
+    bare = re.compile(r"\bcmd_op\s+([A-Za-z]+)")
+    ident = (lambda s: s)
+
+    print(f"corpus: {CLI}  ({len(src)} bytes)")
+    print("\n--- construct census ---")
+    for label, n in _census(src):
+        print(f"  {label}: {n}")
+
+    print("\n--- 2x2 over the SURVIVING defences (comment filter x anchor) ---")
+    for cf, cf_lbl in ((now._drop_comment_lines, "on "), (ident, "OFF")):
+        for rx, rx_lbl in ((anchored, "on "), (bare, "OFF")):
+            got = set(rx.findall(cf(src)))
+            print(f"  comment-filter={cf_lbl} anchor={rx_lbl} -> n={len(got):3d} "
+                  f"{sorted(got)}")
+
+    print("\n--- rig ---")
+    rig_src = RIG.read_text(encoding="utf-8")
+    got = now.parse_dispatched_ops(RIG)
+    leaked = sorted(o for o in got if o.startswith("phantom"))
+    print(f"  parsed n={len(got)}  phantoms leaked={leaked}")
+
+    if not args.base:
+        print("\n(pass --base <ref> to add the pre-deletion masker rows)")
+        return 0
+
+    out = subprocess.run(["git", "-C", str(REPO), "show", f"{args.base}:{REL}"],
+                         capture_output=True, text=True)
+    if out.returncode:
+        print(f"\ncannot read {REL} at {args.base}: {out.stderr.strip()}")
+        return 1
+    tmp = Path(tempfile.mkdtemp()) / "before_surface_parity.py"
+    tmp.write_text(out.stdout, encoding="utf-8")
+    before = _load("tsp_before", tmp)
+    if not hasattr(before, "mask_shell_noncode"):
+        print(f"\n{args.base} has no mask_shell_noncode -- pick an earlier ref")
+        return 1
+
+    print(f"\n--- 2x2 over the ORIGINAL defences (masker x anchor) at {args.base} ---")
+    for mk, mk_lbl in ((before.mask_shell_noncode, "on "), (ident, "OFF")):
+        for rx, rx_lbl in ((anchored, "on "), (bare, "OFF")):
+            got = set(rx.findall(mk(src)))
+            print(f"  masker={mk_lbl} anchor={rx_lbl} -> n={len(got):3d} {sorted(got)}")
+
+    b = before.parse_dispatched_ops(CLI)
+    a = now.parse_dispatched_ops(CLI)
+    print(f"\n  BEFORE parse_dispatched_ops n={len(b)}")
+    print(f"  AFTER  parse_dispatched_ops n={len(a)}")
+    print(f"  IDENTICAL ? {a == b}   before-only={sorted(b - a)} "
+          f"after-only={sorted(a - b)}")
+    print(f"  (positive control: the two parsers DO differ on the pre-deletion "
+          f"rig -- see the module docstring)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -1177,10 +1177,14 @@ def classify(text):
     WORDING IS LOAD-BEARING HERE: the dispatch helper is named in BACKTICKS with
     a word BEFORE it, never followed directly by a bare word. The surface-parity
     gate harvests wire ops by matching that helper name followed by whitespace and
-    an identifier, and it skips only lines whose first non-space char is `#` — a
-    docstring line is not one. Prose of the form "<helper> stderr" is therefore
-    harvested as a phantom wire op and reddens the MERGED tree while this branch
-    and the gate branch are each green alone.
+    an identifier, in COMMAND POSITION (start of line, or after a separator such
+    as ; && || | or an opening paren), and it drops only whole-line comments — a
+    docstring line is not one, and it does not model quoted regions at all, so
+    being inside this program body buys nothing. Prose of the form
+    "<helper> stderr" is therefore harvested as a phantom wire op and reddens the
+    MERGED tree while this branch and the gate branch are each green alone.
+    Keeping a word before the backticked name is what defeats the command-position
+    anchor; see claudedocs/browser-bridge-shell-masker-measurement.py.
 
     Order matters: the op-level line is the most specific, then the server body
     that the HTTP branches echo verbatim, then a last-resort token.

--- a/scripts/browser-bridge/tests/fixtures/cmd_op_parse_rig.sh
+++ b/scripts/browser-bridge/tests/fixtures/cmd_op_parse_rig.sh
@@ -14,6 +14,20 @@
 # turning the gate red with a diagnostic that sent the reader hunting for an op
 # that does not exist. Invisible on either branch alone. The class of bug, not the
 # word `stderr`, is what the cases below pin.
+#
+# 🔴 WHAT THIS RIG DELIBERATELY NO LONGER CONTAINS, and why. Five cases used to
+# live here -- phantommultilinedq (a multi-line double-quoted string),
+# phantomdocstring and phantomsqblock (mentions at column 0 inside a
+# single-quoted `python3 -c` program body), phantomheredoc and
+# phantomquotedheredoc (heredoc bodies, plain and `<<-`-with-quoted-delimiter).
+# Each was rejected ONLY by `mask_shell_noncode`, a 129-line hand-rolled shell
+# lexer that test_surface_parity.py used to carry. That lexer was DELETED after a
+# 2x2 measurement over the real `browser` CLI showed it rejected nothing the
+# command-position anchor did not already reject (19 ops parsed with it, 19
+# without, identical names). Keeping those cases would pin behaviour the parser
+# no longer has. The shapes are named here so the blind spot is on the record;
+# reintroducing them means reintroducing a lexer, so re-run
+# `claudedocs/browser-bridge-shell-masker-measurement.py` first.
 
 # --- MUST be harvested: genuine dispatches, in real command position ---------
 
@@ -42,50 +56,24 @@ die "no answer from the extension -- retry with cmd_op phantomdq in the message"
 
 echo 'inline note: cmd_op phantomsq is a mention, not a call'
 
-# A multi-line DOUBLE-quoted string. The mention below sits at column 0, i.e. in
-# what looks like command position -- only quote tracking rejects it.
-usage_text="
-cmd_op phantommultilinedq OP [EXTRA]
-"
-
-# A multi-line SINGLE-quoted string: the `python3 -c '...'` shape from #278.
-python3 -c '
-def explain(kind):
-    """Docs for the machine-readable cause.
-
-cmd_op phantomdocstring is only ever mentioned here, never dispatched.
-    """
-    return kind
-'
-
-# A heredoc body. Unquoted at the character level, and the mention starts the
-# line, so ONLY heredoc tracking rejects it.
-cat <<EOF
-cmd_op phantomheredoc OP [FIELDS] -- wire format reference
-EOF
-
-# An indented/tab-stripped heredoc with a QUOTED delimiter.
-cat <<-'HELP'
-	cmd_op phantomquotedheredoc -- also only documentation
-HELP
-
 # A backtick-quoted mention inside prose (the exact #278 shape).
 printf '%s\n' "see \`cmd_op phantombacktick\` above"
 
 # --- cases that isolate ONE defence each -------------------------------------
-# The two below exist because a mutation sweep found the corresponding defence
-# was NOT load-bearing on the earlier rig: removing it left the suite green.
+# Each of the two below exists because it is the ONLY case in this rig that the
+# named defence rejects: delete that defence and this line, and only this line,
+# leaks.
 
-# UNQUOTED prose in live command context. Quote/comment/heredoc masking all pass
-# it through untouched -- ONLY the command-position anchor rejects it. (Mutation
+# UNQUOTED prose in live command context. A whole-line comment filter passes it
+# through untouched -- ONLY the command-position anchor rejects it. (Mutation
 # P5, "drop command-position anchoring", survived until this line existed.)
 echo usage: cmd_op phantombareword OP [EXTRA]
 
-# A single-quoted `python3 -c` block containing NO double quotes, with the
-# mention at column 0 -- i.e. in apparent command position. ONLY single-quote
-# masking rejects it. The earlier docstring case was being caught by accident:
-# the `"""` in it toggled double-quote state, so removing single-quote masking
-# left the suite green for the wrong reason. (Mutation P6.)
-python3 -c '
-cmd_op phantomsqblock is mentioned in a single-quoted program body
-'
+# A WHOLE-LINE comment that quotes a dispatch verbatim, so the `$(` inside it
+# puts the mention in apparent command position and the anchor ACCEPTS it --
+# ONLY the whole-line comment filter rejects it. This is not hypothetical: it is
+# the shape of `browser`'s own comment
+#   # substitution (`resp="$(cmd_op nav ...)"`), and a subshell cannot write the
+# which was the single mention the deleted shell lexer really was catching on
+# the live CLI. It is harmless there only because `nav` happens to be a real op.
+# substitution (`resp="$(cmd_op phantomcommentsubst ...)"`), harvested by anchor

--- a/scripts/browser-bridge/tests/test_surface_parity.py
+++ b/scripts/browser-bridge/tests/test_surface_parity.py
@@ -140,11 +140,13 @@ def parse_dispatched_ops(path: Path = BROWSER_CLI) -> set[str]:
         OFF     OFF      27   8 junk words: OP, already, can, dispatches,
                               in, inside, runs, splices
 
-    So on the corpus it is pointed at, the lexer detected NOTHING the
-    command-position anchor did not already reject. Its whole marginal
-    contribution was ONE comment -- `# substitution (`resp="$(cmd_op nav ...)"`)`
-    -- which the anchor accepts (a `$(` precedes) and which the one-line
-    comment filter above now rejects for a reason that cannot be got wrong.
+    So on the corpus it is pointed at, the lexer changed the parsed op set by
+    NOTHING. Below the set, it removed exactly ONE command-position hit that the
+    anchor accepts: `browser`'s own whole-line comment quoting a dispatch
+    verbatim, whose `$(` puts the mention in apparent command position. That hit
+    is invisible in the set only because the op it names is also really
+    dispatched. It is the one case worth keeping, and the whole-line comment
+    filter above now rejects it for a reason that cannot be got wrong.
 
     🔴 WHAT THIS PARSER THEREFORE CANNOT SEE, stated rather than implied: a
     `cmd_op <word>` mention at the START OF A LINE inside a multi-line quoted

--- a/scripts/browser-bridge/tests/test_surface_parity.py
+++ b/scripts/browser-bridge/tests/test_surface_parity.py
@@ -33,6 +33,20 @@ guards firing against known-bad input.
 
 This module is part of the hermetic set (``scripts/run-tests.sh``), so it runs
 in ``nix build .#checks.x86_64-linux.pytests`` -- the repo's real pre-merge gate.
+
+🔴 NO SHELL LEXER LIVES HERE ANY MORE. This module used to carry
+``mask_shell_noncode``, a 129-line hand-rolled shell lexer (CODE/SQ/DQ/BQ
+states, a ``$(`` suspend stack, a heredoc queue) whose job was to answer "is
+this byte inside code?" before the dispatch regex ran. Successive audit rounds
+kept finding real over-strips in it and each fix added another branch; the
+defect rate never fell, because the thing being patched was a hand-rolled shell
+lexer. It was deleted on MEASUREMENT, not taste: on the corpus it is pointed at
+it detected nothing the command-position anchor did not already reject. The
+numbers, the two replacement options that were tried and refuted, and the
+residual blind spot are in ``parse_dispatched_ops``'s docstring; the script that
+produced them is `claudedocs/browser-bridge-shell-masker-measurement.py`.
+**If a future round is tempted to reinstate quote/heredoc tracking, run that
+script first and act on what it prints.**
 """
 import re
 import sys
@@ -78,163 +92,85 @@ def parse_subcommands(path: Path = BROWSER_CLI) -> list[str]:
     return m.group(1).split()
 
 
-def mask_shell_noncode(src: str) -> str:
-    """Blank out everything in a shell script that is NOT live code, preserving
-    every byte offset and newline so the result can be regex-scanned positionally.
-
-    Masked: comments, single-/double-quoted strings (INCLUDING multi-line ones),
-    backquoted spans, and heredoc bodies. Command substitutions ``$( … )`` are
-    NOT masked even inside double quotes, because that is real command position
-    -- the CLI genuinely dispatches from there (``resp="$(cmd_op screenshot …)"``).
-
-    WHY. A `cmd_op X` MENTION inside a docstring, heredoc, error message or
-    prose string is not a dispatch of `X`. The first version of this parser
-    matched any line whose first non-space character was not `#`, and harvested a
-    phantom op from a Python docstring on a merged tree (see
-    tests/fixtures/cmd_op_parse_rig.sh for the measurement and the pinned cases).
-
-    Deliberately a small lexer, not a shell parser: it handles the constructs the
-    `browser` CLI actually uses. If it over-masks, the non-empty guard in
-    ``parse_dispatched_ops`` and the exact-set control in
-    ``test_the_dispatch_parser_ignores_mentions_and_keeps_calls`` both fail loudly
-    -- over-tightening cannot pass vacuously.
-    """
-    out = list(src)
-    n = len(src)
-    i = 0
-    state = "CODE"          # CODE | SQ | DQ | BQ
-    substack: list[str] = []  # states suspended by an open `$(`
-    heredocs: list[tuple[str, bool]] = []  # (delimiter, strip_leading_tabs)
-
-    def blank(a: int, b: int) -> None:
-        for k in range(a, min(b, n)):
-            if out[k] != "\n":
-                out[k] = " "
-
-    while i < n:
-        c = src[i]
-
-        if state == "CODE":
-            if c == "\\" and i + 1 < n:
-                i += 2
-                continue
-            # `#` starts a comment only at the start of a word.
-            if c == "#" and (i == 0 or src[i - 1] in " \t\n;&|(<"):
-                j = src.find("\n", i)
-                j = n if j < 0 else j
-                blank(i, j)
-                i = j
-                continue
-            if src.startswith("$(", i):
-                substack.append(state)
-                i += 2
-                continue
-            if c == ")" and substack:
-                state = substack.pop()
-                i += 1
-                continue
-            if c == "'":
-                state = "SQ"
-                blank(i, i + 1)
-                i += 1
-                continue
-            if c == '"':
-                state = "DQ"
-                blank(i, i + 1)
-                i += 1
-                continue
-            if c == "`":
-                state = "BQ"
-                blank(i, i + 1)
-                i += 1
-                continue
-            m = re.match(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2", src[i:])
-            if m and not src.startswith("<<<", i):
-                heredocs.append((m.group(3), bool(m.group(1))))
-                i += m.end()
-                continue
-            if c == "\n" and heredocs:
-                i += 1
-                for delim, strip_tabs in heredocs:
-                    while i < n:
-                        eol = src.find("\n", i)
-                        eol = n if eol < 0 else eol
-                        line = src[i:eol]
-                        probe = line.lstrip("\t") if strip_tabs else line
-                        blank(i, eol)
-                        i = min(eol + 1, n)
-                        if probe.strip() == delim:
-                            break
-                heredocs = []
-                continue
-            i += 1
-            continue
-
-        if state == "SQ":
-            if c == "'":
-                state = "CODE"
-            blank(i, i + 1)
-            i += 1
-            continue
-
-        if state == "BQ":
-            if c == "`":
-                state = "CODE"
-            blank(i, i + 1)
-            i += 1
-            continue
-
-        # DQ
-        if c == "\\" and i + 1 < n:
-            blank(i, i + 2)
-            i += 2
-            continue
-        if src.startswith("$(", i):
-            # NOT blanked: `$(` inside double quotes REOPENS command position,
-            # and the `(` is what the command-position regex anchors on. Blanking
-            # it here silently loses `resp="$(cmd_op screenshot "$full")"` -- a
-            # real dispatch (measured: the parser returned 18 ops instead of 19).
-            substack.append("DQ")
-            state = "CODE"
-            i += 2
-            continue
-        if c == '"':
-            state = "CODE"
-            blank(i, i + 1)
-            i += 1
-            continue
-        blank(i, i + 1)
-        i += 1
-
-    return "".join(out)
-
-
 #: A `cmd_op` call in genuine COMMAND POSITION: at the start of a statement, or
 #: immediately after a separator/opening construct. A substring mention such as
 #: "from `cmd_op stderr` it emits" or "usage: cmd_op OP [FIELDS]" is not a call,
 #: and neither is one preceded by a word character or a quote.
 _CMD_OP_CALL = re.compile(r"(?:^|[;&|(]|\bthen\b|\bdo\b|\belse\b)\s*cmd_op\s+([A-Za-z]+)", re.M)
 
+#: A WHOLE-LINE comment. This is the only "is it code?" question this module
+#: asks, and it is the only one it can answer without being wrong: a shell
+#: dispatch can never begin with `#`, so dropping such a line can remove a
+#: MENTION and never a call. There is no over-strip failure mode to audit.
+_COMMENT_LINE = re.compile(r"^[ \t]*#")
+
+
+def _drop_comment_lines(src: str) -> str:
+    """Blank whole-line comments, keeping every other line (and the line count)
+    intact so `_CMD_OP_CALL`'s `^` anchor still means "start of line"."""
+    return "".join(
+        "\n" if _COMMENT_LINE.match(ln) else ln
+        for ln in src.splitlines(keepends=True))
+
 
 def parse_dispatched_ops(path: Path = BROWSER_CLI) -> set[str]:
     """Ops the CLI actually puts on the wire, parsed from its `cmd_op <op>` call
     sites.
 
-    Two independent conditions, both required -- a MENTION of `cmd_op X` is not a
-    dispatch of `X`:
-      1. the occurrence survives ``mask_shell_noncode`` (not in a comment, string
-         or heredoc body), and
+    Two conditions, both required -- a MENTION of `cmd_op X` is not a dispatch
+    of `X`:
+      1. the occurrence is not on a whole-line comment, and
       2. it sits in genuine command position (start of statement, or after
          ``;`` ``&&`` ``||`` ``|`` ``(`` ``$(`` ``then`` ``do`` ``else``).
+
+    🔴 THERE USED TO BE A THIRD, `mask_shell_noncode` -- a 129-line hand-rolled
+    shell lexer (CODE/SQ/DQ/BQ states, a `$(` suspend stack, a heredoc queue).
+    It was DELETED, on measurement rather than on taste. Re-run the numbers
+    before reinstating any of it; the script is
+    `claudedocs/browser-bridge-shell-masker-measurement.py`.
+
+    WHAT WAS MEASURED, on the real `browser` CLI (144 KB, 53 `cmd_op`
+    occurrences of which 25 are prose), as a 2x2 over the two defences:
+
+        masker  anchor   ops parsed
+        ------  ------   ----------
+        on      on       19   <- what shipped
+        OFF     on       19   IDENTICAL, same 19 names
+        on      OFF      19   IDENTICAL, same 19 names
+        OFF     OFF      27   8 junk words: OP, already, can, dispatches,
+                              in, inside, runs, splices
+
+    So on the corpus it is pointed at, the lexer detected NOTHING the
+    command-position anchor did not already reject. Its whole marginal
+    contribution was ONE comment -- `# substitution (`resp="$(cmd_op nav ...)"`)`
+    -- which the anchor accepts (a `$(` precedes) and which the one-line
+    comment filter above now rejects for a reason that cannot be got wrong.
+
+    🔴 WHAT THIS PARSER THEREFORE CANNOT SEE, stated rather than implied: a
+    `cmd_op <word>` mention at the START OF A LINE inside a multi-line quoted
+    string or a heredoc body, and one in a TRAILING comment behind a `(`/`;`.
+    Measured on the CLI today: zero heredocs, zero process substitutions, zero
+    backticks outside comments and strings, and no multi-line quoted block with
+    a `cmd_op` mention in column 0. The CLI's own `python3 -c` docstring near
+    `classify()` documents the wording discipline that keeps it that way.
+    The failure mode if that changes is a PHANTOM op, which
+    ``test_the_classification_matches_what_the_cli_actually_dispatches`` and
+    ``test_the_dispatch_parser_did_not_over_tighten_on_the_real_cli`` both
+    report loudly by name -- it is not a silent hole. That is the trade this
+    deletion accepts, and it is the reason no replacement lexer was written:
+    stdlib `shlex` was tried and MEASURED to lose 8 of the 19 real dispatches
+    (it cannot see `"$(cmd_op ...)"` at all, because a double-quoted span is one
+    token to it), and no real shell parser (`shfmt`, `shellcheck`, a bash
+    grammar) is in this repo's devShell, so using one means a new input to the
+    hermetic pre-merge check for one test's benefit.
     """
-    ops = set(_CMD_OP_CALL.findall(mask_shell_noncode(_read(path))))
+    ops = set(_CMD_OP_CALL.findall(_drop_comment_lines(_read(path))))
     if not ops:
         raise AssertionError(
             f"HARNESS BROKEN: parsed ZERO `cmd_op <op>` dispatch sites from "
             f"{path.name}. Every op-parity assertion in this module would pass "
-            f"vacuously. If the CLI is fine, the command-position regex or the "
-            f"shell masker has been over-tightened -- fix the parser, do not "
-            f"relax the callers.")
+            f"vacuously. If the CLI is fine, the command-position regex has "
+            f"been over-tightened -- fix the parser, do not relax the callers.")
     return ops
 
 
@@ -397,14 +333,26 @@ RIG_REAL_DISPATCHES = {
 def test_the_dispatch_parser_ignores_mentions_and_keeps_calls():
     """A `cmd_op X` MENTION is not a dispatch of `X`.
 
-    RED-FIRST, MEASURED against this rig with the previous parser (which matched
-    any line not starting with `#`): it harvested 7 phantom ops --
-    phantombacktick, phantomdocstring, phantomdq, phantomheredoc,
-    phantommultilinedq, phantomquotedheredoc, phantomsq -- while keeping all 8
-    real ones. The real-world instance was a Python docstring inside a
-    `python3 -c` block on a merged tree, which produced a phantom wire op named
-    `stderr` and a diagnostic that sent the reader hunting for an op that does
-    not exist.
+    RED-FIRST, MEASURED against this rig with the ORIGINAL parser -- a bare
+    `\\bcmd_op\\s+(\\w+)` over every line whose first non-space character was not
+    `#`, i.e. NO command-position anchor and NO masking. It harvested 11 phantom
+    ops while keeping all 8 real ones. The real-world instance was a Python
+    docstring inside a `python3 -c` block on a merged tree, which produced a
+    phantom wire op named `stderr` and a diagnostic that sent the reader hunting
+    for an op that does not exist.
+
+    🔴 THE RIG NO LONGER CARRIES ALL 11, and that is deliberate. 5 of them
+    (phantomdocstring, phantomheredoc, phantommultilinedq, phantomquotedheredoc,
+    phantomsqblock) were rejected ONLY by `mask_shell_noncode`, the hand-rolled
+    shell lexer this module used to carry. That lexer was deleted after a
+    measurement showed it rejected NOTHING on the real CLI that the
+    command-position anchor did not already reject (see
+    ``parse_dispatched_ops``'s docstring for the 2x2, and
+    `claudedocs/browser-bridge-shell-masker-measurement.py` to re-run it).
+    Keeping their cases here would pin a behaviour this module no longer has --
+    a test for deleted code, which is not coverage. The 6 the anchor owns stay,
+    and `phantomcommentsubst` was ADDED because it is the one shape the deleted
+    lexer really was catching on the live CLI.
     """
     got = parse_dispatched_ops(RIG)
     leaked = sorted(o for o in got if o.startswith("phantom"))
@@ -433,8 +381,17 @@ def test_the_dispatch_parser_did_not_over_tighten_on_the_real_cli():
     pin the shapes the CLI actually uses -- in particular `screenshot`, which is
     dispatched from inside a command substitution nested in double quotes
     (`resp="$(cmd_op screenshot "$full")"`). MEASURED: an earlier version of the
-    masker blanked the `$(` and lost exactly that one op, 19 -> 18, while every
-    other test in this file stayed green.
+    now-deleted shell masker blanked the `$(` and lost exactly that one op,
+    19 -> 18, while every other test in this file stayed green. The op count is
+    19 and has been 19 under every version of the parser measured.
+
+    🔴 This is also where a PHANTOM shows up. The parser does not model
+    multi-line quoted strings or heredoc bodies, so a `cmd_op <word>` mention in
+    column 0 inside one would be harvested and reported here as
+    `only-in-CLI=[<word>]`. That is loud and names the offending word; it is not
+    a silent hole. The fix in that case is to reword the mention (the CLI's own
+    `classify()` docstring documents the discipline), not to reintroduce a
+    hand-rolled lexer.
     """
     wire, server_ops, _subs = _inventory()
     dispatched = parse_dispatched_ops()
@@ -444,26 +401,12 @@ def test_the_dispatch_parser_did_not_over_tighten_on_the_real_cli():
     assert "screenshot" in dispatched, (
         "`screenshot` is dispatched from `resp=\"$(cmd_op screenshot ...)\"` -- a "
         "command substitution nested inside double quotes. Losing it means the "
-        "masker stopped treating `$(` as reopening command position.")
+        "command-position anchor stopped treating `$(` as command position.")
     assert "getHtml" in dispatched, "`getHtml` is dispatched from a plain call site"
     assert dispatched == (wire | server_ops), (
         f"the CLI's real dispatch sites no longer equal server.py's op inventory. "
         f"only-in-CLI={sorted(dispatched - (wire | server_ops))} "
         f"only-in-server={sorted((wire | server_ops) - dispatched)}")
-
-
-def test_the_cli_uses_no_live_backtick_command_substitution():
-    """`mask_shell_noncode` masks backquoted spans conservatively, because the
-    only backticks in the CLI are inside prose comments (113 of them, MEASURED).
-    If a real ```...``` substitution were ever introduced, a dispatch inside it
-    would be silently masked away -- so pin the assumption rather than leave it
-    implicit."""
-    masked = mask_shell_noncode(_read(BROWSER_CLI))
-    assert "`" not in masked, (
-        "the `browser` CLI now contains a backtick OUTSIDE a comment/string. "
-        "mask_shell_noncode treats backquoted spans as non-code, so a `cmd_op` "
-        "dispatch inside one would be silently dropped. Rewrite it as $( ) or "
-        "teach the masker about backtick substitution.")
 
 
 def test_the_parsed_inventory_is_non_empty_and_plausible():


### PR DESCRIPTION
## What this is

`scripts/browser-bridge/tests/test_surface_parity.py` carried `mask_shell_noncode`, a **129-line hand-rolled shell lexer** (CODE/SQ/DQ/BQ states, a `$(` suspend stack, a heredoc queue) whose only job was to answer *"is this byte inside code?"* before the `cmd_op <op>` dispatch regex ran. Successive audit rounds kept finding real over-strips in it and each fix added a branch. The defect rate never fell, because the thing being patched was a hand-rolled shell lexer.

**It is deleted.** Not rewritten — deleted, on a measurement taken before anything changed.

## The measurement that decided it

2x2 over the two defences, on the real `browser` CLI (144,273 bytes; 53 `cmd_op` occurrences, 25 of them prose):

| masker | anchor | ops parsed |
|---|---|---|
| on | on | **19** ← what shipped |
| **OFF** | on | **19** — identical, same 19 names |
| on | **OFF** | **19** — identical, same 19 names |
| OFF | OFF | 27 — 8 junk words: `OP`, `already`, `can`, `dispatches`, `in`, `inside`, `runs`, `splices` |

Each defence was **independently sufficient**. The lexer detected nothing the command-position anchor had not already rejected.

Its entire marginal contribution was **one line** — the CLI's own comment quoting a dispatch verbatim, whose `$(` puts the mention in apparent command position:

```
# substitution (`resp="$(cmd_op nav …)"`), and a subshell cannot write the
```

…harmless only because `nav` happens to be a real op. That single case is now rejected by a **whole-line comment filter**: one regex, no state, and *no over-strip failure mode*, because a shell dispatch can never begin with `#`.

**Positive control** (the comparison can report DIFFERENT): the same before/after comparison over the *pre-deletion* rig moves, 8 → 13, naming the five mentions only the masker rejected.

**Before/after on the real input**: `parse_dispatched_ops()` returns the same 19 names. Shown, not asserted — `claudedocs/browser-bridge-shell-masker-measurement.py --base cdfd14ab` loads the pre-deletion module out of git and prints both halves.

## Why not a replacement parser

Tried and refuted rather than assumed:

* **stdlib `shlex`** (posix, `punctuation_chars`, newline as separator) parses **11 of the 19** real dispatches. A double-quoted span is one token to it, so it cannot see `resp="$(cmd_op screenshot …)"` at all — which is how 8 of the 19 are spelled.
* **A whole-line-shape whitelist** leaks exactly the same 5 rig mentions as no masking at all (prose at column 0 inside a quoted block matches `^cmd_op <word>`), so it buys nothing over the anchor while adding a second grammar.
* **`shfmt` / `shellcheck`** are not in the devShell, so a real shell parser means a new input to the hermetic pre-merge check for one test's benefit.

## Mutation matrix on the two surviving defences

`PYTHONDONTWRITEBYTECODE=1`, `-p no:cacheprovider`, file restored from a `cp -a` copy between mutants:

| mutant | verdict | counts | own reason |
|---|---|---|---|
| baseline | — | 14 passed / 0 failed | — |
| M1 command-position anchor removed | **KILLED** | 13 / 1 | `phantombareword` |
| M2 whole-line comment filter removed | **KILLED** | 13 / 1 | `phantomcommentsubst` |
| P parser wired to nothing | **KILLED** | 10 / 4 | `HARNESS BROKEN: parsed ZERO` |
| N indented-comment handling removed | **SURVIVED** | 14 / 0 | negative control — proves the harness can report SURVIVED |

M2 is what makes the new filter's *reachability* a measurement rather than a claim. N is honest: the `[ \t]*` in `_COMMENT_LINE` is not currently reached by any fixture.

## What was removed with it

A test for deleted code is not coverage, so these went too:

* `test_the_cli_uses_no_live_backtick_command_substitution` — its whole subject was the masker's backtick state.
* The 5 rig cases only the masker rejected: `phantomdocstring`, `phantomheredoc`, `phantommultilinedq`, `phantomquotedheredoc`, `phantomsqblock`. Their shapes stay **named in the rig header** so the blind spot is on the record.

Added `phantomcommentsubst`, taken from the shape of the live CLI comment above.

Still covering the real behaviour: 6 anchor-rejected phantoms + 8 real dispatch shapes in the rig, the exact-set assertion `got == RIG_REAL_DISPATCHES`, the non-empty harness guard, and the real-CLI parity assertions (`dispatched == wire | server_ops`).

## Residual blind spot, stated rather than implied

The surviving parser cannot see a `cmd_op <word>` mention **(a)** at the start of a line inside a multi-line quoted string or heredoc body, or **(b)** in a trailing comment behind a separator. Neither exists in the CLI today — measured: 0 heredoc openers, 0 process substitutions, 0 `$( (`, 0 backticks outside comments/strings, 12 `$'\n'` (all inside `${…}` in a double-quoted word, never near a mention).

If one appears the result is a **phantom op**, reported loudly by name as `only-in-CLI=[…]` by two tests. A false RED, not a silent hole — the existing fail-safes, unchanged; no third one was added.

## Also fixed: a stale claim in the production CLI

`browser`'s own `classify()` docstring told readers the gate *"skips only lines whose first non-space char is `#`"* and said nothing about the command-position anchor — which is the defence its "wording is load-bearing" discipline actually defeats. That sentence has been wrong since the two PRs that landed the same day (#277 added the parser, #278 wrote the note). Corrected, with a pointer to the measurement script.

## Verification

* `scripts/browser-bridge/tests/` — **914 passed** (dev-host tier, in the devShell).
* `test_surface_parity.py` alone — 15 → **14** (one test deleted).
* `bash -n scripts/browser-bridge/browser` — OK.
* Nix tier (`devrc-pytests`) — CI on this PR.
