### PR TITLE
docs(disk-accounting): round-2 audit — stop supplying rationales that keep turning out false

### DIFF
--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -13,26 +13,32 @@
 # 🔴 THAT PREDECESSOR IS DELETED (2026-09-09) — do not go looking for it. It was
 # committed to main by #1412 without anyone noticing it had already been
 # superseded, then deleted once the question was actually asked. It had no tests,
-# no code referenced it, and it was never observed to run to completion.
+# and no code referenced it. (Its ROOT run was never seen to finish — it died at
+# /nix; `claudedocs/handoff-nix-disk-cleanup.md` is the record. Unprivileged runs
+# DID complete, so "never ran to completion" is wider than the evidence.)
 #
-# Most of it is subsumed here — its 1/3/4 by section 2, its 5 by section 7, its 7
-# by 6b, its 8 by 6c. 🔴 BUT NOT ALL OF IT, and an earlier draft of this comment
-# claimed "every one of its ten sections", which was wrong. What was NOT carried
-# over, so that nobody re-derives it as missing:
-#   - its section 2 grepped the FULL `dumpe2fs -h` output; section 1 here greps a
-#     fixed field list, so `Filesystem features` (bigalloc/64bit/metadata_csum —
-#     bigalloc changes block accounting outright), `Free blocks`, `Free inodes`,
-#     `Mount count` and `Reserved GDT blocks` are no longer reported.
-#   - its section 6 checked for an EXTERNAL ext4 journal at /proc/1/root/.journal.
-#   - its 6b-equivalent split /nix/store into dirs/files/symlinks.
-#   - its 8 resolved the invoking user's home via SUDO_USER instead of assuming
-#     /home (harmless while home is under /home, which it is on both hosts).
-# None of that argued for keeping the file; it argues for not claiming a total
-# subsumption nobody checked. Reserved-block COUNT and journal SIZE are still
-# reported by section 1, which is what the residual arithmetic actually consumes.
+# 🔴 NO SUBSUMPTION MAPPING IS GIVEN HERE, DELIBERATELY. Two have been written
+# and BOTH were wrong; a third is not worth your trust. Read the two files if you
+# need to know what moved — `git show c68750f6^:scripts/diagnose-nix-disk.sh`.
+# The retracted drafts, recorded so nobody derives a fourth:
+#   - draft 1: "every one of its ten sections is subsumed here." False — it
+#     claimed a total nobody had checked.
+#   - draft 2: a per-section map plus a loss list. Wrong in four places, measured
+#     2026-09-10: it said the predecessor grepped the FULL `dumpe2fs -h` output
+#     (it greps a fixed 10-term list, exactly like section 1 — only the LISTS
+#     differ); it listed `Free blocks`/`Free inodes` as lost, though both are read
+#     and USED here via `stat -f -c %f/%d`; it claimed "reserved-block count and
+#     journal size … is what the residual arithmetic actually consumes", when the
+#     only dumpe2fs field any arithmetic reads is `Inode size`; and it kept a
+#     sentence from draft 1 ("the one thing it displayed that this file does not
+#     is `swapon --show`") that its own loss list six lines above contradicted.
+# The lesson generalises past this comment: a hand-derived correspondence between
+# two programs is a CLAIM, and the fact that the previous draft of it was wrong is
+# better information than any new draft.
 #
-# The one thing it displayed that this file does not is `swapon --show` — chasing
-# exactly that difference is what surfaced the `/swapfile` defect fixed in
+# What IS solid, because it was measured rather than mapped: chasing the one
+# display difference — the predecessor ran `swapon --show` and `ls -lh /swapfile`
+# — is what surfaced the `/swapfile` defect fixed in
 # toplevel_accountable_entries().
 #
 # This script must run as root. It counts what the previous one could not, and it
@@ -235,9 +241,20 @@ _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 # presented as a total.
 #
 # 🔴 "ALL THREE OF THIS FUNCTION'S CALLERS", NOT "EVERY CALLER" — the wider
-# wording stood here for a round and was false. `split_by_device` below does not
-# use this enumeration and is a KNOWN FOURTH SITE with the same shape and NO
-# count: its `[ -d "$p" ] || continue` drops a directory root cannot stat (a gvfs
+# wording stood here for a round and was false.
+#
+# 🔴 AND THERE IS NOW A FIFTH SITE: `toplevel_accountable_entries()`, added
+# 2026-09-09, enumerates depth-1 with the same shape and sends its stderr NOWHERE
+# — not to `$DENIED_LOG`, not to a file. A top-level entry root cannot stat is
+# therefore dropped from section 2 with no tally, and section 3's residual — the
+# number that function exists to feed — absorbs it silently. This ledger is the
+# place a maintainer of that function looks, so it is recorded HERE and not only
+# in the test file's sweep-ledger comment, which is where it was written first.
+# It is not a regression (the glob it replaced dropped unstattable entries too,
+# and equally silently); it is the same debt at one more site.
+#
+# `split_by_device` below is the FOURTH such site, also with no count: its
+# `[ -d "$p" ] || continue` drops a directory root cannot stat (a gvfs
 # or sshfs mount under /home/<user>/… is exactly the root-reachable mechanism)
 # and nothing tallies it. It is recorded rather than fixed because bash's file
 # tests cannot separate the three reasons `[ -d "$p" ]` says no — not a
@@ -700,7 +717,14 @@ report_denials() {
 }
 
 # Enumerate the top-level entries of a filesystem root that section 2 must
-# account for, one per line.
+# account for, NUL-SEPARATED — not one per line.
+#
+# 🔴 CONSUME IT WITH `read -r -d ''`, NEVER a plain `read`. `find -print0` emits
+# NO newlines at all, so a `while IFS= read -r d` loop receives all 17 top-level
+# entries as ONE record: one garbage path gets walked, every other entry silently
+# vanishes, and section 3's residual becomes the whole filesystem. This comment
+# said "one per line" for a day while the body already emitted NUL — the sentence
+# that describes an interface is part of the interface.
 #
 # 🔴 THIS EXISTS BECAUSE SECTION 2 SKIPPED TOP-LEVEL *FILES*. The loop read
 # `[ -d "$d" ] || continue`, so every top-level entry that was not a directory
@@ -744,8 +768,9 @@ report_denials() {
 # `.journal` and its whole subtree were invisible — the same defect this function
 # exists to fix, one flag away); it emits NUL-separated names, so an entry
 # containing a newline cannot split into phantom paths that `find` then reports
-# as "vanished mid-scan (benign)"; and an empty root yields nothing rather than a
-# literal unmatched glob.
+# as "vanished mid-scan (benign)"; and an EMPTY DIRECTORY yields nothing rather
+# than a literal unmatched glob. (An empty *argument* is a different case: `find ""`
+# ERRORS, which is what the `[ -n "$root" ] || root=/` line below prevents.)
 toplevel_accountable_entries() {
   local root="${1:-/}"
   # "/" -> "" would make find's operand empty; "//" -> "/" normalises the
@@ -866,7 +891,8 @@ echo "      shortfall is unmeasured FILES, never metadata."
 
 echo
 echo "=== 2. Inodes and allocated bytes per top-level entry ==="
-echo "  EVERY top-level entry is listed, not just directories. /swapfile is a regular"
+echo "  Top-level FILES are listed, not just directories — /proc /sys /dev /run /mnt"
+echo "  are still pruned, so this is not literally every entry. /swapfile is a regular"
 echo "  file allocating 48.00 GiB on this fs (measured 2026-09-09) and used to be"
 echo "  dropped by a '[ -d ] || continue' guard, so it had NO ROW AT ALL here and its"
 echo "  48 GiB was absent from the byte column below — the column section 3 calls"

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1283,8 +1283,10 @@ canary_n="$(printf '%s\n' "$canary_hits" | grep -c . || true)"
 lacks "the sweep does NOT flag a guarded canary line" "$canary_hits" "/guarded"
 lacks "the sweep does NOT flag a commented canary line" "$canary_hits" "/this-is-a-comment"
 
-# 🔴 A LEDGER, failing when the set GROWS *or* SHRINKS. One line in the script
-# is reported and is deliberately NOT guarded: section 2's
+# 🔴 A LEDGER, failing when the set GROWS *or* SHRINKS. TWO lines in the script
+# are reported and are not guarded — the count is asserted below, so read it
+# there rather than trusting this sentence, which said "One line" for a round
+# after the second was pinned seven lines down. The first is section 2's
 # `find "$d" … | awk …` is the body of a `read … < <(…)` process substitution,
 # and MEASURED 2026-09-07 a process substitution's status is NOT checked by
 # `set -e` — which is exactly why denials in section 2 do not kill the run. If
@@ -1295,16 +1297,24 @@ sweep_n="$(printf '%s\n' "$sweep_hits" | grep -c . || true)"
   || fail "the set -e sweep found $sweep_n unguarded statement-level commands, expected the 2 pinned below — a new one truncates the report with no message: [$sweep_hits]"
 has "pinned #1: section 2's process-substitution find" \
     "$sweep_hits" 'find "$d" -xdev -printf'
-# 🔴 PINNED #2, ADDED 2026-09-09, AND DELIBERATELY NOT GUARDED. It is the `find`
-# inside toplevel_accountable_entries(). Guarding it with `|| true` — the change
-# that would make this ledger go back to 1 — would MASK a short enumeration,
-# which is the precise failure the function exists to prevent: fewer top-level
-# entries means section 2 silently omits rows and section 3's residual is wrong.
-# It cannot abort the run either way: the only caller invokes it inside a process
-# substitution, whose exit status bash does not check. Unlike #1 its stderr is
-# NOT redirected into DENIED_LOG, so a failure here is loud on the terminal
-# rather than counted in section 4's blind-spot report — that is the trade, and
-# it is written down here rather than discovered later.
+# 🔴 PINNED #2, ADDED 2026-09-09: the `find` inside toplevel_accountable_entries().
+#
+# 🔴 THERE IS NO BEHAVIOURAL REASON TO LEAVE IT UNGUARDED, AND THIS COMMENT NO
+# LONGER OFFERS ONE. It previously claimed that `|| true` "would MASK a short
+# enumeration". That is FALSE, and it was the THIRD rationale supplied for this
+# function after two others were retracted as false — which is why none is
+# offered now. MEASURED, bash 5.3.15: a `find` that emits 2 records and then
+# exits non-zero is consumed IDENTICALLY with and without `|| true` — 2 records,
+# run continues, rc 0 both ways. Nothing reads the status (the only caller is a
+# process substitution, whose exit status bash does not check), and masking
+# requires a reader. The entry is here because the sweep COUNTS it, which is
+# bookkeeping and needs no justification; adding `|| true` would change nothing
+# observable either.
+#
+# What IS true and is the thing to know: unlike #1, its stderr goes nowhere — not
+# to DENIED_LOG, not to a file — so a top-level entry that cannot be stat'd is
+# dropped from section 2 with no tally. That debt is recorded where a maintainer
+# of the function will look, in the `_depth1_nul` site ledger in the script.
 has "pinned #2: the top-level enumerator's find" \
     "$sweep_hits" 'find "$root" -mindepth 1 -maxdepth 1'
 
@@ -1374,23 +1384,36 @@ has "the sort ledger names the inode-breakdown capture" "$sort_hits" '| sort -rn
 # --------------------------------------------------------------------------- #
 echo "== 12. SECTION 2 ACCOUNTS FOR TOP-LEVEL FILES, NOT ONLY DIRECTORIES =="
 # 🔴 The defect this pins: section 2's loop read `[ -d "$d" ] || continue`, so a
-# top-level entry that was not a directory never reached `find`. Section 3's
-# residual is that loop's total, so the miss shows up as unexplained space
-# rather than as an error. MEASURED on the workbench 2026-09-09: `/swapfile` is
-# a regular file of 100663328 512B blocks = 48.00 GiB on the same device as `/`.
+# top-level entry that was not a directory never reached `find`. MEASURED on the
+# workbench 2026-09-09: `/swapfile` is a regular file of 100663328 512B blocks =
+# 48.00 GiB on the same device as `/`, and it got NO ROW in section 2 at all.
+#
+# 🔴 WHICH NUMBER MOVED: section 2's BYTE COLUMN lost 48 GiB. Section 3's
+# residual is `INODES_USED - TOTAL_INODES` — a count of INODES — so it moved by
+# exactly ONE. This comment previously said the miss "shows up as unexplained
+# space", which is the same false mechanism the script's own banner was corrected
+# for; it survived here because the sweep that fixed the banner never reached the
+# test file.
 #
 # The fixture uses a REGULAR FILE at the top level (the /swapfile shape), a
-# directory (must still be listed), a symlink (must not — `-d`/`-f` follow them
-# and the target is walked on its own), a fifo (an inode with no data blocks),
-# and a skip-listed name.
+# directory, a symlink, a fifo, and a skip-listed name. 🔴 The symlink and the
+# fifo MUST BE LISTED — see the assertions below and the reasoning with them.
+# An earlier version of this paragraph said the symlink "must not" be listed,
+# eleven lines above an assertion requiring that it is. A maintainer resolving
+# that contradiction toward the comment would have reinstated an exclusion that
+# was measured to make section 3's residual WORSE.
 tl="$TMP/toplevel"
 mkdir -p "$tl/realdir" "$tl/proc" "$tl/.hiddendir"
 printf 'x' > "$tl/swapfile"
 printf 'x' > "$tl/.hiddenfile"
 ln -s realdir "$tl/linkdir"
-# 🔴 NO `|| true` HERE. With it, a host without mkfifo silently never creates the
-# path and the fifo assertion below passes because the entry does not exist —
-# green for the wrong reason. If mkfifo is missing this suite should say so.
+# 🔴 NO `|| true` HERE — but note the reason CHANGED when the fifo assertion
+# flipped from `lacks` to `has`, and the old reason is no longer the one.
+# It used to be: with `|| true`, a host without mkfifo creates no path and a
+# `lacks` assertion passes vacuously. That is now backwards — a `has` assertion
+# FAILS when the entry is absent, so the suite would go red either way. The
+# reason to keep it unguarded today is only that it fails HERE, naming the
+# missing tool, instead of three lines later as a confusing assertion failure.
 mkfifo "$tl/afifo"
 
 # The function emits NUL-separated names; render them one per line to assert on.


### PR DESCRIPTION
Round 2 of `/audit-pr` on the merged #1455. **Five 🟡, no 🔴 — and four of the five were sentences the round-1 fix wrote about itself.** No code changes: the diff is comments and banner text only, verified mechanically (no non-comment, non-`echo` line changed).

## The one that mattered

`scripts/tests/test_diagnose_disk_accounting.sh:1383` said a top-level symlink **"must not"** be listed — **eleven lines above an assertion requiring that it is**. The same block restated the "shows up as unexplained space" mechanism the script's banner had already been corrected for.

That block was never swept: round 1 fixed the phrase at its two *script* sites and never looked in the *test* file, which carried the same false claim in different words. A maintainer resolving the contradiction toward the comment flips `has`→`lacks` and reinstates an exclusion that was measured to make section 3's residual **worse** — and the suite stays green, because a comment "documents" it.

## A third false rationale, for the same function, after two were retracted

The sweep ledger claimed guarding the enumerator's `find` with `|| true` *"would MASK a short enumeration"*.

**Measured, bash 5.3.15** — a `find` that emits 2 records then exits non-zero:

| | records | run continued | rc |
|---|---|---|---|
| unguarded | 2 | yes | 0 |
| `\|\| true` | 2 | yes | 0 |

Identical. Nothing reads the status (the only caller is a process substitution, whose status bash does not check), and masking requires a reader. The comment now **states there is no behavioural reason and offers none** — reaching for a fresh justification is exactly what regenerates the error.

## The subsumption ledger is deleted, not corrected a third time

- **Draft 1:** "every one of its ten sections is subsumed here." A total nobody checked.
- **Draft 2:** a per-section map plus a loss list. Wrong in four places, measured:
  - the predecessor greps a **fixed 10-term list**, not the "FULL" `dumpe2fs -h` output — section 1 greps a fixed list too, only the *lists* differ
  - `Free blocks`/`Free inodes` were listed as lost; both are read **and used** via `stat -f -c %f/%d`
  - "reserved-block count and journal size … is what the residual arithmetic actually consumes" — the only dumpe2fs field any arithmetic reads is `Inode size`
  - it kept a sentence from draft 1 that its own loss list six lines above contradicted

Both drafts are recorded as retracted so nobody derives a fourth. A hand-derived correspondence between two programs is a claim, and *"the last draft was wrong"* is better information than any new draft.

## Also

- the enumerator's header said **"one per line"** while the body emitted NUL. A consumer trusting it receives all 17 entries as **one record** — one garbage path walked, everything else silently gone, residual = the whole filesystem.
- the `_depth1_nul` **site ledger** — where a maintainer of this function actually looks — was short by one. The new enumerator is a **fifth** same-shape depth-1 site whose stderr goes nowhere, so an unstattable top-level entry is dropped with no tally. Not a regression (the glob it replaced did the same); the same debt at one more site, now recorded where it will be read rather than only in the test file.
- "EVERY top-level entry is listed" narrowed — five names are still pruned.
- "an empty root yields nothing" split from the `find ""` **error** case it was conflated with.
- "never observed to run to completion" narrowed to the **root** run, per `claudedocs/handoff-nix-disk-cleanup.md:156`.
- the `mkfifo` guard's reason described the pre-flip `lacks` assertion and is backwards now that it is `has`.
- the sweep ledger said "One line" after the second was pinned seven lines below.

## Verification

Suite: **222 assertions, 0 failures**. The source-scanning ledgers read the script text, so comment edits can trip them — they did not.

⚠ **The ladder is not finished.** Round 2 returned findings that needed fixing, so a round 3 on this delta is the stop condition, not this PR. The delta is small and entirely comment text.

⚠ Round 2's battery run was killed at row 59 of 72 by an unrelated interruption; the auditor verified the three new rows individually instead (all killed by their own named guard) and did not reach the `survives comment-reword` control. Recorded rather than claimed as covered.