### PR TITLE
docs(activity): a bare #id in a mentions row is unique only within its own tracker

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -151,6 +151,17 @@ On the workbench a `switch` + an extension reload is the whole procedure.
   `$__timeFilter` / range comparisons (they're UTC, aligned with `now()`).
 - **Both hosts are hostname `nixos`** → without `ACTIVITY_HOST` in the env, every row
   collides on `host=nixos`. Set it per host.
+- 🔴 **A `source='mentions'` row carries a BARE id (`#544`), and an id is unique only
+  within ITS OWN tracker — so "has a previous session already handled this?" gets a
+  CONFIDENT WRONG YES.** The trackers in play here (GitHub repos, clawgate tasks,
+  ClickUp) number independently, and the row records the string, not the tracker.
+  Measured 2026-09-11: searching for prior work on `civitai/cli#544`/`#545` returned
+  rows dated 2026-08-29 → 2026-09-09 that were **clawgate task ids** — the cli issues
+  did not exist until 2026-09-10 16:10Z, so every hit predated its own subject.
+  **Discriminate by the subject's CREATION TIME, not by the id**: bound the query with
+  `ts >= '<when the thing was created>'` and treat anything earlier as a different
+  tracker. The failure is silent and lands in the reassuring direction — it reads as
+  "already handled", which is the answer that makes you stop looking.
 - 🔴 **Never decide "is this source expected on this host?" from prose.** "keylog + browser
   + i3 are GUI-only → laptop-only; the workbench is headless" was FALSE for a long time —
   the workbench runs a real X/i3 session (see the source table above). Read the TABLE;


### PR DESCRIPTION
## The trap

A `source='mentions'` row in `activity.events` records the **string** `#544` — not which tracker minted it. GitHub repos, clawgate tasks and ClickUp all number independently.

So the question *"has a previous session already handled this?"* gets a confident **wrong yes**, and it fails in the reassuring direction: "already handled" is the answer that makes you stop looking.

## Measured

2026-09-11, while triaging `civitai/cli`. Searching telemetry for prior work on cli#544 / #545 returned `mention-detected` rows dated **2026-08-29 → 2026-09-09**. Those are **clawgate task ids** — the cli issues did not exist until **2026-09-10 16:10Z**, so every hit predated its own subject. The session that found them nearly reported "a previous session already took partial action".

## The fix this adds

Bound the query by the subject's creation time rather than trusting the id:

```sql
ts >= '<when the thing was created>'
```

…and treat anything earlier as a different tracker.

## Why this skill

`mention-detected` has **no owning skill** — confirmed with `command grep` rather than the gitignore-blind wrapper, since I was about to quote a zero. The `activity` skill is where someone reading those rows already is, and it already carries the sibling `host=nixos` collision gotcha, so this sits directly beneath it.

## Verification

`nix-shell -p python3Packages.pytest --run "python3 -m pytest scripts/tests/test_skill_audit.py scripts/tests/test_index_append_protocol.py -q"` → **210 passed**, rc 0.

Note: `~/.claude/skills/activity/SKILL.md` resolves into `/nix/store` (a `home.file` copy, not an `mkOutOfStoreSymlink`), so this is **not live until a `home-manager switch`** after merge.