### PR TITLE
docs(protect): #1471 fixed one copy of the expired reason and left two

### DIFF
--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -516,9 +516,14 @@
 # 🔴 THE ARM FIRES ON DISAGREEMENT, NOT ON THE BARE STATE. Measured 2026-09-02:
 # `required_status_checks` is absent from the protection object and
 # `enforce_admins` is false on innovation-upstream/devrc — and that is a DECISION,
-# not drift. The operator turned the Tekton merge gate off because it was slowing
-# work down, and it stays off until the Tekton capacity issue is addressed, which
-# a different session owns. A checker that keys on the bare state fires on every
+# not drift. It is OFF as a STANDING preference: a solo-contributor repo whose
+# operator requires the ability to ship immediately. ⚠ This paragraph used to say
+# "until the Tekton capacity issue is addressed, which a different session owns"
+# — conditional, and the condition was already met (capacity measured fine
+# 2026-09-10), so it read as an instruction to restore protection against the
+# operator's wishes. The authoritative wording is `bp_declared_off_reason()`'s;
+# this comment does not restate the reason, it points there. A checker that keys
+# on the bare state fires on every
 # 6-hourly run for as long as that decision stands: `drift-check.service`'s
 # OnFailure is `notify-failure@`, the ONE toast class deliberately wired to bypass
 # do-not-disturb. The measured breach rate and the arithmetic against the rate

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -6583,9 +6583,14 @@ def test_rc24_is_ranked_between_rc8_and_rc17_in_the_severity_table():
 # THE DECLARED EXPECTATION (rc 24 / rc 25)
 #
 # 🔴 THE DESIGN DECISION THESE TESTS EXIST TO PIN. Measured 2026-09-02: the merge
-# gate on innovation-upstream/devrc is OFF, DELIBERATELY — the operator turned it
-# off until the Tekton capacity issue is addressed, which a different session
-# owns. The bare-state arm therefore reported it as DRIFT on every run that
+# gate on innovation-upstream/devrc is OFF, DELIBERATELY — and as of 2026-09-10 it
+# is off as a STANDING preference (solo-contributor repo; the operator requires
+# the ability to ship immediately), not pending any event. ⚠ This block used to
+# say "until the Tekton capacity issue is addressed, which a different session
+# owns" — conditional, and the condition was already met, so it read as an
+# instruction to restore protection. The authoritative wording lives in
+# `bp_declared_off_reason()`; nothing here restates the reason.
+# The bare-state arm therefore reported it as DRIFT on every run that
 # reached it, and would have indefinitely, while `drift-check.service`'s
 # OnFailure is the ONE toast class deliberately wired to bypass do-not-disturb.
 # That is the permanently-red gate `claude/RULES.md` refuses, arrived at from a


### PR DESCRIPTION
Follow-up to #1471, which replaced the conditional *"off until the Tekton capacity issue is addressed"* reason in `bp_declared_off_reason()` — and whose own commit message argued for one-rule-one-place while doing it. It then missed two more copies of that sentence:

| site | what it was doing |
|---|---|
| `scripts/drift-check.sh:520` | the rc 24/25 header block — **in the same file the fix edited** — still asserting the conditional reason as current |
| `scripts/tests/test_drift_check.py:6587` | the comment block that says it exists to **pin this design decision**, pinning the expired version of it |

Found by grepping `origin/main` for the retracted phrase after the merge and getting **2 where 0 was expected**. That check takes seconds and should have run before #1471 merged, not after.

## The fix is deferral, not a fourth synchronised copy

Both sites now state the standing reason (solo-contributor repo; the operator requires the ability to ship immediately) and then **point at `bp_declared_off_reason()`** rather than restating it. The only authoritative reason text is the one the code returns.

That matters because the failure mode here is not "someone forgot to grep". A reason duplicated at four sites regenerates the stale copy at three of them — which is exactly what happened. Removing the duplication is the fix; a more careful sweep is not.

## On the surviving occurrences

Four mentions of the old phrase remain, and all four are **deliberate quotes of the retracted wording**, each introduced by *"used to say"* / *"IT USED TO READ"* / *"and that was a trap"*. They are kept on purpose so nobody re-derives the conditional version from scratch.

⚠ A grep for the phrase alone cannot distinguish those from a live claim — read the sentence around it. That is a real limitation of the check that found this bug, stated here rather than left for the next person to trip on.

## Verification

**461 passed** on `test_drift_check.py` at this tree; `bash -n` clean on `drift-check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zKmAWntvACVnzP6kbxW9b