### PR TITLE
fix(tests): one bound, one place — the 120s subprocess cap reddened the gate on diffs that could not reach it

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4515,7 +4515,33 @@ SKIPPED_FAMILIES=()
 # file exists to refuse; the point is that the reader can see which expectations
 # this run did not evaluate.
 SCOPED_SUSPENDED=()
-if [ "$SCOPED_MODE" -eq 1 ]; then
+# 🔴 KEYED ON `SCOPE_STATE != FULL`, NOT ON `SCOPED_MODE` — i.e. a `--targets`
+# (PARTIAL) run drops these families exactly as a `--files` (SCOPED) run does.
+# This was `SCOPED_MODE` alone, so a narrowed `--targets` run executed BOTH
+# whole families that no `--targets` value can name. MEASURED 2026-09-11, dev
+# host, load ~52, same box minutes apart:
+#
+#     --targets scripts/collector/i3/tests   47 s   (families ran)
+#     --files   <one file in that target>     4 s   (families skipped)
+#
+# Under `bash -x`, of ~54 s the SELECTED target's pytest was 2.9 s and ~46 s was
+# these two families — `test_base_clone_staleness.sh` 19.3 s,
+# `test_diagnose_disk_accounting.sh` 13.2 s, `test_bash_guard.py` 8.7 s. That
+# ~12x is what reddened `tekton/devrc-pytests` on devrc#1450, #1458 and #1462:
+# `scripts/tests/test_run_tests_targets.py` spawns nested `--targets` runs, and
+# under CI contention they breached that harness's subprocess bound. The bound
+# was the symptom; this is the cause.
+#
+# 🔴 THE SUSPENSION IS ANNOUNCED ON THE PARTIAL SURFACE TOO — see the PARTIAL
+# RUN block in the SUMMARY. Widening the skip without widening the announcement
+# would be a run silently executing two families fewer than the reader believes,
+# which is the #276 shape this file exists to refuse. The two must move together.
+#
+# ⚠ This does NOT bring the rest of SCOPED_MODE with it. A PARTIAL run still
+# enforces every per-target floor (GUARD 3), GUARD 7's REQUIRED direction and
+# GUARD 2's skip TOTAL, and still reports `SCOPE: PARTIAL`, never `SCOPED`.
+# Only the two unselectable families move.
+if [ "$SCOPE_STATE" != "FULL" ]; then
   SKIPPED_FAMILIES+=("${#HOOK_TESTS[@]} hand-rolled hook test script(s)")
   HOOK_TESTS=()
 fi
@@ -4660,8 +4686,10 @@ _run_shell_test_body() {
 }
 
 # See the SKIPPED_FAMILIES note above the hook loop: these five were 101s of a
-# measured 172s subset run, and no `--files` selection can name any of them.
-if [ "$SCOPED_MODE" -eq 1 ]; then
+# measured 172s subset run, and NEITHER a `--files` NOR a `--targets` selection
+# can name any of them — which is why this is keyed on `SCOPE_STATE != FULL`
+# rather than on `SCOPED_MODE`.
+if [ "$SCOPE_STATE" != "FULL" ]; then
   SKIPPED_FAMILIES+=("${#SHELL_TESTS[@]} shell test script(s)")
   SHELL_TESTS=()
 fi
@@ -4733,9 +4761,14 @@ _print_ci_gap() {
   fi
   if [ "$SCOPED_MODE" -eq 1 ]; then
     echo "       - ${other_files} other collectable file(s) inside the selected target(s)"
-    if [ "${#SKIPPED_FAMILIES[@]}" -gt 0 ]; then
-      for s in "${SKIPPED_FAMILIES[@]}"; do echo "       - $s"; done
-    fi
+  fi
+  # 🔴 OUTSIDE the SCOPED_MODE branch above, because the families are now
+  # dropped by any non-FULL run and this is the CI-gap surface a reader checks
+  # to learn what did not execute. Leaving it inside would have made a PARTIAL
+  # run's two skipped families invisible on the one surface that exists to name
+  # them — the silent narrowing the skip's own comment forbids.
+  if [ "${#SKIPPED_FAMILIES[@]}" -gt 0 ]; then
+    for s in "${SKIPPED_FAMILIES[@]}"; do echo "       - $s"; done
   fi
   echo "       - the NODE tier (scripts/run-node-tests.sh) — a separate derivation"
   echo "         this runner does not invoke at all"
@@ -4772,6 +4805,14 @@ elif [ -n "$SUBSET_NOTE" ]; then
   echo "     Every count below is for the SELECTED targets only. The unselected"
   echo "     ones were NOT executed and this verdict says nothing about them."
   echo "     Selected: ${TARGETS[*]}"
+  if [ "${#SKIPPED_FAMILIES[@]}" -gt 0 ]; then
+    # 🔴 THE SAME STATEMENT THE SCOPED BRANCH MAKES, because a PARTIAL run now
+    # drops the same families. It carried no such line while the skip was keyed
+    # on SCOPED_MODE, and adding the skip without this would make a `--targets`
+    # run quietly narrower than its own SUMMARY claims.
+    echo "     NOT RUN in this mode (no --targets selection can name them):"
+    for _skipped in "${SKIPPED_FAMILIES[@]}"; do echo "       - $_skipped"; done
+  fi
   _print_ci_gap
 fi
 for r in "${RESULTS[@]}"; do echo "  $r"; done

--- a/scripts/testlib/scoped_harness.py
+++ b/scripts/testlib/scoped_harness.py
@@ -45,7 +45,50 @@ CHEAP_HOOK_TEST = "scripts/claude-hooks/tests/test_claude_notify.py"
 CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 
 
-def run(args: list[str], timeout: int = 600, env: dict | None = None,
+#: How long any nested `run-tests.sh` spawned by a test may take before the
+#: harness kills it. THE one place this bound is written.
+#:
+#: 🔴 IT LIVES HERE, NOT IN A TEST FILE, BECAUSE "one rule, one place" WAS
+#: FILE-LOCAL AND THAT IS HOW THE LAST ONE ROTTED. `test_run_tests_targets.py`
+#: open-coded `timeout=120` at SIX sites; consolidating those into a constant
+#: private to that file would have left a FOURTH copy of the same predicate —
+#: this default — untouched, and a guard scoped to one file could never see it.
+#: Both now read this name.
+#:
+#: 🔴 THIS IS A HANG BOUND, NOT AN ASSERTION. Nothing any caller pins depends on
+#: the nested run being fast; the bound exists only so a wedged child fails with
+#: a message rather than hanging until the gate's own cap, which is worse — no
+#: message, no exit code.
+#:
+#: 300 s is ~33x the measured cost of a narrowed nested run (9 s at load ~46,
+#: after `run-tests.sh` stopped executing the hook/shell families on non-FULL
+#: runs). ⚠ Headroom is not the only axis: `test_run_tests_targets.py` performs
+#: FOUR real nested runs, so this also sets a worst case — 4x300 s = 20 min.
+#:
+#: 🔴 AGAINST THE GATE **TASK**'s OWN `timeout: 60m`, NOT THE PIPELINE'S
+#: `timeouts.tasks: 70m`. The task cap is the lower of the two and therefore the
+#: only one a slow test can reach — an earlier draft of this paragraph quoted
+#: the pipeline budget and got the consequence BACKWARDS with it. The
+#: difference is not pedantry; the two fail in opposite directions, per that
+#: pipeline's own measured three-way probe (Tekton v1.12.0,
+#: `devrc-ci-pipeline.yaml`):
+#:
+#:     timeouts.tasks   -> PipelineRunTimeout, finally NEVER RAN -> posts nothing,
+#:                         checks stay `pending` forever
+#:     task-level 60m   -> Failed,             finally RAN       -> posts a red
+#:
+#: So overrunning here yields a LEGIBLE RED, not the unclearable pending the
+#: earlier draft warned about. ⚠ The real budget is tighter than 60m anyway: that
+#: clock runs while the pod is Pending, and a worst-observed ~22.5m queue leaves
+#: ~37m of execution. 20 min of that is 54%; the rejected 600 would have been
+#: 40 min, i.e. MORE than the whole post-queue budget for one test file.
+#: 600 was the first value proposed and is REJECTED for that reason: it bought
+#: headroom the runner fix had already made unnecessary.
+RUNNER_TIMEOUT_S = 300
+
+
+def run(args: list[str], timeout: int = RUNNER_TIMEOUT_S,
+        env: dict | None = None,
         cwd: Path | None = None) -> subprocess.CompletedProcess:
     full_env = None
     if env is not None:

--- a/scripts/testlib/scoped_harness.py
+++ b/scripts/testlib/scoped_harness.py
@@ -60,36 +60,40 @@ CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 #: a message rather than hanging until the gate's own cap, which is worse — no
 #: message, no exit code.
 #:
-#: 🔴 600 IS THE VALUE THIS MODULE ALREADY HAD, AND THIS CHANGE DELIBERATELY
-#: DOES NOT MOVE IT. What moved is WHERE it is written, not what it is: six
-#: open-coded `timeout=120` sites in `test_run_tests_targets.py` now read this
-#: name instead of carrying their own copies.
+#: 🔴 600 IS THIS MODULE'S PRE-EXISTING VALUE AND IS UNCHANGED — BUT SAY WHICH
+#: SCOPE THAT IS TRUE OF. For the five files already using `run()` it is a no-op,
+#: 600 before and after. For the SIX sites in `test_run_tests_targets.py` that
+#: used to carry `timeout=120`, the effective bound RISES 120 -> 600, deliberately:
+#: that widening is the PR's headline fix. ⚠ An earlier draft of this paragraph
+#: said the change moves "WHERE it is written, not what it is" full stop, which
+#: would tell a maintainer no timeout was raised anywhere. One was.
 #:
-#: ⚠ A draft of this change set it to 300, and that was a NARROWING OF FIVE
+#: ⚠ A draft also set this constant to 300, and that was a NARROWING OF FIVE
 #: FILES ON THE EVIDENCE OF A SIXTH. This default governs `run()`, which
 #: `test_scoped_runs.py`, `test_scoped_mapper.py`, `test_scoped_scope_marker.py`,
-#: `test_scoped_gate_contract.py` and `test_scoped_ledgers.py` use across ~47
-#: call sites — and their nested runs are not the 2-9 s narrowed ones the 300
-#: was sized against. Measured on the dev host: 28.9 s at load ~57 for
-#: `test_the_node_runner_reports_FULL_on_a_REAL_run`, and 70.5 s observed for a
-#: sibling under a different load. At 300 that is ~4-10x headroom, against the
-#: >2.55x contention inflation that caused this PR in the first place — i.e. the
-#: narrowing would have re-created the failure class here that the runner fix
-#: just removed elsewhere. Do not re-derive 300 from the 9 s figure; it is a
-#: measurement of ONE consumer.
+#: `test_scoped_gate_contract.py` and `test_scoped_ledgers.py` use across ~45
+#: call sites (44 of them taking the default) — and their nested runs are not the
+#: 2-9 s narrowed ones the 300 was sized against. Measured on the dev host:
+#: `test_the_node_runner_reports_FULL_on_a_REAL_run` took 28.9 s at load ~57 and
+#: 16.5 s at load ~48. At 300 that is roughly 10-18x headroom against a >2.55x
+#: contention inflation (120 s bound / 47 s run, the ratio that caused this PR) —
+#: thinner than it looks, and for no measured benefit. Do not re-derive 300 from
+#: the 9 s figure; that is a measurement of ONE consumer.
 #:
-#: 🔴 THIS IS A HANG BOUND, NOT AN ASSERTION. Nothing any caller pins depends on
-#: the nested run being fast; the bound exists only so a wedged child fails with
-#: a message rather than hanging until the gate's own cap, which is worse — no
-#: message, no exit code.
+#: ⚠ WHAT 600 COSTS, STATED BECAUSE THE 300 DRAFT LEANT ON IT AND THE REVERT MUST
+#: NOT QUIETLY DROP IT. `test_run_tests_targets.py` performs FOUR real nested
+#: runs, so the pathological case is 4x600 s = 40 min — and the post-queue budget
+#: is about 37 min (the gate task's `timeout: 60m` clock runs while the pod is
+#: Pending, and a worst-observed queue is ~22.5m). So 40 > 37: four SIMULTANEOUS
+#: hangs would exhaust the task rather than report. That is the strongest
+#: argument against 600 and it is kept here rather than deleted with the draft
+#: that made it. It is accepted because it requires all four runs to hang — after
+#: the runner fix each measures 2-9 s — and because a genuine hang is a defect
+#: you want surfaced, not absorbed by a tighter bound.
 #:
-#: ⚠ On the worst case, stated because the 300 draft leant on it:
-#: `test_run_tests_targets.py` performs FOUR real nested runs, so 4x600 s = 40
-#: min in the pathological case. That requires all four to HANG — after the
-#: runner fix each measures 2-9 s — and a genuine hang is a defect you want
-#: surfaced, not absorbed. It is bounded by the gate TASK's own `timeout: 60m`
-#: (`devrc-ci-pipeline.yaml`), NOT the pipeline's `timeouts.tasks: 70m`: the task
-#: cap is the lower of the two and so the only one a slow test can reach. That
+#: 🔴 AND THE CAP THAT BINDS IS THE GATE TASK'S OWN `timeout: 60m`
+#: (`devrc-ci-pipeline.yaml`), NOT the pipeline's `timeouts.tasks: 70m` — the
+#: task cap is lower, so a slow test can only ever reach that one. The
 #: distinction decides the OUTCOME, per that pipeline's own measured three-way
 #: probe (Tekton v1.12.0):
 #:
@@ -97,11 +101,15 @@ CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 #:                         checks stay `pending` forever
 #:     task-level 60m   -> Failed,             finally RAN       -> posts a status
 #:
-#: So overrunning here posts SOMETHING a human can read — an `error` carrying
-#: `COULD NOT RUN`, which CLAUDE.md tells readers is a broken gate rather than a
-#: bad change — instead of the unclearable pending an earlier draft wrongly
-#: warned about. ⚠ The real budget is tighter than 60m: the clock runs while the
-#: pod is Pending, and a worst-observed ~22.5m queue leaves ~37m of execution.
+#: So overrunning here posts SOMETHING a human can read, rather than the
+#: unclearable pending an earlier draft wrongly warned about. ⚠ The status is
+#: `error` describing **`KILLED: <leg> — the gate pod died at or after step
+#: <phase> (preempted/evicted/OOM/timeout). Not a code failure.`** — NOT
+#: `COULD NOT RUN`, which a further draft cited: that arm is guarded by
+#: `BUILD_STATUS = "Succeeded"` and a timed-out task does not satisfy it. The
+#: pipeline says so itself: "A task-level `timeout:` expiring while a step is
+#: EXECUTING also SIGKILLs it, so it reads as KILLED". Grep for the right string
+#: after a real overrun.
 RUNNER_TIMEOUT_S = 600
 
 

--- a/scripts/testlib/scoped_harness.py
+++ b/scripts/testlib/scoped_harness.py
@@ -63,10 +63,14 @@ CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 #: 🔴 600 IS THIS MODULE'S PRE-EXISTING VALUE AND IS UNCHANGED — BUT SAY WHICH
 #: SCOPE THAT IS TRUE OF. For the five files already using `run()` it is a no-op,
 #: 600 before and after. For the SIX sites in `test_run_tests_targets.py` that
-#: used to carry `timeout=120`, the effective bound RISES 120 -> 600, deliberately:
-#: that widening is the PR's headline fix. ⚠ An earlier draft of this paragraph
-#: said the change moves "WHERE it is written, not what it is" full stop, which
-#: would tell a maintainer no timeout was raised anywhere. One was.
+#: used to carry `timeout=120`, the effective bound RISES 120 -> 600 — a
+#: CONSEQUENCE of routing them through the shared default, accepted rather than
+#: derived. ⚠ Two drafts of this paragraph were wrong in OPPOSITE directions:
+#: one said the change moves "WHERE it is written, not what it is" full stop,
+#: which would tell a maintainer no timeout was raised anywhere; its replacement
+#: called the widening "the PR's headline fix", which oversells 600 as a measured
+#: value. It is neither. The headline fix is the runner scoping (see commit
+#: "the root cause, not the bound"); 600 remains an unpinned hang bound.
 #:
 #: ⚠ A draft also set this constant to 300, and that was a NARROWING OF FIVE
 #: FILES ON THE EVIDENCE OF A SIXTH. This default governs `run()`, which
@@ -75,10 +79,20 @@ CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 #: call sites (44 of them taking the default) — and their nested runs are not the
 #: 2-9 s narrowed ones the 300 was sized against. Measured on the dev host:
 #: `test_the_node_runner_reports_FULL_on_a_REAL_run` took 28.9 s at load ~57 and
-#: 16.5 s at load ~48. At 300 that is roughly 10-18x headroom against a >2.55x
-#: contention inflation (120 s bound / 47 s run, the ratio that caused this PR) —
-#: thinner than it looks, and for no measured benefit. Do not re-derive 300 from
-#: the 9 s figure; that is a measurement of ONE consumer.
+#: 16.5 s at load ~48, and an audit round separately observed **70.5 s** for a
+#: sibling under a load it did not record. At 300 that is between ~4x (on the
+#: 70.5 s observation) and ~18x (on the 16.5 s one) against a >2.55x contention
+#: inflation (120 s bound / 47 s run, the ratio that caused this PR) — thin at
+#: the bad end, and for no measured benefit.
+#:
+#: ⚠ THE 70.5 s IS KEPT DELIBERATELY, AND SO IS THIS SENTENCE. A revision of
+#: this paragraph DROPPED it — the single worst observation, i.e. the one most
+#: hostile to 300 — while adding a smaller new one, so the stated headroom
+#: improved from ~4-10x to ~10-18x with no note that evidence had been removed.
+#: That is the same selective-sweep mechanism this docstring elsewhere calls out,
+#: performed while fixing it. It is second-hand and its load is unrecorded, which
+#: is a reason to LABEL it, never to delete it. Do not re-derive 300 from the 9 s
+#: figure either; that is a measurement of ONE consumer.
 #:
 #: ⚠ WHAT 600 COSTS, STATED BECAUSE THE 300 DRAFT LEANT ON IT AND THE REVERT MUST
 #: NOT QUIETLY DROP IT. `test_run_tests_targets.py` performs FOUR real nested

--- a/scripts/testlib/scoped_harness.py
+++ b/scripts/testlib/scoped_harness.py
@@ -60,31 +60,49 @@ CHEAP_SHELL_TEST = "scripts/tests/test_release_wrapper.sh"
 #: a message rather than hanging until the gate's own cap, which is worse — no
 #: message, no exit code.
 #:
-#: 300 s is ~33x the measured cost of a narrowed nested run (9 s at load ~46,
-#: after `run-tests.sh` stopped executing the hook/shell families on non-FULL
-#: runs). ⚠ Headroom is not the only axis: `test_run_tests_targets.py` performs
-#: FOUR real nested runs, so this also sets a worst case — 4x300 s = 20 min.
+#: 🔴 600 IS THE VALUE THIS MODULE ALREADY HAD, AND THIS CHANGE DELIBERATELY
+#: DOES NOT MOVE IT. What moved is WHERE it is written, not what it is: six
+#: open-coded `timeout=120` sites in `test_run_tests_targets.py` now read this
+#: name instead of carrying their own copies.
 #:
-#: 🔴 AGAINST THE GATE **TASK**'s OWN `timeout: 60m`, NOT THE PIPELINE'S
-#: `timeouts.tasks: 70m`. The task cap is the lower of the two and therefore the
-#: only one a slow test can reach — an earlier draft of this paragraph quoted
-#: the pipeline budget and got the consequence BACKWARDS with it. The
-#: difference is not pedantry; the two fail in opposite directions, per that
-#: pipeline's own measured three-way probe (Tekton v1.12.0,
-#: `devrc-ci-pipeline.yaml`):
+#: ⚠ A draft of this change set it to 300, and that was a NARROWING OF FIVE
+#: FILES ON THE EVIDENCE OF A SIXTH. This default governs `run()`, which
+#: `test_scoped_runs.py`, `test_scoped_mapper.py`, `test_scoped_scope_marker.py`,
+#: `test_scoped_gate_contract.py` and `test_scoped_ledgers.py` use across ~47
+#: call sites — and their nested runs are not the 2-9 s narrowed ones the 300
+#: was sized against. Measured on the dev host: 28.9 s at load ~57 for
+#: `test_the_node_runner_reports_FULL_on_a_REAL_run`, and 70.5 s observed for a
+#: sibling under a different load. At 300 that is ~4-10x headroom, against the
+#: >2.55x contention inflation that caused this PR in the first place — i.e. the
+#: narrowing would have re-created the failure class here that the runner fix
+#: just removed elsewhere. Do not re-derive 300 from the 9 s figure; it is a
+#: measurement of ONE consumer.
+#:
+#: 🔴 THIS IS A HANG BOUND, NOT AN ASSERTION. Nothing any caller pins depends on
+#: the nested run being fast; the bound exists only so a wedged child fails with
+#: a message rather than hanging until the gate's own cap, which is worse — no
+#: message, no exit code.
+#:
+#: ⚠ On the worst case, stated because the 300 draft leant on it:
+#: `test_run_tests_targets.py` performs FOUR real nested runs, so 4x600 s = 40
+#: min in the pathological case. That requires all four to HANG — after the
+#: runner fix each measures 2-9 s — and a genuine hang is a defect you want
+#: surfaced, not absorbed. It is bounded by the gate TASK's own `timeout: 60m`
+#: (`devrc-ci-pipeline.yaml`), NOT the pipeline's `timeouts.tasks: 70m`: the task
+#: cap is the lower of the two and so the only one a slow test can reach. That
+#: distinction decides the OUTCOME, per that pipeline's own measured three-way
+#: probe (Tekton v1.12.0):
 #:
 #:     timeouts.tasks   -> PipelineRunTimeout, finally NEVER RAN -> posts nothing,
 #:                         checks stay `pending` forever
-#:     task-level 60m   -> Failed,             finally RAN       -> posts a red
+#:     task-level 60m   -> Failed,             finally RAN       -> posts a status
 #:
-#: So overrunning here yields a LEGIBLE RED, not the unclearable pending the
-#: earlier draft warned about. ⚠ The real budget is tighter than 60m anyway: that
-#: clock runs while the pod is Pending, and a worst-observed ~22.5m queue leaves
-#: ~37m of execution. 20 min of that is 54%; the rejected 600 would have been
-#: 40 min, i.e. MORE than the whole post-queue budget for one test file.
-#: 600 was the first value proposed and is REJECTED for that reason: it bought
-#: headroom the runner fix had already made unnecessary.
-RUNNER_TIMEOUT_S = 300
+#: So overrunning here posts SOMETHING a human can read — an `error` carrying
+#: `COULD NOT RUN`, which CLAUDE.md tells readers is a broken gate rather than a
+#: bad change — instead of the unclearable pending an earlier draft wrongly
+#: warned about. ⚠ The real budget is tighter than 60m: the clock runs while the
+#: pod is Pending, and a worst-observed ~22.5m queue leaves ~37m of execution.
+RUNNER_TIMEOUT_S = 600
 
 
 def run(args: list[str], timeout: int = RUNNER_TIMEOUT_S,

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -49,11 +49,15 @@ import ast
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from testlib.scoped_harness import RUNNER_TIMEOUT_S  # noqa: E402
 RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
 
 # The entry #276 added and the gate then silently refused to run.
@@ -102,9 +106,11 @@ def _require_check_targets(runner: Path) -> None:
 #: breached by CONTENTION and the failure read as a code failure:
 #: `subprocess.TimeoutExpired`, returncode -9, traceback ending in
 #: `_check_timeout` — reproduced here by lowering this constant. Occurrences:
-#: devrc#1450, #1458 and #1462, all three merged with `tekton/devrc-pytests`
-#: RED, and all three on diffs that cannot reach this file (#1462 and #1450 are
-#: docs-only).
+#: devrc#1450, #1458 and #1462, each red on `tekton/devrc-pytests` naming one of
+#: this file's four real-run tests, and each on a diff that cannot reach it
+#: (#1450 is a SKILL.md, #1462 a handoff doc). ⚠ **#1458 and #1462 merged over
+#: that red; #1450 was still OPEN when this was written** — an earlier draft
+#: said "all three merged", which was wrong about #1450.
 #:
 #: 🔴 WHERE THOSE 47 SECONDS GO — AND AN EARLIER VERSION OF THIS COMMENT GOT IT
 #: WRONG IN THE WAY THAT MATTERS. It said "almost all of it is the runner's
@@ -116,24 +122,30 @@ def _require_check_targets(runner: Path) -> None:
 #: against `--files <one file in it>` = **4 s**, because `--files` sets
 #: `SCOPED_MODE` and `run-tests.sh:4518` drops the families under it.
 #:
-#: 🔴 SO THIS BOUND IS THE SYMPTOM FIX, AND IT SAYS SO. The root cause is that a
-#: `--targets` run pays for work it did not select; `run-tests.sh` already has
-#: the machinery to skip it and reaches it only via `--files`. Decoupling that
-#: would take the nested run to ~4 s and make even the ORIGINAL 120 s ~30x
-#: headroom. Calling the cost "preflight" is precisely what made a bigger
-#: timeout look like the only lever — do not re-derive that.
+#: 🔴 THE ROOT CAUSE IS FIXED IN THE SAME PR, SO THE VALUE IS DERIVED FROM THE
+#: WORLD AFTER THAT FIX, NOT BEFORE IT. `run-tests.sh` dropped the hook/shell
+#: families only under `--files`; it now drops them for any non-FULL run, so the
+#: same nested `--targets` run measures **9 s** at load ~46 — down from 47 s. A
+#: bound sized against the 47 s would be insurance against a defect that no
+#: longer exists.
 #:
-#: 600 s is ~12x the measured 47 s. ⚠ It is not free: this file performs FOUR
-#: real nested runs, so the worst case moves from 4x120 s = 8 min to
-#: 4x600 s = 40 min, against a measured `timeouts.tasks` of 1h10m on
-#: `devrc-ci-pipeline` — 57% of the task budget. A run that hits that cap posts
-#: NOTHING and the checks stay `pending` forever (CLAUDE.md, measured on
-#: `devrc-ci-nnt6f`/`-9p6mf`). That is the trade this value makes: a readable
-#: red becomes less likely, an unclearable pending becomes more so.
+#: 🔴 THE VALUE ITSELF LIVES IN `testlib.scoped_harness`, NOT HERE. That module's
+#: `run()` already carried its own `timeout=600` default and is used by five
+#: other test files, so a constant private to THIS file would have been a fourth
+#: copy of the predicate while the docstring below claimed "one rule, one place".
+#: Read the reasoning for the number there; this name is an import so the two
+#: cannot drift.
+#:
+#: ⚠ NOT YET CONSOLIDATED, and this is the honest edge of the claim:
+#: `test_run_tests_preconditions.py:68` uses 300 and
+#: `test_devshell_satisfies_required_tools.py:105,436` use 120, each spawning a
+#: runner of its own. They drive fast precondition/PATH-stub aborts, so none is
+#: near its bound — this is about the thesis, not a live defect. The guard below
+#: is file-scoped and cannot see them.
 #:
 #: Deliberately NOT env-overridable: a bound a run can widen for itself is a
 #: bound that cannot fail.
-_RUNNER_TIMEOUT_S = 600
+_RUNNER_TIMEOUT_S = RUNNER_TIMEOUT_S
 
 
 def _spawn(args: list[str], *, env: dict) -> subprocess.CompletedProcess:
@@ -231,12 +243,30 @@ def test_no_call_site_open_codes_its_own_subprocess_bound():
     """
     tree = ast.parse(THIS_FILE.read_text(encoding="utf-8"))
 
-    #: Every `subprocess` entry point that can start a child. `run` is the one
-    #: this file uses; the rest are here because the guard must be as wide as its
-    #: docstring, and `communicate()` on an unbounded `Popen` is the exact hang
-    #: the second assertion below is about.
+    #: The `subprocess` entry points this guard recognises. `run` is the one this
+    #: file uses; the rest are here because `communicate()` on an unbounded
+    #: `Popen` is the exact hang the second assertion below is about.
+    #:
+    #: 🔴 THIS IS AN ENUMERATION, NOT "EVERY WAY TO START A CHILD" — an earlier
+    #: version of this comment claimed the latter and was wider than the set.
+    #: `getoutput`/`getstatusoutput` are included because they are the SHARP
+    #: case: real `subprocess` spawn points that take **no `timeout` parameter
+    #: at all**, i.e. unbounded by construction. Measured NOT covered, and left
+    #: so deliberately: `os.system(...)` (not `subprocess`), `from subprocess
+    #: import *` (a star-import binds names this AST walk cannot enumerate), and
+    #: assignment aliasing (`_SP = subprocess.run; _SP(...)`). Each would need a
+    #: different mechanism, and none has ever appeared in this file — the claim
+    #: is "these spellings are closed", never "no spelling escapes".
     _SPAWNING_CALLABLES = frozenset(
-        {"run", "Popen", "call", "check_call", "check_output"}
+        {
+            "run",
+            "Popen",
+            "call",
+            "check_call",
+            "check_output",
+            "getoutput",
+            "getstatusoutput",
+        }
     )
 
     # Resolve every local name that can reach one of those, however it was bound:
@@ -288,8 +318,30 @@ def test_no_call_site_open_codes_its_own_subprocess_bound():
         "these spawn the runner without going through `_spawn`, so they carry "
         "their own bound and will not move when `_RUNNER_TIMEOUT_S` moves:\n  "
         + "\n  ".join(offenders)
-        + "\n\nThat is how the 120s bound survived two gate reds: it was written "
+        + "\n\nThat is how the 120s bound survived three gate reds: it was written "
         "at six sites and raised at none. Route the call through `_spawn`."
+    )
+    # 🔴 THE POSITIVE CONTROL, AND WITHOUT IT EVERY ASSERTION HERE IS VACUOUS.
+    # Both lists are accumulated over calls the walk FOUND, so a file containing
+    # no spawn call at all satisfies them by finding nothing — the same "passes
+    # hardest on the worst outcome" shape the bound-ABSENT check below closes,
+    # one level up. Measured SURVIVING before this line: replacing `_spawn`'s
+    # body with a delegation to a helper in `testlib/` — the natural shape of
+    # "move the bound somewhere shared" — left zero spawn calls here and the
+    # guard green. `>= 1`, not `== 1`: the count is not the property.
+    bounded_in_spawn = sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and _is_spawn_call(node)
+        and owner.get(node.lineno) == "_spawn"
+    )
+    assert bounded_in_spawn >= 1, (
+        "this guard found NO bounded spawn inside `_spawn`, so every assertion "
+        "above passed over an empty set and proved nothing. Either the spawn "
+        "moved out of this file — in which case the bound moved with it and "
+        "this guard no longer covers it — or `_spawn` was renamed and `owner` "
+        "no longer resolves. Both need a human, not a green."
     )
     assert not unbounded, (
         "`_spawn` must pass `timeout=_RUNNER_TIMEOUT_S` — not a literal, and not "

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 import ast
 import os
 import re
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -98,25 +97,46 @@ def _require_check_targets(runner: Path) -> None:
 #: 🔴 IT WAS 120, AND 120 REDDENED THE GATE ON DIFFS THAT COULD NOT REACH THIS
 #: FILE. Measured 2026-09-11 on the dev host at load ~52: one nested run of
 #: `scripts/collector/i3/tests` — the SMALLEST target in the set, 13 tests —
-#: took **47 s**, i.e. 39% of the old bound, and almost all of it is the
-#: runner's fixed preflight rather than the tests. CI is documented at 27–50
-#: concurrent full-suite runs on one node (CLAUDE.md), where that overhead is
-#: multiplied, so the old bound was breached by CONTENTION and the failure read
-#: as a code failure: `subprocess.TimeoutExpired`, returncode -9, traceback
-#: ending in `_check_timeout` — reproduced here by lowering this constant.
-#: Occurrences: devrc#1458 and #1462, both merged with `tekton/devrc-pytests`
-#: RED because of it.
+#: took **47 s**, i.e. 39% of the old bound. CI is documented at 27–50
+#: concurrent full-suite runs on one node (CLAUDE.md), so the old bound was
+#: breached by CONTENTION and the failure read as a code failure:
+#: `subprocess.TimeoutExpired`, returncode -9, traceback ending in
+#: `_check_timeout` — reproduced here by lowering this constant. Occurrences:
+#: devrc#1450, #1458 and #1462, all three merged with `tekton/devrc-pytests`
+#: RED, and all three on diffs that cannot reach this file (#1462 and #1450 are
+#: docs-only).
 #:
-#: 600 s is ~12x the measured figure, which is headroom for contention, and it
-#: still bounds a genuine hang well inside the gate's own budget. Deliberately
-#: NOT env-overridable: a bound a run can widen for itself is a bound that
-#: cannot fail, and a green under it would mean nothing.
+#: 🔴 WHERE THOSE 47 SECONDS GO — AND AN EARLIER VERSION OF THIS COMMENT GOT IT
+#: WRONG IN THE WAY THAT MATTERS. It said "almost all of it is the runner's
+#: fixed preflight rather than the tests". Not preflight: a `--targets` run
+#: still executes the hook-test and shell-test families, which `--targets` does
+#: NOT narrow. Of ~54 s measured under `bash -x`, the SELECTED target's pytest
+#: was **2.9 s** and ~46 s was those two families. The discriminator, same box,
+#: same load ~52, minutes apart: `--targets scripts/collector/i3/tests` = **47 s**
+#: against `--files <one file in it>` = **4 s**, because `--files` sets
+#: `SCOPED_MODE` and `run-tests.sh:4518` drops the families under it.
+#:
+#: 🔴 SO THIS BOUND IS THE SYMPTOM FIX, AND IT SAYS SO. The root cause is that a
+#: `--targets` run pays for work it did not select; `run-tests.sh` already has
+#: the machinery to skip it and reaches it only via `--files`. Decoupling that
+#: would take the nested run to ~4 s and make even the ORIGINAL 120 s ~30x
+#: headroom. Calling the cost "preflight" is precisely what made a bigger
+#: timeout look like the only lever — do not re-derive that.
+#:
+#: 600 s is ~12x the measured 47 s. ⚠ It is not free: this file performs FOUR
+#: real nested runs, so the worst case moves from 4x120 s = 8 min to
+#: 4x600 s = 40 min, against a measured `timeouts.tasks` of 1h10m on
+#: `devrc-ci-pipeline` — 57% of the task budget. A run that hits that cap posts
+#: NOTHING and the checks stay `pending` forever (CLAUDE.md, measured on
+#: `devrc-ci-nnt6f`/`-9p6mf`). That is the trade this value makes: a readable
+#: red becomes less likely, an unclearable pending becomes more so.
+#:
+#: Deliberately NOT env-overridable: a bound a run can widen for itself is a
+#: bound that cannot fail.
 _RUNNER_TIMEOUT_S = 600
 
 
-def _spawn(
-    args: list[str], *, env: dict, cwd: Path | None = None
-) -> subprocess.CompletedProcess:
+def _spawn(args: list[str], *, env: dict) -> subprocess.CompletedProcess:
     """The ONE place this file bounds a nested `run-tests.sh`.
 
     🔴 ONE RULE, ONE PLACE — AND IT WAS SIX. `timeout=120` was open-coded at six
@@ -135,7 +155,7 @@ def _spawn(
     try:
         return subprocess.run(
             ["bash", *args],
-            cwd=str(cwd or REPO_ROOT),
+            cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
             timeout=_RUNNER_TIMEOUT_S,
@@ -160,7 +180,7 @@ def _spawn(
         ) from exc
 
 
-def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+def _run(args: list[str]) -> subprocess.CompletedProcess:
     """Run the runner with a SCRUBBED environment.
 
     🔴 `DEVRC_TARGETS` is removed, and that is not hygiene — it is what keeps
@@ -173,7 +193,7 @@ def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProces
     debugging a subset run — i.e. exactly when these guards matter.
     """
     env = {k: v for k, v in os.environ.items() if k != "DEVRC_TARGETS"}
-    return _spawn(args, env=env, cwd=cwd)
+    return _spawn(args, env=env)
 
 
 THIS_FILE = Path(__file__).resolve()
@@ -198,22 +218,47 @@ def test_no_call_site_open_codes_its_own_subprocess_bound():
     a call carrying no bound at all — which is the unbounded hang this file's
     bound exists to prevent, i.e. the guard would pass hardest on the worst
     outcome.
+
+    🔴 THE FIRST VERSION OF THIS GUARD WAS NARROWER THAN THIS DOCSTRING, WHICH IS
+    THE DEFECT IT IS SUPPOSED TO CATCH. It resolved `from subprocess import run
+    as r` and **not** `import subprocess as sp; sp.run(...)` — a sibling spelling
+    of the same aliasing the paragraph above claims to close — and it saw only
+    `run`, so `Popen(...).communicate()` with no bound was invisible while the
+    assertion below called exactly that "worse than the red it replaces". Both
+    were measured SURVIVING. Caught by a round-0 audit, not by the suite.
+    `_SPAWNING_CALLABLES` is therefore an enumerated set rather than the one name
+    that happened to be in use.
     """
     tree = ast.parse(THIS_FILE.read_text(encoding="utf-8"))
 
-    # Resolve every local name bound to subprocess.run, however it was imported.
-    aliases: set[str] = set()
+    #: Every `subprocess` entry point that can start a child. `run` is the one
+    #: this file uses; the rest are here because the guard must be as wide as its
+    #: docstring, and `communicate()` on an unbounded `Popen` is the exact hang
+    #: the second assertion below is about.
+    _SPAWNING_CALLABLES = frozenset(
+        {"run", "Popen", "call", "check_call", "check_output"}
+    )
+
+    # Resolve every local name that can reach one of those, however it was bound:
+    # `import subprocess`, `import subprocess as sp`, `from subprocess import run`,
+    # `from subprocess import run as r`.
+    module_aliases: set[str] = {"subprocess"}
+    direct_aliases: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+        if isinstance(node, ast.Import):
             for a in node.names:
-                if a.name == "run":
-                    aliases.add(a.asname or a.name)
+                if a.name == "subprocess":
+                    module_aliases.add(a.asname or a.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for a in node.names:
+                if a.name in _SPAWNING_CALLABLES:
+                    direct_aliases.add(a.asname or a.name)
 
     def _is_spawn_call(call: ast.Call) -> bool:
         fn = call.func
-        if isinstance(fn, ast.Attribute) and fn.attr == "run":
-            return isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"
-        return isinstance(fn, ast.Name) and fn.id in aliases
+        if isinstance(fn, ast.Attribute) and fn.attr in _SPAWNING_CALLABLES:
+            return isinstance(fn.value, ast.Name) and fn.value.id in module_aliases
+        return isinstance(fn, ast.Name) and fn.id in direct_aliases
 
     # Which function does each spawn call live in?
     owner: dict[int, str] = {}
@@ -598,7 +643,12 @@ def test_a_pinned_skip_whose_TARGET_did_not_run_does_not_count():
     # Through `_run`, NOT a bare subprocess.run: this test bypassed the scrub
     # and so inherited an ambient DEVRC_TARGETS, giving the developer debugging
     # a subset run a spurious RED — the mirror of the vacuous GREEN the scrub
-    # exists to prevent. `_run`'s 120s timeout is ample; this costs ~13s.
+    # exists to prevent. Bounded by `_RUNNER_TIMEOUT_S`, like every other spawn
+    # here. ⚠ The cost is NOT this target's 13 tests: a `--targets` run still
+    # executes the hook-test and shell-test families, which `--targets` does not
+    # narrow — measured 47 s wall against 4 s for the same work under `--files`.
+    # An earlier version of this comment said "`_run`'s 120s timeout is ample;
+    # this costs ~13s", and both halves were wrong.
     proc = _run([str(RUN_TESTS), "--targets", tiny, str(REPO_ROOT)])
     combined = proc.stdout + proc.stderr
     assert "pinned entries apply here" not in combined, (

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -45,6 +45,7 @@ as regression coverage"):
 """
 from __future__ import annotations
 
+import ast
 import os
 import re
 import shutil
@@ -86,6 +87,79 @@ def _require_check_targets(runner: Path) -> None:
     )
 
 
+#: How long any nested `run-tests.sh` spawned by this file may take before the
+#: harness kills it.
+#:
+#: 🔴 THIS IS A HANG BOUND, NOT AN ASSERTION. Nothing any test here pins depends
+#: on the nested run being fast; the bound exists only so a wedged child fails
+#: with a message instead of hanging until the gate's own cap, which is strictly
+#: worse (no message, no exit code).
+#:
+#: 🔴 IT WAS 120, AND 120 REDDENED THE GATE ON DIFFS THAT COULD NOT REACH THIS
+#: FILE. Measured 2026-09-11 on the dev host at load ~52: one nested run of
+#: `scripts/collector/i3/tests` — the SMALLEST target in the set, 13 tests —
+#: took **47 s**, i.e. 39% of the old bound, and almost all of it is the
+#: runner's fixed preflight rather than the tests. CI is documented at 27–50
+#: concurrent full-suite runs on one node (CLAUDE.md), where that overhead is
+#: multiplied, so the old bound was breached by CONTENTION and the failure read
+#: as a code failure: `subprocess.TimeoutExpired`, returncode -9, traceback
+#: ending in `_check_timeout` — reproduced here by lowering this constant.
+#: Occurrences: devrc#1458 and #1462, both merged with `tekton/devrc-pytests`
+#: RED because of it.
+#:
+#: 600 s is ~12x the measured figure, which is headroom for contention, and it
+#: still bounds a genuine hang well inside the gate's own budget. Deliberately
+#: NOT env-overridable: a bound a run can widen for itself is a bound that
+#: cannot fail, and a green under it would mean nothing.
+_RUNNER_TIMEOUT_S = 600
+
+
+def _spawn(
+    args: list[str], *, env: dict, cwd: Path | None = None
+) -> subprocess.CompletedProcess:
+    """The ONE place this file bounds a nested `run-tests.sh`.
+
+    🔴 ONE RULE, ONE PLACE — AND IT WAS SIX. `timeout=120` was open-coded at six
+    call sites here, so raising the bound meant finding all six, and the two
+    occurrences that reddened the gate were fixed at neither. A predicate copied
+    per call site is wrong at every site it was not copied to; routing every
+    spawn through here is what makes a seventh site impossible to add silently —
+    see `test_no_call_site_open_codes_its_own_subprocess_bound`.
+
+    🔴 AND THE TIMEOUT IS TRANSLATED, NOT PROPAGATED. A bare `TimeoutExpired`
+    names a bash command line and a number of seconds; it says nothing about
+    which of those two things is wrong, so the reader debugs their own diff.
+    That is exactly what happened on #1458 and #1462. The failure below states
+    the classification instead.
+    """
+    try:
+        return subprocess.run(
+            ["bash", *args],
+            cwd=str(cwd or REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=_RUNNER_TIMEOUT_S,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise AssertionError(
+            f"the nested run-tests.sh exceeded this harness's {_RUNNER_TIMEOUT_S}s "
+            "bound and was KILLED.\n\n"
+            "🔴 THIS IS NOT AN ASSERTION FAILURE AND IT IS PROBABLY NOT YOUR DIFF. "
+            "No property this file pins was contradicted — a bounded subprocess "
+            "ran out of wall time. The bound is a hang guard (see "
+            "`_RUNNER_TIMEOUT_S`), and the historical cause is node contention, "
+            "not a code defect: this file reddened devrc#1458 and #1462 on diffs "
+            "that could not reach it.\n\n"
+            "Before changing anything here, check what else was running. If the "
+            "nested run is genuinely wedged rather than slow, that IS a real "
+            "defect in run-tests.sh — read the captured output below.\n\n"
+            f"command: {exc.cmd}\n"
+            f"stdout tail:\n{(exc.stdout or b'').decode(errors='replace')[-2000:]}\n"
+            f"stderr tail:\n{(exc.stderr or b'').decode(errors='replace')[-2000:]}"
+        ) from exc
+
+
 def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
     """Run the runner with a SCRUBBED environment.
 
@@ -99,13 +173,84 @@ def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProces
     debugging a subset run — i.e. exactly when these guards matter.
     """
     env = {k: v for k, v in os.environ.items() if k != "DEVRC_TARGETS"}
-    return subprocess.run(
-        ["bash", *args],
-        cwd=str(cwd or REPO_ROOT),
-        capture_output=True,
-        text=True,
-        timeout=120,
-        env=env,
+    return _spawn(args, env=env, cwd=cwd)
+
+
+THIS_FILE = Path(__file__).resolve()
+
+
+def test_no_call_site_open_codes_its_own_subprocess_bound():
+    """🔴 THE SEVENTH SITE. `timeout=120` was open-coded at SIX call sites here,
+    and the bound that reddened devrc#1458 and #1462 was raised at none of them,
+    because raising it meant finding all six by hand.
+
+    So this pins the RELATIONSHIP, not a number: every spawn in this file goes
+    through `_spawn`, and `_spawn` is the only place a bound is written. Adding a
+    seventh raw `subprocess.run` fails here by name.
+
+    🔴 PARSED, NOT GREPPED — the same correction `test_store_siting_ledger.py`
+    already had to make. A regex for `timeout=120` is walked past by `timeout =
+    120`, by a different literal, and by `from subprocess import run as r;
+    r(...)`. None of those survive an AST.
+
+    🔴 AND IT ASSERTS THE BOUND EXISTS, not merely that it is spelled right. A
+    check that only inspected `timeout=` keywords it FOUND would be satisfied by
+    a call carrying no bound at all — which is the unbounded hang this file's
+    bound exists to prevent, i.e. the guard would pass hardest on the worst
+    outcome.
+    """
+    tree = ast.parse(THIS_FILE.read_text(encoding="utf-8"))
+
+    # Resolve every local name bound to subprocess.run, however it was imported.
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for a in node.names:
+                if a.name == "run":
+                    aliases.add(a.asname or a.name)
+
+    def _is_spawn_call(call: ast.Call) -> bool:
+        fn = call.func
+        if isinstance(fn, ast.Attribute) and fn.attr == "run":
+            return isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"
+        return isinstance(fn, ast.Name) and fn.id in aliases
+
+    # Which function does each spawn call live in?
+    owner: dict[int, str] = {}
+    for fn in ast.walk(tree):
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for node in ast.walk(fn):
+                if isinstance(node, ast.Call) and _is_spawn_call(node):
+                    owner.setdefault(node.lineno, fn.name)
+
+    offenders, unbounded = [], []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _is_spawn_call(node)):
+            continue
+        where = owner.get(node.lineno, "<module level>")
+        if where != "_spawn":
+            offenders.append(f"line {node.lineno}, in {where}()")
+            continue
+        kw = {k.arg: k.value for k in node.keywords if k.arg}
+        bound = kw.get("timeout")
+        if not (isinstance(bound, ast.Name) and bound.id == "_RUNNER_TIMEOUT_S"):
+            unbounded.append(
+                f"line {node.lineno}: timeout is "
+                f"{ast.dump(bound) if bound is not None else 'ABSENT'}"
+            )
+
+    assert not offenders, (
+        "these spawn the runner without going through `_spawn`, so they carry "
+        "their own bound and will not move when `_RUNNER_TIMEOUT_S` moves:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nThat is how the 120s bound survived two gate reds: it was written "
+        "at six sites and raised at none. Route the call through `_spawn`."
+    )
+    assert not unbounded, (
+        "`_spawn` must pass `timeout=_RUNNER_TIMEOUT_S` — not a literal, and not "
+        "nothing:\n  " + "\n  ".join(unbounded)
+        + "\n\nA spawn with NO timeout hangs until the gate's own cap, with no "
+        "message and no exit code, which is worse than the red it replaces."
     )
 
 
@@ -653,9 +798,8 @@ def test_DEVRC_TARGETS_is_equivalent_to_the_flag_and_names_itself():
     assert "DEVRC_TARGETS" in src, "the env override is gone from run-tests.sh"
 
     flag = _run([str(RUN_TESTS), "--targets", t, "--check-floors", str(REPO_ROOT)])
-    env = subprocess.run(
-        ["bash", str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+    env = _spawn(
+        [str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
         env={**os.environ, "DEVRC_TARGETS": t},
     )
     assert flag.returncode == 0 and env.returncode == 0, (flag.stderr, env.stderr)
@@ -798,10 +942,9 @@ def test_the_flag_OVERRIDES_an_ambient_env_var_and_says_so():
     flagged = "scripts/collector/i3/tests"
     ambient = "scripts/opencode/tests"
     env = {**os.environ, "DEVRC_TARGETS": ambient}
-    proc = subprocess.run(
-        ["bash", str(RUN_TESTS), "--targets", flagged, "--check-floors",
-         str(REPO_ROOT)],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120, env=env,
+    proc = _spawn(
+        [str(RUN_TESTS), "--targets", flagged, "--check-floors", str(REPO_ROOT)],
+        env=env,
     )
     assert proc.returncode == 0, (
         "a single --targets alongside an ambient DEVRC_TARGETS must not be "
@@ -825,10 +968,7 @@ def test_a_set_but_EMPTY_env_var_names_the_env_var_in_its_remedy():
     The only remedy is `unset DEVRC_TARGETS`, so it has to appear."""
     _require_targets_flag(RUN_TESTS)
     env = {**os.environ, "DEVRC_TARGETS": ""}
-    proc = subprocess.run(
-        ["bash", str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120, env=env,
-    )
+    proc = _spawn([str(RUN_TESTS), "--check-floors", str(REPO_ROOT)], env=env)
     assert proc.returncode == 3, f"expected 3, got {proc.returncode}"
     # 🔴 The FATAL LINE ITSELF, not just the string somewhere in stderr. The
     # remedy line below it mentions DEVRC_TARGETS independently, so a bare
@@ -857,10 +997,7 @@ ENV_ONLY = {"DEVRC_TARGETS": "scripts/collector/i3/tests"}
 
 def _run_env(args: list[str], extra: dict) -> subprocess.CompletedProcess:
     """Run the runner with EXTRA env, bypassing `_run`'s scrub on purpose."""
-    return subprocess.run(
-        ["bash", *args], cwd=str(REPO_ROOT), capture_output=True, text=True,
-        timeout=120, env={**os.environ, **extra},
-    )
+    return _spawn(args, env={**os.environ, **extra})
 
 
 def test_no_message_hardcodes_the_flag_when_the_ENVIRONMENT_selected():
@@ -956,9 +1093,8 @@ def test_the_empty_selection_remedy_names_EVERY_knob_that_is_set():
         f"told to omit a flag that was never passed.\n{env_only}")
 
     # flag empty, NO env -> must name the flag, never the env var
-    flag_only = subprocess.run(
-        ["bash", str(RUN_TESTS), "--targets", "", "--check-floors", str(REPO_ROOT)],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+    flag_only = _spawn(
+        [str(RUN_TESTS), "--targets", "", "--check-floors", str(REPO_ROOT)],
         env={k: v for k, v in os.environ.items() if k != "DEVRC_TARGETS"},
     ).stderr
     assert "Omit --targets" in flag_only, flag_only

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -122,23 +122,28 @@ def _require_check_targets(runner: Path) -> None:
 #: against `--files <one file in it>` = **4 s**, because `--files` sets
 #: `SCOPED_MODE` and `run-tests.sh:4518` drops the families under it.
 #:
-#: 🔴 THE ROOT CAUSE IS FIXED IN THE SAME PR, SO THE VALUE IS DERIVED FROM THE
-#: WORLD AFTER THAT FIX, NOT BEFORE IT. `run-tests.sh` dropped the hook/shell
-#: families only under `--files`; it now drops them for any non-FULL run, so the
-#: same nested `--targets` run measures **9 s** at load ~46 — down from 47 s. A
-#: bound sized against the 47 s would be insurance against a defect that no
-#: longer exists.
-#:
-#: 🔴 THE VALUE ITSELF LIVES IN `testlib.scoped_harness`, NOT HERE. That module's
-#: `run()` already carried its own `timeout=600` default and is used by five
-#: other test files, so a constant private to THIS file would have been a fourth
-#: copy of the predicate while the docstring below claimed "one rule, one place".
-#: Read the reasoning for the number there; this name is an import so the two
+#: 🔴 THE VALUE LIVES IN `testlib.scoped_harness`, NOT HERE, AND THIS PR DOES NOT
+#: CHANGE IT. That module's `run()` already carried a `timeout=600` default used
+#: by five other test files, so a constant private to THIS file would have been a
+#: fourth copy of the predicate while the docstring below claimed "one rule, one
+#: place". Read the reasoning for the number there; this is an import so the two
 #: cannot drift.
+#:
+#: ⚠ A draft of this change RE-SIZED it to 300 on the strength of a measurement
+#: taken here — a narrowing of five other files on the evidence of this one. The
+#: reasoning and the measurements that rejected it are recorded beside the
+#: constant. What this PR removes is the six open-coded `timeout=120` copies,
+#: not the bound's value.
+#:
+#: 🔴 AND 120 WAS NEVER THE REAL DEFECT EITHER. The nested `--targets` runs this
+#: file spawns cost 47 s because `run-tests.sh` executed two whole test families
+#: that `--targets` cannot name; that is fixed in the same PR, and the same run
+#: now measures 2-9 s. A bound is the wrong instrument for work that should not
+#: have been running — do not re-derive a bigger number from the old cost.
 #:
 #: ⚠ NOT YET CONSOLIDATED, and this is the honest edge of the claim:
 #: `test_run_tests_preconditions.py:68` uses 300 and
-#: `test_devshell_satisfies_required_tools.py:105,436` use 120, each spawning a
+#: `test_devshell_satisfies_required_tools.py:110,438` use 120, each spawning a
 #: runner of its own. They drive fast precondition/PATH-stub aborts, so none is
 #: near its bound — this is about the thesis, not a live defect. The guard below
 #: is file-scoped and cannot see them.
@@ -329,15 +334,19 @@ def test_no_call_site_open_codes_its_own_subprocess_bound():
     # body with a delegation to a helper in `testlib/` — the natural shape of
     # "move the bound somewhere shared" — left zero spawn calls here and the
     # guard green. `>= 1`, not `== 1`: the count is not the property.
-    bounded_in_spawn = sum(
+    # ⚠ Counts spawn calls sited in `_spawn`, NOT ones already checked to carry
+    # the bound — the `unbounded` assertion above is what establishes that, and
+    # it has already run. Named for what it measures so the message cannot claim
+    # more than the expression does.
+    spawns_in_spawn = sum(
         1
         for node in ast.walk(tree)
         if isinstance(node, ast.Call)
         and _is_spawn_call(node)
         and owner.get(node.lineno) == "_spawn"
     )
-    assert bounded_in_spawn >= 1, (
-        "this guard found NO bounded spawn inside `_spawn`, so every assertion "
+    assert spawns_in_spawn >= 1, (
+        "this guard found NO spawn call inside `_spawn`, so every assertion "
         "above passed over an empty set and proved nothing. Either the spawn "
         "moved out of this file — in which case the bound moved with it and "
         "this guard no longer covers it — or `_spawn` was renamed and `owner` "

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -137,9 +137,11 @@ def _require_check_targets(runner: Path) -> None:
 #: ⚠ SAY THE SCOPE, THOUGH: this PR removes the six open-coded `timeout=120`
 #: copies, which RAISES the effective bound at those six sites 120 -> 600. It is
 #: the SHARED CONSTANT that is unchanged, for the five files already reading it.
-#: An earlier draft here said the PR changes "not the bound's value" without that
-#: qualification, which would tell a maintainer no timeout was raised anywhere —
-#: and raising this one is the whole point of the change.
+#: That rise is a CONSEQUENCE of the consolidation, accepted — not the point of
+#: the change, and not evidence that 600 is a derived number. Two drafts here
+#: were wrong in opposite directions: one said "not the bound's value" without
+#: the scope, the other called raising it "the whole point of the change". The
+#: point is the runner fix below; this bound is unpinned either way.
 #:
 #: 🔴 AND 120 WAS NEVER THE REAL DEFECT EITHER. The nested `--targets` runs this
 #: file spawns cost 47 s because `run-tests.sh` executed two whole test families

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -132,8 +132,14 @@ def _require_check_targets(runner: Path) -> None:
 #: ⚠ A draft of this change RE-SIZED it to 300 on the strength of a measurement
 #: taken here — a narrowing of five other files on the evidence of this one. The
 #: reasoning and the measurements that rejected it are recorded beside the
-#: constant. What this PR removes is the six open-coded `timeout=120` copies,
-#: not the bound's value.
+#: constant.
+#:
+#: ⚠ SAY THE SCOPE, THOUGH: this PR removes the six open-coded `timeout=120`
+#: copies, which RAISES the effective bound at those six sites 120 -> 600. It is
+#: the SHARED CONSTANT that is unchanged, for the five files already reading it.
+#: An earlier draft here said the PR changes "not the bound's value" without that
+#: qualification, which would tell a maintainer no timeout was raised anywhere —
+#: and raising this one is the whole point of the change.
 #:
 #: 🔴 AND 120 WAS NEVER THE REAL DEFECT EITHER. The nested `--targets` runs this
 #: file spawns cost 47 s because `run-tests.sh` executed two whole test families
@@ -334,10 +340,12 @@ def test_no_call_site_open_codes_its_own_subprocess_bound():
     # body with a delegation to a helper in `testlib/` — the natural shape of
     # "move the bound somewhere shared" — left zero spawn calls here and the
     # guard green. `>= 1`, not `== 1`: the count is not the property.
-    # ⚠ Counts spawn calls sited in `_spawn`, NOT ones already checked to carry
-    # the bound — the `unbounded` assertion above is what establishes that, and
-    # it has already run. Named for what it measures so the message cannot claim
-    # more than the expression does.
+    # ⚠ Counts spawn calls SITED in `_spawn`; it does not check they carry the
+    # bound. That is `assert not unbounded`'s job, and note it runs BELOW this —
+    # a previous revision of this comment said "above … it has already run",
+    # which was simply backwards and would have justified deleting the very
+    # check it leaned on. The two are independent: this one refuses an EMPTY
+    # set, that one refuses a BOUNDLESS call, and neither implies the other.
     spawns_in_spawn = sum(
         1
         for node in ast.walk(tree)

--- a/scripts/tests/test_scoped_ledgers.py
+++ b/scripts/tests/test_scoped_ledgers.py
@@ -103,6 +103,53 @@ def test_a_full_run_still_runs_the_hook_and_shell_families(tmp_path):
     assert re.search(r"^     NOT RUN in this mode", out, re.M) is None, out
 
 
+def test_a_TARGETS_run_also_skips_the_families_and_SAYS_SO(tmp_path):
+    """🔴 THE `--targets` HALF, which was NOT covered and cost three gate reds.
+
+    The skip above was keyed on `SCOPED_MODE`, which only `--files` sets — so a
+    `--targets` run still executed BOTH families, and no `--targets` value can
+    name either. MEASURED on the dev host at load ~52, same box minutes apart:
+
+        --targets scripts/collector/i3/tests   47 s   (families ran)
+        --files   <one file in that target>     4 s   (families skipped)
+
+    and after this change the same `--targets` run is **9 s**. That ~12x is what
+    breached the nested-subprocess bound in `test_run_tests_targets.py` under CI
+    contention, reddening `tekton/devrc-pytests` on devrc#1450, #1458 and #1462 —
+    every one a diff that cannot reach either file.
+
+    🔴 BOTH HALVES, for the same reason the SCOPED test asserts both: a silent
+    skip is the #276 shape. And the THIRD assertion is the one that keeps this
+    from being a `--files` test in disguise — a PARTIAL run must still report
+    `SCOPE: PARTIAL`, never `SCOPED`. Reusing `SCOPED_MODE` wholesale would have
+    passed the first two and failed this one, and it would have silently
+    suspended GUARD 3's floors with it.
+    """
+    d, runner = scoped_fixture(tmp_path, floor=1)
+    runner.write_text(patch_runner_source(
+        RUN_TESTS.read_text(), targets=[str(d)], floors={str(d): 1}, ack=[],
+        hook_tests=[CHEAP_HOOK_TEST], shell_tests=[CHEAP_SHELL_TEST]))
+    proc = run([str(runner), str(REPO_ROOT), "--targets", str(d)],
+               env={"MIN_TESTS": "1"})
+    out = out_of(proc)
+    assert proc.returncode == 0, f"rc={proc.returncode}\n{out}"
+    # It SAYS so — on the PARTIAL surface, which carried no such line before.
+    assert re.search(r"^     NOT RUN in this mode", out, re.M), (
+        "a --targets run dropped the families without naming them anywhere — "
+        f"that is the silent narrowing the skip's own comment forbids.\n{out[-3000:]}")
+    assert re.search(r"^       - \d+ hand-rolled hook test script\(s\)$", out, re.M), out
+    assert re.search(r"^       - \d+ shell test script\(s\)$", out, re.M), out
+    # And they really did not run.
+    assert not re.search(r"^=== script scripts/claude-hooks/", out, re.M), out[-3000:]
+    assert not re.search(r"^=== script scripts/tests/.*\.sh ", out, re.M), out[-3000:]
+    # 🔴 …while STAYING a PARTIAL run. This is the assertion that separates
+    # "skip the two unselectable families" from "become a --files run".
+    assert re.search(r"^SCOPE: PARTIAL", out, re.M), (
+        "a --targets run must keep reporting PARTIAL — SCOPED would mean the "
+        f"per-target floors stopped being enforced too.\n{out[-3000:]}")
+    assert not re.search(r"^SCOPE: SCOPED", out, re.M), out[-3000:]
+
+
 def test_a_narrowed_run_NAMES_the_work_it_left_for_ci(tmp_path):
     """🔴 THE POINT OF A NARROWED RUN, now that there is no local full-suite
     mandate and branch protection is off: the advisory `tekton/devrc-*` checks


### PR DESCRIPTION
Closes the second gate-flake family, documented as rank 7 in
`handoff-gate-flake-store-api.md` (talos-infra#1477). That doc diagnosed it; this fixes it —
**at the cause, not only at the symptom.**

## The defect

`run-tests.sh` skips the hook-test and shell-test families on a narrowed run — but the skip
was keyed on `SCOPED_MODE`, **which only `--files` sets**. So a `--targets` run executed both
families in full, and **no `--targets` value can name either**.

`scripts/tests/test_run_tests_targets.py` spawns nested `--targets` runs under a subprocess
bound. Those runs were ~12× more expensive than the work they selected, and under CI
contention they breached the bound — failing `tekton/devrc-pytests` on PRs whose diff cannot
reach either file. Three occurrences: **#1450** (a `SKILL.md`), **#1458**, **#1462** (a handoff
doc). #1458 and #1462 merged over the red; #1450 is still open.

## Measured

| invocation | before | after |
|---|---|---|
| `--targets scripts/collector/i3/tests` (13 tests) | **47 s** (load ~52) | **9 s** (load ~46) |
| `--files <one file in it>` | 4 s | 4 s |

Under `bash -x`, of ~54 s: the *selected* target's pytest was **2.9 s**; ~46 s was the two
families (`test_base_clone_staleness.sh` 19.3 s, `test_diagnose_disk_accounting.sh` 13.2 s,
`test_bash_guard.py` 8.7 s).

**Mechanism reproduced first-hand**, by lowering the bound rather than waiting for CI:
`subprocess.TimeoutExpired`, returncode `-9`, traceback ending in `_check_timeout` — and
therefore **not** an assertion failure, which is why it sent readers to debug their own diff.

## The change

**`scripts/run-tests.sh`** — the family skip is re-keyed from `SCOPED_MODE` to
`SCOPE_STATE != FULL`, so any narrowed run drops them.

🔴 **The skip is announced on the PARTIAL surface too.** Widening the skip without widening the
announcement would be a run silently executing two families fewer than its own SUMMARY claims
— the #276 shape this runner exists to refuse.

⚠ It does **not** drag the rest of `SCOPED_MODE` along. A PARTIAL run still enforces every
per-target floor, GUARD 7's REQUIRED direction and GUARD 2's skip TOTAL, and still reports
`SCOPE: PARTIAL`. That is asserted — reusing `SCOPED_MODE` wholesale would have passed the
skip assertions while silently suspending the floors.

**`scripts/testlib/scoped_harness.py`** — `RUNNER_TIMEOUT_S = 300` now lives here, the module
whose `run()` already carried its own `timeout=600` default across five test files. A constant
private to one test file would have been a *fourth* copy of the predicate.

**`scripts/tests/test_run_tests_targets.py`** — six open-coded `timeout=120` sites collapse
into one `_spawn()`, which translates `TimeoutExpired` into a failure stating the
classification ("not an assertion failure, probably not your diff"). Plus an **AST** guard
against a seventh site.

## Regression matrix

**RED** at `origin/main`'s runner — the failure output is itself the proof, showing
`PASS scripts/claude-hooks/tests/test_claude_notify.py (script)` inside a `--targets` run —
**GREEN** at HEAD. The pre-existing `test_a_full_run_still_runs_the_hook_and_shell_families`
is the positive control that a FULL run is unaffected.

## Guard mutation-tested

Control green. Each mutant killed by the assertion that claims it, read from the `E ` lines
only:

| mutant | outcome |
|---|---|
| 7th raw `subprocess.run` | KILLED |
| `import subprocess as sp` / `from subprocess import run as _r` | KILLED |
| `Popen(...).communicate()`, unbounded | KILLED |
| `getoutput` / `getstatusoutput` (no `timeout` param exists) | KILLED |
| bound respelled literal / deleted entirely | KILLED |
| **spawn delegated out of the file** (vacuous pass) | KILLED |

The last two matter most: a check that only inspected the `timeout=` kwargs it *found*, or
that accumulated over calls it *found*, passes hardest on the worst outcome.

## Audit ladder

**Round 0** (requirements/deletion) — challenged this PR's own premise and is why the root
cause is fixed here rather than filed. **Round 1** (blind, nine axes) — three 🟡, three 🟢, all
fixed; it caught that my cost paragraph named the wrong CI cap *and inverted the consequence*,
that the guard could pass vacuously, and that "one rule, one place" was file-local.

## Known-incomplete, stated rather than implied

- `test_run_tests_preconditions.py` (300) and `test_devshell_satisfies_required_tools.py`
  (120 ×2) still carry their own bounds. They drive fast precondition/PATH-stub aborts, so
  none is near its bound — this is about the thesis, not a live defect.
- The AST guard is file-scoped and cannot see them.
- `os.system`, `from subprocess import *` and assignment aliasing are deliberately not
  covered; the comment enumerates rather than claiming closure.