### PR TITLE
fix(main-status-watch): close #1469's audit ladder — the outermost net could never escalate, and 155 of 440 enumerated mutants lived

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,8 +254,13 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   `serverMode` unit, so it is running on the workbench and you should not assume it on any
   other host. This FILE named `drift-check` ten times and this zero times, which is how the
   sentence below came to be written wrong.
-  ⏳ **`scripts/main-status-watch.py` shortens that window, and it is NOT LIVE UNTIL A
-  SWITCH.** It reads `main`'s own `tekton/devrc-main-*` statuses every 10 min (a few API
+  ✅ **`scripts/main-status-watch.py` shortens that window, and it IS LIVE** — MEASURED
+  2026-09-11 on the workbench: `main-status-watch.timer` `ActiveState=active`,
+  `UnitFileState=enabled`, last run 00:45 CDT, `ExecMainStatus=0`. ⚠ This line read **NOT
+  LIVE UNTIL A SWITCH** for a day after `ship.sh` had converged both hosts to `86b1ddec` —
+  the sentence was written before the deploy and nothing re-read it, so re-measure rather
+  than trusting this paragraph's age: `systemctl --user list-timers main-status-watch.timer
+  --all`. It reads `main`'s own `tekton/devrc-main-*` statuses every 10 min (a few API
   calls, not a build) and, on an authoritative red, starts `main-green-check` EARLY instead
   of waiting for the 4-hourly timer — so detection becomes ~20 min (CI) + ≤10 min (poll) +
   ~20 min (the deadman's confirmation) rather than up to ~5.5h. 🔴 **It never decides

--- a/scripts/main-status-watch.py
+++ b/scripts/main-status-watch.py
@@ -53,9 +53,13 @@
 #  12   BLIND: too many consecutive unmeasured runs; fails the unit, no toast
 #   2   usage
 #
-# TEST SEAMS (none is read anywhere else, and `scripts/tests/
-# test_main_status_watch.py` pins that the production path still resolves the
-# operator's own origin and really invokes systemctl):
+# TEST SEAMS (none is read anywhere else). Every behavioural test drives the
+# seams, so `scripts/tests/test_main_status_watch.py` pins BOTH production argvs
+# textually AND drives their parsing directly — `git remote get-url origin` in
+# `test_resolve_repo_parses_every_origin_url_shape`, and
+# `systemctl … main-green-check` in
+# `test_the_production_trigger_is_systemctl_start_main_green_check` — so a seam
+# cannot drift away from what production does while the suite stays green.
 #   MAIN_STATUS_WATCH_GH        argv0 for the API reader (default: `gh`)
 #   MAIN_STATUS_WATCH_TRIGGER   full command to start the deadman
 #   MAIN_STATUS_WATCH_CACHE     state directory
@@ -67,6 +71,16 @@
 # two-way — an undocumented knob is a knob nobody can find, and one named here
 # but no longer read is a lie. BUDGET was read for a full commit before anything
 # mentioned it; that is the shape this guard exists to stop recurring.
+# ⚠ NOTHING ELSE IN THIS COMMENT MAY BEGIN A LINE WITH A KNOB NAME. That guard
+# reads the LEDGER above by matching `^#  <NAME> `, so an ordinary sentence
+# wrapping onto a line that happens to start with one would register as a ledger
+# entry for a knob that has none — a two-way pin satisfied by prose. A draft of
+# this very paragraph did it.
+# ⚠ AND AN EARLIER WORDING OVERSTATED THE SEAM PINS above: it said the tests
+# pinned that the production path "resolves the operator's OWN origin". They did
+# not — every test set the repo override, so `resolve_repo` had NO coverage and
+# an enumerated mutation sweep found ten survivors inside it. No test reads the
+# real remote; what is pinned is the argv and the URL parsing.
 """Start the main-green deadman early when main's own CI says main is red."""
 import json
 import os
@@ -128,11 +142,27 @@ def print_header():
 # is the roll-up mistake in a second spelling; treating it as GREEN would be
 # worse still, so it is classified as NOT-A-VERDICT and the walk continues past
 # it. That is the narrowest rule that can be wrong in only one direction.
-NOT_A_VERDICT = ("superseded", "killed", "no-gate-pod", "error-other", "pending")
+#
+# ⚠ `commit_verdict` BRANCHES ON `green` AND `red` ONLY. The finer classes below
+# are not consulted by anything — they exist so this function is TOTAL, with a
+# named answer for every shape a row can take, and they are pinned by
+# `test_classify_maps_a_row_to_its_documented_class`. Until that test existed
+# they had no consumer at all, and an enumerated mutation sweep found every arm
+# of this function undriven: the catch-all could be turned into `return "green"`
+# — i.e. a state GitHub adds tomorrow folded into "main is green" — while a
+# 61-test suite stayed fully green. A tuple named NOT_A_VERDICT used to sit here
+# enumerating the same classes; nothing read it either, so it was deleted rather
+# than left reading as a contract it could not enforce.
 
 
 def classify(state, description):
-    """One status row -> a verdict class. Pure; the tests drive it directly."""
+    """One status row -> a verdict class. Pure, and the tests drive it directly.
+
+    🔴 UNRECOGNISED MEANS `error-other`, WHICH MEANS NOT-A-VERDICT — never green.
+    Both fall-through returns below are the arm an unknown `state` lands on, and
+    "absence reads as green" is the single failure this whole file is built
+    against.
+    """
     desc = (description or "").strip()
     if state == "success":
         return "green"
@@ -385,6 +415,16 @@ class State:
             return n, False
 
     def reset_streak(self):
+        # ⚠ ITS RESULT IS DELIBERATELY NOT CONSULTED, unlike every other writer
+        # on this class — and that asymmetry is a decision, not an oversight a
+        # mutation sweep should re-file. `open_episode`, `close_episode` and
+        # `bump_streak` each return a flag the caller MUST branch on, because
+        # each of their failures is silent and dangerous. This one fails NOISY,
+        # not silent — and that is the whole distinction: a reset that does not
+        # land leaves the streak HIGH, so a later unmeasured run escalates
+        # SOONER than it should. That is a quiet false alarm (rc 12 fails the
+        # unit and does not toast), never a missed one. Flipping this return
+        # value is therefore an equivalent mutant, and the sweep says so.
         try:
             self.streak.write_text("0\n", encoding="utf-8")
             return True
@@ -412,6 +452,21 @@ def blind_escalate():
     """
     raw = os.environ.get("MAIN_STATUS_WATCH_BLIND_ESCALATE")
     return int(raw) if (raw or "").isdigit() else BLIND_ESCALATE_DEFAULT
+
+
+def cache_root():
+    """Where the two state files live — ONE PLACE.
+
+    🔴 THIS WAS OPEN-CODED AT TWO SITES, and the second one is the one that runs
+    when the first has already failed: `main` derives it, and so did the
+    outermost exception net. Two copies drifting apart would send the blind
+    streak to a different directory than the next run reads, which silently
+    un-ladders the net — and the ladder's failure mode is SILENCE, so the
+    divergence would not announce itself. Same rule, same reason, as
+    `blind_escalate()` directly above.
+    """
+    return Path(os.environ.get("MAIN_STATUS_WATCH_CACHE") or
+                Path.home() / ".cache" / "main-status-watch")
 
 
 def ladder_exit(state, escalate, reason):
@@ -460,9 +515,15 @@ class Unmeasured(Exception):
 # `TimeoutStartSec=180`. Being SIGTERM'd by systemd would fail the unit with no
 # message and no streak entry — the script would never get to say COULD NOT
 # MEASURE. So it owns its own deadline, set BELOW the unit's, and exits through
-# its normal unmeasured path instead. `test_the_total_budget_is_under_the_units_
-# timeout` pins the ordering of the two numbers so tightening one cannot silently
-# invert them.
+# its normal unmeasured path instead.
+# `test_the_total_budget_PLUS_the_trigger_timeout_is_under_the_units_timeout`
+# pins the ordering of those numbers so tightening one cannot silently invert
+# them. ⚠ That name is the THIRD-number version; this comment cited the
+# two-number name the same commit had already renamed, so the citation read as
+# authority and resolved to nothing. `test_every_test_this_script_names_
+# actually_exists` now fails on a dangling one. (A name wrapped across a comment
+# line-break is exactly what hid it from every grep, so that guard re-joins the
+# halves before looking — and this comment is deliberately wrapped that way.)
 TOTAL_BUDGET_S = 120
 # 🔴 A THIRD NUMBER, and the pin used to name only two. `trigger_deadman`'s
 # subprocess timeout is NOT charged against _DEADLINE — the budget covers the
@@ -618,22 +679,25 @@ def main(argv):
         # text" — the rationale the env-var guard was filed under — was simply
         # FALSE. `main-green-check.sh` already prints its own header for
         # --help; making that claim true is the better fix than deleting it.
-        # Refuses rather than printing nothing if the sentinel moves, for the
-        # same reason main-green-check.sh does: a --help that silently prints
-        # zero lines and exits 0 is the reassuring zero this file argues against.
-        # 🔴 THE RETURN VALUE IS CONSUMED. It used to be discarded, so a moved
-        # sentinel printed one diagnostic line and still exited 0 — a --help
-        # that silently prints nothing and reports success, which is the
-        # reassuring zero this file argues against. `main-green-check.sh` calls
-        # `die` (exit 2) in the same situation; matching it makes the comparison
-        # in this comment true rather than aspirational.
+        #
+        # 🔴 AND THE RETURN VALUE IS CONSUMED. It used to be discarded, so a
+        # moved sentinel printed ONE diagnostic line and still exited 0 — a
+        # --help that reports success having printed no help, the reassuring
+        # zero this file argues against. `main-green-check.sh` calls `die`
+        # (exit 2) in the same situation; matching it makes the comparison in
+        # this comment true rather than aspirational.
+        # ⚠ ONE RULE, ONE PLACE: this used to be TWO paragraphs stating the
+        # same rule, and the first described the pre-fix behaviour as
+        # "silently prints zero lines", which is not what it did. The arm is
+        # covered by `test_a_MOVED_docstring_sentinel_REFUSES_rather_than_
+        # dumping_the_file`; before that it had none, and three separate
+        # mutants of it survived a fully green suite.
         return RC_OK if print_header() else RC_USAGE
     if len(argv) > 1:
         say(f"unknown argument: {argv[1]}")
         return RC_USAGE
 
-    state = State(os.environ.get("MAIN_STATUS_WATCH_CACHE") or
-                  Path.home() / ".cache" / "main-status-watch")
+    state = State(cache_root())
     try:
         state.mkdir()
     except OSError as exc:
@@ -804,12 +868,20 @@ def _guarded_main(argv):
     the journal, and the blind ladder counts it — so a bug that recurs escalates
     to rc 12 exactly like a persistent outage. A run that cannot look is
     reported as a run that could not look, never as 'main is green'.
+
+    🔴 ONE ARM, NOT TWO — AND THE SECOND ONE WAS F1's SHAPE FOR THE THIRD TIME.
+    There used to be a dedicated `except Unmeasured` here that printed COULD NOT
+    MEASURE and returned rc 11 WITHOUT bumping the streak. rc 11 is a systemd
+    SUCCESS, so that arm could never advance a ladder and never fail the unit:
+    permanently silent, the exact fault this file's F1/F3 comments condemn and
+    that `ladder_exit` says it answers "wherever that condition arises". The
+    paragraph above was describing the net as a whole and was therefore FALSE
+    for the arm nearest to it — a coverage claim wider than its implementation.
+    `Unmeasured` is an `Exception`, so deleting the special case is the fix:
+    the general arm already reports it AND counts it.
     """
     try:
         return main(argv)
-    except Unmeasured as exc:            # a path that raised after the handler
-        say(f"COULD NOT MEASURE — {exc}")
-        return RC_UNMEASURED
     except Exception as exc:  # noqa: BLE001 — deliberate; see the docstring
         import traceback
         say(f"COULD NOT MEASURE — UNEXPECTED {type(exc).__name__}: {exc}")
@@ -817,9 +889,7 @@ def _guarded_main(argv):
         say("  Nothing is claimed about main; the 4-hourly deadman is unaffected.")
         traceback.print_exc()
         try:
-            root = os.environ.get("MAIN_STATUS_WATCH_CACHE") or \
-                Path.home() / ".cache" / "main-status-watch"
-            st = State(root)
+            st = State(cache_root())
             st.mkdir()
             n, persisted = st.bump_streak()
             escalate = blind_escalate()

--- a/scripts/main-status-watch.py
+++ b/scripts/main-status-watch.py
@@ -78,9 +78,10 @@
 # this very paragraph did it.
 # ⚠ AND AN EARLIER WORDING OVERSTATED THE SEAM PINS above: it said the tests
 # pinned that the production path "resolves the operator's OWN origin". They did
-# not — every test set the repo override, so `resolve_repo` had NO coverage and
-# an enumerated mutation sweep found ten survivors inside it. No test reads the
-# real remote; what is pinned is the argv and the URL parsing.
+# not — every test set the repo override, so nothing exercised `resolve_repo`
+# past its first line: TEN of its ELEVEN enumerated mutants survived, the one
+# death being the override branch itself, which every test needs. No test reads
+# the real remote; what is pinned is the argv and the URL parsing.
 """Start the main-green deadman early when main's own CI says main is red."""
 import json
 import os
@@ -143,16 +144,20 @@ def print_header():
 # worse still, so it is classified as NOT-A-VERDICT and the walk continues past
 # it. That is the narrowest rule that can be wrong in only one direction.
 #
-# ⚠ `commit_verdict` BRANCHES ON `green` AND `red` ONLY. The finer classes below
-# are not consulted by anything — they exist so this function is TOTAL, with a
-# named answer for every shape a row can take, and they are pinned by
-# `test_classify_maps_a_row_to_its_documented_class`. Until that test existed
-# they had no consumer at all, and an enumerated mutation sweep found every arm
-# of this function undriven: the catch-all could be turned into `return "green"`
-# — i.e. a state GitHub adds tomorrow folded into "main is green" — while a
-# 61-test suite stayed fully green. A tuple named NOT_A_VERDICT used to sit here
-# enumerating the same classes; nothing read it either, so it was deleted rather
-# than left reading as a contract it could not enforce.
+# ⚠ `commit_verdict` BRANCHES ON `green` AND `red` ONLY, WHICH IS WHY THE FINER
+# CLASSES NEEDED A TEST OF THEIR OWN. Downstream, `superseded`/`killed`/
+# `no-gate-pod`/`error-other` are indistinguishable, so an end-to-end test can
+# only ever see "not a verdict" — measured, 35 of this function's 60 enumerated
+# mutants survived a fully green 61-test suite, and the 25 that died were
+# exactly the ones that moved an answer INTO green-or-red. Worse, the two
+# fall-through `return "error-other"`s are reached by no fixture at all: turning
+# either into `return "green"` survived. That is a state GitHub adds tomorrow
+# folded into "main is green", closing a red episode. They are now pinned by
+# `test_classify_maps_a_row_to_its_documented_class`, which drives this function
+# directly — the only way to see a distinction the caller cannot make.
+# A tuple named NOT_A_VERDICT used to sit here enumerating the same classes;
+# nothing read it, so it was deleted rather than left reading as a contract it
+# could not enforce.
 
 
 def classify(state, description):

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -8,10 +8,7 @@ lands p50 ~19.6 min after the commit — so the signal to look sooner already
 exists. The script under test converts that signal into an early start of the
 deadman, and claims nothing about main itself.
 
-🔴 WHAT THESE TESTS ARE, HONESTLY LABELLED. The script is new, so NOTHING here is
-regression coverage for a defect observed at a base containing it; a test that
-passes before and after is an invariant guard and is not counted as coverage.
-They are:
+🔴 WHAT THESE TESTS ARE, HONESTLY LABELLED. They are:
 
   * two CONTROLS, first in the file, because every behavioural test below is a
     reassuring zero if the harness cannot go red or cannot see a trigger;
@@ -20,10 +17,23 @@ They are:
   * REAL-FIXTURE guards built from status descriptions this repo actually
     posted, which is the only reason the truncation hazard below is provable
     rather than imagined;
-  * two STATIC guards pinning relationships the behavioural tests structurally
-    cannot see — that the script never reads the roll-up endpoint, and that the
-    production trigger really is `systemctl … main-green-check` with no
-    `--force`.
+  * STATIC guards pinning relationships the behavioural tests structurally
+    cannot see — the roll-up endpoint, both production argvs, the DND wiring,
+    the env-knob ledger, the two consolidated one-place rules, and that every
+    test the script CITES exists;
+  * MUTATION-DERIVED guards (the round-3 block at the end), each carrying the
+    mutant id it kills instead of a base ref.
+
+⚠ TWO CLAIMS THAT USED TO SIT HERE WERE FALSIFIED BY THE FILE'S OWN GROWTH, and
+both are the "a fix round's own prose is the likeliest next finding" shape:
+"NOTHING here is regression coverage for a defect observed at a base containing
+it" stopped being true the moment round 2 landed — `test_an_ENOSPC_SHAPED_state_
+dir_ESCALATES_rather_than_reporting_success`, `test_a_REPEATEDLY_failing_trigger_
+ESCALATES_to_blind` and `test_a_failed_episode_write_does_NOT_trigger` each
+carry a measured pre-fix sequence in their own docstring. And "two STATIC
+guards" counted that section when it held two; it has grown several times
+since. Neither sentence was re-read when the thing it counted changed, which
+is the argument for describing a section rather than counting it.
 
 🔴 THE SEAM THESE TESTS DRIVE IS NOT THE PRODUCTION TRIGGER. Every behavioural
 test sets MAIN_STATUS_WATCH_TRIGGER, so none of them ever starts a real systemd
@@ -31,12 +41,14 @@ unit. `test_the_production_trigger_is_systemctl_start_main_green_check` pins the
 real command textually so the seam cannot drift away from what production does
 while every behavioural test stays green.
 """
+import ast
 import json
 import os
 import re
 import subprocess
 import sys
 import time
+import types
 from pathlib import Path
 
 import pytest
@@ -185,6 +197,12 @@ def test_NEGATIVE_CONTROL_the_harness_can_go_red(h):
     assert proc.returncode == RC_TRIGGERED, proc.stdout + proc.stderr
     with pytest.raises(AssertionError):
         assert proc.returncode == RC_OK, "deliberately wrong: a red must not read as OK"
+    # 🔴 A FIRST RED MUST NOT REPORT A PRE-EXISTING EPISODE. `State._read`
+    # returns "" when the file is absent, and every mutant returning a WORD
+    # there instead survived the sweep: the run then announces an ancient
+    # episode "since <that word>" on a box that has never seen a red. Same rc,
+    # same trigger, a log that describes a state the machine was never in.
+    assert "red episode" not in proc.stdout, proc.stdout
 
 
 def test_POSITIVE_CONTROL_the_trigger_receipt_can_move_off_zero(h):
@@ -638,19 +656,38 @@ def test_an_unexpected_exception_is_REPORTED_and_LADDERED_not_swallowed(h):
     check and then explodes deep inside `classify`, where `.strip()` meets a
     dict — a genuinely UNANTICIPATED failure, which is the only kind the net is
     for.
+
+    🔴 AND IT HAD TO BE REBUILT A SECOND TIME, FOR A FAULT THIS FILE ALREADY
+    NAMES ONE SCREEN AWAY. It asserted `returncode in (RC_UNMEASURED, RC_BLIND)`
+    — the same disjunction `test_a_failed_episode_write_does_NOT_trigger`'s
+    docstring condemns as unable to tell "ladders" from "never escalates".
+    Measured: it let TWENTY-ONE mutants of the net survive a fully green suite,
+    including every `RC_BLIND` in it swapped for `RC_OK` and `n >= escalate`
+    forced False — i.e. a net that can never escalate reads exactly like one
+    that can. One rule, two places; this was the copy left unfixed. Assert the
+    EXACT code on each run, and RUN THE LADDER so the escalation is observed
+    rather than allowed.
     """
     sha = "b3" + "0" * 38
     h.serve_commits([sha])
     h.serve_statuses(sha, [
         {"context": CTX_PY, "state": "failure", "description": {"nested": "object"}},
     ])
-    proc = h.run()
-    assert proc.returncode in (RC_UNMEASURED, RC_BLIND), proc.stdout
+    proc = h.run(MAIN_STATUS_WATCH_BLIND_ESCALATE=2)
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
     assert "UNEXPECTED AttributeError" in proc.stdout, proc.stdout
     assert "BUG in main-status-watch" in proc.stdout
-    assert "blind ladder (streak" in proc.stdout, "an unexpected failure must be counted"
+    assert "blind ladder (streak 1/2" in proc.stdout, "an unexpected failure must be counted"
     assert "GREEN" not in proc.stdout
     assert not h.triggered()
+    # the ladder must actually ADVANCE — and the traceback must survive to the
+    # journal, which is stderr, not stdout.
+    assert "Traceback" in proc.stderr, "the net swallowed the traceback"
+    second = h.run(MAIN_STATUS_WATCH_BLIND_ESCALATE=2)
+    assert second.returncode == RC_BLIND, (
+        f"got {second.returncode} — a recurring bug must escalate exactly like a "
+        "persistent outage, or rc 11 reports success forever"
+    )
 
 
 def test_a_NON_VERDICT_is_never_treated_as_green(h):
@@ -983,8 +1020,15 @@ def test_a_trigger_TIMEOUT_leaves_the_episode_open(h):
 def test_a_NON_timeout_trigger_failure_DROPS_the_episode_so_a_retry_is_possible(h):
     write_exec(h.trigger, 'echo "Unit not found." >&2\nexit 5\n')
     _red_commit(h, "c8" + "0" * 38)
-    assert h.run(MAIN_STATUS_WATCH_BLIND_ESCALATE=9).returncode == RC_UNMEASURED
+    proc = h.run(MAIN_STATUS_WATCH_BLIND_ESCALATE=9)
+    assert proc.returncode == RC_UNMEASURED
     assert not (h.cache / "red-episode").exists()
+    # 🔴 THE MIRROR IMAGE OF "never claim a state change you did not achieve":
+    # never report a FAILURE that did not happen either. Dropping the `not` from
+    # `if not state.close_episode():` survived the sweep — the episode really was
+    # dropped while the run warned that it had not been, which would send an
+    # operator looking for a stuck file that is not there.
+    assert "could not drop the episode" not in proc.stdout, proc.stdout
     # and once the trigger works again, it really does retry
     write_exec(h.trigger, f'echo "$@" >> "{h.receipt}"\nexit 0\n')
     assert h.run(MAIN_STATUS_WATCH_BLIND_ESCALATE=9).returncode == RC_TRIGGERED
@@ -1004,13 +1048,47 @@ def test_a_failing_trigger_is_UNMEASURED_not_a_silent_success(h):
 
 def _code_only():
     """Executable lines only. A static guard that reads prose is walkable by
-    rewording AND breakable by documenting the very hazard it forbids."""
+    rewording AND breakable by documenting the very hazard it forbids.
+
+    ⚠ THE NAME USED TO OVER-CLAIM: it stripped `#` comments and kept every
+    DOCSTRING, so each guard below still read a large amount of prose — and this
+    file's own docstrings discuss `/status`, `--force` and `systemctl` at
+    length. Nothing tripped yet, which is the point: the guard was one
+    explanatory sentence away from a false red, in a file whose habit is to
+    explain its hazards next to them. Docstrings are stripped by AST now, so
+    the sentence is true rather than aspirational.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    drop = set()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)) and ast.get_docstring(node) is not None:
+            first = node.body[0]
+            drop.update(range(first.lineno, first.end_lineno + 1))
     out = []
-    for line in SCRIPT.read_text(encoding="utf-8").splitlines():
-        if line.lstrip().startswith("#"):
+    for i, line in enumerate(src.splitlines(), 1):
+        if i in drop or line.lstrip().startswith("#"):
             continue
         out.append(line)
     return "\n".join(out)
+
+
+def test_code_only_really_strips_the_prose_it_claims_to():
+    """The instrument behind four static guards, with both controls.
+
+    NEGATIVE: a phrase that exists ONLY in a docstring must be gone.
+    POSITIVE: a phrase that exists only in executable code must survive — or
+    `_code_only` could satisfy the first assertion by returning nothing at all,
+    and every guard reading it would pass vacuously.
+    """
+    code = _code_only()
+    raw = SCRIPT.read_text(encoding="utf-8")
+    only_in_a_docstring = "Raised for every reason the world could not be read"
+    assert only_in_a_docstring in raw, "fixture phrase moved; this guard is blind"
+    assert only_in_a_docstring not in code, "docstring prose still reaches the guards"
+    assert "def classify(state, description):" in code, (
+        "_code_only stripped executable lines too — every guard reading it is vacuous"
+    )
 
 
 def test_the_script_never_reads_the_rollup_status_endpoint():
@@ -1179,3 +1257,312 @@ def test_a_context_typo_is_not_silent():
     src = SCRIPT.read_text(encoding="utf-8")
     assert 'CONTEXT_PREFIX = "tekton/devrc-main-"' in src
     assert "no authoritative" in src
+
+
+# ══ ROUND 3: THE ARMS AN ENUMERATED SWEEP PROVED UNCOVERED ════════════════════
+# 🔴 HONESTLY LABELLED. Every case in this block was found by MUTATION, not by a
+# defect anyone observed running: the 440-mutant enumerated sweep that produced
+# them is described in the PR. So each is a MUTATION-DERIVED guard — the matrix
+# it carries is "red on mutant M<nnn>, green at HEAD", not "red at a base".
+# `test_an_Unmeasured_that_ESCAPES_mains_handler_still_LADDERS` is the one
+# exception: it is red at the pre-change source, because that one was a defect.
+
+
+def test_a_MOVED_docstring_sentinel_REFUSES_rather_than_dumping_the_file(tmp_path):
+    """🔴 THE SURVIVOR THE ROUND-2 SWEEP FOUND AND NOBODY CLOSED.
+
+    `print_header` bounds the header by the module docstring's opening line, and
+    the whole arm that fires when that sentinel MOVES had no coverage at all:
+    three separate mutants of it survived a fully green 61-test suite —
+
+      * `return False` -> `return True`  (the refusal becomes a silent rc 0)
+      * `if end is None:` -> `if False:`  (`src[1:None]` DUMPS THE WHOLE FILE)
+      * deleting the diagnostic `say(...)` (the operator's only clue)
+
+    Every behavioural test reaches this function on the HAPPY path only, where
+    the sentinel is always found, so none of them can see any of the three. The
+    file argues at length that a `--help` printing nothing and exiting 0 is the
+    reassuring zero it exists to prevent — this is the test that makes the
+    argument enforceable.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    moved = src.replace('"""Start the main-green deadman early',
+                        '"""Begin the main-green deadman early', 1)
+    assert moved != src, "the docstring sentinel is not where this test thinks"
+    copy = tmp_path / "moved-sentinel.py"
+    copy.write_text(moved, encoding="utf-8")
+    proc = subprocess.run([sys.executable, str(copy), "--help"],
+                          capture_output=True, text=True, timeout=60)
+    assert proc.returncode == RC_USAGE, proc.stdout + proc.stderr
+    assert "cannot locate the end of the header" in proc.stdout
+    # and it must NOT fall back to dumping the source: a header knob name would
+    # appear in the output if `src[1:None]` had printed the whole file.
+    assert "MAIN_STATUS_WATCH_BUDGET" not in proc.stdout, (
+        "a moved sentinel dumped the file instead of refusing"
+    )
+    # POSITIVE CONTROL for the line above: the UNmoved script really does print
+    # that knob, so its absence is evidence rather than a pattern that never
+    # matches anything.
+    ok = subprocess.run([sys.executable, str(SCRIPT), "--help"],
+                        capture_output=True, text=True, timeout=60)
+    assert "MAIN_STATUS_WATCH_BUDGET" in ok.stdout
+
+
+def test_an_unknown_argument_is_a_USAGE_error(h):
+    """The other half of the argv arm, and it was uncovered too: mutating
+    `RC_USAGE = 2` to 3, and forcing `if len(argv) > 1` to False, both survived.
+    """
+    proc = subprocess.run([sys.executable, str(SCRIPT), "--not-a-flag"],
+                          capture_output=True, text=True, timeout=60, env=h.env())
+    assert proc.returncode == RC_USAGE, proc.stdout + proc.stderr
+    assert "unknown argument: --not-a-flag" in proc.stdout
+    assert not h.triggered()
+
+
+# ── classify's vocabulary ─────────────────────────────────────────────────────
+# 🔴 THE SWEEP'S WORST FINDING, AND IT IS AN "ABSENCE READS AS GREEN" ONE.
+# `classify`'s docstring said the tests drive it directly. They did not — NOTHING
+# called it, and every mutant of its `pending` and `error` arms survived,
+# INCLUDING turning the final catch-all `return "error-other"` into
+# `return "green"`. That mutant is not cosmetic: the catch-all is what an
+# UNRECOGNISED state lands on, so a state GitHub adds tomorrow would be folded
+# into "main is green" — closing an open red episode and disarming the
+# accelerator on the strength of a word nobody has seen yet.
+
+@pytest.mark.parametrize(
+    "state,description,expected",
+    [
+        ("success", REAL_SUCCESS, "green"),
+        ("failure", REAL_NO_NAME, "red"),
+        ("pending", "devrc gate running", "pending"),
+        ("error", REAL_SUPERSEDED, "superseded"),
+        ("error", REAL_KILLED, "killed"),
+        ("error", REAL_NO_GATE_POD, "no-gate-pod"),
+        ("error", "something this pipeline has never posted", "error-other"),
+        # the arms nothing drove: an unrecognised state, and a missing one.
+        ("queued", "a state this leg does not post today", "error-other"),
+        ("", "", "error-other"),
+        (None, None, "error-other"),
+    ],
+)
+def test_classify_maps_a_row_to_its_documented_class(state, description, expected):
+    assert _load().classify(state, description) == expected
+
+
+def test_an_UNRECOGNISED_state_is_never_green_end_to_end(h):
+    """The behavioural half of the case above, because a unit test on `classify`
+    alone cannot see what the walk does with its answer. A state neither this
+    leg nor this script knows must leave `main` UNCLAIMED — not green, not red.
+    """
+    sha = "a9" + "0" * 38
+    h.serve_commits([sha])
+    h.serve_statuses(sha, [_status(CTX_PY, "queued", "a state nobody predicted")])
+    proc = h.run()
+    assert proc.returncode == RC_OK, proc.stdout
+    assert "no authoritative" in proc.stdout
+    assert "GREEN" not in proc.stdout
+    assert not h.triggered()
+
+
+def test_the_flake_screen_refuses_an_EMPTY_description_set():
+    """`screen_all_known_flakes([])` returns True if its first guard is removed —
+    i.e. it would SUPPRESS a confirmation run having been told nothing at all.
+    The caller cannot reach that today, which is exactly why the guard needs a
+    test rather than a caller: an unreachable guard nobody drives is one refactor
+    away from being deleted as dead.
+    """
+    mod = _load()
+    assert mod.screen_all_known_flakes([]) is False
+    # POSITIVE CONTROL: the function CAN return True, so the assertion above is
+    # not passing because it always returns False.
+    assert mod.screen_all_known_flakes(
+        [f"FAILED: pytests — FAILING: {KNOWN_FLAKE_NAME} | TOTAL failed=1"]
+    ) is True
+
+
+# ── the production repo path ──────────────────────────────────────────────────
+# 🔴 THE HEADER CLAIMED THIS WAS PINNED AND IT WAS NOT. Every behavioural test
+# sets MAIN_STATUS_WATCH_REPO, so `resolve_repo` had ZERO coverage: forcing
+# `if not m` to True or False, and `proc.returncode != 0` to either, all survived.
+# That is the same seam-drift hazard `test_the_production_trigger_...` exists for,
+# on the other production argv.
+
+def _fake_git(monkeypatch, mod, *, rc=0, stdout="", calls=None):
+    def run(cmd, **kw):
+        if calls is not None:
+            calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, rc, stdout, "")
+    monkeypatch.setattr(mod, "subprocess", types.SimpleNamespace(
+        run=run,
+        TimeoutExpired=subprocess.TimeoutExpired,
+        CompletedProcess=subprocess.CompletedProcess,
+    ))
+
+
+@pytest.mark.parametrize("url", [
+    "git@github.com:owner/name.git",
+    "https://github.com/owner/name.git",
+    "https://github.com/owner/name",
+    "ssh://git@github.com/owner/name.git",
+])
+def test_resolve_repo_parses_every_origin_url_shape(monkeypatch, url):
+    mod = _load()
+    monkeypatch.delenv("MAIN_STATUS_WATCH_REPO", raising=False)
+    calls = []
+    _fake_git(monkeypatch, mod, stdout=url + "\n", calls=calls)
+    assert mod.resolve_repo() == "owner/name"
+    # and it asked the question production asks — the seam cannot drift away
+    # from `git remote get-url origin` while the behavioural tests stay green.
+    assert calls[0][:2] == ["git", "-C"]
+    assert calls[0][-3:] == ["remote", "get-url", "origin"]
+
+
+def test_the_repo_override_wins_and_does_not_shell_out(monkeypatch):
+    mod = _load()
+    monkeypatch.setenv("MAIN_STATUS_WATCH_REPO", "o/r")
+    calls = []
+    _fake_git(monkeypatch, mod, stdout="git@github.com:other/thing.git\n", calls=calls)
+    assert mod.resolve_repo() == "o/r"
+    assert calls == [], "the override must short-circuit before running git"
+
+
+def test_an_unparseable_origin_url_is_UNMEASURED_not_a_guess(monkeypatch):
+    mod = _load()
+    monkeypatch.delenv("MAIN_STATUS_WATCH_REPO", raising=False)
+    _fake_git(monkeypatch, mod, stdout="not-a-url\n")
+    with pytest.raises(mod.Unmeasured) as exc:
+        mod.resolve_repo()
+    assert "cannot parse owner/name" in str(exc.value)
+
+
+def test_a_FAILING_git_is_UNMEASURED_not_an_empty_repo_name(monkeypatch):
+    mod = _load()
+    monkeypatch.delenv("MAIN_STATUS_WATCH_REPO", raising=False)
+    _fake_git(monkeypatch, mod, rc=128, stdout="")
+    with pytest.raises(mod.Unmeasured) as exc:
+        mod.resolve_repo()
+    assert "cannot read origin remote" in str(exc.value)
+
+
+# ── the API reader's own failure reporting ────────────────────────────────────
+
+def test_a_NON_ZERO_gh_exit_is_reported_with_its_code_and_stderr(h):
+    """Forcing `if proc.returncode != 0:` to False survived, because the fake gh
+    printed NOTHING on failure — so `json.loads("")` raised and the run was
+    unmeasured either way, for the wrong reason. `gh api` really does print a
+    JSON error body on stdout, and with it the returncode check is the ONLY
+    thing standing between an HTTP 403 and a confident 'no commits returned'.
+    """
+    write_exec(h.gh,
+               'echo "{\\"message\\": \\"API rate limit exceeded\\"}"\n'
+               'echo "gh: rate limited" >&2\nexit 1\n')
+    proc = h.run()
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert "exited 1" in proc.stdout, proc.stdout
+    assert "rate limited" in proc.stdout, "the operator's only clue is dropped"
+    assert not h.triggered()
+
+
+def test_an_EMPTY_commit_list_is_UNMEASURED_not_a_quiet_nothing_to_do(h):
+    """`if not isinstance(commits, list) or not commits:` forced to False
+    survived: with the guard gone an empty list walks zero commits and reports
+    rc 0, 'no authoritative verdict in the newest 0 commits'. An API that
+    returned no commits at all has told us nothing, and 'nothing to do' is the
+    reassuring zero — it must ladder like every other unreadable answer.
+    """
+    h.serve("/repos/o/r/commits?sha=main&per_page=20", [])
+    proc = h.run()
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert "no commits returned" in proc.stdout
+    assert not h.triggered()
+
+
+# ── the outermost net ─────────────────────────────────────────────────────────
+
+def test_an_Unmeasured_that_ESCAPES_mains_handler_still_LADDERS(tmp_path, monkeypatch):
+    """🔴 THE ONE ROUND-3 FINDING THAT IS A DEFECT, NOT A COVERAGE GAP, AND IT IS
+    F1's SHAPE FOR THE THIRD TIME.
+
+    `_guarded_main` had a dedicated `except Unmeasured` arm that printed COULD
+    NOT MEASURE and returned rc 11 — WITHOUT bumping the blind streak. rc 11 is
+    a systemd SUCCESS, so an `Unmeasured` raised anywhere outside `main`'s own
+    handler was an arm that can never advance a ladder and never fails the unit:
+    permanently silent, which is precisely what this file's F1/F3 comments
+    condemn and what `ladder_exit`'s docstring says it applies "wherever that
+    condition arises".
+
+    Its own docstring asserted the opposite — "the blind ladder counts it — so a
+    bug that recurs escalates to rc 12 exactly like a persistent outage" — a
+    coverage claim wider than the implementation, for the arm the sentence was
+    describing. The fix deletes the special case: `Unmeasured` is an `Exception`,
+    so the general arm already reports it AND ladders it.
+
+    RED at the pre-change source (11, 11); GREEN here (11, 12).
+    """
+    mod = _load()
+    monkeypatch.setenv("MAIN_STATUS_WATCH_CACHE", str(tmp_path / "cache"))
+    monkeypatch.setenv("MAIN_STATUS_WATCH_BLIND_ESCALATE", "2")
+
+    def boom(argv):
+        raise mod.Unmeasured("a path that raised after the handler")
+
+    monkeypatch.setattr(mod, "main", boom)
+    first = mod._guarded_main(["main-status-watch.py"])
+    second = mod._guarded_main(["main-status-watch.py"])
+    assert (first, second) == (RC_UNMEASURED, RC_BLIND), (
+        f"got {first},{second} — an arm whose failures are never counted can "
+        "never escalate, and rc 11 is a systemd SUCCESS"
+    )
+    assert (tmp_path / "cache" / "blind-streak").exists(), (
+        "nothing was recorded, so this arm is permanently silent"
+    )
+
+
+def test_the_state_directory_default_lives_in_exactly_one_place():
+    """🔴 A CONSOLIDATION GUARD, the same one the escalation default already has.
+
+    The cache root was open-coded at TWO sites — `main` and the outermost net —
+    and the second is the one that runs when the first has already failed. Two
+    copies drifting apart would send the blind streak to a different directory
+    than the one the next run reads, which silently un-ladders the net: the
+    failure mode is SILENCE, so it would not announce itself.
+    """
+    code = _code_only()
+    assert code.count("MAIN_STATUS_WATCH_CACHE") == 1, (
+        "the cache env var is read in more than one place — call cache_root()"
+    )
+    assert code.count('".cache"') == 1, "the default path is derived twice"
+    assert code.count("cache_root()") >= 2, "the helper must actually be used"
+
+
+def test_every_test_this_script_names_actually_exists():
+    """🔴 THE PROSE FINDING THAT REPEATED AT EVERY ROUND OF THIS ARC: a comment
+    pointing at a test by name, where the test was renamed and only one copy of
+    the rule moved.
+
+    Measured: `main-status-watch.py:463` named
+    `test_the_total_budget_is_under_the_units_timeout`, which the round-2 fix had
+    renamed to `..._PLUS_the_trigger_timeout_...` when it added the third number.
+    The pointer read as a citation and resolved to nothing.
+
+    The name is joined across comment line-breaks first, because that wrap is
+    exactly what hid it from every grep anyone ran.
+
+    ⚠ THE JOIN MUST ALLOW AN INDENTED `#`, and the first version of this guard
+    did not — it anchored the continuation at column 0, so a wrapped name inside
+    a FUNCTION body stayed split and read as a name nobody defined. It failed on
+    its own first run against a citation this very PR added, which is the
+    cheapest possible way to learn that a pattern is narrower than its claim.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    joined = re.sub(r"_\n[ \t]*#[ \t]*", "_", src)
+    referenced = set(re.findall(r"\btest_[a-z][A-Za-z0-9_]+", joined))
+    defined, stems = set(), set()
+    for p in sorted((ROOT / "scripts" / "tests").glob("test_*.py")):
+        stems.add(p.stem)
+        defined |= set(re.findall(r"^def (test_[A-Za-z0-9_]+)", p.read_text(encoding="utf-8"), re.M))
+    assert referenced, "the script names no tests at all — this guard is vacuous"
+    # POSITIVE CONTROL: the comparison set is real and CAN match.
+    assert "test_a_context_typo_is_not_silent" in defined
+    missing = sorted(referenced - defined - stems)
+    assert not missing, f"the script cites tests that do not exist: {missing}"

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -1566,3 +1566,164 @@ def test_every_test_this_script_names_actually_exists():
     assert "test_a_context_typo_is_not_silent" in defined
     missing = sorted(referenced - defined - stems)
     assert not missing, f"the script cites tests that do not exist: {missing}"
+
+
+# ══ ROUND 4: WHAT THE ROUND-3 DELTA'S OWN SWEEP FOUND ═════════════════════════
+# 🔴 AN AUDIT FIX RESETS THE VERIFICATION GATE, and re-running the sweep against
+# the FIXED tree is what makes that concrete. It cut survivors 155 -> 73 and then
+# found three arms round 3 had not reached — one of them an arm round 3's own PR
+# body claimed it had covered. That claim was written from the finding list, not
+# from the diff.
+
+def test_a_commit_with_ONLY_FOREIGN_contexts_is_no_verdict_not_green(h):
+    """🔴 THE ONE ROUND 3 SAID IT HAD CLOSED AND HAD NOT.
+
+    `commit_verdict` returns `"none"` when NO row carries the main-gate prefix,
+    and mutating that return to `"green"` survived both sweeps: the existing
+    foreign-context test always serves a real leg alongside the foreign one, so
+    the empty-`per_ctx` arm is never reached. A commit carrying only
+    `tekton/devrc-cairn-client-runs` rows would then report main GREEN off
+    another pipeline's verdict — and a green CLOSES an open red episode, so the
+    accelerator would be disarmed by a status it must not read at all.
+    """
+    sha = "b9" + "0" * 38
+    h.serve_commits([sha])
+    h.serve_statuses(sha, [
+        _status("tekton/devrc-cairn-client-runs", "success", "all good elsewhere"),
+        _status("tekton/devrc-something-else", "failure", "FAILED: a different pipeline"),
+    ])
+    proc = h.run()
+    assert proc.returncode == RC_OK, proc.stdout
+    assert "no authoritative" in proc.stdout, proc.stdout
+    assert "GREEN" not in proc.stdout, "another pipeline's verdict was read as main's"
+    assert not h.triggered()
+
+
+def test_an_OPEN_episode_SURVIVES_a_foreign_only_commit(h):
+    """The consequence that makes the case above matter rather than merely be
+    wrong: if a foreign-only commit read as green it would close the episode,
+    and the next red in the same window would re-trigger the deadman."""
+    _red_commit(h, "c9" + "0" * 38)
+    assert h.run().returncode == RC_TRIGGERED
+    foreign = "d9" + "0" * 38
+    h.serve_commits([foreign])
+    h.serve_statuses(foreign, [_status("tekton/devrc-cairn-client-runs", "success", "ok")])
+    assert h.run().returncode == RC_OK
+    assert (h.cache / "red-episode").exists(), "a foreign verdict closed the episode"
+
+
+def test_the_NETs_own_ladder_FAILS_THE_UNIT_when_it_cannot_PERSIST(h, monkeypatch):
+    """🔴 F2's SHAPE INSIDE THE NET — THE ONE COPY NOTHING DROVE.
+
+    `ladder_exit` handles an unwritable streak by failing the unit NOW, and
+    `test_an_ENOSPC_SHAPED_state_dir_ESCALATES_rather_than_reporting_success`
+    pins it. The outermost net re-implements the same rule, and its copy had no
+    test: mutating its `RC_BLIND` to `RC_OK`, or forcing `not persisted` to
+    False, all survived. Under ENOSPC — the cause `open_episode`'s docstring
+    names — the net would then report SUCCESS while permanently blind, which is
+    the exact pair of bugs (F1's silence, F2's uncountable alarm) this file was
+    built to remove.
+
+    The directory is made 0o500 AFTER it exists and BEFORE any streak file is
+    written, so `mkdir(exist_ok=True)` succeeds and the write is what fails —
+    the shape ENOSPC actually produces.
+    """
+    mod = _load()
+    cache = h.tmp / "net-cache"
+    cache.mkdir()
+    monkeypatch.setenv("MAIN_STATUS_WATCH_CACHE", str(cache))
+
+    def boom(argv):
+        raise ValueError("a shape nobody predicted")
+
+    monkeypatch.setattr(mod, "main", boom)
+    os.chmod(cache, 0o500)
+    try:
+        rc = mod._guarded_main(["main-status-watch.py"])
+    finally:
+        os.chmod(cache, 0o700)
+    assert rc == RC_BLIND, (
+        f"got {rc} — a net whose ladder cannot be written must fail the unit now, "
+        "not report success forever"
+    )
+    assert not (cache / "blind-streak").exists(), "fixture is wrong: the write succeeded"
+
+
+def test_the_episode_bound_matches_the_deadmans_OWN_cadence():
+    """🔴 A CROSS-FILE RELATIONSHIP ASSERTED IN PROSE AND PINNED BY NOTHING.
+
+    `EPISODE_MAX_AGE_S`'s comment argues the number is not a taste: 4h is chosen
+    to equal `main-green-check`'s own `OnUnitActiveSec`, because past that point
+    the deadman re-runs against the tip ANYWAY, so re-triggering adds no work
+    that was not already going to happen. Change the deadman's cadence and that
+    argument is silently false — the same failure
+    `test_the_total_budget_PLUS_the_trigger_timeout_is_under_the_units_timeout`
+    exists to stop for TimeoutStartSec, one file over. Mutating the `4` survived
+    both sweeps, because the behavioural test reads the constant out of the
+    implementation it is testing.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(r"^EPISODE_MAX_AGE_S = (\d+) \* 60 \* 60", src, re.M)
+    assert m, "EPISODE_MAX_AGE_S is no longer written in hours; re-read this guard"
+    episode_hours = int(m.group(1))
+    home_nix = (ROOT / "nix" / "home.nix").read_text(encoding="utf-8")
+    start = home_nix.index("systemd.user.timers.main-green-check")
+    end = home_nix.index("systemd.user.services.main-status-watch")
+    block = home_nix[start:end]
+    cadence = re.search(r'OnUnitActiveSec = "(\d+)h"', block)
+    assert cadence, "the deadman timer's cadence is no longer stated in whole hours"
+    assert episode_hours == int(cadence.group(1)), (
+        f"the episode bound is {episode_hours}h but main-green-check re-runs every "
+        f"{cadence.group(1)}h — the bound's whole argument is that they are equal"
+    )
+
+
+def test_a_commit_entry_with_NO_sha_is_skipped_not_walked(h):
+    """A malformed entry must be stepped over, not turned into a request for
+    `/commits//statuses`. Forcing `if not sha: continue` off survived: the walk
+    then asks for an empty sha, gets nothing, and the whole run is UNMEASURED —
+    one bad element in the list costing the verdict that was two entries down.
+    """
+    good = "e9" + "0" * 38
+    h.serve("/repos/o/r/commits?sha=main&per_page=20", [{"sha": ""}, {"sha": good}])
+    h.serve_statuses(good, [_status(CTX_PY, "failure", REAL_SEVEN_FAILED_ONE_NAMED),
+                            _status(CTX_NODE, "success", REAL_SUCCESS)])
+    proc = h.run()
+    assert proc.returncode == RC_TRIGGERED, proc.stdout
+    assert "(walked 1)" in proc.stdout, "the sha-less entry was counted as walked"
+
+
+def test_an_EMPTY_stderr_still_produces_a_readable_diagnostic(h):
+    """The `(no stderr)` fallback: forcing the conditional the other way makes
+    `err[0]` raise IndexError on an empty list, turning a clean COULD NOT
+    MEASURE into an UNEXPECTED IndexError — a bug report about the watcher
+    instead of a report about `gh`."""
+    write_exec(h.gh, "exit 7\n")
+    proc = h.run()
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert "exited 7" in proc.stdout
+    assert "(no stderr)" in proc.stdout, proc.stdout
+    assert "UNEXPECTED" not in proc.stdout, "the fallback raised instead of reporting"
+
+
+def test_a_failing_triggers_stderr_reaches_the_operator(h):
+    """`systemctl`'s own words are the only clue why the start failed — a unit
+    that is not loaded says so. Dropping them survived the sweep."""
+    write_exec(h.trigger, 'echo "Failed to start: Unit not found." >&2\nexit 5\n')
+    _red_commit(h, "f9" + "0" * 38)
+    proc = h.run()
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert "Unit not found" in proc.stdout, proc.stdout
+
+
+def test_the_flake_screen_refuses_a_row_that_NAMES_NOTHING_with_a_zero_count():
+    """The `not names` guard, made reachable. Every other fixture reaches it with
+    a count that DISAGREES anyway, so the next guard decides and this one never
+    runs — the "isolate the mutation" trap in its natural habitat. Here the
+    count agrees with the empty name set, which is the one shape where removing
+    this guard flips the answer to SUPPRESS.
+    """
+    mod = _load()
+    assert mod.parse_failing_names("FAILED: pytests — failed=0 FAILING: |") == []
+    assert mod.screen_all_known_flakes(
+        ["FAILED: pytests — failed=0 FAILING: |"]) is False

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -661,10 +661,16 @@ def test_an_unexpected_exception_is_REPORTED_and_LADDERED_not_swallowed(h):
     NAMES ONE SCREEN AWAY. It asserted `returncode in (RC_UNMEASURED, RC_BLIND)`
     — the same disjunction `test_a_failed_episode_write_does_NOT_trigger`'s
     docstring condemns as unable to tell "ladders" from "never escalates".
-    Measured: it let TWENTY-ONE mutants of the net survive a fully green suite,
-    including every `RC_BLIND` in it swapped for `RC_OK` and `n >= escalate`
-    forced False — i.e. a net that can never escalate reads exactly like one
-    that can. One rule, two places; this was the copy left unfixed. Assert the
+    MEASURED: it let SIXTEEN mutants of the general net survive a fully green
+    suite, including both of its `RC_BLIND`s swapped for `RC_OK` and
+    `n >= escalate` forced False — i.e. a net that can never escalate reads
+    exactly like one that can. (⚠ The first version of this sentence said
+    TWENTY-ONE. That was the whole function's survivor count, 23, minus a
+    rounding-down nobody did: 3 were log-line deletions and 4 belonged to a
+    different arm, the `except Unmeasured` this PR deletes. A measured number
+    stated wider than what was measured is the same fault as a guard stated
+    wider than its implementation, in the file auditing exactly that.)
+    One rule, two places; this was the copy left unfixed. Assert the
     EXACT code on each run, and RUN THE LADDER so the escalation is observed
     rather than allowed.
     """
@@ -1321,13 +1327,22 @@ def test_an_unknown_argument_is_a_USAGE_error(h):
 
 # ── classify's vocabulary ─────────────────────────────────────────────────────
 # 🔴 THE SWEEP'S WORST FINDING, AND IT IS AN "ABSENCE READS AS GREEN" ONE.
-# `classify`'s docstring said the tests drive it directly. They did not — NOTHING
-# called it, and every mutant of its `pending` and `error` arms survived,
-# INCLUDING turning the final catch-all `return "error-other"` into
-# `return "green"`. That mutant is not cosmetic: the catch-all is what an
-# UNRECOGNISED state lands on, so a state GitHub adds tomorrow would be folded
-# into "main is green" — closing an open red episode and disarming the
-# accelerator on the strength of a word nobody has seen yet.
+# `classify`'s docstring said the tests drive it directly. No test called it at
+# all — and an end-to-end test STRUCTURALLY CANNOT see most of what it decides,
+# because `commit_verdict` branches on green/red only and folds every other
+# class into "not a verdict". MEASURED: 35 of its 60 enumerated mutants survived
+# a fully green suite, and the 25 that died were exactly those that moved an
+# answer INTO green-or-red. ⚠ Be precise about that — an earlier wording here
+# said "every mutant of its pending and error arms survived", and a quarter of
+# them did not. Overstating a measurement is the same fault as overstating a
+# guard, in the file that exists to catch it.
+#
+# The part that is not merely unobservable is the pair of fall-through
+# `return "error-other"`s: NO fixture reaches either, so turning one into
+# `return "green"` survived. The catch-all is what an UNRECOGNISED state lands
+# on, so a state GitHub adds tomorrow would be folded into "main is green" —
+# closing an open red episode and disarming the accelerator on the strength of a
+# word nobody has seen yet.
 
 @pytest.mark.parametrize(
     "state,description,expected",
@@ -1382,10 +1397,14 @@ def test_the_flake_screen_refuses_an_EMPTY_description_set():
 
 # ── the production repo path ──────────────────────────────────────────────────
 # 🔴 THE HEADER CLAIMED THIS WAS PINNED AND IT WAS NOT. Every behavioural test
-# sets MAIN_STATUS_WATCH_REPO, so `resolve_repo` had ZERO coverage: forcing
-# `if not m` to True or False, and `proc.returncode != 0` to either, all survived.
-# That is the same seam-drift hazard `test_the_production_trigger_...` exists for,
-# on the other production argv.
+# sets the repo override, so nothing exercised `resolve_repo` past its first
+# line: forcing `if not m` to True or False, and `proc.returncode != 0` to
+# either, all survived — TEN of its ELEVEN enumerated mutants. ⚠ Not "zero
+# coverage", which is what this comment said first: the ONE death is the
+# override branch itself, and it dies only because every other test in the file
+# depends on it. Incidental coverage of the line that bypasses the function is
+# not coverage of the function. That is the same seam-drift hazard
+# `test_the_production_trigger_...` exists for, on the other production argv.
 
 def _fake_git(monkeypatch, mod, *, rc=0, stdout="", calls=None):
     def run(cmd, **kw):


### PR DESCRIPTION
Closes the audit ladder left open on #1469 (merged `86b1ddec`). Round 3 never ran, and the
sweep meant to close it **died mid-run with its verdict unknown**, after surfacing one genuine
survivor nobody then fixed. Three rounds ran here; **the ladder went clean at round 6.**

This is LIVE code — a systemd-user timer firing every 10 minutes on both hosts.

## The sweep, and why it is evidence rather than a claim

Mutants are **enumerated from the AST**, never hand-picked — the handoff's own process lesson,
because two prior sweeps self-reported 24/24 and 31/31 while independent samples found
survivors both times. **440 mutants**: every `return RC_*` flipped to each of the other four
codes, every statement-level call deleted, every `if`/`ifexp` condition forced to both
constants, every comparison and boolean operator flipped, every `not` dropped, every numeric
constant perturbed, every compared string literal perturbed.

| round | mutants | killed | survived |
|---|---|---|---|
| 3 — the tree as merged (`b315cdd3`) | 440 | 265 | **155** |
| 4 — after round 3's fixes | 439 | 365 | 73 |
| 6 — after round 4's | 439 | 380 | **58** |

Hygiene, every item of which has burned an agent on this arc: `PYTHONDONTWRITEBYTECODE=1` and
a **fresh tree per mutant** (CPython caches on whole-second mtime + size, so a same-length edit
in the same second scores SURVIVED without executing); a **positive control** injected once per
20-mutant batch — 22 of them, all KILLED in every sweep; a **negative control** required green;
verdicts read by **counting pytest's own result lines** with colour disabled, never a piped
exit code, with any run not collecting the exact expected count reported ERROR rather than
SURVIVED (zero ERRORs); and a stub `systemctl` first on PATH so a mutant that broke the trigger
seam could not start the operator's real deadman. Its log stayed empty.

🔴 **The controls earned their keep twice.** A verification sweep came back **439/439 KILLED**
with its negative control RED — a 100% kill rate is the signature of a harness that fails
everything, and the whole 457-run sweep was **void**, not perfect (the new citation guard globs
its own directory for sibling test files, and the mutant tree carried one). Separately, a
self-check comparing each mutant's recorded source text against its node class found **1 of
440** whose span landed inside an f-string and replaced a space — reported as VOID rather than
counted as a survivor.

## The defect — RED at `b315cdd3`, GREEN here

`_guarded_main` carried a dedicated `except Unmeasured` arm that printed COULD NOT MEASURE and
returned **rc 11 without bumping the blind streak**. rc 11 is a systemd *success*, so that arm
could never advance a ladder and never fail the unit: permanently silent. That is F1's shape
for the third time in this file, inside the net whose own docstring asserts *"the blind ladder
counts it … escalates to rc 12 exactly like a persistent outage"* — a coverage claim wider than
its implementation, describing the arm directly beneath it. `Unmeasured` is an `Exception`;
deleting the special case is the fix, since the general arm already reports it **and** counts it.

## The coverage gaps the sweep proved

| where | survivors | what a survivor means |
|---|---|---|
| `classify` | 35 of 60 | no test called it, and an end-to-end test **structurally cannot** see most of what it decides — `commit_verdict` branches on green/red only. The genuinely unreached part is the pair of fall-through `return "error-other"`s: turning either into `return "green"` survived. That is a `state` GitHub adds tomorrow folded into *main is green*, closing a red episode. |
| `_guarded_main` | 16 in the general net | `test_an_unexpected_exception_…` asserted `returncode in (RC_UNMEASURED, RC_BLIND)` — the disjunction its own neighbour's docstring condemns as unable to tell *ladders* from *never escalates*. Both of the net's `RC_BLIND`s could become `RC_OK`, and `n >= escalate` could be forced False. |
| `commit_verdict` | 2 | a commit whose statuses are **all foreign contexts** reported main GREEN off another pipeline's verdict — and a green CLOSES an open red episode. **Found in round 4, after round 3's PR body had already claimed it closed.** |
| `resolve_repo` | 10 of 11 | nothing exercised it past its first line. The one death is the override branch, and it dies only because every other test depends on it — incidental coverage of the line that *bypasses* a function is not coverage of the function. Meanwhile the header claimed the tests pinned that the production path resolves the operator's own origin. |
| the net's ladder copy | 5 | the outermost net re-implements `ladder_exit`'s un-persistable-streak rule and **nothing drove its copy**. Under ENOSPC it would report SUCCESS while permanently blind. One rule, two places, fourth time on this file. |
| `EPISODE_MAX_AGE_S` | 1 | its whole argument is that 4h **equals** `main-green-check`'s `OnUnitActiveSec`, and nothing pinned it — the behavioural test reads the constant out of the implementation it tests. Now pinned against `nix/home.nix`, as `TimeoutStartSec` already was. |
| `print_header` | 3 | the round-2 survivor, still open. The refusal could become a silent rc 0; the guard could be turned off so `src[1:None]` **dumps the whole file** as `--help`; the diagnostic could be deleted. |
| `main`'s argv arm | 6 | an unknown argument, and `RC_USAGE` itself, had no test. |
| `find_newest_verdict` | 3 | an **empty commit list** degraded to a quiet rc 0, *"no verdict in the newest 0 commits"*; a sha-less entry cost the whole walk instead of being skipped. |
| `gh_json` / `trigger_deadman` | 5 | a non-zero `gh` exit was only unmeasured *by accident* (the fake printed nothing, so `json.loads("")` raised instead); the `(no stderr)` fallback raised IndexError under mutation; a failing trigger's stderr — the only clue the unit is not loaded — was unasserted. |
| `State._read` | 5 | the absent-file return could be any word, and the run would then announce an ancient red episode on a box that has never seen a red. |
| `screen_all_known_flakes` | 2 | an empty description set would **suppress** a confirmation run having been told nothing. |

Each new guard names the mutant it kills and is labelled a **mutation-derived guard**, not
regression coverage — the matrix it carries is *red on mutant M&lt;nnn&gt;, green at HEAD*.

## Prose, which the handoff predicted would be the likeliest finding — and was, at every round

- `NOT_A_VERDICT` was read by **nothing, anywhere** — a tuple reading as the classification
  contract while enforcing none. Deleted.
- a comment cited `test_the_total_budget_is_under_the_units_timeout`, **renamed by the same
  commit that wrote the citation**. A new guard re-joins names wrapped across comment
  line-breaks (the wrap is what hid it from every grep) and fails on a dangling one. 🔴 It
  failed on its **own first run**, against a citation this PR added, because the first version
  anchored the continuation at column 0.
- the `--help` rationale was **two paragraphs of one rule**, and the stale copy described the
  pre-fix behaviour as printing nothing when it printed a line.
- the test file's header said **nothing in it was regression coverage** (round 2 made that
  false) and counted *"two STATIC guards"* for a section that has grown several times.
- `_code_only()` promised *"executable lines only"* and kept every **docstring** — one
  explanatory sentence away from a false red, in a file whose habit is to explain its hazards
  next to them. Now strips them by AST, with both controls.
- 🔴 **round 5 found three of my OWN measured numbers stated wider than what was measured**:
  "twenty-one mutants of the net" was the whole function's 23 minus a rounding-down nobody did
  (the real figure is 16); "every mutant of `classify`'s pending and error arms survived" — a
  quarter of them did not; "`resolve_repo` had ZERO coverage" — ten of eleven. A measured
  number stated wider than what was measured is the same fault as a guard stated wider than its
  implementation, in the PR auditing exactly that. Each correction is left visible in the source
  rather than silently rewritten.
- `CLAUDE.md` said this unit is **NOT LIVE UNTIL A SWITCH**. Measured on the workbench
  2026-09-11: timer `active`, `enabled`, last run 00:45 CDT, `ExecMainStatus=0`.

Also consolidates the cache-root expression, open-coded at two sites — the second being the one
that runs *after* the first has already failed.

## The 58 that remain, and why each is not a finding

**23** are `say(…)` deletions: log narration is deliberately not pinned line by line, because
pinning every line is the spelled-guard trap. Two exceptions were closed because the line is the
**only** signal on its arm — `print_header`'s diagnostic, and the inverted
`if not state.close_episode()` which reported a failure that did not happen. **11** are
log-formatting constants (`sha[:8]`, `// 3600`). **4** are `--help` formatting, whose *content*
is pinned. The rest are argued equivalent: `reset_streak`'s unconsulted return (a failed reset
fails *noisy*, not silent — now documented in the source); `screen_all_known_flakes`'s
`count is None` (subsumed, since `None != len(names)` is always true); `commit_verdict`'s
`not per_ctx` early return and `classify`'s `if state == "error"` (both fall through to the same
answer); `find_newest_verdict`'s `not isinstance(rows, list)` (the per-row check raises anyway);
`_remaining`'s `_DEADLINE is None` default (unreachable once `main` has run); `trigger_deadman`'s
production branch (covered by the static argv pin instead); and timeout/depth constants with
slack by design — the relationship that matters, `budget + trigger < TimeoutStartSec`, is pinned.
Plus the 1 void f-string span.

## Verification

- **pre-change matrix at `b315cdd3`** — 3 RED: the `Unmeasured` ladder, the cache-root one-place
  guard, the dangling-citation guard. All **96 GREEN** at this HEAD.
- **round-4 kill matrix**, targeted re-sweep with valid controls: all 11 intended mutants killed
  by exactly the test written for each.
- `scripts/scoped-tests.sh` in the dev shell: **6123 collected, 6123 passed, 0 failed**,
  `RESULT: PASS`, `SCOPE: SCOPED (47 files across 9 of 28 hermetic targets)`. That is a scoped
  run and prints so itself — **not** a gate verdict.
- the round-5 commit is comment-only, verified by `ast.dump` equality against its parent, so the
  final sweep's verdict applies to the committed code unchanged.
- the full `nix build` sandbox tier was **not** run locally; the advisory Tekton checks cover it.
