### PR TITLE
docs(handoff): the dash premise is TRUE on the deployed pod — and no longer load-bearing

### DIFF
--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -380,24 +380,29 @@ hosts, so 3–7 became 2–6. The claim `index-store-claims-accuracy-2` was take
 and released on completion; a future session claiming rank 2 gets the **cairn-cutover P3**
 item, not the drift one.
 
-1. **Verify the dash premise against the DEPLOYED pod image**, read-only. The whole
-   `seed.sh` guard rests on `/bin/sh` being dash there; that was measured against the
-   `Dockerfile`'s `FROM`, never the running pod.
-   forcing: none
-
-2. **Decide the token allowlist for the 2 remaining local-only entries**
+1. **Decide the token allowlist for the 2 remaining local-only entries**
    (`civitai-app-requests`, `civitai-developer-docs`). `cairn create` answers `not-found`;
    neither scope is in this token's allowlist. Widening it edits the k8s secret and needs a
    pod delete (the token file is read ONCE at startup).
    forcing: none
 
-3. **Fix `devrc#1170`'s 🟡5 and 🟡6.** Still never started. 🟡5: re-measured 2026-09-04,
+2. **Fix `devrc#1170`'s 🟡5 and 🟡6.** Still never started. 🟡5: re-measured 2026-09-04,
    **0** occurrences of `policy:` in `service_recon.py` on `origin/main`. 🟡6: `--template`
    over an EXISTING entry prints the first-ever-file template and exits 0 silently,
    destroying an `OPEN:` bullet.
    forcing: none
 
 ## Gotchas / decisions / dead-ends
+- ✅ **THE DASH PREMISE IS TRUE ON THE DEPLOYED POD, AND NO LONGER LOAD-BEARING.**
+  Measured 2026-09-10 against the RUNNING image (`subsystem-store-api:0.8.0`, not
+  the `Dockerfile`): `/bin/sh -> dash` (`/usr/bin/dash`), and its `echo "a\tb"`
+  emits a real TAB. Control: bash emits the literal `a\tb`, so the asymmetry is
+  real and the reading is not a no-op. **But every pod-side emit in `seed.sh` is
+  now `printf`, not `echo`** — `grep -nE "sh -c .*echo"` returns nothing — so the
+  dash-specific behaviour cannot reach the join key any more. The premise held
+  AND the code stopped depending on it; verifying it changed no decision, which
+  is the honest outcome for a `forcing: none` item.
+
 - ✅ **THE CO-TENANT FLAKE IS DIAGNOSED AND FIXED — `devrc#1453` → `eeea9025`. It
   was `git maintenance run --auto --quiet --detach`, never `gc --auto`.**
   Committing spawns it DETACHED, so `subprocess.run` returns when the parent exits


### PR DESCRIPTION
docs(handoff): the dash premise is TRUE on the deployed pod — and no longer load-bearing

Rank 1, `forcing: none`. It asked for the one measurement never taken: the whole
`seed.sh` probe guard rested on `/bin/sh` being dash on the POD, and that had only
ever been read off the `Dockerfile`'s `FROM` line.

MEASURED 2026-09-10 against the RUNNING image, read-only
(`subsystem-store-api-cfc9657c4-dh86x`, `harbor.homelab.lan/library/subsystem-store-api:0.8.0`):

  /bin/sh -> dash                    (resolves to /usr/bin/dash)
  pod:  sh -c 'echo "a\tb"'   ->  a<TAB>b     escapes interpreted
  ctl:  bash -c 'echo "a\tb"' ->  a\tb        literal

The bash control matters: "dash emits a tab" only establishes an ASYMMETRY if
bash does not, and without it the reading would be a no-op dressed as a
confirmation. A second local dash reading matched the pod.

So the premise is CONFIRMED. It is also MOOT: every pod-side emit in `seed.sh` is
now `printf`, not `echo` — `grep -nE "sh -c .*echo"` over that file returns
nothing — so the dash-specific escape handling can no longer reach the join key.
The premise held AND the code stopped depending on it.

Verifying it changed no decision. That is the honest outcome for a `forcing:
none` item, and worth recording as such rather than dressed up: the value was
retiring an assumption that had been asserted from a Dockerfile line for weeks,
not finding a defect.

Ranked list re-based 1..2.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AwUQmUw99gqMug4T3ruFNC
