### PR TITLE
fix(scoped-tests): the header justified the script with a figure CLAUDE.md had already retracted

### DIFF
--- a/scripts/scoped-tests.sh
+++ b/scripts/scoped-tests.sh
@@ -5,10 +5,23 @@
 #
 # 🔴 WHY THIS EXISTS — the measured problem, not a hunch. The pytest tier's
 # median wall time is 20.1 min over 237 real runs (p90 38 min). It is not slow
-# because any one thing is slow: it is slow because ~27 concurrent agent
-# sessions each run the FULL ~21k-test suite on one 24-core box, and runs
-# bucketed by overlap go 14.5 min (0 others) -> 48.9 min (6+). The lever is not
-# a faster suite. It is FEWER FULL SUITES.
+# because any one thing is slow: it is slow because dozens of concurrent agent
+# sessions each run the FULL ~21k-test suite on one 24-core box. The lever is
+# not a faster suite. It is FEWER FULL SUITES.
+#
+# ⚠ DO NOT PUT A SIZE ON THE CONTENTION EFFECT HERE. This header used to read
+# "runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min (6+)", and that
+# figure is RETRACTED — `CLAUDE.md` retracted it and says in terms that
+# re-deriving it is the trap, while this file went on asserting it as the
+# measured reason for its own existence. Bucketing runs by how many others
+# overlapped them is LENGTH-BIASED: a long run overlaps more runs BY
+# CONSTRUCTION, and a null Monte Carlo with zero interaction reproduces the
+# shape, the 14.5-min baseline and ~2.06x of the 3.4x. Contention is real and
+# its mechanism is uncontroversial; that dataset cannot size it.
+#
+# The two numbers above and below this note are NOT retracted and are what
+# justify the script: the 20.1-min median, and the collection cost measured
+# next. Neither depends on the overlap bucketing.
 #
 # `run-tests.sh --targets` has existed for a while and buys little on its own,
 # because the target that matters is one monolith. MEASURED 2026-09-08 in this

--- a/scripts/tests/test_retracted_contention_figure.py
+++ b/scripts/tests/test_retracted_contention_figure.py
@@ -38,7 +38,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "scripts"))
-from testlib.public_ip_scan import repo_files  # noqa: E402
+from testlib.public_ip_scan import SKIP_SUFFIXES, repo_files  # noqa: E402
 
 # The figure, in the spellings it has actually been written in.
 #
@@ -48,33 +48,47 @@ from testlib.public_ip_scan import repo_files  # noqa: E402
 # WRONG instruction to delete an unrelated measurement. The figure is always a
 # duration, so the unit is what separates it from every other 48.9.
 #
+# 🔴 `min(?:ute)?s?` BECAUSE `min\b` IS A SPELLING, NOT A UNIT. An earlier
+# draft demanded exactly `min` while its own comment said "the unit is what
+# separates it" — so `48.9 minutes at 6+ overlapping`, `14.5 minutes alone`,
+# `48.9 mins` and `the 48.9-minute figure` were ALL invisible, every one of
+# which the pre-fix pattern had caught. That is the regression this guard
+# exists for, re-opened by the fix that narrowed it. Measured: all four now
+# match, and the three false positives above still do not.
+#
 # 🔴 `[-\s]*` because the HYPHENATED spelling is the one CLAUDE.md's own
 # retraction uses ("the 14.5-min baseline"), and so does this file's sibling
 # note in `scoped-tests.sh`. `\b14\.5\s*min\b` did not match it, so a
 # re-assertion written "14.5-min at 0 overlap" was invisible to the whole guard.
-FIGURE = re.compile(r"\b48\.9[-\s]*min\b|\b14\.5[-\s]*min\b", re.I)
+FIGURE = re.compile(
+    r"\b48\.9[-\s]*min(?:ute)?s?\b|\b14\.5[-\s]*min(?:ute)?s?\b", re.I)
 
 # How much normalised text around each match is pinned.
 CONTEXT = 90
 
-# ⚠ A THIRD TEST WAS DELETED HERE, DELIBERATELY. It asserted "a retraction
-# appears near the figure" and was kept as a second angle after the count
-# version failed. Once the ledger pinned TEXT it became subsumed: the
-# `unledgered` check below fails for ANY file carrying the figure that the
-# ledger does not name, retraction or not — strictly wider than what a
-# proximity test could see. Keeping it bought nothing and cost a false failure
-# on legitimate sites whose retraction sits more than CONTEXT chars from the
-# match. Two guards asserting overlapping things, one wrong at the edges, is
-# worse than one that binds.
+# ⚠ A THIRD TEST WAS DELETED HERE, DELIBERATELY — AND THE COVERAGE OVERLAPS
+# RATHER THAN NESTS. It asserted "a retraction appears within NEAR_LINES=20
+# LINES of the figure". The `unledgered` check below catches what mattered: any
+# file carrying the figure that the ledger does not name. But "strictly wider"
+# was FALSE and is retracted — constructed and measured: a ledgered site whose
+# retraction sits beyond CONTEXT normalised chars can lose that retraction with
+# the digest UNCHANGED, which the deleted test would have caught. Not reachable
+# for the three current sites (their markers fall inside the 90-char windows),
+# so it is latent. 🔴 A FOURTH LEDGER ENTRY INHERITS IT — if you add one, check
+# its retraction marker lands inside the window.
 
 # 🔴 BINARY FILES ARE SKIPPED BY EXTENSION, and `repo_files` does NOT do this —
 # it filters directories only. Read as text with `errors="replace"`, a byte run
-# inside a `.sqlite`/`.woff`/`.zip` can spell the figure between word boundaries
-# and produce a spurious hit nobody can diagnose.
-_BINARY_SUFFIXES = (
-    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".sqlite", ".db",
-    ".woff", ".woff2", ".ttf", ".zip", ".gz", ".tar", ".wasm",
-)
+# inside a binary can spell the figure between word boundaries and produce a
+# spurious hit nobody can diagnose.
+#
+# 🔴 `testlib`'s OWN SET, not a fourth hand-rolled copy. An earlier draft of
+# this file wrote its own tuple in the same commit whose headline was a
+# one-rule-one-place consolidation, and it diverged both ways (added
+# .sqlite/.db/.tar, omitted .webp/.xz/.zst/.otf/.so/.bin). The two extras this
+# tree actually tracks are kept as a named local addition.
+_EXTRA_BINARY = frozenset({".sqlite", ".db", ".tar"})
+_BINARY_SUFFIXES = SKIP_SUFFIXES | _EXTRA_BINARY
 
 
 def _tracked_text_files():
@@ -99,20 +113,32 @@ def _tracked_text_files():
             continue
 
 
-_COMMENT_LEAD = re.compile(r"^[ \t]*(?:#+|//+|\*)[ \t]?")
+# 🔴 THE `*` BRANCH REQUIRES A FOLLOWING SPACE. Without it this ate one star
+# of a markdown `**BOLD**` run landing at a line start, so rewrapping
+# CLAUDE.md's block changed the pinned window and failed the guard with
+# "the text CHANGED" over an edit that changed no words. MEASURED across 7
+# reflow widths: 3 produced a false failure. `* ` is a markdown bullet or a
+# C continuation line; `**` is emphasis and must survive untouched.
+_COMMENT_LEAD = re.compile(r"^[ \t]*(?:#+[ \t]?|//+[ \t]?|\*[ \t])")
 _WS = re.compile(r"\s+")
 
 
 def _normalised(lines):
     """The file as ONE whitespace-collapsed string, comment markers stripped.
 
-    🔴 THIS IS WHAT MAKES THE PIN REFLOW-SAFE. Stripping the leading `#`/`//`
-    makes a shell-comment rewrap invisible; collapsing whitespace makes a
-    markdown reflow invisible. Both are cosmetic and must not fail this test —
-    CLAUDE.md's retraction lives on one very long wrapped line in a file edited
-    daily, and an earlier line-counting version would have failed a routine
-    reflow with "A COUNT GOING UP IS THE REGRESSION THIS GUARD EXISTS FOR", a
-    false accusation. A REWORD is not cosmetic and must fail.
+    Stripping the leading `#`/`//` makes a shell-comment rewrap invisible;
+    collapsing whitespace absorbs a rewrap's newlines. A REWORD is not cosmetic
+    and must fail.
+
+    ⚠ THIS IS NOT "REFLOW-SAFE BY CONSTRUCTION" — that claim was made in this
+    file, in its sibling comments and in its commit message, and it is FALSE.
+    MEASURED over 7 reflow widths of CLAUDE.md's block: the digest moved at 3
+    of them — a `**BOLD**` run landing at a line start (fixed above), and a
+    hyphen break splitting `re-deriving`. The count version it replaced moved
+    at 1 of the 7, so the swap was justified with a comparison that ran the
+    wrong way. What the swap DOES buy is catching an in-place reword, which no
+    count can. Hyphen-break sensitivity is real and unfixed: if a reflow fails
+    this guard, read the printed text before assuming a reword.
     """
     return _WS.sub(" ", " ".join(_COMMENT_LEAD.sub("", l) for l in lines)).strip()
 
@@ -235,7 +261,10 @@ def test_each_ledgered_site_still_QUOTES_the_figure_rather_than_ASSERTING_it():
               "full suites' with no magnitude; the 20.1-min median and the "
               "60.0s collection cost are NOT retracted and are what justify "
               "scoping.\n"
-              "  Cosmetic reflow does NOT reach here: each file is collapsed to "
-              "one whitespace-normalised string with comment markers stripped "
-              "before matching."
+              "  ⚠ A REFLOW CAN REACH HERE. Most rewrapping is absorbed (the "
+              "file is collapsed to one whitespace-normalised string with "
+              "comment markers stripped), but a hyphen break inside a word "
+              "moves the text. Read the printed window: if the WORDS are "
+              "unchanged and only the breaks moved, it is a reflow — update "
+              "the digest."
         )

--- a/scripts/tests/test_retracted_contention_figure.py
+++ b/scripts/tests/test_retracted_contention_figure.py
@@ -116,9 +116,11 @@ def _tracked_text_files():
 # 🔴 THE `*` BRANCH REQUIRES A FOLLOWING SPACE. Without it this ate one star
 # of a markdown `**BOLD**` run landing at a line start, so rewrapping
 # CLAUDE.md's block changed the pinned window and failed the guard with
-# "the text CHANGED" over an edit that changed no words. MEASURED across 7
-# reflow widths: 3 produced a false failure. `* ` is a markdown bullet or a
-# C continuation line; `**` is emphasis and must survive untouched.
+# "the text CHANGED" over an edit that changed no words. `* ` is a markdown
+# bullet or a C continuation line; `**` is emphasis and must survive untouched.
+# ⚠ THIS FIXES THE STAR CAUSE ONLY, NOT ALL REFLOW SENSITIVITY — the hyphen
+# cause below survives it. Two blocks in this file used to credit the same
+# failures to different causes; they cannot both be right.
 _COMMENT_LEAD = re.compile(r"^[ \t]*(?:#+[ \t]?|//+[ \t]?|\*[ \t])")
 _WS = re.compile(r"\s+")
 
@@ -132,13 +134,23 @@ def _normalised(lines):
 
     ⚠ THIS IS NOT "REFLOW-SAFE BY CONSTRUCTION" — that claim was made in this
     file, in its sibling comments and in its commit message, and it is FALSE.
-    MEASURED over 7 reflow widths of CLAUDE.md's block: the digest moved at 3
-    of them — a `**BOLD**` run landing at a line start (fixed above), and a
-    hyphen break splitting `re-deriving`. The count version it replaced moved
-    at 1 of the 7, so the swap was justified with a comparison that ran the
-    wrong way. What the swap DOES buy is catching an in-place reword, which no
-    count can. Hyphen-break sensitivity is real and unfixed: if a reflow fails
-    this guard, read the printed text before assuming a reword.
+    Reproduce it: rewrap CLAUDE.md to width 80 and this normalisation's output
+    CHANGES, because a hyphen break splits a word (`re-deriving` -> `re-
+    deriving`) and no amount of whitespace collapsing rejoins it. The star
+    cause is fixed above; this one is not.
+
+    🔴 AN EARLIER DRAFT SAID "the digest moved at 3 of 7 reflow widths, the
+    count version at 1 of 7" AND NAMED NONE OF THE SEVEN. `claude/RULES.md`
+    requires naming the points you measured, so that pair was unreproducible as
+    written and is WITHDRAWN rather than restated — a wider independent sweep
+    agreed on the DIRECTION (the text pin is more reflow-sensitive than the
+    count it replaced, not less) and disagreed on the proportions. The
+    direction is what the retraction rests on and it stands; the numbers were
+    mine and I could not reproduce them.
+
+    What the text pin genuinely buys over a count is catching an in-place
+    reword, which no count can. If a reflow fails this guard, read the printed
+    text before assuming a reword.
     """
     return _WS.sub(" ", " ".join(_COMMENT_LEAD.sub("", l) for l in lines)).strip()
 

--- a/scripts/tests/test_retracted_contention_figure.py
+++ b/scripts/tests/test_retracted_contention_figure.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""The overlap-bucketing contention figure is RETRACTED — it may be quoted, never asserted.
+
+🔴 WHY THIS EXISTS. `CLAUDE.md` retracted "14.5 min alone -> 48.9 min at 6+
+overlapping" and says in terms that **re-deriving it is the trap**: bucketing
+runs by how many others overlapped them is length-biased (a long run overlaps
+more runs BY CONSTRUCTION), and a null Monte Carlo with zero interaction
+reproduces the shape, the 14.5-min baseline and ~2.06x of the 3.4x.
+
+It was retracted in `CLAUDE.md` and in `claudedocs/handoff-gate-speed-and-ci-signal.md`
+— and `scripts/scoped-tests.sh` went on stating it as the measured reason for its
+own existence, in its `WHY THIS EXISTS` header. One tree, two files, opposite
+claims, with the live one justifying a script. Nothing noticed, because a
+retraction in prose cannot reach a comment in a shell script.
+
+🔴 THE RULE THIS ENFORCES IS A RELATIONSHIP, NOT A WORD. A plain "the string
+must not appear" guard is wrong in both directions: it would fail the three
+legitimate sites that quote the figure IN ORDER to retract it, and it would pass
+a file that re-derived the same claim in different digits. So: wherever the
+figure appears, a retraction must appear near it.
+
+An INVARIANT GUARD, not regression coverage — it pins a property no shipped bug
+violated once `scoped-tests.sh` was fixed in the same commit. Its evidence is
+the positive control below, which fails if the scanner is wired to nothing.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# The figure, in the spellings it has actually been written in. Digits, not
+# prose: a reword is exactly what this must still catch.
+FIGURE = re.compile(r"\b48\.9\b|\b14\.5\s*min\b")
+RETRACTION = re.compile(r"RETRACTED|length-biased", re.I)
+
+# How far from the figure a retraction may sit. The figure and its retraction
+# belong in one paragraph; 20 lines is generous for a wrapped shell comment and
+# still far too tight for an unrelated mention elsewhere in a long file.
+NEAR_LINES = 20
+
+# 🔴 THE COUNT LEDGER, AND WHY PROXIMITY ALONE WAS NOT ENOUGH.
+#
+# The first version of this guard asserted only "a retraction appears within
+# NEAR_LINES of the figure". It was MUTATION-TESTED and SURVIVED the one mutant
+# that matters: re-inserting the bare claim
+#
+#     "runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min (6+)."
+#
+# into `scripts/scoped-tests.sh`'s header — which is EXACTLY where it was
+# re-derived before, and exactly where it would be re-derived again — passed,
+# because the retraction note now sits ten lines below it and satisfied the
+# proximity check. The guard was excusing the one site it exists to watch.
+#
+# So the binding assertion is a COUNT, pinned two-way: each file may carry
+# exactly the occurrences its retraction needs, and no more. A new assertion
+# anywhere moves a number, whatever words surround it. Update these counts only
+# when you have read the diff and the occurrence is part of a RETRACTION.
+EXPECTED_OCCURRENCES = {
+    # The canonical retraction. Quotes the figure once, in one prose line.
+    # (Counts are LINES carrying the figure, not regex matches: CLAUDE.md's
+    # retraction quotes both halves on one wrapped line.)
+    "CLAUDE.md": 1,
+    # The handoff that first retracted it.
+    "claudedocs/handoff-gate-speed-and-ci-signal.md": 1,
+    # The header that used to ASSERT it, now retracting it in place.
+    "scripts/scoped-tests.sh": 1,
+}
+
+
+def _tracked_text_files():
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    for rel in out.split("\0"):
+        if not rel or rel.endswith((".png", ".jpg", ".gif", ".ico", ".pdf")):
+            continue
+        p = REPO / rel
+        try:
+            yield rel, p.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+
+
+def _hits():
+    """-> [(relpath, lineno, line, retracted_nearby)]"""
+    found = []
+    for rel, lines in _tracked_text_files():
+        if rel == "scripts/tests/test_retracted_contention_figure.py":
+            continue  # this file quotes the figure to define it
+        for i, line in enumerate(lines):
+            if not FIGURE.search(line):
+                continue
+            lo, hi = max(0, i - NEAR_LINES), min(len(lines), i + NEAR_LINES + 1)
+            near = any(RETRACTION.search(l) for l in lines[lo:hi])
+            found.append((rel, i + 1, line.strip(), near))
+    return found
+
+
+def test_the_scanner_can_see_the_figure_at_all():
+    """🔴 POSITIVE CONTROL. A reassuring zero below is worthless without it.
+
+    The figure IS in this tree — quoted by every site that retracts it — so a
+    scanner that finds nothing is a scanner wired to nothing, not a clean tree.
+    `claude/RULES.md`: report the pair, never the zero alone.
+    """
+    hits = _hits()
+    assert len(hits) >= 2, (
+        f"the scanner found {len(hits)} occurrence(s) of the retracted figure. "
+        "At least the retracting sites should match, so this is a broken "
+        "scanner rather than a clean tree — check FIGURE against how the "
+        "figure is actually spelled now."
+    )
+
+
+def test_the_figure_appears_exactly_where_and_as_often_as_the_ledger_says():
+    """🔴 THE BINDING ASSERTION — a COUNT, because proximity was walkable.
+
+    Pinned two-way: a file carrying the figure with no ledger entry fails, and
+    a ledger entry naming a file that no longer carries it fails. A
+    re-assertion inside an already-retracting file moves that file's count,
+    which is the mutant the proximity check slept through.
+    """
+    counts = {}
+    for rel, _ln, _text, _near in _hits():
+        counts[rel] = counts.get(rel, 0) + 1
+
+    unledgered = {r: n for r, n in counts.items() if r not in EXPECTED_OCCURRENCES}
+    assert not unledgered, (
+        f"\n\nthe RETRACTED contention figure appears in file(s) with no "
+        f"ledger entry: {unledgered}.\n"
+        "  If this is a new RETRACTION, add it to EXPECTED_OCCURRENCES with "
+        "its count. If it is a new ASSERTION, delete it — bucketing runs by "
+        "overlap is length-biased and that dataset cannot size contention."
+    )
+    stale = {r: n for r, n in EXPECTED_OCCURRENCES.items() if r not in counts}
+    assert not stale, (
+        f"\n\nledger entries naming a file that no longer carries the figure: "
+        f"{sorted(stale)}.\n  A ledger that names nothing reads as coverage "
+        "that no longer runs — drop the entry."
+    )
+    moved = {
+        r: (EXPECTED_OCCURRENCES[r], n)
+        for r, n in counts.items()
+        if r in EXPECTED_OCCURRENCES and n != EXPECTED_OCCURRENCES[r]
+    }
+    assert not moved, (
+        "\n\nthe number of times the RETRACTED contention figure appears has "
+        "changed (file: expected -> found):\n  "
+        + "\n  ".join(f"{r}: {exp} -> {got}" for r, (exp, got) in moved.items())
+        + "\n\n  A COUNT GOING UP IS THE REGRESSION THIS GUARD EXISTS FOR: the "
+          "figure was re-asserted, and a retraction sitting nearby does NOT "
+          "make it true. `scripts/scoped-tests.sh` once stated it as the "
+          "measured reason for its own existence while CLAUDE.md retracted "
+          "it.\n"
+          "  Say 'dozens of concurrent full suites' with no magnitude. The "
+          "20.1-min median and the 60.0s collection cost are NOT retracted "
+          "and are what justify scoping.\n"
+          "  A count going DOWN is fine if you deleted a retraction "
+          "deliberately — update the ledger in the same commit."
+    )
+
+
+def test_the_retracted_figure_is_never_asserted_without_its_retraction():
+    """Quote it to retract it; never state it as a measurement.
+
+    ⚠ WEAKER THAN IT LOOKS, AND KEPT ONLY AS A SECOND ANGLE. Mutation showed
+    this passes when the figure is re-asserted in a file whose retraction note
+    is within NEAR_LINES — which is every file in the ledger. The count test
+    above is what actually binds; this one catches the figure appearing in a
+    file with no retraction anywhere near it.
+    """
+    bare = [(rel, ln, text) for rel, ln, text, near in _hits() if not near]
+    assert not bare, (
+        "\n\nthe RETRACTED overlap-bucketing contention figure is stated "
+        f"without a retraction within {NEAR_LINES} lines:\n  "
+        + "\n  ".join(f"{rel}:{ln}: {text[:100]}" for rel, ln, text in bare)
+        + "\n\n  'runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min "
+          "(6+)' is RETRACTED. Bucketing by overlap is length-biased — a long "
+          "run overlaps more runs BY CONSTRUCTION — and a null Monte Carlo "
+          "with zero interaction reproduces the shape, the 14.5-min baseline "
+          "and ~2.06x of the 3.4x. Contention is real; that dataset cannot "
+          "size it.\n"
+          "  `scripts/scoped-tests.sh` asserted it as the measured reason for "
+          "its own existence while CLAUDE.md retracted it, in the same tree.\n"
+          "  Say 'dozens of concurrent full suites' with no magnitude, or "
+          "quote the figure WITH its retraction. The 20.1-min median and the "
+          "60.0s collection cost are NOT retracted and are what justify "
+          "scoping."
+    )

--- a/scripts/tests/test_retracted_contention_figure.py
+++ b/scripts/tests/test_retracted_contention_figure.py
@@ -14,88 +14,156 @@ claims, with the live one justifying a script. Nothing noticed, because a
 retraction in prose cannot reach a comment in a shell script.
 
 🔴 THE RULE THIS ENFORCES IS A RELATIONSHIP, NOT A WORD. A plain "the string
-must not appear" guard is wrong in both directions: it would fail the three
-legitimate sites that quote the figure IN ORDER to retract it, and it would pass
-a file that re-derived the same claim in different digits. So: wherever the
-figure appears, a retraction must appear near it.
+must not appear" guard would fail the three legitimate sites that quote the
+figure IN ORDER to retract it. So the binding rule pins the normalised TEXT
+around every occurrence, two-way.
+
+🔴 WHAT THIS DOES NOT CATCH — stated, not solved. It is keyed on the literal
+digits, so a re-derivation of the same CLAIM in DIFFERENT digits ("11.2 min ->
+39.1 min at 5+ overlapping") passes untouched, exactly as the plain guard it
+replaces would. An earlier draft of this docstring said a plain guard was wrong
+"in both directions" and then resolved only one of them, which read as coverage
+this file does not provide. The defence against a re-derivation is the prose in
+CLAUDE.md and in `scoped-tests.sh`'s header telling you not to, not this test.
 
 An INVARIANT GUARD, not regression coverage — it pins a property no shipped bug
 violated once `scoped-tests.sh` was fixed in the same commit. Its evidence is
-the positive control below, which fails if the scanner is wired to nothing.
+the positive control below, which fails if the scanner is wired to nothing, and
+the mutation battery in the PR.
 """
+import hashlib
 import re
-import subprocess
+import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+from testlib.public_ip_scan import repo_files  # noqa: E402
 
-# The figure, in the spellings it has actually been written in. Digits, not
-# prose: a reword is exactly what this must still catch.
-FIGURE = re.compile(r"\b48\.9\b|\b14\.5\s*min\b")
-RETRACTION = re.compile(r"RETRACTED|length-biased", re.I)
+# The figure, in the spellings it has actually been written in.
+#
+# 🔴 BOTH BRANCHES REQUIRE `min`, AND THAT IS THE POINT. A bare `\b48\.9\b`
+# matched "48.9% of runs", "an image 48.9 MB" and "cost $48.9" — this repo is
+# full of measured numbers in prose, and a hit on one produces a confident,
+# WRONG instruction to delete an unrelated measurement. The figure is always a
+# duration, so the unit is what separates it from every other 48.9.
+#
+# 🔴 `[-\s]*` because the HYPHENATED spelling is the one CLAUDE.md's own
+# retraction uses ("the 14.5-min baseline"), and so does this file's sibling
+# note in `scoped-tests.sh`. `\b14\.5\s*min\b` did not match it, so a
+# re-assertion written "14.5-min at 0 overlap" was invisible to the whole guard.
+FIGURE = re.compile(r"\b48\.9[-\s]*min\b|\b14\.5[-\s]*min\b", re.I)
 
-# How far from the figure a retraction may sit. The figure and its retraction
-# belong in one paragraph; 20 lines is generous for a wrapped shell comment and
-# still far too tight for an unrelated mention elsewhere in a long file.
-NEAR_LINES = 20
+# How much normalised text around each match is pinned.
+CONTEXT = 90
 
-# 🔴 THE COUNT LEDGER, AND WHY PROXIMITY ALONE WAS NOT ENOUGH.
-#
-# The first version of this guard asserted only "a retraction appears within
-# NEAR_LINES of the figure". It was MUTATION-TESTED and SURVIVED the one mutant
-# that matters: re-inserting the bare claim
-#
-#     "runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min (6+)."
-#
-# into `scripts/scoped-tests.sh`'s header — which is EXACTLY where it was
-# re-derived before, and exactly where it would be re-derived again — passed,
-# because the retraction note now sits ten lines below it and satisfied the
-# proximity check. The guard was excusing the one site it exists to watch.
-#
-# So the binding assertion is a COUNT, pinned two-way: each file may carry
-# exactly the occurrences its retraction needs, and no more. A new assertion
-# anywhere moves a number, whatever words surround it. Update these counts only
-# when you have read the diff and the occurrence is part of a RETRACTION.
-EXPECTED_OCCURRENCES = {
-    # The canonical retraction. Quotes the figure once, in one prose line.
-    # (Counts are LINES carrying the figure, not regex matches: CLAUDE.md's
-    # retraction quotes both halves on one wrapped line.)
-    "CLAUDE.md": 1,
-    # The handoff that first retracted it.
-    "claudedocs/handoff-gate-speed-and-ci-signal.md": 1,
-    # The header that used to ASSERT it, now retracting it in place.
-    "scripts/scoped-tests.sh": 1,
-}
+# ⚠ A THIRD TEST WAS DELETED HERE, DELIBERATELY. It asserted "a retraction
+# appears near the figure" and was kept as a second angle after the count
+# version failed. Once the ledger pinned TEXT it became subsumed: the
+# `unledgered` check below fails for ANY file carrying the figure that the
+# ledger does not name, retraction or not — strictly wider than what a
+# proximity test could see. Keeping it bought nothing and cost a false failure
+# on legitimate sites whose retraction sits more than CONTEXT chars from the
+# match. Two guards asserting overlapping things, one wrong at the edges, is
+# worse than one that binds.
+
+# 🔴 BINARY FILES ARE SKIPPED BY EXTENSION, and `repo_files` does NOT do this —
+# it filters directories only. Read as text with `errors="replace"`, a byte run
+# inside a `.sqlite`/`.woff`/`.zip` can spell the figure between word boundaries
+# and produce a spurious hit nobody can diagnose.
+_BINARY_SUFFIXES = (
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".sqlite", ".db",
+    ".woff", ".woff2", ".ttf", ".zip", ".gz", ".tar", ".wasm",
+)
 
 
 def _tracked_text_files():
-    out = subprocess.run(
-        ["git", "-C", str(REPO), "ls-files", "-z"],
-        capture_output=True, text=True, check=True,
-    ).stdout
-    for rel in out.split("\0"):
-        if not rel or rel.endswith((".png", ".jpg", ".gif", ".ico", ".pdf")):
+    """-> (relpath, lines) for every tracked text file.
+
+    🔴 VIA `repo_files`, NOT A HAND-ROLLED `git ls-files`. `flake.nix`'s
+    `checks.pytests` builds from a `cp -r` of the flake source with NO `.git`,
+    and `scripts/tests` is in `run-tests.sh`'s HERMETIC_TARGETS — so an
+    unguarded `git ls-files` exits 128 THERE while passing on the dev host.
+    MEASURED on this file's first version: 3 failed in a no-`.git` replica of
+    the head tree, while `test_doc_path_rot.py` — which carries the documented
+    fallback — passed 76/76 in the SAME replica. `repo_files` owns that
+    fallback; this is the one-rule-one-place call into it.
+    """
+    for path in repo_files(REPO):
+        if path.suffix.lower() in _BINARY_SUFFIXES:
             continue
-        p = REPO / rel
         try:
-            yield rel, p.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
+            rel = str(path.relative_to(REPO))
+            yield rel, path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except (OSError, ValueError):
             continue
+
+
+_COMMENT_LEAD = re.compile(r"^[ \t]*(?:#+|//+|\*)[ \t]?")
+_WS = re.compile(r"\s+")
+
+
+def _normalised(lines):
+    """The file as ONE whitespace-collapsed string, comment markers stripped.
+
+    🔴 THIS IS WHAT MAKES THE PIN REFLOW-SAFE. Stripping the leading `#`/`//`
+    makes a shell-comment rewrap invisible; collapsing whitespace makes a
+    markdown reflow invisible. Both are cosmetic and must not fail this test —
+    CLAUDE.md's retraction lives on one very long wrapped line in a file edited
+    daily, and an earlier line-counting version would have failed a routine
+    reflow with "A COUNT GOING UP IS THE REGRESSION THIS GUARD EXISTS FOR", a
+    false accusation. A REWORD is not cosmetic and must fail.
+    """
+    return _WS.sub(" ", " ".join(_COMMENT_LEAD.sub("", l) for l in lines)).strip()
 
 
 def _hits():
-    """-> [(relpath, lineno, line, retracted_nearby)]"""
+    """-> [(relpath, window)] — one entry per match, with its pinned context."""
     found = []
     for rel, lines in _tracked_text_files():
         if rel == "scripts/tests/test_retracted_contention_figure.py":
             continue  # this file quotes the figure to define it
-        for i, line in enumerate(lines):
-            if not FIGURE.search(line):
-                continue
-            lo, hi = max(0, i - NEAR_LINES), min(len(lines), i + NEAR_LINES + 1)
-            near = any(RETRACTION.search(l) for l in lines[lo:hi])
-            found.append((rel, i + 1, line.strip(), near))
+        text = _normalised(lines)
+        for m in FIGURE.finditer(text):
+            lo = max(0, m.start() - CONTEXT)
+            found.append((rel, text[lo:m.end() + CONTEXT]))
     return found
+
+
+# 🔴 THE LEDGER PINS NORMALISED TEXT, AND BOTH EARLIER VERSIONS WERE WALKABLE.
+#
+# v1 asserted "a RETRACTED marker appears within 20 lines of the figure". It
+# SURVIVED the mutant that matters — re-inserting the bare claim into
+# `scoped-tests.sh`'s header, the exact site it was re-derived at before —
+# because the retraction note the same commit added sat ten lines below and
+# satisfied the window. No window size fixes that: an in-place edit is always
+# adjacent to the note that excuses it.
+#
+# v2 asserted a per-file COUNT. It ALSO survived, for a different reason: the
+# killing mutant REPLACES the quoting line with an assertion built from the
+# SAME two tokens, so the count is identical whether you count lines or
+# matches. A count cannot tell quotation from assertion.
+#
+# So this pins the text, which is what `claude/RULES.md` prescribes for a prose
+# artifact: "when the artifact under test IS prose … pin the WHOLE normalised
+# string. A cosmetic reword then fails the test — pay it, for a machine-readable
+# claim."
+#
+# Digest of the sorted normalised windows around every occurrence in each file.
+# Regenerate ONLY after reading the text the failure prints — see that message.
+EXPECTED_SITES = {
+    "CLAUDE.md": "007080f0f6c54edb",
+    "claudedocs/handoff-gate-speed-and-ci-signal.md": "701dca06b11b1941",
+    "scripts/scoped-tests.sh": "fde2e081df2cd385",
+}
+
+
+def _digest(windows):
+    h = hashlib.sha256()
+    for w in sorted(windows):
+        h.update(w.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()[:16]
 
 
 def test_the_scanner_can_see_the_figure_at_all():
@@ -114,78 +182,60 @@ def test_the_scanner_can_see_the_figure_at_all():
     )
 
 
-def test_the_figure_appears_exactly_where_and_as_often_as_the_ledger_says():
-    """🔴 THE BINDING ASSERTION — a COUNT, because proximity was walkable.
+def test_each_ledgered_site_still_QUOTES_the_figure_rather_than_ASSERTING_it():
+    """🔴 THE BINDING ASSERTION — pinned TEXT, because two counts were walkable.
 
-    Pinned two-way: a file carrying the figure with no ledger entry fails, and
-    a ledger entry naming a file that no longer carries it fails. A
-    re-assertion inside an already-retracting file moves that file's count,
-    which is the mutant the proximity check slept through.
+    Pinned two-way: a file carrying the figure with no ledger entry fails, an
+    entry naming a file that no longer carries it fails, and any change to the
+    normalised text around an occurrence fails.
+
+    The last one is the point. The killing mutant rewrites the quoting line IN
+    PLACE into an assertion built from the same tokens — identical under any
+    count, adjacent to the retraction note under any proximity window, and
+    caught here only because the words changed.
     """
-    counts = {}
-    for rel, _ln, _text, _near in _hits():
-        counts[rel] = counts.get(rel, 0) + 1
+    sites = {}
+    for rel, window in _hits():
+        sites.setdefault(rel, []).append(window)
 
-    unledgered = {r: n for r, n in counts.items() if r not in EXPECTED_OCCURRENCES}
+    unledgered = sorted(r for r in sites if r not in EXPECTED_SITES)
     assert not unledgered, (
-        f"\n\nthe RETRACTED contention figure appears in file(s) with no "
-        f"ledger entry: {unledgered}.\n"
-        "  If this is a new RETRACTION, add it to EXPECTED_OCCURRENCES with "
-        "its count. If it is a new ASSERTION, delete it — bucketing runs by "
-        "overlap is length-biased and that dataset cannot size contention."
+        "\n\nthe RETRACTED contention figure appears in file(s) with no ledger "
+        f"entry: {unledgered}.\n"
+        "  If this is a new RETRACTION, add it with its digest. If it is a new "
+        "ASSERTION, delete it — bucketing runs by overlap is length-biased and "
+        "that dataset cannot size contention."
     )
-    stale = {r: n for r, n in EXPECTED_OCCURRENCES.items() if r not in counts}
+    stale = sorted(r for r in EXPECTED_SITES if r not in sites)
     assert not stale, (
-        f"\n\nledger entries naming a file that no longer carries the figure: "
-        f"{sorted(stale)}.\n  A ledger that names nothing reads as coverage "
-        "that no longer runs — drop the entry."
+        "\n\nledger entries naming a file that no longer carries the figure: "
+        f"{stale}.\n  A ledger that names nothing reads as coverage that no "
+        "longer runs — drop the entry."
     )
-    moved = {
-        r: (EXPECTED_OCCURRENCES[r], n)
-        for r, n in counts.items()
-        if r in EXPECTED_OCCURRENCES and n != EXPECTED_OCCURRENCES[r]
-    }
-    assert not moved, (
-        "\n\nthe number of times the RETRACTED contention figure appears has "
-        "changed (file: expected -> found):\n  "
-        + "\n  ".join(f"{r}: {exp} -> {got}" for r, (exp, got) in moved.items())
-        + "\n\n  A COUNT GOING UP IS THE REGRESSION THIS GUARD EXISTS FOR: the "
-          "figure was re-asserted, and a retraction sitting nearby does NOT "
-          "make it true. `scripts/scoped-tests.sh` once stated it as the "
-          "measured reason for its own existence while CLAUDE.md retracted "
-          "it.\n"
-          "  Say 'dozens of concurrent full suites' with no magnitude. The "
-          "20.1-min median and the 60.0s collection cost are NOT retracted "
-          "and are what justify scoping.\n"
-          "  A count going DOWN is fine if you deleted a retraction "
-          "deliberately — update the ledger in the same commit."
-    )
-
-
-def test_the_retracted_figure_is_never_asserted_without_its_retraction():
-    """Quote it to retract it; never state it as a measurement.
-
-    ⚠ WEAKER THAN IT LOOKS, AND KEPT ONLY AS A SECOND ANGLE. Mutation showed
-    this passes when the figure is re-asserted in a file whose retraction note
-    is within NEAR_LINES — which is every file in the ledger. The count test
-    above is what actually binds; this one catches the figure appearing in a
-    file with no retraction anywhere near it.
-    """
-    bare = [(rel, ln, text) for rel, ln, text, near in _hits() if not near]
-    assert not bare, (
-        "\n\nthe RETRACTED overlap-bucketing contention figure is stated "
-        f"without a retraction within {NEAR_LINES} lines:\n  "
-        + "\n  ".join(f"{rel}:{ln}: {text[:100]}" for rel, ln, text in bare)
-        + "\n\n  'runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min "
-          "(6+)' is RETRACTED. Bucketing by overlap is length-biased — a long "
-          "run overlaps more runs BY CONSTRUCTION — and a null Monte Carlo "
-          "with zero interaction reproduces the shape, the 14.5-min baseline "
-          "and ~2.06x of the 3.4x. Contention is real; that dataset cannot "
-          "size it.\n"
-          "  `scripts/scoped-tests.sh` asserted it as the measured reason for "
-          "its own existence while CLAUDE.md retracted it, in the same tree.\n"
-          "  Say 'dozens of concurrent full suites' with no magnitude, or "
-          "quote the figure WITH its retraction. The 20.1-min median and the "
-          "60.0s collection cost are NOT retracted and are what justify "
-          "scoping."
-    )
+    moved = {r: (EXPECTED_SITES[r], _digest(w))
+             for r, w in sites.items() if _digest(w) != EXPECTED_SITES[r]}
+    if moved:
+        detail = []
+        for r in sorted(moved):
+            exp, got = moved[r]
+            detail.append(f"{r}: expected {exp}, found {got}")
+            detail += [f"    …{w}…" for w in sorted(sites[r])]
+        raise AssertionError(
+            "\n\nthe text around the RETRACTED contention figure CHANGED:\n  "
+            + "\n  ".join(detail)
+            + "\n\n  🔴 READ THE TEXT ABOVE BEFORE UPDATING THE DIGEST. The "
+              "failure this guard exists for is a quoting line rewritten IN "
+              "PLACE into an assertion — same tokens, same count, retraction "
+              "note still beside it. `scripts/scoped-tests.sh` once stated the "
+              "figure as the measured reason for its own existence while "
+              "CLAUDE.md retracted it.\n"
+              "  Still QUOTING it in order to retract it? Legitimate edit — "
+              "update the digest.\n"
+              "  ASSERTING it? Delete the assertion. Say 'dozens of concurrent "
+              "full suites' with no magnitude; the 20.1-min median and the "
+              "60.0s collection cost are NOT retracted and are what justify "
+              "scoping.\n"
+              "  Cosmetic reflow does NOT reach here: each file is collapsed to "
+              "one whitespace-normalised string with comment markers stripped "
+              "before matching."
+        )


### PR DESCRIPTION
## The defect

`scripts/scoped-tests.sh`'s **WHY THIS EXISTS** header stated, as the measured reason for the script's own existence:

> `runs bucketed by overlap go 14.5 min (0 others) -> 48.9 min (6+). The lever is not a faster suite. It is FEWER FULL SUITES.`

`CLAUDE.md`, **in the same tree**, retracts exactly that figure:

> *An earlier version of this line said "14.5 min alone → 48.9 min at 6+ overlapping"; that is **RETRACTED**, and re-deriving it is the trap. Bucketing runs by how many others overlapped them is length-biased — a long run overlaps more runs BY CONSTRUCTION — and a null Monte Carlo with zero interaction reproduces the shape, the 14.5-min baseline and ~2.06x of the 3.4x. Contention is real and its mechanism is uncontroversial; that dataset cannot size it.*

So one tree carried two opposite claims about one number, and the live one was the justification for a script. `claudedocs/handoff-gate-speed-and-ci-signal.md` retracts it too — `scoped-tests.sh` was the only site still asserting it. Nothing noticed, because a retraction in prose cannot reach a comment in a shell script.

By this repo's own doctrine — *"a comment is a claim too"* — that is a defect, not a nit.

## The fix

The header now says "dozens of concurrent full suites" with **no magnitude**, and records the retraction in place so it is not re-derived.

**The two numbers that actually justify the script are untouched**, and are now explicitly labelled as not retracted:
- the 20.1-min median over 237 real runs
- `pytest scripts/tests --collect-only` = **60.0s** before a single test runs, vs **0.64s** for one file

Neither depends on the overlap bucketing. The case for scoping is unaffected.

## The guard, and why it took four versions

Each version was defeated by a *different* mechanism, and each was found by mutation rather than by reading.

**v1 pinned proximity** — "a retraction appears within 20 lines". It survived re-inserting the bare claim into `scoped-tests.sh`'s header, because the retraction note the same commit added sat ten lines below and satisfied the window. No window size fixes that: an in-place edit is always adjacent to the note that excuses it.

**v2 pinned a per-file count.** It survived too, for an unrelated reason — the killing mutant *replaces* the quoting line with an assertion built from the same two tokens, so the count is identical whether you count lines or matches. A count cannot tell quotation from assertion.

**v3 pinned normalised text**, which is RULES.md's rule for a prose artifact. That closed the in-place case, but narrowed `FIGURE` to require the literal `min` — re-opening the regression class the guard exists for.

**v4** fixes that (`min(?:ute)?s?`) and makes the comment-lead strip's `*` branch **require a following space** — it was eating one star of a markdown `**BOLD**` run at a line start. The branch is kept, not dropped: `* ` is still stripped as a bullet.

| mutant | v1 | v2 | v3 | v4 |
|---|---|---|---|---|
| M3 in-place re-assert, note retained | **SURVIVED** | **SURVIVED** | KILLED | KILLED |
| M2 full header revert | killed | **SURVIVED** | KILLED | KILLED |
| M5 spelled-out unit (`48.9 minutes`) | (blind) | (blind) | **blind** | KILLED |
| M4 hyphenated (`14.5-min`) | (blind) | (blind) | KILLED | KILLED |
| N1 bare re-assert, new line | KILLED | KILLED | KILLED | KILLED |
| N3 re-assert in an unledgered file | KILLED | KILLED | KILLED | KILLED |
| N2 blinded scanner (positive control) | KILLED | KILLED | KILLED | KILLED |
| control | GREEN | GREEN | GREEN | GREEN |

⚠ **Two claims made in earlier commit messages here are RETRACTED**, both caught by the round-2 delta audit:

- *"reflow-safe by construction"* — **false**. The `**BOLD**` cause is fixed; hyphen-break sensitivity is real, unfixed, and now stated in the docstring and in the failure message rather than denied. ⚠ A further retraction, round 3: this bullet used to carry "v3's digest moved at 3 of 7 reflow widths, the count version at 1 of 7" and **named none of the seven**, so nobody could check it. Those numbers are **withdrawn, not replaced** — an independent sweep agreed on the direction and disagreed on the proportions, and I am not publishing numbers I did not measure. Reproducible substitute: rewrap CLAUDE.md to width 80 and the normalised output changes. The direction is what the retraction rests on, and it stands.
- *"strictly wider than what a proximity test could see"* — **false**. A ledgered site whose retraction sits beyond `CONTEXT` chars can lose that retraction with the digest unchanged. Coverage overlaps, it does not nest. Latent for the three current sites; a fourth entry inherits it, and the note says so.

What the text pin genuinely buys over a count is catching an in-place reword. That claim survives.

## Tests

🟢 **CI green at `760c8769` — including the tier this PR's headline finding was about.**

| check | result |
|---|---|
| `tekton/devrc-pytests` (the sandbox tier) | **pass** — collected 22,083 · passed 22,081 · failed **0** |
| `tekton/devrc-nodetests` | pass — 1,449 tests, 0 fail |
| `tekton/devrc-cairn-client-runs` | pass |

That is the authoritative answer to round 1's 🔴: the guard no longer reds the tier that gates.

**12 collected, 12 passed** — `test_scoped_mapper.py` + `test_retracted_contention_figure.py`, measured at `1c3b59b2`.

⚠ An earlier version of this body said "13 passed … at `c38c5484`". Both halves were wrong and are corrected here: `c38c5484` is this PR's **base**, where the test file does not exist, and the count dropped to 12 when round 1 deleted the subsumed proximity test. A commit message also claimed this correction had been made when it had not — the round-2 audit caught the claim-about-a-claim.

Sandbox-tier repro, with a discriminating control, in a no-`.git` replica of the head tree:

| | before | after |
|---|---|---|
| `test_retracted_contention_figure.py` | **3 failed** (exit 128) | 2 passed |
| `test_doc_path_rot.py` (carries the fallback) | 76 passed | 76 passed |

Scope-limited by design: a comment change plus one test file, with the full-tier ritual deleted per the re-scoped merge policy.

## Found by

Round 0 (the requirements & deletion pass added in #1440), running on #1445. Round 0's job is to ask whether a thing should exist — which surfaces the case where the stated reason for its existence is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBnXuHA2pzzqFUTc9gp61u
