### PR TITLE
fix(disk-accounting): replace the prose site register with a machine-checked ledger

### DIFF
--- a/claudedocs/handoff-journald-26-11-migration.md
+++ b/claudedocs/handoff-journald-26-11-migration.md
@@ -275,7 +275,8 @@ workbench working tree where a `git checkout` would have deleted them unreported
 - 🔴 **A sweep that fixes a claim must reach EVERY site, and the test file is a site.** Round
   1 corrected the false residual-units phrase at its two script sites; the test file carried
   the same claim in other words and was left, producing a comment that contradicted an
-  assertion eleven lines below it.
+  assertion 25 lines below it (measured at `ae2c2427`: lines 1383 and 1408 — an
+  earlier retelling of this said "eleven" and it propagated to three sites).
 - **"The laptop is unreachable" was FALSE and is retracted — it is reachable on nebula, and
   the LAN address is same-network-only by design.** A prior version of the ranked list said
   the laptop was unreachable on BOTH nebula (`10.42.0.100`) and LAN (`192.168.50.155`) at
@@ -442,7 +443,7 @@ independently. Kept for the load-vs-assertion reasoning; nothing here is open.
   `e8551af6..ae2c2427` → 5 🟡 / 0 🔴, fixed in #1490 (`f0172420`). **Round 3 has not run.**
 - **Observed (with values):** across both rounds, **7 of 14 findings were about prose the
   previous round wrote while explaining itself** — not logic. Round 2's headline: the test
-  file said a top-level symlink *"must not"* be listed, **eleven lines above an assertion
+  file said a top-level symlink *"must not"* be listed, **25 lines above an assertion
   requiring that it is**, because round 1 swept the false phrase at its two SCRIPT sites and
   never looked in the TEST file, which carried the same claim in different words.
 - **Ruled out:** that the code is wrong. Both retracted rationales and all four mutation

--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -243,26 +243,30 @@ _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 # 🔴 "ALL THREE OF THIS FUNCTION'S CALLERS", NOT "EVERY CALLER" — the wider
 # wording stood here for a round and was false.
 #
-# 🔴 AND THERE IS NOW A FIFTH SITE: `toplevel_accountable_entries()`, added
-# 2026-09-09, enumerates depth-1 with the same shape and sends its stderr NOWHERE
-# — not to `$DENIED_LOG`, not to a file. A top-level entry root cannot stat is
-# therefore dropped from section 2 with no tally, and section 3's residual — the
-# number that function exists to feed — absorbs it silently. This ledger is the
-# place a maintainer of that function looks, so it is recorded HERE and not only
-# in the test file's sweep-ledger comment, which is where it was written first.
-# It is not a regression (the glob it replaced dropped unstattable entries too,
-# and equally silently); it is the same debt at one more site.
+# 🔴 THE UNTALLIED-DROP SITES ARE NOT NUMBERED HERE ANY MORE, AND THAT IS THE
+# FIX. A prose register of them has now been SHORT TWICE in consecutive audit
+# rounds: one round found it missing `toplevel_accountable_entries()` and added
+# it as "the FIFTH site"; the next round found the ordinals themselves were the
+# defect, because a numbered list reads as CLOSED and the section-5 PVC loop had
+# never been in it. An ordinal is a claim about a SET, and nothing was checking
+# the set — so each fix made the register more confidently wrong.
 #
-# `split_by_device` below is the FOURTH such site, also with no count: its
-# `[ -d "$p" ] || continue` drops a directory root cannot stat (a gvfs
-# or sshfs mount under /home/<user>/… is exactly the root-reachable mechanism)
-# and nothing tallies it. It is recorded rather than fixed because bash's file
-# tests cannot separate the three reasons `[ -d "$p" ]` says no — not a
-# directory, stat refused, or an unmatched glob left the pattern itself — so a
-# count there needs a different enumeration, not a `+ 1`. What limits the damage
-# is that `report_foreign_mounts`'s empty branch does not read as a clean result:
-# it tells the reader outright that an empty list on a host with foreign mounts
-# under /home is a BUG.
+# The CRITERION, which is what a maintainer actually needs:
+#   a depth-1 enumeration that drops entries it cannot stat, WITHOUT tallying
+#   the drop — so the count it feeds is a FLOOR presented as a total.
+# The membership is enumerated and pinned two-way by
+# `scripts/tests/test_diagnose_disk_accounting.sh` ("UNTALLIED-DROP SITE
+# LEDGER"), which fails when the set GROWS or SHRINKS and prints the sites.
+# 🔴 READ THE TEST FOR THE LIST. Do not re-count them here; that is the mistake
+# this paragraph exists to stop.
+#
+# Why they are recorded rather than fixed: bash's file tests cannot separate the
+# three reasons `[ -d "$p" ]` says no — not a directory, stat refused, or an
+# unmatched glob left the pattern itself — so a count needs a different
+# enumeration, not a `+ 1`. What limits the damage at `split_by_device` is that
+# `report_foreign_mounts`'s empty branch does not read as a clean result: it
+# tells the reader outright that an empty list on a host with foreign mounts
+# under /home is a BUG. The section-5 PVC loop has no such backstop.
 #
 # The `|| true` here covers route (a) ONLY — find's own rc 1 — of the two aborts
 # `size_breakdown`'s comment describes. Route (b), `xargs` rc 123, happens one

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1308,8 +1308,14 @@ has "pinned #1: section 2's process-substitution find" \
 # run continues, rc 0 both ways. Nothing reads the status (the only caller is a
 # process substitution, whose exit status bash does not check), and masking
 # requires a reader. The entry is here because the sweep COUNTS it, which is
-# bookkeeping and needs no justification; adding `|| true` would change nothing
-# observable either.
+# bookkeeping and needs no justification.
+#
+# 🔴 A clause saying "adding `|| true` would change nothing OBSERVABLE either"
+# stood here and was FALSE — six lines above the assertion that disproves it.
+# It makes THIS ledger go red: `sweep_n` drops to 1 and both the count and
+# `pinned #2` fail. Nothing BEHAVIOURAL changes; the ledger is an observation.
+# The overreach was one clause past a correct sentence, which is where these
+# keep happening.
 #
 # What IS true and is the thing to know: unlike #1, its stderr goes nowhere — not
 # to DENIED_LOG, not to a file — so a top-level entry that cannot be stat'd is
@@ -1399,7 +1405,10 @@ echo "== 12. SECTION 2 ACCOUNTS FOR TOP-LEVEL FILES, NOT ONLY DIRECTORIES =="
 # directory, a symlink, a fifo, and a skip-listed name. 🔴 The symlink and the
 # fifo MUST BE LISTED — see the assertions below and the reasoning with them.
 # An earlier version of this paragraph said the symlink "must not" be listed,
-# eleven lines above an assertion requiring that it is. A maintainer resolving
+# 25 lines above an assertion requiring that it is (MEASURED at ae2c2427: the
+# comment sat at 1383, the assertion at 1408 — an earlier retelling said
+# "eleven", a decorative specific inside a retraction about false specifics).
+# A maintainer resolving
 # that contradiction toward the comment would have reinstated an exclusion that
 # was measured to make section 3's residual WORSE.
 tl="$TMP/toplevel"
@@ -1407,13 +1416,21 @@ mkdir -p "$tl/realdir" "$tl/proc" "$tl/.hiddendir"
 printf 'x' > "$tl/swapfile"
 printf 'x' > "$tl/.hiddenfile"
 ln -s realdir "$tl/linkdir"
-# 🔴 NO `|| true` HERE — but note the reason CHANGED when the fifo assertion
-# flipped from `lacks` to `has`, and the old reason is no longer the one.
-# It used to be: with `|| true`, a host without mkfifo creates no path and a
-# `lacks` assertion passes vacuously. That is now backwards — a `has` assertion
-# FAILS when the entry is absent, so the suite would go red either way. The
-# reason to keep it unguarded today is only that it fails HERE, naming the
-# missing tool, instead of three lines later as a confusing assertion failure.
+# 🔴 NO `|| true` HERE, AND THERE IS NO BEHAVIOURAL REASON FOR THAT — this
+# comment supplies none, because the two it supplied before were both false.
+#   - draft 1: "with `|| true` a host without mkfifo creates no path and the
+#     assertion below passes vacuously." True when the assertion was `lacks`;
+#     it is `has` now, which FAILS on a missing entry either way.
+#   - draft 2: "it fails HERE, naming the missing tool, instead of three lines
+#     later as a confusing assertion failure." FALSE, and it assumed `set -e`.
+#     🔴 THIS SUITE IS `set -uo pipefail` (line 48) — NO `-e`. MEASURED with a
+#     stand-in returning 127: guarded and unguarded are byte-identical — rc 1,
+#     221 ok, the SAME single failure (`a fifo is counted …`), and the same
+#     `command not found` on stderr. Nothing fails "here"; the run continues
+#     through every remaining assertion, and the assertion failure arrives in
+#     BOTH variants, 15 lines later rather than three.
+# Keep it unguarded because `|| true` would add noise that buys nothing. That is
+# a style preference, not a mechanism, and it is stated as one.
 mkfifo "$tl/afifo"
 
 # The function emits NUL-separated names; render them one per line to assert on.
@@ -1497,6 +1514,47 @@ lacks "section 2 does NOT pipe the enumerator into while (subshell would drop th
     "$consumer_src" 'toplevel_accountable_entries / |'
 has "the consumer reads NUL-delimited records" \
     "$(grep -n 'read -r -d' "$SCRIPT")" "read -r -d '' d"
+
+# --------------------------------------------------------------------------- #
+echo "== 13. UNTALLIED-DROP SITE LEDGER — pinned two-way =="
+# 🔴 THIS REPLACES A PROSE REGISTER THAT WAS SHORT TWICE IN TWO ROUNDS.
+# The script used to carry a numbered list of the places that enumerate depth-1
+# and DROP entries they cannot stat without tallying the drop. Round N found it
+# missing one and added "the FIFTH site"; round N+1 found the ordinals were
+# themselves the defect — a numbered list reads as CLOSED, and the section-5 PVC
+# loop had never been in it. An ordinal is a claim about a SET; nothing checked
+# the set, so each fix made the register more confidently wrong.
+#
+# The criterion: a depth-1 enumeration that drops unstattable entries with no
+# tally, so the count it feeds is a FLOOR presented as a total.
+#
+# 🔴 THIS LEDGER FAILS WHEN THE SET GROWS *OR* SHRINKS. A new site is a new
+# untallied drop nobody wrote down; a vanished one means the shape changed and
+# the criterion needs re-reading. Either way a human must look. Adding a site
+# here is NOT the fix for finding one — recording it is the fix; tallying it is
+# a different, larger change (bash's `[ -d ]` cannot separate "not a directory"
+# from "stat refused" from "unmatched glob").
+bracket_sites="$(grep -n '\[ -d "\$p" \] || continue' "$SCRIPT" | cut -d: -f1 | tr '\n' ' ')"
+bracket_n="$(printf '%s' "$bracket_sites" | wc -w)"
+
+# POSITIVE CONTROL: the pattern must be able to match at all. A ledger whose
+# grep silently stopped matching would report a serene 0 and pin nothing —
+# the exact shape this file's other ledgers carry a control for.
+[ "$bracket_n" -ge 1 ] \
+  && pass "POSITIVE CONTROL: the untallied-drop pattern matches ($bracket_n site(s))" \
+  || fail "POSITIVE CONTROL FAILED: the pattern matched NOTHING — this ledger is wired to nothing and its count below is meaningless"
+
+[ "$bracket_n" -eq 2 ] \
+  && pass "exactly 2 untallied-drop sites, as pinned" \
+  || fail "the untallied-drop ledger found $bracket_n site(s), expected the 2 pinned below — a new one is a FLOOR presented as a total that nobody wrote down; a vanished one means the shape changed. Lines: [$bracket_sites]"
+
+# Name them, so the failure above is actionable and so a SWAP (one site removed,
+# another added) cannot pass on the count alone.
+sites_ctx="$(grep -n -B2 '\[ -d "\$p" \] || continue' "$SCRIPT")"
+has "pinned site: split_by_device's foreign-entry loop" \
+    "$sites_ctx" 'for p in "$base"/*/* "$base"/*/.*'
+has "pinned site: section 5's per-PVC inode loop" \
+    "$sites_ctx" 'for p in /var/lib/rancher/k3s/storage/*'
 
 # --------------------------------------------------------------------------- #
 # 🔴 DO NOT print `RESULT: PASS (exit=0)` here — that grammar is RESERVED to


### PR DESCRIPTION
Round 3 of the audit ladder on the disk-accounting change. Four findings; one is structural and the rest are the ladder's own prose.

## The structural one: a prose register short TWICE in two rounds

`scripts/diagnose-disk-accounting.sh` carried a numbered register of *untallied-drop sites* — places that enumerate depth-1 and drop entries they cannot `stat` **without tallying the drop**, so the count they feed is a floor presented as a total.

- **Round 2** found it missing `toplevel_accountable_entries()`. The fix added it as *"the FIFTH site"*.
- **Round 3** found the **ordinals were themselves the defect**. A numbered list reads as CLOSED — and section 5's per-PVC loop, byte-identical in shape to the declared FOURTH (`[ -d "$p" ] || continue`, exactly two hits in the file), had never been in it.

An ordinal is a claim about a **set**, and nothing was checking the set. So each round's fix made the register more confidently wrong.

**The register is no longer prose.** The script states the *criterion*; test section 13 enumerates the sites by grep, pins the count **two-way**, **names each one** (so a swap cannot pass on the count alone), and carries a positive control proving the pattern can match at all.

Mutation-verified in both directions:

| mutant | result |
|---|---|
| a third site appears | fails the count (`found 3 site(s), expected the 2 pinned`) |
| section-5 site's test changed to `-e` | fails the count **and** its named assertion |

🔴 **The ledger caught a false claim in the commit that adds it.** I asserted `split_by_device`'s loop header was `for p in "$@"`; it is `for p in "$base"/*/* "$base"/*/.*`. Red on the first run. That is the argument for the machine check in one line.

## A new false rationale — in the commit titled "stop supplying rationales that keep turning out false"

The `mkfifo` guard's comment claimed the run *"fails HERE, naming the missing tool, instead of three lines later"*. **That assumed `set -e`. This suite is `set -uo pipefail` (line 48) — no `-e`.**

Measured with a stand-in returning 127:

| variant | rc | ok: | failures | stderr |
|---|---|---|---|---|
| unguarded | 1 | 221 | 1 — `a fifo is counted …` | `command not found` |
| with `|| true` | 1 | 221 | same | same |

Byte-identical. Nothing fails "here"; the run continues through every remaining assertion, and the failure arrives in **both** variants **15** lines later, not three. Both dead drafts are now recorded, and the reason is stated as what it is — a style preference, not a mechanism.

## Two smaller ones

- A clause claiming `|| true` on the enumerator's `find` *"would change nothing observable either"* was false **six lines above the assertion that disproves it** — it makes that ledger red (`sweep_n` drops to 1). Nothing *behavioural* changes; the ledger is an observation. One clause past a correct sentence.
- **"eleven lines above" was 25** (measured at `ae2c2427`: 1383 vs 1408), and the wrong figure had propagated to three sites. Corrected at all three.

## Verification

Suite: **226 assertions, 0 failures**. The new ledger is mutation-verified in both directions, with a positive control.

⚠ **The ladder is not finished.** Round 3 returned findings that needed fixing, so round 4 on this delta is the stop condition.

Worth noting: this is the first round to ship a **structural** fix rather than more prose. Across three rounds, 11 of 18 findings were about sentences a previous round wrote about itself — the register was the right thing to make machine-checkable, and the remaining load-bearing sentences may want the same treatment.
