### PR TITLE
fix(obs-read): --json carried labels only as a rendered display string

### DIFF
--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -177,10 +177,16 @@ validated preset; treat unvalidated ones as starting points.
 🔴 **`rows[].metric` (prometheus) and `rows[].stream` (loki streams) are RENDERED
 DISPLAY STRINGS** — `{a=1, b=2}` — built for the human-readable table. They are
 NOT objects and they are NOT Prometheus's `data.result[].metric`, despite the
-name. Field-accessing them RAISES — `jq` prints `Cannot index string with string`
-and exits **5**, Python raises `TypeError` — and under a suppressor (`.metric.job?`,
-`// empty`, a bare `except`) it instead returns nothing silently, while `row_count`
-sits in the same document saying the query matched.
+name. Field-accessing them RAISES — `jq` prints `Cannot index string with string` and
+exits **5**; Python raises `TypeError` on `row["metric"]["job"]` and
+`AttributeError` on `row["metric"].get("job")`. Only `?` / `try…catch` (jq) or a
+bare `except` (Python) make it silent, and a silent miss is the dangerous one:
+`row_count` sits in the same document saying the query matched.
+
+🔴 **`// empty` is NOT an error suppressor** — jq's `//` is a null/false
+alternative, so the indexing error propagates before it can apply and the
+pipeline still exits 5 (measured, jq 1.8.1; `jq -n 'error("boom") // 1'` errors
+too). `.labels? // {}` is safe because of the **`?`**, not the `//`.
 
 **`rows[].labels` is the label set as a `{str: str}` dict.** Use it:
 

--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -177,21 +177,32 @@ validated preset; treat unvalidated ones as starting points.
 🔴 **`rows[].metric` (prometheus) and `rows[].stream` (loki streams) are RENDERED
 DISPLAY STRINGS** — `{a=1, b=2}` — built for the human-readable table. They are
 NOT objects and they are NOT Prometheus's `data.result[].metric`, despite the
-name. Field-accessing them returns nothing, silently, while `row_count` sits in
-the same document saying the query matched.
+name. Field-accessing them RAISES — `jq` prints `Cannot index string with string`
+and exits **5**, Python raises `TypeError` — and under a suppressor (`.metric.job?`,
+`// empty`, a bare `except`) it instead returns nothing silently, while `row_count`
+sits in the same document saying the query matched.
 
 **`rows[].labels` is the label set as a `{str: str}` dict.** Use it:
 
 ```bash
-obs-read --cluster dpprod --backend prometheus --kind instant --json \
+OBS=~/workspace/devrc/scripts/obs-read   # NOT on $PATH — see the rule above
+$OBS --cluster dpprod --backend prometheus --json \
   --query 'kube_job_status_start_time{cluster="dp-1"}' \
   | jq -r '.rows[] | "\(.labels.job_name) \(.labels.namespace)"'
 ```
 
 Present on prometheus **vector** and **matrix** rows and on loki **matrix** and
-**streams** rows. Absent on prometheus **scalar**/**string** results, which have
-no label set at all — so read it with `.get("labels", {})` / `.labels? // {}`
-rather than assuming every row carries one.
+**streams** rows. Absent on prometheus **scalar**/**string** results and on ALL
+**pyroscope** rows (`{function, self_samples, self_pct}` — a flamebearer has no
+label set) — so read it with `.get("labels", {})` / `.labels? // {}` rather than
+assuming every row carries one.
+
+⚠ **Cost, measured, so it is a choice and not a surprise:** each label set is
+serialised twice — rendered into `metric`/`stream` for the table, structured into
+`labels` for parsers — so `--json` is roughly **2x** larger on a label-rich query
+(measured on production loki: 235 streams, 141,096 -> 289,342 bytes). The
+duplication is what keeps `metric`/`stream` byte-identical for existing readers.
+Pipe through `jq` and select what you need; do not cat a wide `--json` raw.
 
 🔴 **Read `row_count` and `matched_nothing` before concluding anything from an
 empty parse.** A zero from your own parser is a fact about your parser; those two

--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -171,3 +171,29 @@ validated preset; treat unvalidated ones as starting points.
   `Handling connection for P` line per connection and blocks at 64 KiB unread).
 - Known limitation (documented, unchanged): a matched-nothing result still exits
   0 — check the `--json` `matched_nothing`/`warning` fields to fail a pipeline.
+
+## The `--json` row schema — read a label from `labels`, NEVER from `metric`
+
+🔴 **`rows[].metric` (prometheus) and `rows[].stream` (loki streams) are RENDERED
+DISPLAY STRINGS** — `{a=1, b=2}` — built for the human-readable table. They are
+NOT objects and they are NOT Prometheus's `data.result[].metric`, despite the
+name. Field-accessing them returns nothing, silently, while `row_count` sits in
+the same document saying the query matched.
+
+**`rows[].labels` is the label set as a `{str: str}` dict.** Use it:
+
+```bash
+obs-read --cluster dpprod --backend prometheus --kind instant --json \
+  --query 'kube_job_status_start_time{cluster="dp-1"}' \
+  | jq -r '.rows[] | "\(.labels.job_name) \(.labels.namespace)"'
+```
+
+Present on prometheus **vector** and **matrix** rows and on loki **matrix** and
+**streams** rows. Absent on prometheus **scalar**/**string** results, which have
+no label set at all — so read it with `.get("labels", {})` / `.labels? // {}`
+rather than assuming every row carries one.
+
+🔴 **Read `row_count` and `matched_nothing` before concluding anything from an
+empty parse.** A zero from your own parser is a fact about your parser; those two
+fields are the tool's own answer, and they disagreed with a hand-written parser
+three times in a row once.

--- a/scripts/obs-read
+++ b/scripts/obs-read
@@ -419,6 +419,11 @@ def parse_loki(payload) -> QueryResult:
     for stream in result:
         if not isinstance(stream, dict):
             continue
+        # Loki sends a streams label set under `stream`, NOT `metric` (that is
+        # the matrix/vector key). Same structured-labels contract as the
+        # prometheus rows above — `stream` keeps the rendered display string
+        # the table reads, `labels` carries the dict a parser reads.
+        labels = _raw_labels(stream.get("stream", {}))
         name = _fmt_labels(stream.get("stream", {}))
         values = stream.get("values", []) or []
         total_lines += len(values)
@@ -427,7 +432,8 @@ def parse_loki(payload) -> QueryResult:
             last = values[-1]
             if isinstance(last, list) and len(last) == 2:
                 sample = str(last[1])[:120]
-        rows.append({"stream": name, "lines": len(values), "sample": sample})
+        rows.append({"stream": name, "labels": labels,
+                     "lines": len(values), "sample": sample})
     matched_nothing = (total_lines == 0)
     detail = "" if matched_nothing else "%d log line(s) across %d stream(s)" % (
         total_lines, len(rows))

--- a/scripts/obs-read
+++ b/scripts/obs-read
@@ -270,6 +270,27 @@ def _num(s):
     return int(f) if f.is_integer() else f
 
 
+def _raw_labels(labels) -> dict:
+    """The label set as STRUCTURED data, for --json consumers.
+
+    `_fmt_labels` renders a label set for the human-readable TABLE: it returns a
+    string like `{a=1, b=2}`, which is neither JSON nor Prometheus's own wire
+    shape. That string used to be the ONLY representation carried in `--json`
+    output, so every machine consumer had to regex a rendered display string to
+    recover one label — and a consumer that instead assumed Prometheus's native
+    `data.result[].metric` dict got nothing, silently, with `row_count` sitting
+    right there saying otherwise.
+
+    So `rows[].labels` carries the dict and `rows[].metric` keeps the rendered
+    string. Both are emitted: the table renderer reads `metric`, parsers read
+    `labels`, and neither has to know about the other. Values are coerced to
+    `str` because that is what both backends promise on the wire.
+    """
+    if not isinstance(labels, dict):
+        return {}
+    return {str(k): str(v) for k, v in labels.items()}
+
+
 def _fmt_labels(labels: dict) -> str:
     """Render a metric/stream label set compactly and deterministically."""
     if not isinstance(labels, dict) or not labels:
@@ -338,16 +359,18 @@ def parse_prometheus(payload) -> QueryResult:
     for series in (result or []):
         if not isinstance(series, dict):
             continue
+        labels = _raw_labels(series.get("metric", {}))
         name = _fmt_labels(series.get("metric", {}))
         if rtype == "matrix":
             values = series.get("values", []) or []
             last = values[-1] if values else None
             val = _num(last[1]) if isinstance(last, list) and len(last) == 2 else None
-            rows.append({"metric": name, "value": val, "points": len(values)})
+            rows.append({"metric": name, "labels": labels,
+                         "value": val, "points": len(values)})
         else:  # vector (default)
             v = series.get("value")
             val = _num(v[1]) if isinstance(v, list) and len(v) == 2 else None
-            rows.append({"metric": name, "value": val})
+            rows.append({"metric": name, "labels": labels, "value": val})
 
     cols = ["metric", "value"] + (["points"] if rtype == "matrix" else [])
     matched_nothing = (len(rows) == 0)
@@ -376,11 +399,13 @@ def parse_loki(payload) -> QueryResult:
         for series in result:
             if not isinstance(series, dict):
                 continue
+            labels = _raw_labels(series.get("metric", {}))
             name = _fmt_labels(series.get("metric", {}))
             values = series.get("values", []) or []
             last = values[-1] if values else None
             val = _num(last[1]) if isinstance(last, list) and len(last) == 2 else None
-            rows.append({"metric": name, "value": val, "points": len(values)})
+            rows.append({"metric": name, "labels": labels,
+                         "value": val, "points": len(values)})
         matched_nothing = (len(rows) == 0)
         detail = ""
         if not matched_nothing and _all_values_zero(rows):

--- a/scripts/tests/test_obs_read.py
+++ b/scripts/tests/test_obs_read.py
@@ -1085,3 +1085,63 @@ def test_cli_no_cluster_subprocess():
                        text=True, timeout=15)
     assert r.returncode == 2
     assert "--cluster is REQUIRED" in r.stderr
+
+
+# --------------------------------------------------------------------------- #
+# rows[].labels — STRUCTURED labels for --json consumers
+#
+# Regression: `rows[].metric` is a DISPLAY string (`{a=1, b=2}`) produced by
+# _fmt_labels for the table. It was the only representation carried in --json,
+# so a machine consumer had to regex a rendered string to recover one label, and
+# a consumer assuming Prometheus's own `data.result[].metric` dict silently got
+# nothing while `row_count` said otherwise. These pin the dict being present,
+# correct, and additive.
+# --------------------------------------------------------------------------- #
+def test_prometheus_vector_row_carries_structured_labels():
+    qr = obs.parse_prometheus(
+        prom_vector([({"job_name": "verify-b2-29818380", "namespace": "sr"}, "42")]))
+    row = qr.rows[0]
+    # the dict a parser should use
+    assert row["labels"] == {"job_name": "verify-b2-29818380", "namespace": "sr"}
+    # and it must be a real mapping, NOT the rendered string
+    assert isinstance(row["labels"], dict)
+    assert row["labels"]["job_name"] == "verify-b2-29818380"
+
+
+def test_structured_labels_are_additive_not_a_replacement():
+    """The table renderer reads `metric`; it must survive untouched."""
+    qr = obs.parse_prometheus(prom_vector([({"code": "5xx"}, "7")]))
+    row = qr.rows[0]
+    assert row["metric"] == "{code=5xx}"        # display string preserved
+    assert row["labels"] == {"code": "5xx"}     # dict added alongside
+    assert "metric" in qr.columns and "labels" not in qr.columns
+
+
+def test_structured_labels_reach_the_json_document():
+    """The defect was in --json specifically, so drive render(), not the parser."""
+    qr = obs.parse_prometheus(prom_vector([({"pod": "api-0"}, "1")]))
+    out, _ = obs.render(qr, True, "q", "dpprod", "prometheus")
+    doc = json.loads(out)
+    assert doc["rows"][0]["labels"] == {"pod": "api-0"}
+    # a consumer can now select a label without parsing a rendered string
+    assert [r["labels"]["pod"] for r in doc["rows"]] == ["api-0"]
+
+
+def test_prometheus_matrix_row_carries_structured_labels():
+    qr = obs.parse_prometheus(
+        prom_matrix([({"inst": "a"}, [[1, "1"], [2, "3"]])]))
+    assert qr.rows[0]["labels"] == {"inst": "a"}
+    assert qr.rows[0]["points"] == 2          # existing fields intact
+
+
+def test_label_values_are_coerced_to_str():
+    """Both backends promise strings on the wire; a non-str must not leak out
+    and make `labels[k] == "1"` fail for a caller comparing against the wire."""
+    assert obs._raw_labels({"n": 1, "b": True}) == {"n": "1", "b": "True"}
+
+
+def test_raw_labels_tolerates_a_missing_or_junk_label_set():
+    """A scalar/string Prometheus result has no metric dict; must not raise."""
+    assert obs._raw_labels(None) == {}
+    assert obs._raw_labels("not-a-dict") == {}
+    assert obs._raw_labels({}) == {}

--- a/scripts/tests/test_obs_read.py
+++ b/scripts/tests/test_obs_read.py
@@ -1145,3 +1145,57 @@ def test_raw_labels_tolerates_a_missing_or_junk_label_set():
     assert obs._raw_labels(None) == {}
     assert obs._raw_labels("not-a-dict") == {}
     assert obs._raw_labels({}) == {}
+
+
+# --------------------------------------------------------------------------- #
+# Loki — BOTH branches. Added after a round-1 audit mutation battery showed the
+# loki matrix `labels` could be deleted with the whole suite still green (the
+# prometheus tests above cannot see it), and that the loki STREAMS branch — the
+# highest-traffic path, log queries — still carried labels only as a rendered
+# display string, i.e. the very defect this change exists to fix.
+#
+# 🔴 Loki sends a streams label set under `stream` and a matrix one under
+# `metric`. Those are DIFFERENT KEYS in the API; conflating them is the same
+# class of bug. These pin each branch reading its own key.
+# --------------------------------------------------------------------------- #
+def test_loki_matrix_row_carries_structured_labels():
+    """Kills the mutant that drops `labels` from the loki matrix branch."""
+    payload = {"status": "success", "data": {"resultType": "matrix", "result": [
+        {"metric": {"namespace": "sr"}, "values": [[1, "1"], [2, "3"]]}]}}
+    qr = obs.parse_loki(payload)
+    assert qr.rows[0]["labels"] == {"namespace": "sr"}
+    assert qr.rows[0]["metric"] == "{namespace=sr}"   # display string intact
+    assert qr.rows[0]["points"] == 2
+
+
+def test_loki_streams_row_carries_structured_labels():
+    """The log path. Reads Loki's `stream` key, not `metric`."""
+    payload = {"status": "success", "data": {"resultType": "streams", "result": [
+        {"stream": {"namespace": "civitai-dp-prod", "pod": "api-0"},
+         "values": [["1700000000000000000", "boom"]]}]}}
+    qr = obs.parse_loki(payload)
+    row = qr.rows[0]
+    assert row["labels"] == {"namespace": "civitai-dp-prod", "pod": "api-0"}
+    # the exact access that was impossible before: select one label, no regex
+    assert row["labels"]["pod"] == "api-0"
+    assert row["stream"] == "{namespace=civitai-dp-prod, pod=api-0}"
+    assert row["lines"] == 1 and row["sample"] == "boom"
+
+
+def test_loki_streams_labels_are_additive_and_stay_out_of_the_table():
+    """`columns` drives render_table, so the new key must not appear in it."""
+    payload = {"status": "success", "data": {"resultType": "streams", "result": [
+        {"stream": {"pod": "api-0"}, "values": [["1", "x"]]}]}}
+    qr = obs.parse_loki(payload)
+    assert qr.columns == ["stream", "lines", "sample"]
+    assert "labels" not in qr.columns
+    assert "labels" in qr.rows[0]
+
+
+def test_loki_streams_labels_reach_the_json_document():
+    payload = {"status": "success", "data": {"resultType": "streams", "result": [
+        {"stream": {"pod": "api-0"}, "values": [["1", "x"]]}]}}
+    qr = obs.parse_loki(payload)
+    out, _ = obs.render(qr, True, "q", "dpprod", "loki")
+    doc = json.loads(out)
+    assert doc["rows"][0]["labels"] == {"pod": "api-0"}


### PR DESCRIPTION
## The defect

`rows[].metric` in `--json` is the output of `_fmt_labels()` — `{a=1, b=2}` — a
string built for the human-readable table. It was the **only** representation of
a label set in JSON output, so any machine consumer had to regex a rendered
display string to recover a single label.

## How it was found

Querying `kube_job_status_start_time` for job durations, I wrote a parser against
Prometheus's native `data.result[].metric` dict — the shape you'd reasonably
expect from a tool that proxies Prometheus. It returned `[]`, and I reported
"0 series" **three times** before catching it.

🔴 **The silent-zero guard was not at fault and did its job**: the very same
document said `row_count: 5` and `matched_nothing: false`. The shape is what
pushed the caller into hand-parsing, and the hand-parse is what failed.

What finally caught it was a contradiction no data can produce: `count(...)`
returning **5** while `topk(3, ...)` returned **0 series** on a *less* restrictive
selector. A filter cannot increase results, so the fault had to be in my parser.

## The change

Adds `rows[].labels` — the label set as a dict — to prometheus vector/matrix and
loki matrix rows.

Strictly **additive**:
- `rows[].metric` unchanged (the table still reads it)
- `qr.columns` unchanged, and `render_table` selects by column name, so it
  cannot see the new key — table output is unchanged by construction
- no flag, no behaviour change to any existing consumer

```
row_count: 3
  job_name = verify-b2-29815500  ns = storage-resolver     # no regex
```

## Tests

Six new, **verified RED at `origin/main`** (`_raw_labels` does not exist there)
and green at HEAD. Suite goes **74 → 80 pass**.

They pin the dict is present and correct, that it is *additive* rather than a
replacement, that it survives into the rendered JSON document (the defect was in
`--json` specifically, so one test drives `render()` rather than the parser),
that values are coerced to `str` to match both backends' wire promise, and that
a junk/`None` label set does not raise — scalar and string Prometheus results
carry no metric dict at all.

## Not done

`parse_pyroscope` builds its own row shape (`function`/`self_pct`) and has no
label set, so it is untouched.
