### PR TITLE
docs(handoff): round 2 of #1383 — all three new findings were created by round 1's own fixes

### DIFF
--- a/claudedocs/handoff-tmux-restore-chain.md
+++ b/claudedocs/handoff-tmux-restore-chain.md
@@ -26,32 +26,44 @@ worked: every link in the save→plan→restore chain was broken, silently, for 
 | #1344 | `1ecc03c1` | no instrument existed to read a reboot; adds `tmux-restore-observe.sh` |
 | #1351 | `9353d958` | the unit MANUFACTURED a tmux server systemd then killed; adds the no-server REFUSAL |
 | #1375 | head `10570f92` | 81-row gate inventory + `scripts/check-gate-inventory.py` |
-| **#1415** | **`176f412b`** | **the kill-server guard — MERGED, SHIPPED, VERIFIED LIVE on both hosts** |
-| **#1376** | **`e55533ea`** | **socket-activation trigger — MERGED, SHIPPED, VERIFIED LIVE on both hosts** |
+| #1415 | `176f412b` | the wide-tmux-kill guard — **LIVE and verified on both hosts** |
+| #1376 | `e55533ea` | socket-activation trigger — **LIVE and verified on both hosts** |
+| #1383 | `a4d9d083` | timestamped plan generations + the four round-1 audit fixes |
+| #1464 | `82219263` | retires the staged OOM script (operator decision after a round-0 audit) |
+| #1460 | `f3412fc1` | a `nix/home.nix` comment measured false in BOTH halves |
+| #1443 | `cdfd14ab` | handoff update |
+| #1467 | `cd556159` | transcript-push caps were tuned to an UNDEPLOYED server; push was 413-dead fleet-wide |
 
-- 🔴 **THE REBOOT — 2026-09-06 18:01:46**, from 32 days of uptime; still the only time the BOOT
-  path has ever been exercised, and it ran the OLD timer design. **#1376 REPLACED the trigger, so
-  the mechanism now deployed has never fired at boot on either host.**
-- 🔴 **OPERATOR DIRECTIVE, 2026-09-09: PROCEED REGARDLESS OF LOAD.** Do not hold merges for load.
-- 🔴 **OPERATOR DECISION, 2026-09-09: THE REBOOT IS ON HOLD.** Recommended and explicitly deferred
-  — do not run one, and do not re-propose it without being asked.
+- 🔴 **THE REBOOT — 2026-09-06 18:01:46** is still the only time the BOOT path has ever been
+  exercised, and it ran the **OLD timer design**. #1376 REPLACED the trigger, so the mechanism now
+  deployed **has never fired at boot on either host.**
+- 🔴 **OPERATOR DECISION: THE REBOOT IS ON HOLD.** Recommended and explicitly deferred — do not run
+  one, and do not re-propose it unasked.
+- 🔴 **OPERATOR DIRECTIVE: PROCEED REGARDLESS OF LOAD.** Do not hold merges for load.
+- 🔴 **THE LOCAL FULL-SUITE RITUAL IS RETIRED** (CLAUDE.md changed 2026-09-09 mid-session). CI is
+  ADVISORY, ~42% of reds are noise — act on the failing TEST, not the colour. Run a change-scoped
+  subset: `nix develop ~/workspace/devrc -c python3 -m pytest <paths> -q`.
 
-### This session (2026-09-09)
-- 🔴 **THE GUARD IS LIVE.** Verified by REPRODUCING THE SYMPTOM against the deployed artifact on
-  **both** hosts, not by grep: `TMUX_TMPDIR=$SCRATCH/run tmux kill-server` → **DENIED**, with
-  controls proving it is not a blanket denier (`echo hello`, `tmux -L my-probe-$$ kill-server`,
-  `tmux kill-pane` all ALLOWED; `ssh <host> tmux kill-server` DENIED). Deployed store path
-  `ylm9slz…-hm_guard_core.py`, identical on both hosts. Hit count 0 → 3, positive control 4.
-- 🔴 **THE SOCKET TRIGGER IS LIVE.** Both hosts: `tmux-session-restore.path` **active**,
-  `tmux-session-restore.timer` **inactive**, watching `/run/user/1000/tmux-1000/default`
-  (`PathChanged`), `TMUX_TMPDIR=%t` expanded, and `ConditionPathExists=%t/tmux-%U/default` present
-  at line 10 of the deployed unit. The laptop's 12 live conversations were untouched by the switch.
-- **Both hosts converged and CROSS-HOST COMPARED** at `605b29ac` — the first time today `ship.sh`
-  could make that claim rather than `NOT COMPARED` (see the #1439 block below).
-- **PRs opened this session:** **#1464** (retire the OOM script — the operator's decision),
-  **#1460** (correct a false `nix/home.nix` comment), **#1443** (this handoff).
-  **#1459 was opened and then CLOSED** by that same decision.
-- **Claims: all released except `tmux-restore-plan-generations`** (#1383), which this session holds.
+### Verified LIVE on both hosts (by reproducing behaviour, not by grep)
+- The guard DENIES the incident command against the **deployed** artifact, with controls proving it
+  is not a blanket denier (`echo hello`, `tmux -L my-probe-$$ …`, `kill-pane` all ALLOWED).
+- `tmux-session-restore.path` **active**, `.timer` **inactive**, `ConditionPathExists` present.
+- Generations migration FIRED: the plan is a symlink into `restore-plans/`, stamps are **UTC**
+  (`20260910T143956` against a local mtime of 09:39 — the UTC-5 offset).
+- transcript-push returns **HTTP 200** on both hosts; the laptop's user manager is back to
+  `running` (was `degraded`).
+- `ship.sh` now reaches the laptop over nebula (#1439) and can say **"2 hosts compared"**.
+
+### Closed without merging (durable — do not re-open or re-derive)
+- **#1459** fixed a MEASURED data-loss path in the staged OOM script (a re-run whose
+  `nixos-rebuild` failed restored a STALE backup over `/etc/nixos/configuration.nix`, taking
+  unrelated operator edits with it). It was **opened and then CLOSED** by the operator's decision
+  to delete the script entirely — the fix was correct work on something that should not exist.
+  The reasoning, including the counter-argument, is on #1459 and in #1464's body.
+
+### Open PRs from this session
+- **#1480** — finding 5 (the initiative-scan skill never mentioned generations). **OPEN, NOT MERGED.**
+- **#1481** — the measured 1 MiB proxy limit + the tail-bytes-vs-wire-body correction. OPEN.
 
 ## Open investigations — live diagnosis state
 
@@ -619,44 +631,121 @@ First full audit, 2026-09-09. Verdict **merge after fixing 🔴 1**. Line number
   killed by two independent mutants. via: measurement
 - **Next probe:** fix 1–4 in one commit, re-run the change-scoped subset, merge.
 
-## Next steps (ranked)
-🔴 **RANKS WERE RENUMBERED THIS SESSION AND THAT IS A HAZARD** — `claim-work --slug-for <doc> <rank>`
-derives the slug FROM the rank, so re-ranking silently re-points live claims. It is safe right now
-only because every rank-derived claim has been RELEASED; the one live claim
-(`tmux-restore-plan-generations`, rank 2 below) is TOPICAL, not rank-derived. **Prefer a topical
-slug over a rank-derived one from here on.**
+### 🟡 A — one bad filename in the generations dir BRICKS every future save, permanently and silently
+Found by #1383's round-2 delta audit. **Introduced by my own round-1 fix 1b** (the new `raise`).
+- **Symptom + exact repro:** put a well-shaped but impossible stamp in the generations dir —
+  `restore-plan_20260931T000000.json` (September 31st) — beside one real generation, then save.
+- **Observed (with values):** same fixture, both trees:
+  ```
+  BASE  -> returned '20260910T233348'   (save proceeds)
+  HEAD  -> RuntimeError: could not claim a free generation stamp newer than
+           '20260931T000000' ...        (SAVE FAILS)
+  ```
+  Any `\d{8}T\d{6}` name that sorts above today's UTC stamp and fails `strptime` does it — one
+  corrupted digit (`…T990000`, `…0932T…`) is enough.
+- **Ruled out:** that it is self-healing — `prune_generations` deletes from the **older** end, so
+  the poison file is the one thing pruning can never reach. via: code
+- **Ruled out:** that anything surfaces it — `tmux-post-save.sh` backgrounds and disowns, so the
+  traceback goes to `~/.cache/tmux-session-restore.log` and the plan silently stops being
+  refreshed. Only `plan_staleness_hours` notices, much later. via: code
+- 🔴 **The comment two lines above it is now FALSE**: the `except ValueError` arm still reads
+  *"Leave the base alone and let the step loop do what it can rather than crash the save."*
+- **Leading hypothesis:** make the raise conditional on having TRIED real candidates, or advance
+  `base` past an unparseable `newest` instead of leaving it.
+- **Next probe:** none — measured. This is the first follow-up to open.
 
-1. **Merge #1464 — retire the staged OOM script.** The operator's decision, already taken. Deletes
-   `nix/system/apply-tmux-oom-protection.sh` + its test file (840 lines) and drops both ledger
-   entries in the same change (the ledger is two-way and fails on a SHRINK).
-   IN FLIGHT: innovation-upstream/devrc#1464
-   forcing: user — operator chose "delete it, close #1459 too" on 2026-09-09 after a round-0 audit.
-2. **Fix #1383's four findings, then merge.** 🔴 1 + 🟡 2/3/4 above, in one commit. Its green is on
-   a base 78 commits stale, but the merged tree was measured at 1714 passed.
-   IN FLIGHT: innovation-upstream/devrc#1383
-   forcing: incident — 2026-09-07, a continuum autosave overwrote a 47-entry plan with 10 entries
-   and no backup, which is why 20 windows needed manual identification.
-3. **Merge #1460** — corrects a `nix/home.nix` comment measured false in BOTH halves.
-   IN FLIGHT: innovation-upstream/devrc#1460
-   forcing: regression — the comment would lead a maintainer to the wrong conclusion either way.
-4. **Merge #1443** — this handoff doc.
-   IN FLIGHT: innovation-upstream/devrc#1443
-   forcing: none
-5. **Decide who owns the laptop's `transcript-push` 413** (ingress limit in homelab-talos vs a cap
-   in the pusher), then fix it.
-   forcing: regression — the laptop's user manager reports `degraded` on every switch, and
-   transcripts are not reaching clawgate from that host.
-6. **Implement opencode restore** (decisions already taken: full auto-parity; an UNBOUND opencode
-   pane sends NOTHING and is listed; the save-side tally must distinguish "no opencode panes
-   existed" from "existed and I bound zero").
+### 🟡 B — the `calendar.timegm` half of the UTC fix has NO guard, and it is the half that matters here
+- **Symptom + exact repro:** revert the anchor at `tmux-session-restore.py:590` to `time.mktime`
+  while keeping the UTC stamper, and run the suite.
+- **Observed (with values):** mutant **SURVIVED** with `187 passed`. Its actual effect, six
+  consecutive saves in five zones:
+  ```
+  America/Winnipeg  20260911T041853 → … → 20260912T051858   final +25.00h
+  UTC / Asia/Tokyo / Pacific/Auckland                        final  +0.00h
+  ```
+  Runaway **+5h per save** on the operator's own zone (any host west of UTC), clamped to zero east
+  of it. The shipped `timegm` version is +0.00h in all five.
+- **Ruled out:** that the existing DST test covers it — that test calls `generation_stamp`
+  directly and never exercises the anchor; the end-to-end one is self-labelled non-deterministic.
+  via: measurement
+- **Next probe:** add a guard that exercises the ANCHOR across saves, not just the stamper.
+
+### 🟡 C — `free_generation_stamp` is no longer a query: a failed save leaves a zero-byte "generation"
+- **Symptom + exact repro:** interrupt between the `O_CREAT|O_EXCL` claim and `_write_atomic`.
+- **Observed (with values):**
+  ```
+  file created by the claim : restore-plan_20260911T041824.json  size 0
+  list_generations sees it  : ['20260911T041824']
+  prune(keep=2)             : the EMPTY one is RETAINED as a generation
+  restore --plan <empty>    : JSONDecodeError -> uncaught at cmd_restore:1384
+  ```
+  It **is** counted toward `KEEP_GENERATIONS`; it is **not** selected as `previous_gen`, **not**
+  named by the shrink report, **not** auto-restored. `read_plan` copes (returns `None`), but
+  `cmd_restore:1384` uses a bare `json.loads`.
+- **Ruled out:** that it needs a SIGKILL — `adopt_pre_generation_files:708` claims the stamp
+  BEFORE `PLAN.read_text()`. Measured with a non-UTF-8 legacy plan: `UnicodeDecodeError`, and a
+  0-byte file left behind and listed as a generation. via: measurement
+- **Ruled out:** that it is live today — 129 plan files on the workbench, **0 of size 0**.
+  via: measurement
+- **Next probe:** none — measured. Second follow-up to open.
+
+### 🟢 Open, lower severity (all measured, none live today)
+- **D** — two thirds of round-1 claim 4 ship unguarded: mutants dropping the failure-unlink and
+  dropping the pid from `_point_at` both SURVIVED a 187-green suite.
+- **E** — per-PID temp names converted one bounded leftover into **unbounded per-PID litter that
+  nothing reaps**: `prune_generations(keep=0)` reaps none of six simulated orphans, and
+  `list_generations()` correctly returns `[]`, so nothing will ever see them.
+- **F** — `test_a_concurrent_save_cannot_take_a_stamp_another_save_claimed` does not pin `O_EXCL`;
+  it pins the side effect. Dropping `O_EXCL` was killed by a DIFFERENT test. The docstring reads
+  as the atomicity guard and is not one.
+- **G** — the DST parametrisation leaks libc's timezone into the rest of the pytest process
+  (`monkeypatch.setenv` restores the var but never re-runs `tzset()`). Latent under xdist; a
+  deliberate hunt for a victim found none (1752 passed).
+- **Round-1 🟢 6, 7, 8 remain open**: `read_plan` has no element-type guard (`:775`), the two
+  pointers still move non-atomically (`:833-834`), `_write_atomic` has no `fsync`.
+
+### ✅ ANSWERED — the mixed local/UTC generation ordering on disk is SAFE, and it is not luck
+- **Observed (with values):** measured at five offsets (−6, 0, +5.75, +9, +12) with three legacy
+  local-time generations meeting three new UTC ones: in every zone the legacy stamps land on the
+  **oldest** end and `prune(keep=1)` deletes the correct end. The anchor
+  `max(base, timegm(newest)+1)` is what does it.
+- **Ruled out:** that a pre-existing local stamp could sort above a new UTC one and misdirect
+  pruning. The only cost east of UTC is one-time cosmetic misdating, self-healing as wall-clock
+  catches up. via: measurement
+- Live workbench state is consistent: 129 files, `20260910T012436` (local) through
+  `20260911T041039` (UTC), monotonic, no gaps.
+
+## Next steps (ranked)
+🔴 **Prefer a TOPICAL claim slug over a rank-derived one** — ranks were renumbered twice in this
+arc, and `claim-work --slug-for <doc> <rank>` derives the slug FROM the rank, so re-ranking
+silently re-points live claims.
+
+1. **Fix 🟡 A — the bricked save chain.** `scripts/tmux-session-restore.py:591-597`, `:612`. Make the
+   raise conditional on having tried real candidates, and correct the now-false `except ValueError`
+   comment in the same change.
+   forcing: regression — introduced by #1383's own round-1 fix, merged and shipped to both hosts;
+   one corrupted filename silently stops the restore plan being refreshed.
+2. **Fix 🟡 C — the claim that creates state.** A failed save leaves a zero-byte file that
+   `list_generations` counts and `cmd_restore:1384` tracebacks on.
+   forcing: regression — same source; reachable without a kill via `adopt_pre_generation_files`.
+3. **Fix 🟡 B — guard the anchor.** A mutant reverting `timegm` → `mktime` survives a green suite
+   and costs +5h per save on this host's zone.
+   forcing: regression — the fix is load-bearing exactly where the suite is blind.
+4. **Merge #1480** (finding 5) and **#1481** (the measured proxy limit). Both open, both verified.
+   IN FLIGHT: innovation-upstream/devrc#1480, #1481
+   forcing: gate — #1480 closes a round-1 audit finding that is still open on `main`.
+5. **Round 3 on #1383** after 1–3 land. Round 2 returned findings, so the ladder continues; the
+   first clean round ends it.
+   forcing: gate — the ladder's stop rule is keyed on findings, and round 2 produced seven.
+6. **Implement opencode restore** (design decided: full auto-parity; an UNBOUND opencode pane sends
+   NOTHING and is listed; the save-side tally must distinguish "no opencode panes existed" from
+   "existed and I bound zero").
    forcing: user — operator asked for opencode restore parity on 2026-09-07 and chose the design.
-7. **Work clawgate task 526** (drift-check chain-liveness arm) — and fix its `ZacxDev/devrc` repo
-   field first.
-   forcing: incident — 2026-09-07, the laptop's chain was found dead only because a human went
-   looking; 9 conversations were one reboot from loss.
-8. **Reboot to confirm the boot path.** 🔴 **ON HOLD BY THE OPERATOR — do not run one, and do not
-   re-propose it unasked.** Recorded because it is still the only thing that can verify the arc:
-   #1376 replaced the trigger and the deployed mechanism has never fired at boot.
+7. **Work clawgate task 526** (drift-check chain-liveness arm) — fix its `ZacxDev/devrc` repo field
+   first; this repo's origin is `innovation-upstream/devrc`.
+   forcing: incident — 2026-09-07, the laptop's chain was found dead only because a human looked.
+8. **Reboot to confirm the boot path.** 🔴 **ON HOLD BY THE OPERATOR.** Recorded because it remains
+   the only thing that can verify this arc.
    forcing: none
 9. **`--assume-empty` for `restore --dry-run`.**
    forcing: none
@@ -959,6 +1048,57 @@ ELSE.** They map to ranks 1–3 below. A resuming session on the SAME host+workt
   13026), measured before deleting 20 tests in #1464. Check this before any deletion — floors are
   per-target minimums and a deletion can breach one.
 
+- 🔴 **A FIX ROUND INTRODUCES THE NEXT FINDING — THIS ARC HAS NOW DONE IT SIX TIMES.** #1383's
+  round 2 found that ALL THREE new 🟡s were created by round 1's own fixes: the `raise` (A), the
+  `O_EXCL` claim (C), and the untested anchor (B). Budget for round 3.
+- 🔴 **I MERGED #1383 WITH FIVE OF NINE FINDINGS OPEN AND REPORTED "FOUR".** The audit returned
+  🔴1 + 🟡2,3,4,5 + 🟢6,7,8,9. I fixed 1–4 and described the set to the operator as "the 🔴 plus
+  three 🟡" — omitting 🟡 5 entirely. Count the findings in the audit, not the ones you fixed.
+- 🔴 **AND I THEN TOLD THE ROUND-2 AUDITOR THAT 5 WAS "FIXED AFTERWARDS IN #1480" — IT IS NOT
+  MERGED.** The auditor checked `gh pr view` and corrected me. A PR is not a fix until it lands;
+  do not brief a later round on the basis of an open PR.
+- 🔴 **`git checkout -- <file>` TO CLEAN UP A MUTATION ALSO REVERTS THE FIX YOU JUST WROTE.**
+  Committed and pushed a tree that deleted a script while the ledger still named it — red, exactly
+  as my own negative control had just demonstrated. Restore a mutated file from a `cp -a` copy.
+- 🔴 **`no tests ran in 0.12s` IS A BROKEN SELECTOR, NOT A PASS.** I passed
+  `scripts/claude-hooks/tests/test_tmux_session_restore.py`; the real path is
+  `scripts/session-analysis/tests/`.
+- 🔴 **A MUTANT THAT "SURVIVED" MAY NEVER HAVE RUN.** One scored SURVIVED because the mutating
+  `python3` was not on PATH and the `command not found` was not read. Verify the mutant DIFFERS
+  from the original before scoring it.
+- 🔴 **A FIXTURE CAN MAKE A GUARD UNREACHABLE.** Two of mine did: a DST epoch constant a day off
+  the transition (both parametrisations passed at base), and an exhaustion fixture occupying a
+  contiguous run of stamps — which cannot exhaust the search, because the anchor JUMPS PAST
+  `newest`. Derive fixture constants; do not guess them.
+- 🔴 **A TEST DOUBLE THAT ACCEPTS WHAT PRODUCTION REFUSES IS NOT A TEST.** #1467: the stub server
+  accepted any number of sessions, so a client tuned above the real cap passed every test and
+  failed every tick in the field for ~19 hours. The double now enforces the deployed cap.
+- 🔴 **`merged` IS NOT `deployed`, IN THE PRODUCER DIRECTION TOO.** #1408 raised the client push
+  caps to match a clawgate server that was never shipped. Verify the RUNNING server before tuning
+  a client to it — the app names its own cap in the refusal.
+- 🔴 **TWO HOSTS, TWO ROUTES, TWO DIFFERENT ERRORS.** workbench → NodePort (no proxy, hit the APP's
+  session cap); laptop → nebula (nginx in path, hit the PROXY's byte limit). Diagnosing from one
+  host alone would have been wrong.
+- 🔴 **`MAX_PUSH_BYTES` BOUNDS TAIL BYTES, NOT THE WIRE BODY** — 900,000 produced 922,643 B on the
+  wire, 88% of the MEASURED 1 MiB proxy ceiling. Measure a proxy limit with a DELIBERATELY INVALID
+  token: under the limit → 401 from the app, over it → 413 from nginx, and nothing is ever stored.
+- 🔴 **`PIPESTATUS` IS A BASHISM** — zsh uses `pipestatus`. Verify a squash landed by CONTENT in
+  `origin/main`, never by `--is-ancestor` (false after every squash, forever).
+- 🔴 **`--is-ancestor` OVER A BRANCH LIST IS A FALSE-POSITIVE MACHINE** — it reported ~22 laptop
+  branches as "UNMERGED"; nearly all were squash-merged.
+- 🔴 **A trailing `echo "RC=$?"` in a BACKGROUNDED command makes the harness report exit 0 for a
+  red run** — seen for a gate that said `RESULT=FAIL` and a `ship.sh` that exited 255.
+- 🔴 **A failed `cd` in a compound command runs the REST IN THE WRONG DIRECTORY.** A refused
+  `worktree add` left `cd` failing, and the following `git merge origin/main` ran in the BASE CLONE
+  on `main`. Harmless here (a pure fast-forward), but use `git -C <path>`, which this repo's
+  CLAUDE.md already mandates.
+- **A laptop sha in NO clone is usually another session mid-flight, not a diverged host** —
+  `git reflog` on that host settled it in one command.
+- **Round 0 of `/audit-pr` earned its keep on first real use**: it attributed the OOM script's
+  requirement to a verbatim operator ask issued 23 minutes after the incident, under a diagnosis
+  refuted the next day, and measured the payload inert against 4/4 recorded OOM events. Trial
+  ledger: `ran: 1 · changed the outcome: 1`.
+
 ## How to verify
 ```bash
 # 1. the guard is LIVE — reproduce the SYMPTOM, do not grep
@@ -971,25 +1111,26 @@ print("incident ->", "DENIED" if m.evaluate("TMUX_TMPDIR=/tmp/x tmux kill-server
 print("control  ->", "DENIED" if m.evaluate("tmux kill-pane -t %1","claude-code") else "ALLOWED")
 PY
 
-# 2. the socket trigger is live on BOTH hosts
+# 2. socket trigger live on BOTH hosts
 systemctl --user is-active tmux-session-restore.path tmux-session-restore.timer
 ssh zach@10.42.0.100 'systemctl --user is-active tmux-session-restore.path tmux-session-restore.timer'
 
-# 3. both hosts converged AND compared (not "NOT COMPARED")
-bash ~/workspace/devrc/scripts/ship.sh   # read every per-host line, not the verdict
+# 3. generations: UTC stamps, plan is a symlink, no zero-byte files (🟡 C's tell)
+ls -l ~/.config/initiatives/restore-plan.json
+find ~/.config/initiatives/restore-plans -name 'restore-plan_*.json' -size 0 | wc -l   # must be 0
 
-# 4. the laptop's chain is alive (save side is the half that was dead)
-ssh zach@10.42.0.100 'ls -l ~/.tmux/resurrect/last ~/.config/initiatives/restore-plan.json'
+# 4. transcript-push actually succeeds (not just "deployed")
+systemctl --user start transcript-push.service && \
+  journalctl --user -u transcript-push.service -n 3 --no-pager -o cat | grep -E 'pushed|not accepted'
 
-# 5. change-scoped tests — NOT the full gate
-nix develop ~/workspace/devrc -c python3 -m pytest <paths> -q
+# 5. both hosts converged AND compared
+bash ~/workspace/devrc/scripts/ship.sh     # read every per-host line, not the verdict
 
-# 6. open PRs from this arc
-for n in 1383 1443 1460 1464; do
-  gh pr view $n --repo innovation-upstream/devrc \
-    --json number,state,mergeable,mergeStateStatus \
-    --jq '"#\(.number) \(.state) \(.mergeable)/\(.mergeStateStatus)"'
-done
+# 6. change-scoped tests — NOT the full gate
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  scripts/session-analysis/tests/test_tmux_session_restore.py \
+  scripts/tests/test_tmux_restore_observe.py \
+  scripts/tests/test_tmux_restore_trigger.py -q
 
 # 7. the recovery method + evidence, if another incident needs it
 ls ~/.cache/restore-rescue-2026-09-07/


### PR DESCRIPTION
Records the rest of the arc, and three new 🟡 from #1383's round-2 delta audit. **Verdict: safe to stay merged, no revert** — none is live on either host today.

- **🟡 A** — one well-shaped but impossible filename in the generations dir (`restore-plan_20260931T000000.json`) **bricks every future save, permanently and silently**. Measured: BASE proceeds, HEAD raises. `prune_generations` deletes from the *older* end, so the poison file is the one thing pruning can never reach — and the `except ValueError` comment two lines up still promises it "cannot crash the save". Introduced by round 1's new `raise`.
- **🟡 C** — `free_generation_stamp` is no longer a query: the `O_CREAT|O_EXCL` claim leaves a zero-byte file that `list_generations` counts as a generation. Reachable **without** a kill, via `adopt_pre_generation_files` claiming before `read_text()`.
- **🟡 B** — the `calendar.timegm` half has **no guard**: a mutant reverting it survives a 187-green suite and costs **+5h per save** on this host's zone, zero east of UTC. The fix is load-bearing exactly where the suite is blind.

Also verified positively: the six red-at-base claims and both invariant-guard labels hold, and the **mixed local/UTC ordering on disk is safe and not luck** (measured at five offsets).

🔴 Two process failures of mine are recorded in Gotchas rather than quietly fixed: I merged #1383 having fixed **four of nine** findings while describing the set as "the 🔴 plus three 🟡" — omitting 🟡 5 — and then briefed the round-2 auditor that 5 was "fixed afterwards in #1480", which is **open, not merged**. The auditor checked and corrected me.