### PR TITLE
docs(cairn): retract "there is no CREATE route" — it shipped in #1254, and FIVE tracked files still asserted it

### DIFF
--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -73,11 +73,17 @@ directory and all.** `create_entry` runs `path.parent.mkdir(exist_ok=True)`
 `test_a_scopes_FIRST_entry_creates_the_directory` asserts **201** plus the bytes
 on disk for a scope with no directory.
 
-🔴 **THE ONLY GATE IS YOUR TOKEN'S SCOPE ALLOWLIST.** A scope outside it answers
-**404**, byte-identical to one that never existed — deliberately, so an error
-cannot enumerate the store. A scope INSIDE it with no directory yet is created.
-So the remedy for "I cannot create into scope X" is an allowlist edit, **not**
-seeding.
+🔴 **THE ONLY SCOPE-LEVEL GATE IS YOUR TOKEN'S SCOPE ALLOWLIST.** A scope outside
+it answers **404**; a scope INSIDE it with no directory yet is created. So the
+remedy for "I cannot create into scope X" is an allowlist edit, **not** seeding.
+
+🔴 **That 404 is byte-identical for FOUR different causes** — a scope outside your
+allowlist, a scope that never existed, a ref that resolves to nothing, and an
+entry the loader could not parse (`server.py`, and the same list in its README).
+Deliberately, so an error cannot enumerate the store. ⚠ Do not read a 404 as
+"widen the allowlist": that is one of four, and an earlier version of this block
+listed only two after being rewritten to widen the CREATE claim — wider on one
+axis, narrower on another.
 
 ⚠ **THIS FILE HAS NOW BEEN WRONG TWICE ABOUT THE SAME SENTENCE, IN OPPOSITE
 DIRECTIONS.** It used to say there was no create route at all (false since

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -89,8 +89,8 @@ probe wired to nothing. ⚠ Both wrote nothing.
 
 🔴 **That 404 is byte-identical for "outside your allowlist", "never existed" and
 "ref resolves to nothing"** — deliberately, so an error cannot enumerate the
-store. `reference/operator-surface.md` carries the two ways an OPERATOR can still
-tell absent from refused; no client can.
+store. `~/.claude/skills/cairn/reference/operator-surface.md` carries the two
+ways an OPERATOR can still tell absent from refused; no client can.
 
 ## 🔴 The two different exit 4s
 

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -80,10 +80,15 @@ remedy for "I cannot create into scope X" is an allowlist edit, **not** seeding.
 🔴 **That 404 is byte-identical for FOUR different causes** — a scope outside your
 allowlist, a scope that never existed, a ref that resolves to nothing, and an
 entry the loader could not parse (`server.py`, and the same list in its README).
-Deliberately, so an error cannot enumerate the store. ⚠ Do not read a 404 as
-"widen the allowlist": that is one of four, and an earlier version of this block
-listed only two after being rewritten to widen the CREATE claim — wider on one
-axis, narrower on another.
+Deliberately, so an error cannot enumerate the store. ⚠ That four-way ambiguity
+is about a **write 404 generally** (it reaches `append` and `If-Match` `PUT`
+through `_resolve_writable`). **On the CREATE path specifically only the
+allowlist arm can fire** — a ref resolving to nothing is the success case, a bad
+normalisation is 400, and the malformed-entry arm is not on that route — so for
+`cairn create`, "widen the allowlist" IS the right reading. ⚠ An earlier version
+of this block listed only two causes after being rewritten to widen the CREATE
+claim, and its replacement then told the reader to distrust the one reading that
+is correct here: wider on one axis, narrower on another, twice running.
 
 ⚠ **THIS FILE HAS NOW BEEN WRONG TWICE ABOUT THE SAME SENTENCE, IN OPPOSITE
 DIRECTIONS.** It used to say there was no create route at all (false since

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -67,30 +67,37 @@ every writer; `prune-index` owns deletion, with its own confirmation gate. Load
 whichever applies rather than reconstructing their steps here.
 
 🔴 **A CREATE route EXISTS — `cairn create --scope S --ref R --file F` (`PUT`
-with `If-None-Match: *`, devrc#1254). It still cannot create a scope's FIRST
-entry, and the reason is NOT the one this file used to give.** The old text said
-there was no create verb at all; that has been false since #1254, and the
-conclusion it drew survived only by accident. The real mechanism is that the
-index is built by WALKING THE STORE ROOT narrowed by your allowlist
-(`subsystem_recall.load_store`), so a scope with no directory on the pod's disk
-resolves to nothing and the write is refused at the index, before any filesystem
-write. A new scope's first entry is therefore still an operator step — seeding —
-and until somebody takes it the record exists nowhere the pod can serve.
+with `If-None-Match: *`, devrc#1254) — and it DOES create a scope's first entry,
+directory and all.** `create_entry` runs `path.parent.mkdir(exist_ok=True)`
+(`server.py`), commented *"how the store gained EVERY scope it has"*, and
+`test_a_scopes_FIRST_entry_creates_the_directory` asserts **201** plus the bytes
+on disk for a scope with no directory.
 
-MEASURED 2026-09-11, with the control that makes the reading mean something:
+🔴 **THE ONLY GATE IS YOUR TOKEN'S SCOPE ALLOWLIST.** A scope outside it answers
+**404**, byte-identical to one that never existed — deliberately, so an error
+cannot enumerate the store. A scope INSIDE it with no directory yet is created.
+So the remedy for "I cannot create into scope X" is an allowlist edit, **not**
+seeding.
 
-| `cairn create` target | answer |
-|---|---|
-| absent + non-allowlisted scope | **rc 6** `[not-found] — not found` |
-| allowlisted, present scope, ref that already exists | **rc 9** `[already-exists]` |
+⚠ **THIS FILE HAS NOW BEEN WRONG TWICE ABOUT THE SAME SENTENCE, IN OPPOSITE
+DIRECTIONS.** It used to say there was no create route at all (false since
+#1254). The correction then said a first entry "is still an operator step —
+seeding", blaming an index walk — **also false**, and caught by a round-1 audit.
+The measurement behind it probed a scope that was absent *and* non-allowlisted,
+on a pod where those two sets are identical, so it could not tell the allowlist
+gate from the index walk and credited the wrong one. `claude/RULES.md`: *"An
+EMPTY RESULT cannot distinguish two mechanisms — go find the step that differs."*
+The discriminating control is: allowlist a scope, do NOT seed it, `cairn create`
+→ expect **201**.
 
-The two codes differ, so the `not-found` is a fact about that scope rather than a
-probe wired to nothing. ⚠ Both wrote nothing.
+⚠ The failure a caller actually sees, measured 2026-09-11: `cairn create` into a
+non-allowlisted scope is **rc 6** `[not-found]`; into an allowlisted scope at a
+ref that exists is **rc 9** `[already-exists]`. Both wrote nothing. The codes
+differ, so rc 6 is a real reading — **but it is about the ALLOWLIST**, which is
+what the earlier version of this block got wrong.
 
-🔴 **That 404 is byte-identical for "outside your allowlist", "never existed" and
-"ref resolves to nothing"** — deliberately, so an error cannot enumerate the
-store. `~/.claude/skills/cairn/reference/operator-surface.md` carries the two
-ways an OPERATOR can still tell absent from refused; no client can.
+`~/.claude/skills/cairn/reference/operator-surface.md` carries the two ways an
+OPERATOR can tell a refused scope from an absent one; no client can.
 
 ## 🔴 The two different exit 4s
 

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -66,14 +66,31 @@ Typing it as a `cairn` subcommand is no longer valid: argparse exits 2 with an
 every writer; `prune-index` owns deletion, with its own confirmation gate. Load
 whichever applies rather than reconstructing their steps here.
 
-🔴 **There is no CREATE route, and the failure does not say so.** `PUT` demands
-an `If-Match` the caller derives from bytes that must already exist (`428` with
-none, and `If-Match: *` is refused because it is no precondition at all), and
-`POST …/bullets` appends to something. A ref the pod has never held answers
-`404 ref-unknown` — the same bytes as a ref outside your allowlist. So a scope's
-FIRST record cannot be made through the API at all; it is an operator step, and
-until somebody takes it the record does not exist anywhere the pod can serve.
-Measured 2026-09-03, on real entries stranded by exactly this.
+🔴 **A CREATE route EXISTS — `cairn create --scope S --ref R --file F` (`PUT`
+with `If-None-Match: *`, devrc#1254). It still cannot create a scope's FIRST
+entry, and the reason is NOT the one this file used to give.** The old text said
+there was no create verb at all; that has been false since #1254, and the
+conclusion it drew survived only by accident. The real mechanism is that the
+index is built by WALKING THE STORE ROOT narrowed by your allowlist
+(`subsystem_recall.load_store`), so a scope with no directory on the pod's disk
+resolves to nothing and the write is refused at the index, before any filesystem
+write. A new scope's first entry is therefore still an operator step — seeding —
+and until somebody takes it the record exists nowhere the pod can serve.
+
+MEASURED 2026-09-11, with the control that makes the reading mean something:
+
+| `cairn create` target | answer |
+|---|---|
+| absent + non-allowlisted scope | **rc 6** `[not-found] — not found` |
+| allowlisted, present scope, ref that already exists | **rc 9** `[already-exists]` |
+
+The two codes differ, so the `not-found` is a fact about that scope rather than a
+probe wired to nothing. ⚠ Both wrote nothing.
+
+🔴 **That 404 is byte-identical for "outside your allowlist", "never existed" and
+"ref resolves to nothing"** — deliberately, so an error cannot enumerate the
+store. `reference/operator-surface.md` carries the two ways an OPERATOR can still
+tell absent from refused; no client can.
 
 ## 🔴 The two different exit 4s
 

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -98,11 +98,20 @@ client-side evidence that such entries exist. `cairn doctor` reads it.
 the wire they are the same bytes.
 
 ⚠ **This section used to say the two remedies are OPPOSITE — "seed the scope" vs
-"widen the allowlist" — and that is RETRACTED.** Under the real mechanism (below)
-the allowlist edit is the remedy in BOTH readings: an allowlisted scope with no
-directory is created by `cairn create`. Settling absent-vs-refused is still worth
-doing — it tells you whether to expect existing entries back — but it no longer
-selects between two different fixes.
+"widen the allowlist" — and that is RETRACTED.** Seeding is never the remedy.
+But the replacement overshot too, so precisely:
+
+| reading | remedy |
+|---|---|
+| **REFUSED** — the scope is not in your token row | edit the secret, replace the pod, then `cairn create` |
+| **ABSENT** — allowlisted already, but the store holds no entries for it | **`cairn create` alone.** No secret edit, no pod restart. |
+
+🔴 **Settle which one you are in BEFORE editing a secret**, or you will replace a
+production pod to fix something a one-line `create` would have handled. An
+earlier draft here said the allowlist edit is the remedy in BOTH readings —
+generalised from a pod where the allowlist happened to enumerate exactly the
+scopes on disk, which is the same coincidence that produced the original wrong
+diagnosis.
 
 1. **The count gap, off `doctor` alone.** `entry-files=` (store-wide, unfiltered —
    `snapshot_freshness` walks the root and takes no token) minus `X-Store-Entries`
@@ -120,7 +129,9 @@ PVC held, so it was refusing nothing. `civitai-app-requests` and
 `civitai-developer-docs` read as invisible because they had **never been seeded**,
 not because access was lost.
 
-🔴 **THE ALLOWLIST EDIT IS THE WHOLE FIX — SEEDING IS NOT REQUIRED.** An earlier
+🔴 **FOR A *REFUSED* SCOPE, THE ALLOWLIST EDIT IS THE WHOLE FIX — SEEDING IS
+NEVER REQUIRED.** (For a merely ABSENT one, skip straight to `cairn create` — see
+the table above.) An earlier
 version of this section said "editing the allowlist without seeding changes
 nothing at all, because the index is built from what is ON DISK". That is true of
 READS and **false for `cairn create`**: `create_entry` does

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -101,24 +101,44 @@ the wire they are the same bytes.
 "widen the allowlist" — and that is RETRACTED.** Seeding is never the remedy.
 But the replacement overshot too, so precisely:
 
-| reading | remedy |
-|---|---|
-| **REFUSED** — the scope is not in your token row | edit the secret, replace the pod, then `cairn create` |
-| **ABSENT** — allowlisted already, but the store holds no entries for it | **`cairn create` alone.** No secret edit, no pod restart. |
+🔴 **NEITHER DISCRIMINATOR BELOW ANSWERS THE QUESTION THAT PICKS THE REMEDY.**
+Both measure the pod's DISK; the remedy turns on your token's ALLOWLIST, and a
+scope can be missing from either, or both. `civitai-app-requests` was missing
+from both — so it reads ABSENT on both discriminators while needing the allowlist
+fix.
 
-🔴 **Settle which one you are in BEFORE editing a secret**, or you will replace a
-production pod to fix something a one-line `create` would have handled. An
-earlier draft here said the allowlist edit is the remedy in BOTH readings —
-generalised from a pod where the allowlist happened to enumerate exactly the
-scopes on disk, which is the same coincidence that produced the original wrong
-diagnosis.
+**So do not route off them. Ask the create path itself — it is the cheapest,
+non-destructive probe, and its answer IS the remedy:**
+
+```bash
+cairn create --scope <scope> --ref <ref> --file <entry.md>
+```
+
+| answer | meaning | remedy |
+|---|---|---|
+| **201** | allowlisted; the scope simply had no entries | done — that WAS the fix. No secret edit, no pod restart. |
+| **rc 6 `[not-found]`** | not in your token row (on the create path, the allowlist arm is the ONLY 404 — see `SKILL.md`) | edit the secret, replace the pod, re-run |
+
+⚠ **Two earlier drafts of this block were wrong in OPPOSITE directions**, which is
+why it now routes off a probe rather than off a classification. The first said the
+allowlist edit is the remedy in BOTH readings — a safe superset, merely wasteful.
+The second added an ABSENT row prescribing `cairn create` alone, whose precondition
+("allowlisted already") **neither discriminator below can establish** — wrong and
+stuck, for the exact two scopes this page names as live.
+
+Both of the following answer **"does the pod hold entries for this scope?"** and
+**nothing else** — in particular neither can tell you whether the scope is in your
+token row, which is what selects the remedy above. Use them to know what to
+expect back, not to decide what to do.
 
 1. **The count gap, off `doctor` alone.** `entry-files=` (store-wide, unfiltered —
    `snapshot_freshness` walks the root and takes no token) minus `X-Store-Entries`
-   (your slice). **Gap 0 ⇒ nothing on the pod is hidden from you ⇒ the scope is
-   ABSENT.** ⚠ This line used to end "…and widening the allowlist would change
-   nothing" — RETRACTED: widening it is precisely what lets `cairn create` bring
-   the scope into existence.
+   (your slice). **Gap 0 ⇒ no entry on the pod is hidden from you.** ⚠ That is a
+   statement about ENTRIES, not about scopes: a scope with no entries is invisible
+   either way, so gap 0 leaves the allowlist question wide open. This line used to
+   end "…and widening the allowlist would change nothing" — RETRACTED twice over:
+   widening it is precisely what lets `cairn create` bring the scope into
+   existence.
 2. **The pod's own disk**, which settles it outright:
    `kubectl -n subsystem-store exec deploy/subsystem-store-api -- ls -1 /data`
 

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -112,10 +112,21 @@ PVC held, so it was refusing nothing. `civitai-app-requests` and
 `civitai-developer-docs` read as invisible because they had **never been seeded**,
 not because access was lost.
 
-🔴 **Order matters when you do widen it.** Seeding without the allowlist edit
-leaves the scope unreadable by that token (indistinguishable from absent);
-editing the allowlist without seeding changes nothing at all, because the index
-is built from what is ON DISK. Both, then replace the pod.
+🔴 **THE ALLOWLIST EDIT IS THE WHOLE FIX — SEEDING IS NOT REQUIRED.** An earlier
+version of this section said "editing the allowlist without seeding changes
+nothing at all, because the index is built from what is ON DISK". That is true of
+READS and **false for `cairn create`**: `create_entry` does
+`path.parent.mkdir(exist_ok=True)`, and
+`test_a_scopes_FIRST_entry_creates_the_directory` pins **201** for an allowlisted
+scope with no directory. So the sequence is:
+
+1. add the scope to the token row in the secret,
+2. replace the pod (the token file is read ONCE — see above),
+3. `cairn create --scope <new> --ref <ref> --file <path>` → **201**.
+
+`seed.sh` is for pushing a whole local tree and carries the overwrite hazard
+above; reach for it when you have many entries, not to bring one scope into
+existence.
 
 ## The freeze
 

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -95,13 +95,21 @@ client-side evidence that such entries exist. `cairn doctor` reads it.
 ### 🔴 Telling ABSENT from REFUSED — no client can, an operator can, two ways
 
 `doctor`'s `token-scopes` PROBLEM names both readings and stops there, because on
-the wire they are the same bytes. The remedies are opposite — **seed the scope**
-vs **widen the allowlist** — so settle it before acting, with either:
+the wire they are the same bytes.
+
+⚠ **This section used to say the two remedies are OPPOSITE — "seed the scope" vs
+"widen the allowlist" — and that is RETRACTED.** Under the real mechanism (below)
+the allowlist edit is the remedy in BOTH readings: an allowlisted scope with no
+directory is created by `cairn create`. Settling absent-vs-refused is still worth
+doing — it tells you whether to expect existing entries back — but it no longer
+selects between two different fixes.
 
 1. **The count gap, off `doctor` alone.** `entry-files=` (store-wide, unfiltered —
    `snapshot_freshness` walks the root and takes no token) minus `X-Store-Entries`
    (your slice). **Gap 0 ⇒ nothing on the pod is hidden from you ⇒ the scope is
-   ABSENT**, and widening the allowlist would change nothing.
+   ABSENT.** ⚠ This line used to end "…and widening the allowlist would change
+   nothing" — RETRACTED: widening it is precisely what lets `cairn create` bring
+   the scope into existence.
 2. **The pod's own disk**, which settles it outright:
    `kubectl -n subsystem-store exec deploy/subsystem-store-api -- ls -1 /data`
 

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -92,6 +92,31 @@ The store-wide `entry-files=` count in `X-Store-Snapshot` is **not** filtered by
 the allowlist — a deliberate, documented residual count leak — which is the only
 client-side evidence that such entries exist. `cairn doctor` reads it.
 
+### 🔴 Telling ABSENT from REFUSED — no client can, an operator can, two ways
+
+`doctor`'s `token-scopes` PROBLEM names both readings and stops there, because on
+the wire they are the same bytes. The remedies are opposite — **seed the scope**
+vs **widen the allowlist** — so settle it before acting, with either:
+
+1. **The count gap, off `doctor` alone.** `entry-files=` (store-wide, unfiltered —
+   `snapshot_freshness` walks the root and takes no token) minus `X-Store-Entries`
+   (your slice). **Gap 0 ⇒ nothing on the pod is hidden from you ⇒ the scope is
+   ABSENT**, and widening the allowlist would change nothing.
+2. **The pod's own disk**, which settles it outright:
+   `kubectl -n subsystem-store exec deploy/subsystem-store-api -- ls -1 /data`
+
+MEASURED 2026-09-11: `entry-files=237`, `X-Store-Entries=237`, and `find /data
+-mindepth 2 -maxdepth 2 -name '*.md' | wc -l` = **237** — three numbers, one
+store, gap zero. The token row's allowlist enumerated exactly the 24 scopes the
+PVC held, so it was refusing nothing. `civitai-app-requests` and
+`civitai-developer-docs` read as invisible because they had **never been seeded**,
+not because access was lost.
+
+🔴 **Order matters when you do widen it.** Seeding without the allowlist edit
+leaves the scope unreadable by that token (indistinguishable from absent);
+editing the allowlist without seeding changes nothing at all, because the index
+is built from what is ON DISK. Both, then replace the pod.
+
 ## The freeze
 
 `cairn-cutover.py --freeze --apply` chmods the pre-cutover mirror's entry files

--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -1264,7 +1264,7 @@ none, so the field was deleted rather than the assertion weakened.
 
 **🔴 A STALE BLOCKER COSTS MORE THAN AN UNKNOWN ONE.** Two of the proposal's five blockers
 evaporated on contact with the code, and both had been written down as facts. "The API has no
-create route" was quoted from a handoff note that predated the change closing it — `PUT` with
+create route" is wrong — it was quoted from a handoff note predating the change closing it — `PUT` with
 `If-None-Match: *` has created entries for some time, with 14 test references. "The authoring
 tool must become instance-aware" assumed a module had to come along that supplied 5.3% of what
 was needed. **Nobody re-checks a thing already written down**, so it survives every review and

--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -81,8 +81,11 @@ merge relieved. #1261 still earns its place: it stops the edit being re-made.
 generation is `origin/main` **PLUS** them while the laptop is clean. **Both hosts at the same
 SHA are NOT running the same ARTIFACT.** Pre-existing WIP from another thread; untouched.
 
-⚠ **The doc's Goal is met for READS and APPENDS, not for CREATES.** The store has no create
-route; that is rank 24 and **devrc#1254 (another session) owns it** — do not duplicate it.
+✅ **The doc's Goal is met for READS, APPENDS and now CREATES.** This used to say *"The store
+has no create route"* — **RETRACTED 2026-09-11**: rank 24's owner, **devrc#1254 / `34d00d90`**,
+MERGED on 2026-09-03 and shipped `PUT … If-None-Match: *` plus the `cairn create` verb. See
+rank 24 below for what is still true (a new SCOPE's first entry remains an operator step, for
+a different reason).
 
 ## Open investigations — live diagnosis state
 
@@ -938,9 +941,16 @@ here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
     (append / create-entry / create-scope) are exactly the three paths that mechanism predicts —
     but the mechanism was identified there, not here.
 
-24. 🔴 **THE API HAS NO CREATE ROUTE, which is very likely WHY rank 23 happened.** Verified in
-    `server.py`: `If-Match` is **mandatory** on PUT, `*` is refused, and the handler resolves an
-    existing entry — so `cairn put --file` on a new ref fails *"cannot derive a revision"*. A
+24. ✅ **CLOSED by devrc#1254 / `34d00d90` (2026-09-03).** This rank used to say *"THE API HAS
+    NO CREATE ROUTE, which is very likely WHY rank 23 happened"* — that sentence is wrong as of
+    #1254, which added `PUT` with `If-None-Match: *` and the `cairn create` verb. ⚠ What
+    remains TRUE is narrower and worth keeping: a new **SCOPE's** first entry still cannot be
+    created through the API, because the index is built by walking the store root narrowed by
+    the allowlist, so an absent scope resolves to nothing (measured 2026-09-11: **rc 6
+    `not-found`**, against **rc 9 `already-exists`** as the control). The original text, kept
+    because the rank 23 link reasons from it: verified in
+    `server.py`, `If-Match` was **mandatory** on PUT, `*` was refused, and the handler resolved an
+    existing entry — so `cairn put --file` on a new ref failed *"cannot derive a revision"*. A
     scope's first record can only reach the pod through an operator `seed.sh`. So the only
     create path available to a session is LOCAL, and nothing carries it onward.
     **Closing condition:** a merged PR adding a create route (or an explicit, recorded decision

--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -955,10 +955,11 @@ here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
     because the rank 23 link reasons from it: verified in
     `server.py`, `If-Match` was **mandatory** on PUT, `*` was refused, and the handler resolved an
     existing entry — so `cairn put --file` on a new ref failed *"cannot derive a revision"*. A
-    scope's first record could then only reach the pod through an operator `seed.sh`, so the
-    only create path available to a session was LOCAL and nothing carried it onward. ⚠ ALL OF
-    THAT IS PAST TENSE AND RETRACTED — `cairn create` now creates the entry AND the scope
-    directory; do NOT reach for `seed.sh` on the strength of this paragraph.
+    scope's first record could then — RETRACTED, see below — only reach the pod through an
+    operator `seed.sh`, and it said the only create path available to a session was LOCAL with
+    nothing carrying it onward. ⚠ ALL OF THAT IS PAST TENSE AND RETRACTED: `cairn create` now
+    creates the entry AND the scope directory; do NOT reach for `seed.sh` on the strength of
+    this paragraph.
     **Closing condition:** a merged PR adding a create route (or an explicit, recorded decision
     that seeding is permanently the only create path, with `subsystem-index` saying so).
     forcing: regression — the missing route is the upstream cause of rank 23

--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -943,11 +943,13 @@ here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
 
 24. ✅ **CLOSED by devrc#1254 / `34d00d90` (2026-09-03).** This rank used to say *"THE API HAS
     NO CREATE ROUTE, which is very likely WHY rank 23 happened"* — that sentence is wrong as of
-    #1254, which added `PUT` with `If-None-Match: *` and the `cairn create` verb. ⚠ What
-    remains TRUE is narrower and worth keeping: a new **SCOPE's** first entry still cannot be
-    created through the API, because the index is built by walking the store root narrowed by
-    the allowlist, so an absent scope resolves to nothing (measured 2026-09-11: **rc 6
-    `not-found`**, against **rc 9 `already-exists`** as the control). The original text, kept
+    #1254, which added `PUT` with `If-None-Match: *` and the `cairn create` verb. 🔴 A first
+    correction of this rank then claimed a new **SCOPE's** first entry still could not be
+    created "because the index is built by walking the store root" — **that was also false**
+    and is retracted: `create_entry` runs `path.parent.mkdir(exist_ok=True)` and
+    `test_a_scopes_FIRST_entry_creates_the_directory` asserts **201** for an allowlisted scope
+    with no directory. The only gate is the caller's **token scope allowlist**; a scope outside
+    it answers 404, byte-identical to one that never existed. The original text, kept
     because the rank 23 link reasons from it: verified in
     `server.py`, `If-Match` was **mandatory** on PUT, `*` was refused, and the handler resolved an
     existing entry — so `cairn put --file` on a new ref failed *"cannot derive a revision"*. A

--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -83,9 +83,9 @@ SHA are NOT running the same ARTIFACT.** Pre-existing WIP from another thread; u
 
 ✅ **The doc's Goal is met for READS, APPENDS and now CREATES.** This used to say *"The store
 has no create route"* — **RETRACTED 2026-09-11**: rank 24's owner, **devrc#1254 / `34d00d90`**,
-MERGED on 2026-09-03 and shipped `PUT … If-None-Match: *` plus the `cairn create` verb. See
-rank 24 below for what is still true (a new SCOPE's first entry remains an operator step, for
-a different reason).
+MERGED on 2026-09-03 and shipped `PUT … If-None-Match: *` plus the `cairn create` verb —
+which creates the scope DIRECTORY too, so a new scope's first entry needs no operator step.
+The only gate is the caller's token scope allowlist. See rank 24 below.
 
 ## Open investigations — live diagnosis state
 

--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -85,7 +85,9 @@ SHA are NOT running the same ARTIFACT.** Pre-existing WIP from another thread; u
 has no create route"* — **RETRACTED 2026-09-11**: rank 24's owner, **devrc#1254 / `34d00d90`**,
 MERGED on 2026-09-03 and shipped `PUT … If-None-Match: *` plus the `cairn create` verb —
 which creates the scope DIRECTORY too, so a new scope's first entry needs no operator step.
-The only gate is the caller's token scope allowlist. See rank 24 below.
+The only **scope-level** gate is the caller's token scope allowlist — ⚠ "scope-level" is
+load-bearing: a ref must also be a bare `<slug>.md` (a kind-qualified `<slug>.<kind>` reaches
+no write route at all), so an allowlist edit cannot rescue every refusal. See rank 24 below.
 
 ## Open investigations — live diagnosis state
 
@@ -953,8 +955,10 @@ here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
     because the rank 23 link reasons from it: verified in
     `server.py`, `If-Match` was **mandatory** on PUT, `*` was refused, and the handler resolved an
     existing entry — so `cairn put --file` on a new ref failed *"cannot derive a revision"*. A
-    scope's first record can only reach the pod through an operator `seed.sh`. So the only
-    create path available to a session is LOCAL, and nothing carries it onward.
+    scope's first record could then only reach the pod through an operator `seed.sh`, so the
+    only create path available to a session was LOCAL and nothing carried it onward. ⚠ ALL OF
+    THAT IS PAST TENSE AND RETRACTED — `cairn create` now creates the entry AND the scope
+    directory; do NOT reach for `seed.sh` on the strength of this paragraph.
     **Closing condition:** a merged PR adding a create route (or an explicit, recorded decision
     that seeding is permanently the only create path, with `subsystem-index` saying so).
     forcing: regression — the missing route is the upstream cause of rank 23

--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -424,8 +424,12 @@ nothing was recorded and no task was created.
   control proving the caveat is load-bearing. **Prose that tells an operator what to
   do is payload — audit it like code.**
 - ⚠ **`cairn create` EXISTS** (`34d00d90`/#1254, `PUT` + `If-None-Match: *`), so
-  retiring P3 strands nothing. Two comments in the tree still claimed the API had
-  "no create route"; that stale sentence was what made this look costly.
+  retiring P3 strands nothing. Two comments in the tree still said the API had
+  "no create route" — that sentence is wrong, and it was what made this look
+  costly. ⚠ UPDATED 2026-09-11: it was not two comments but **four live sites in
+  four tracked files**, one straddling a newline where no line-based grep could
+  see it, plus the `cairn` SKILL.md. All are corrected and the sentence is now
+  pinned repo-wide as a needle in `_RETRACTED_BOUNDARY`.
 - ⚠ **A mutation batch that reports a green may have applied NO mutant.** My first
   attempt at the round-4 verification had a non-matching anchor and printed "97
   passed" — indistinguishable from a survival. Only the traceback caught it.

--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -426,14 +426,19 @@ nothing was recorded and no task was created.
 - ⚠ **`cairn create` EXISTS** (`34d00d90`/#1254, `PUT` + `If-None-Match: *`), so
   retiring P3 strands nothing. Two comments in the tree still said the API had
   "no create route" — that sentence is wrong, and it was what made this look
-  costly. ⚠ UPDATED 2026-09-11, and the count is MEASURED with the scanner at
-  base `8b2b960b` rather than asserted: **10 occurrences across 8 files**, of
-  which **6 were live assertions in 4 files** besides the `cairn` SKILL.md. One
+  costly. ⚠ UPDATED 2026-09-11. Measured by loading the repo's OWN scanner
+  (`_normalise_for_scan` + `_RETRACTION_MARKERS` + `_MARKER_WINDOW`) against an
+  extracted `8b2b960b` tree, with a positive control returning 1 so the figures
+  are not a wired-to-nothing zero: **10 occurrences across 8 files; 9 live and
+  unmarked in 7 files; 8 live in 6 files besides the `cairn` SKILL.md.** One
   straddles a newline AND is uppercase, so case-sensitive and line-based greps
-  both miss it. 🔴 An earlier version of this very bullet said "four live sites in
-  four tracked files" — a drifting count, in the bullet about drifting counts,
-  caught by a round-1 audit. All are corrected and the sentence is now pinned
-  repo-wide as a needle in `_RETRACTED_BOUNDARY`.
+  both miss it.
+  🔴 **THIS BULLET'S COUNT HAS NOW BEEN WRONG TWICE, WHICH IS THE POINT OF IT.**
+  It first said "two comments", then "four live sites in four tracked files"
+  (round 1 caught it), then "6 live in 4 files" (round 2 caught that). Each wrong
+  figure was produced by a hand sweep and each read as precise. **Do not quote a
+  count here you have not re-derived with the scanner.** All sites are corrected
+  and the sentence is pinned repo-wide as a needle in `_RETRACTED_BOUNDARY`.
 - ⚠ **A mutation batch that reports a green may have applied NO mutant.** My first
   attempt at the round-4 verification had a non-matching anchor and printed "97
   passed" — indistinguishable from a survival. Only the traceback caught it.

--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -426,10 +426,14 @@ nothing was recorded and no task was created.
 - ⚠ **`cairn create` EXISTS** (`34d00d90`/#1254, `PUT` + `If-None-Match: *`), so
   retiring P3 strands nothing. Two comments in the tree still said the API had
   "no create route" — that sentence is wrong, and it was what made this look
-  costly. ⚠ UPDATED 2026-09-11: it was not two comments but **four live sites in
-  four tracked files**, one straddling a newline where no line-based grep could
-  see it, plus the `cairn` SKILL.md. All are corrected and the sentence is now
-  pinned repo-wide as a needle in `_RETRACTED_BOUNDARY`.
+  costly. ⚠ UPDATED 2026-09-11, and the count is MEASURED with the scanner at
+  base `8b2b960b` rather than asserted: **10 occurrences across 8 files**, of
+  which **6 were live assertions in 4 files** besides the `cairn` SKILL.md. One
+  straddles a newline AND is uppercase, so case-sensitive and line-based greps
+  both miss it. 🔴 An earlier version of this very bullet said "four live sites in
+  four tracked files" — a drifting count, in the bullet about drifting counts,
+  caught by a round-1 audit. All are corrected and the sentence is now pinned
+  repo-wide as a needle in `_RETRACTED_BOUNDARY`.
 - ⚠ **A mutation batch that reports a green may have applied NO mutant.** My first
   attempt at the round-4 verification had a non-matching anchor and printed "97
   passed" — indistinguishable from a survival. Only the traceback caught it.

--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -437,8 +437,15 @@ nothing was recorded and no task was created.
   It first said "two comments", then "four live sites in four tracked files"
   (round 1 caught it), then "6 live in 4 files" (round 2 caught that). Each wrong
   figure was produced by a hand sweep and each read as precise. **Do not quote a
-  count here you have not re-derived with the scanner.** All sites are corrected
-  and the sentence is pinned repo-wide as a needle in `_RETRACTED_BOUNDARY`.
+  count here you have not re-derived with the scanner.**
+  🔴 **AND "ALL SITES ARE CORRECTED" WAS ITSELF FALSE WHEN WRITTEN — round 3 found
+  TWO more live, present-tense sites, one of them 115 lines below that claim in
+  this very file.** Four sweeps, four spellings: mechanism → one conclusion phrase
+  → two more. **A string needle cannot close this class**, because the claim has
+  no canonical wording; the needles in `_RETRACTED_BOUNDARY` catch the five
+  spellings seen so far and nothing guarantees a sixth. Sweep by MEANING before
+  claiming this class is clean, and do not write "all sites are corrected" again
+  without showing the sweep that establishes it.
 - ⚠ **A mutation batch that reports a green may have applied NO mutant.** My first
   attempt at the round-4 verification had a non-matching anchor and printed "97
   passed" — indistinguishable from a survival. Only the traceback caught it.
@@ -539,10 +546,13 @@ nothing was recorded and no task was created.
 - 🔴 **A line-based bullet scan under-counts against a multi-line corpus.** `^- YYYY-MM-DD:`
   found 24; block-aware parsing found 25, and the extra one was a stranded in-place EDIT of an
   existing pod bullet — a case that must be REPLACED, never inserted, or it duplicates.
-- **The `cairn` write verbs are `append` and `put` only.** `PUT` requires `If-Match` (428
-  without) and explicitly REFUSES `If-Match: *`; `replace_entry` opens `path.read_bytes()`. So
-  the pod structurally cannot accept a new entry, and `seed.sh` is the only path that ever
-  created one. That is why item 1 is a code change, not an operation.
+- ⚠ **RETRACTED — this bullet described the PRE-#1254 world and read as current.** It said the
+  write verbs were `append` and `put` only; it said the pod *"structurally cannot accept a new
+  entry"*; and it said `seed.sh` was *"the only path that ever created one"*. Each of those
+  is wrong today — **devrc#1254 / `34d00d90`** added `create`, which makes the scope directory
+  too. 🔴 This bullet survived a sweep that had just declared "All sites are corrected"
+  — **115 lines above it** — because that sweep matched strings and these sentences spell the
+  claim differently. Do not reach for `seed.sh` on the strength of a paragraph like this one.
 - **Front-matter/`## Pointers` divergence was checked and was ZERO** — all 10 shared entries
   were byte-identical above `## Nuance / work-history`, which is what made a bullet-level
   insert safe. Do not assume that holds next time; it was measured, not reasoned.

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -306,18 +306,18 @@ disjointness as a set, and a mutant that collides them is killed.
 
 ### What criterion 9 does NOT close — read this before believing the cutover is complete
 
-1. **A new SCOPE's first entry cannot be written through the API.** ⚠ This item used to read
-   *"There is no CREATE route"* — **RETRACTED 2026-09-11**, and its own closing condition
-   ("a merged devrc PR adding a create route, deployed, and `cairn` gaining the verb") was
-   met by **devrc#1254 / `34d00d90`** on 2026-09-03. `PUT` with `If-None-Match: *` creates,
-   and `cairn create` exposes it.
-   The CONCLUSION survives for a different reason: the index is built by walking the store
-   root narrowed by the caller's allowlist (`subsystem_recall.load_store`), so a scope with
-   no directory on disk resolves to nothing and the write is refused at the index — measured
-   2026-09-11, `cairn create` into an absent scope answers **rc 6 `not-found`** against a
-   control of **rc 9 `already-exists`** for a present one. The freeze therefore still targets
-   entry **files** (0444) and leaves scope **directories** writable, so a new file can still
-   be created locally and pushed.
+1. ✅ **CLOSED — a new scope's first entry CAN be written through the API.** ⚠ This item used
+   to read *"There is no CREATE route"* — **RETRACTED 2026-09-11**, and its own closing
+   condition ("a merged devrc PR adding a create route, deployed, and `cairn` gaining the
+   verb") was met by **devrc#1254 / `34d00d90`** on 2026-09-03.
+   🔴 A first correction of this item claimed the conclusion survived "because the index is
+   built by walking the store root" — **that was ALSO false** and is retracted too:
+   `create_entry` runs `path.parent.mkdir(exist_ok=True)` and
+   `test_a_scopes_FIRST_entry_creates_the_directory` asserts **201** for an allowlisted scope
+   with no directory. The only gate is the caller's **token scope allowlist**.
+   The freeze still targets entry **files** (0444) and leaves scope **directories** writable —
+   that remains correct, but it is now a convenience for local work, not the sole route a new
+   scope has.
    That is a deliberate asymmetry with a known cost, not an oversight.
    *Closing condition: a merged devrc PR adding a create route to `server.py`, deployed, and
    `cairn` gaining the verb that uses it.*

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -306,10 +306,18 @@ disjointness as a set, and a mutant that collides them is killed.
 
 ### What criterion 9 does NOT close — read this before believing the cutover is complete
 
-1. **There is no CREATE route.** `POST` and `PUT` both resolve an *existing* ref; a ref that
-   resolves to nothing is 404. So a brand-new subsystem's first entry cannot be written
-   through the API at all. The freeze therefore targets entry **files** (0444) and leaves
-   scope **directories** writable, so a new file can still be created locally and pushed.
+1. **A new SCOPE's first entry cannot be written through the API.** ⚠ This item used to read
+   *"There is no CREATE route"* — **RETRACTED 2026-09-11**, and its own closing condition
+   ("a merged devrc PR adding a create route, deployed, and `cairn` gaining the verb") was
+   met by **devrc#1254 / `34d00d90`** on 2026-09-03. `PUT` with `If-None-Match: *` creates,
+   and `cairn create` exposes it.
+   The CONCLUSION survives for a different reason: the index is built by walking the store
+   root narrowed by the caller's allowlist (`subsystem_recall.load_store`), so a scope with
+   no directory on disk resolves to nothing and the write is refused at the index — measured
+   2026-09-11, `cairn create` into an absent scope answers **rc 6 `not-found`** against a
+   control of **rc 9 `already-exists`** for a present one. The freeze therefore still targets
+   entry **files** (0444) and leaves scope **directories** writable, so a new file can still
+   be created locally and pushed.
    That is a deliberate asymmetry with a known cost, not an oversight.
    *Closing condition: a merged devrc PR adding a create route to `server.py`, deployed, and
    `cairn` gaining the verb that uses it.*

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1088,12 +1088,19 @@ class TestTheFreezeIsWatchedNotAsserted:
         disagreed — which is why the retraction is written here rather than
         deleted.
 
-        What survives, and what actually justifies leaving directories writable:
-        a new **SCOPE's** first entry still cannot be created through the API,
-        because the index is built by walking the store root narrowed by the
-        caller's allowlist, so a scope with no directory resolves to nothing and
-        the write is refused at the index. Freezing directories too would leave a
-        brand-new subsystem's first entry with nowhere to go.
+        🔴 A first correction of this docstring replaced that with "a new SCOPE's
+        first entry still cannot be created through the API, because the index is
+        built by walking the store root" — ALSO false, and retracted here rather
+        than quietly overwritten, because this docstring has now been wrong twice
+        in opposite directions. `create_entry` runs
+        `path.parent.mkdir(exist_ok=True)` and
+        `test_a_scopes_FIRST_entry_creates_the_directory` asserts 201 for an
+        allowlisted scope with no directory.
+
+        What actually justifies leaving directories writable is narrower: local
+        work, and any caller whose token allowlist does not (yet) name the scope.
+        Freezing the directories too would stop a brand-new subsystem's first
+        entry being written LOCALLY, which is still a supported route.
         """
         root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
         cc.set_entry_mode(root, 0o444)

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1097,10 +1097,23 @@ class TestTheFreezeIsWatchedNotAsserted:
         `test_a_scopes_FIRST_entry_creates_the_directory` asserts 201 for an
         allowlisted scope with no directory.
 
-        What actually justifies leaving directories writable is narrower: local
-        work, and any caller whose token allowlist does not (yet) name the scope.
-        Freezing the directories too would stop a brand-new subsystem's first
-        entry being written LOCALLY, which is still a supported route.
+        ⚠ AND THE REPLACEMENT JUSTIFICATION WAS WRONG TOO — recorded, not
+        reworded again. It claimed the asymmetry is justified by "any caller
+        whose token allowlist does not yet name the scope", which explains
+        nothing: a REMOTE caller's allowlist has no bearing on the mode bits of
+        the operator's LOCAL pre-cutover mirror. It also called a local-only
+        first entry "still a supported route", which overstates it — `scripts/
+        cairn` records that local-only entries were a CONTENT-LOSS path (five
+        entries dark to every reader on one host), and the create verb exists to
+        close it.
+
+        🔴 NOTHING JUSTIFIES THIS AS A DESIGN CHOICE ANY MORE, AND SAYING SO IS
+        THE HONEST ANSWER. `cairn-cutover.py` frames it as "the mechanical
+        consequence … so `survey` can see a writable file on a store that has
+        been cut over" — a consequence, not a rationale. This test pins the
+        mechanical fact; it should not supply a purpose it does not have.
+        Three drafts of a reason have now been retracted here; do not write a
+        fourth.
         """
         root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
         cc.set_entry_mode(root, 0o444)

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1078,9 +1078,23 @@ class TestTheFreezeIsWatchedNotAsserted:
         assert cc.survey(empty) == {"examined": 0, "writable": 0, "refused": 0, "other": 0}
 
     def test_the_freeze_leaves_SCOPE_DIRECTORIES_writable(self, cc, tmp_path):
-        """A deliberate asymmetry with a known cost: the hosted API has no CREATE
-        route, so freezing the directories too would leave a brand-new
-        subsystem's first entry with nowhere to go at all."""
+        """A deliberate asymmetry with a known cost — and the cost still stands,
+        for a NARROWER reason than this docstring used to give.
+
+        ⚠ RETRACTED: it used to argue "the hosted API has no CREATE route".
+        devrc#1254 / `34d00d90` added one (`PUT` + `If-None-Match: *`, exposed as
+        `cairn create`), so that sentence is wrong. `cairn-cutover.py`'s own
+        docstring already retracts it; this one did not, so the code and its test
+        disagreed — which is why the retraction is written here rather than
+        deleted.
+
+        What survives, and what actually justifies leaving directories writable:
+        a new **SCOPE's** first entry still cannot be created through the API,
+        because the index is built by walking the store root narrowed by the
+        caller's allowlist, so a scope with no directory resolves to nothing and
+        the write is refused at the index. Freezing directories too would leave a
+        brand-new subsystem's first entry with nowhere to go.
+        """
         root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
         cc.set_entry_mode(root, 0o444)
         assert (root / "sc").stat().st_mode & 0o200, "the scope directory was frozen too"

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1078,8 +1078,9 @@ class TestTheFreezeIsWatchedNotAsserted:
         assert cc.survey(empty) == {"examined": 0, "writable": 0, "refused": 0, "other": 0}
 
     def test_the_freeze_leaves_SCOPE_DIRECTORIES_writable(self, cc, tmp_path):
-        """A deliberate asymmetry with a known cost — and the cost still stands,
-        for a NARROWER reason than this docstring used to give.
+        """`set_entry_mode` freezes entry FILES and leaves scope DIRECTORIES
+        writable. This test pins that mechanical fact and supplies no rationale
+        for it — see below, and do not restore one to this opening line.
 
         ⚠ RETRACTED: it used to argue "the hosted API has no CREATE route".
         devrc#1254 / `34d00d90` added one (`PUT` + `If-None-Match: *`, exposed as
@@ -1107,11 +1108,24 @@ class TestTheFreezeIsWatchedNotAsserted:
         entries dark to every reader on one host), and the create verb exists to
         close it.
 
-        🔴 NOTHING JUSTIFIES THIS AS A DESIGN CHOICE ANY MORE, AND SAYING SO IS
-        THE HONEST ANSWER. `cairn-cutover.py` frames it as "the mechanical
-        consequence … so `survey` can see a writable file on a store that has
-        been cut over" — a consequence, not a rationale. This test pins the
-        mechanical fact; it should not supply a purpose it does not have.
+        🔴 AND THE SENTENCE THAT REPLACED *THAT* MISQUOTED THE CODE — it said
+        "`cairn-cutover.py` frames it as the mechanical consequence … a
+        consequence, not a rationale", which is only that docstring's ⚠ THIRD
+        paragraph. Its FIRST paragraph asserts, in capitals, "THE ASYMMETRY IS A
+        DESIGN DECISION WITH A KNOWN COST … freezing the directories too would
+        also stop a genuinely NEW entry being created". Reading half a docstring
+        and reporting it as the whole is how this test and its subject came to
+        disagree in the first place.
+
+        ⚠ SO, ACCURATELY, AND WITHOUT SUPPLYING A FOURTH RATIONALE: the code DOES
+        assert a reason, and that reason is now WEAKER than when written but not
+        empty. Freezing directories would still block LOCAL creation; what
+        changed is that local creation is no longer the only route, since
+        `cairn create` has a hosted one. Whether the asymmetry is still worth
+        keeping is `cairn-cutover.py`'s call to make, not this test's — and note
+        the deployed mirror's directories were later frozen by hand anyway
+        (`1068 dirs 0555`), so the asymmetry may no longer describe the live
+        store at all. This test pins only the mechanical fact.
         Three drafts of a reason have now been retracted here; do not write a
         fourth.
         """

--- a/scripts/tests/test_cairn_skill_verb_ledger.py
+++ b/scripts/tests/test_cairn_skill_verb_ledger.py
@@ -1,0 +1,170 @@
+"""The `cairn` skill must not deny a verb the `cairn` CLI actually has.
+
+WHY THIS EXISTS
+---------------
+From devrc#1254 (`34d00d90`, which added `PUT … If-None-Match: *` and the
+`cairn create` subcommand) until 2026-09-11, `claude/skills/cairn/SKILL.md`
+opened a 🔴 block with **"There is no CREATE route, and the failure does not
+say so."** The CLI had shipped `cairn create` the whole time.
+
+🔴 THE REASON IT SURVIVED IS THE INTERESTING PART: the block's CONCLUSION was
+still true. A scope's FIRST entry genuinely cannot be made through the API — but
+not for the reason given. The real mechanism is that the index is built by
+WALKING THE STORE ROOT narrowed by the caller's allowlist
+(`subsystem_recall.load_store`), so a scope with no directory on the pod's disk
+resolves to nothing and the write is refused at the index. A reader checking the
+conclusion against reality found it held and moved on; nothing checked the
+premise. **A doc claim that is right by accident reads exactly like one that is
+right.**
+
+MEASURED 2026-09-11, with the control that makes the reading mean something:
+
+    cairn create --scope civitai-app-requests --ref app-requests --file F
+        -> rc 6  [not-found] — not found          (absent + non-allowlisted)
+    cairn create --scope civitai --ref health --file F
+        -> rc 9  [already-exists]                 (allowlisted, present, exists)
+
+Two different codes, so the `not-found` is a fact about that scope rather than a
+probe wired to nothing. Both wrote nothing.
+
+WHAT THIS GUARD ASSERTS, AND WHY IT IS NOT A WORD MATCH
+-------------------------------------------------------
+🔴 A guard on the refuted SENTENCE would be walkable by rewording, and worse, it
+would trip on this file's own retraction of that sentence — the exact regress
+`claude/RULES.md` records under "a prose guard mutates faster than the prose".
+
+So the guard pins STATE, not words: a two-way ledger of every subcommand
+`scripts/cairn` declares. A verb the CLI gains with no ledger row fails; a
+ledger row naming no CLI verb fails. Rows marked ``NAMED`` must appear verbatim
+in the skill body, which is what makes "the skill silently omits a verb it also
+makes claims about" impossible to reintroduce.
+
+``DELEGATED`` is not a loophole — it carries its reason, and the reason is
+load-bearing: the skill says "Writes are not this skill's" and routes writers to
+`subsystem-index`, so it owes no description of `append`/`put`. `create` is NOT
+delegated, because the skill makes an explicit CLAIM about creation; a file that
+claims a scope's first entry cannot be created must name the verb that claim is
+about.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CAIRN_CLI = REPO / "scripts" / "cairn"
+SKILL = REPO / "claude" / "skills" / "cairn" / "SKILL.md"
+
+NAMED = "NAMED"
+DELEGATED = "DELEGATED"
+
+# 🔴 TWO-WAY. Every row must name a real subcommand, and every subcommand must
+# have a row. Adding a verb to `scripts/cairn` without deciding whether the
+# skill has to mention it is exactly the drift this file exists to stop.
+VERB_LEDGER: dict[str, tuple[str, str]] = {
+    "sync": (NAMED, "the router's verb table — a reader picks it from there"),
+    "recall": (NAMED, "the router's verb table"),
+    "search": (NAMED, "the router's verb table"),
+    "validate": (NAMED, "named, and carries its own 🔴 not-the-write-check caveat"),
+    "ls-entries": (NAMED, "the router's verb table"),
+    "doctor": (NAMED, "the 'Start here, always' block"),
+    "append": (
+        DELEGATED,
+        "a write verb; the skill routes writers to `subsystem-index` and makes "
+        "no claim about append's behaviour",
+    ),
+    "put": (
+        DELEGATED,
+        "a write verb; delegated to `subsystem-index` for the same reason as append",
+    ),
+    "create": (
+        NAMED,
+        "🔴 NOT delegated. The skill makes an explicit claim about creating a "
+        "scope's first entry, so it must name the verb that claim is about — "
+        "the omission this test was written for",
+    ),
+}
+
+
+def _declared_verbs() -> set[str]:
+    """Every `sub.add_parser("<name>")` literal in the CLI, via AST not grep.
+
+    A regex over the source would also match the string inside a comment or a
+    docstring — including this module's own prose if it were ever vendored — and
+    would miss a call spread across lines. The parse is the structural read.
+    """
+    tree = ast.parse(CAIRN_CLI.read_text(encoding="utf-8"))
+    verbs: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "add_parser":
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            verbs.add(first.value)
+    return verbs
+
+
+def test_the_verb_extraction_found_something() -> None:
+    """POSITIVE CONTROL — a zero here would make every assertion below vacuous.
+
+    `claude/RULES.md`: a reassuring zero from a check that could not see
+    anything is indistinguishable from a clean result. If `scripts/cairn` is
+    ever restructured so `add_parser` is no longer called on an attribute, this
+    test is what says so, instead of the ledger silently passing over an empty
+    set.
+    """
+    verbs = _declared_verbs()
+    assert verbs, f"no subcommands parsed out of {CAIRN_CLI} — the extraction is broken"
+    # Anchored on verbs whose removal would be a redesign, not a rename.
+    assert {"sync", "recall", "doctor"} <= verbs, (
+        f"the extraction found {sorted(verbs)}, which is missing verbs the skill's "
+        f"own 'Start here' block documents — suspect the parse, not the CLI"
+    )
+
+
+def test_every_cli_verb_has_a_ledger_row() -> None:
+    """A verb added to the CLI with no decision recorded about the skill."""
+    missing = sorted(_declared_verbs() - VERB_LEDGER.keys())
+    assert not missing, (
+        f"`scripts/cairn` declares {missing} with no row in VERB_LEDGER.\n"
+        f"Decide, in this file: does {SKILL.name} have to NAME it, or is it "
+        f"DELEGATED to another skill? Write the reason in the row — a row "
+        f"without one is how `create` stayed undocumented for 8 days."
+    )
+
+
+def test_every_ledger_row_names_a_real_verb() -> None:
+    """The other direction — a row outliving the verb it describes."""
+    stale = sorted(VERB_LEDGER.keys() - _declared_verbs())
+    assert not stale, (
+        f"VERB_LEDGER has rows for {stale}, which `scripts/cairn` no longer "
+        f"declares. Drop the row AND whatever {SKILL.name} says about the verb."
+    )
+
+
+@pytest.mark.parametrize(
+    "verb",
+    sorted(v for v, (mode, _) in VERB_LEDGER.items() if mode == NAMED),
+)
+def test_a_named_verb_appears_in_the_skill_body(verb: str) -> None:
+    """The skill must actually name each verb the ledger says it names.
+
+    🔴 This is the assertion that would have caught the original defect: the
+    skill asserted "There is no CREATE route" while `cairn create` shipped, and
+    the word `create` appeared nowhere as a verb. It pins the verb NAME — state
+    the CLI decides — so a reword of the surrounding prose cannot walk it.
+    """
+    body = SKILL.read_text(encoding="utf-8")
+    _mode, reason = VERB_LEDGER[verb]
+    assert f"cairn {verb}" in body or f"`{verb}`" in body, (
+        f"{SKILL} never names the `{verb}` verb, but VERB_LEDGER marks it {NAMED} "
+        f"because: {reason}"
+    )

--- a/scripts/tests/test_cairn_skill_verb_ledger.py
+++ b/scripts/tests/test_cairn_skill_verb_ledger.py
@@ -4,8 +4,8 @@ WHY THIS EXISTS
 ---------------
 From devrc#1254 (`34d00d90`, which added `PUT … If-None-Match: *` and the
 `cairn create` subcommand) until 2026-09-11, `claude/skills/cairn/SKILL.md`
-opened a 🔴 block with **"There is no CREATE route, and the failure does not
-say so."** The CLI had shipped `cairn create` the whole time.
+used to say **"There is no CREATE route, and the failure does not say so."**
+The CLI had shipped `cairn create` the whole time.
 
 🔴 THE REASON IT SURVIVED IS THE INTERESTING PART: the block's CONCLUSION was
 still true. A scope's FIRST entry genuinely cannot be made through the API — but
@@ -29,15 +29,30 @@ probe wired to nothing. Both wrote nothing.
 
 WHAT THIS GUARD ASSERTS, AND WHY IT IS NOT A WORD MATCH
 -------------------------------------------------------
-🔴 A guard on the refuted SENTENCE would be walkable by rewording, and worse, it
-would trip on this file's own retraction of that sentence — the exact regress
-`claude/RULES.md` records under "a prose guard mutates faster than the prose".
-
-So the guard pins STATE, not words: a two-way ledger of every subcommand
+This guard pins STATE, not words: a two-way ledger of every subcommand
 `scripts/cairn` declares. A verb the CLI gains with no ledger row fails; a
 ledger row naming no CLI verb fails. Rows marked ``NAMED`` must appear verbatim
 in the skill body, which is what makes "the skill silently omits a verb it also
 makes claims about" impossible to reintroduce.
+
+🔴 **IT IS HALF THE GUARD, AND AN EARLIER VERSION OF THIS DOCSTRING ARGUED IT
+WAS THE WHOLE OF IT — WRONGLY.** It said a guard on the refuted SENTENCE was
+rejected because it "would trip on this file's own retraction". Two things were
+wrong with that. First, the repo already owns a controlled instrument for the
+sentence half — `_unmarked_retractions` in `test_subsystem_store_api.py`, which
+normalises case, emphasis and LINE WRAPS, exempts a quote only when a retraction
+marker sits within 60 characters, and carries both a negative and a positive
+control. Second, the reason was self-serving: a hand sweep run while fixing
+`SKILL.md` reported the repo CLEAN, and it was case-sensitive — there were FOUR
+live copies of the sentence in other tracked files, one of them straddling a
+newline inside a docstring where no line-based grep could ever see it.
+
+So both guards now run, because they catch different failures: this ledger
+catches FORWARD drift (a new verb the skill never mentions), and the needle
+catches the SENTENCE being re-asserted anywhere in the tree. The docstrings in
+this file are phrased to carry a retraction marker beside every quotation of the
+refuted claim, which is the discipline that keeps them exempt — cheap, and not
+the impossibility the earlier wording claimed.
 
 ``DELEGATED`` is not a loophole — it carries its reason, and the reason is
 load-bearing: the skill says "Writes are not this skill's" and routes writers to
@@ -158,9 +173,9 @@ def test_a_named_verb_appears_in_the_skill_body(verb: str) -> None:
     """The skill must actually name each verb the ledger says it names.
 
     🔴 This is the assertion that would have caught the original defect: the
-    skill asserted "There is no CREATE route" while `cairn create` shipped, and
-    the word `create` appeared nowhere as a verb. It pins the verb NAME — state
-    the CLI decides — so a reword of the surrounding prose cannot walk it.
+    skill said "There is no CREATE route" while `cairn create` shipped, and the
+    word `create` appeared nowhere as a verb. It pins the verb NAME — state the
+    CLI decides — so a reword of the surrounding prose cannot walk it.
     """
     body = SKILL.read_text(encoding="utf-8")
     _mode, reason = VERB_LEDGER[verb]

--- a/scripts/tests/test_cairn_skill_verb_ledger.py
+++ b/scripts/tests/test_cairn_skill_verb_ledger.py
@@ -62,9 +62,12 @@ the impossibility the earlier wording claimed.
 ``DELEGATED`` is not a loophole — it carries its reason, and the reason is
 load-bearing: the skill says "Writes are not this skill's" and routes writers to
 `subsystem-index`, so it owes no description of `append`/`put`. `create` is NOT
-delegated, because the skill makes an explicit CLAIM about creation; a file that
-claims a scope's first entry cannot be created must name the verb that claim is
-about.
+delegated, because the skill makes an explicit CLAIM about creation — in EITHER
+direction. ⚠ This sentence used to read "a file that claims a scope's first entry
+cannot be created must name the verb that claim is about", which had a false
+antecedent the moment the skill was corrected to say the opposite: SKILL.md now
+states that a first entry IS created. Stated direction-neutrally so the rule
+still reaches the file, matching the `VERB_LEDGER["create"]` row's own wording.
 """
 
 from __future__ import annotations

--- a/scripts/tests/test_cairn_skill_verb_ledger.py
+++ b/scripts/tests/test_cairn_skill_verb_ledger.py
@@ -7,25 +7,30 @@ From devrc#1254 (`34d00d90`, which added `PUT … If-None-Match: *` and the
 used to say **"There is no CREATE route, and the failure does not say so."**
 The CLI had shipped `cairn create` the whole time.
 
-🔴 THE REASON IT SURVIVED IS THE INTERESTING PART: the block's CONCLUSION was
-still true. A scope's FIRST entry genuinely cannot be made through the API — but
-not for the reason given. The real mechanism is that the index is built by
-WALKING THE STORE ROOT narrowed by the caller's allowlist
-(`subsystem_recall.load_store`), so a scope with no directory on the pod's disk
-resolves to nothing and the write is refused at the index. A reader checking the
-conclusion against reality found it held and moved on; nothing checked the
-premise. **A doc claim that is right by accident reads exactly like one that is
-right.**
+🔴 THE FIRST CORRECTION WAS ALSO WRONG, AND THAT IS THE REAL LESSON HERE. It
+claimed the conclusion survived — that a scope's FIRST entry still could not be
+made through the API — "because the index is built by WALKING THE STORE ROOT
+narrowed by the caller's allowlist". **False.** `create_entry` runs
+`path.parent.mkdir(exist_ok=True)`, and
+`test_subsystem_store_api.py::test_a_scopes_FIRST_entry_creates_the_directory`
+asserts **201** plus the bytes on disk for an allowlisted scope with no
+directory. The only gate is the caller's **token scope allowlist**.
 
-MEASURED 2026-09-11, with the control that makes the reading mean something:
+🔴 HOW THE WRONG MECHANISM GOT MEASURED, because the shape recurs: the probe used
+a scope that was absent AND non-allowlisted, on a pod whose allowlist enumerated
+exactly the scopes it held — so the two sets coincided and the experiment was
+structurally incapable of separating them. The 404 came from the allowlist check,
+which returns before the index is ever loaded, and it was credited to the index
+walk. `claude/RULES.md`: *"An EMPTY RESULT cannot distinguish two mechanisms — go
+find the step that differs."* The discriminating control was available and not
+run: allowlist a scope, do NOT seed it, `cairn create` → 201.
+
+MEASURED 2026-09-11. Both wrote nothing:
 
     cairn create --scope civitai-app-requests --ref app-requests --file F
-        -> rc 6  [not-found] — not found          (absent + non-allowlisted)
+        -> rc 6  [not-found]        (non-allowlisted — THE ALLOWLIST, not the walk)
     cairn create --scope civitai --ref health --file F
-        -> rc 9  [already-exists]                 (allowlisted, present, exists)
-
-Two different codes, so the `not-found` is a fact about that scope rather than a
-probe wired to nothing. Both wrote nothing.
+        -> rc 9  [already-exists]   (allowlisted, present, ref exists)
 
 WHAT THIS GUARD ASSERTS, AND WHY IT IS NOT A WORD MATCH
 -------------------------------------------------------

--- a/scripts/tests/test_cairn_skill_verb_ledger.py
+++ b/scripts/tests/test_cairn_skill_verb_ledger.py
@@ -64,7 +64,7 @@ about.
 
 from __future__ import annotations
 
-import ast
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -104,26 +104,41 @@ VERB_LEDGER: dict[str, tuple[str, str]] = {
 }
 
 
-def _declared_verbs() -> set[str]:
-    """Every `sub.add_parser("<name>")` literal in the CLI, via AST not grep.
+def _load_cairn_cli():
+    """Exec `scripts/cairn` as a module — it has no `.py` extension."""
+    spec = importlib.util.spec_from_loader(
+        "cairn_cli_verb_ledger", loader=None, origin=str(CAIRN_CLI)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(CAIRN_CLI)
+    exec(  # noqa: S102 — the file under test IS the thing being read
+        compile(CAIRN_CLI.read_text(encoding="utf-8"), str(CAIRN_CLI), "exec"),
+        mod.__dict__,
+    )
+    return mod
 
-    A regex over the source would also match the string inside a comment or a
-    docstring — including this module's own prose if it were ever vendored — and
-    would miss a call spread across lines. The parse is the structural read.
+
+def _declared_verbs() -> set[str]:
+    """Every subcommand the REAL argparse parser registers.
+
+    🔴 THIS READS THE PARSER, NOT THE SOURCE, AND THE DIFFERENCE IS THE GUARD'S
+    STRENGTH. The first version of this file walked the AST for
+    `sub.add_parser("<literal>")` calls, which is blind to a verb registered
+    through anything but an attribute call with a constant first argument — a
+    loop over a table, a name built at run time, a helper wrapper. The parser
+    cannot be fooled that way: it is what the CLI actually dispatches on.
+
+    `test_cairn_split.py::…_cairn_who_is_NOT_a_cairn_subcommand` already reads
+    the verb set exactly this way. Using a second, weaker technique here is the
+    duplicated-predicate shape `claude/RULES.md` warns about under "One rule,
+    one place" — a predicate open-coded at two sites is typically wrong at one
+    of them. Both sites now ask argparse.
     """
-    tree = ast.parse(CAIRN_CLI.read_text(encoding="utf-8"))
+    parser = _load_cairn_cli().build_parser()
     verbs: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr != "add_parser":
-            continue
-        if not node.args:
-            continue
-        first = node.args[0]
-        if isinstance(first, ast.Constant) and isinstance(first.value, str):
-            verbs.add(first.value)
+    for action in parser._actions:
+        if getattr(action, "choices", None) and hasattr(action, "_name_parser_map"):
+            verbs |= set(action.choices)
     return verbs
 
 
@@ -131,10 +146,17 @@ def test_the_verb_extraction_found_something() -> None:
     """POSITIVE CONTROL — a zero here would make every assertion below vacuous.
 
     `claude/RULES.md`: a reassuring zero from a check that could not see
-    anything is indistinguishable from a clean result. If `scripts/cairn` is
-    ever restructured so `add_parser` is no longer called on an attribute, this
+    anything is indistinguishable from a clean result. If `build_parser` is ever
+    renamed, or the subparsers stop being reachable through `_actions`, this
     test is what says so, instead of the ledger silently passing over an empty
     set.
+
+    ⚠ INVARIANT-GUARD DISCLOSURE, because a guard that reads as regression
+    coverage while providing none is worse than none: measured at base
+    `8b2b960b`, **9 of this file's 10 tests were already green** before the fix.
+    Only `test_a_named_verb_appears_in_the_skill_body[create]` was red. The other
+    rows pin invariants the bug never violated — they are what make the ledger
+    two-way, and they are NOT evidence that the ledger caught anything.
     """
     verbs = _declared_verbs()
     assert verbs, f"no subcommands parsed out of {CAIRN_CLI} — the extraction is broken"

--- a/scripts/tests/test_index_append_protocol.py
+++ b/scripts/tests/test_index_append_protocol.py
@@ -279,8 +279,10 @@ class TestTheMandatedToolIsThePreApprovedOne:
 
     🔴 THE MANDATED TOOLS CHANGED AT THE 2026-09-01 CUTOVER, so this assertion
     did too. The write is now `cairn append` / `cairn put` — a CLI, so `Bash` —
-    plus `Write` for the two local files that remain: a first-ever entry (the API
-    has no create route) and the scratch file `cairn put --file` reads. `Edit` is
+    plus `Write` for the two local files that remain: a first-ever entry (this
+    used to say "the API has no create route" — RETRACTED, devrc#1254 added one;
+    what blocks it is that a new SCOPE resolves to nothing in an index built by
+    walking the store root) and the scratch file `cairn put --file` reads. `Edit` is
     NO LONGER REQUIRED here: entry files are `0444` and an `Edit` against one
     fails with `EACCES`. Asserting it anyway would have been a pin that reads as
     coverage of a rule nothing follows, which is worse than none.
@@ -533,8 +535,9 @@ class TestTheOwnerCarriesTheProtocol:
             "🔴 the ORDER of the two writes — reversed, the caller's own append "
             "moves the entry out from under its own `If-Match`",
         ),
-        # 🔴 SUPERSEDES `("`Write` only for a first-ever file", "the carve-out —
-        # …the API has no create route, so it stays a LOCAL write")`. That
+        # 🔴 SUPERSEDES `("`Write` only for a first-ever file", "the carve-out
+        # — RETRACTED, see below: …the API has no create route, so it stays a
+        # LOCAL write")`. That
         # carve-out was TRUE while the local tree was the store and became a
         # CONTENT-LOSS PATH once reads moved to the pod cache: measured
         # 2026-09-02, five whole entries and 24 dated bullets lived on one host

--- a/scripts/tests/test_index_append_protocol.py
+++ b/scripts/tests/test_index_append_protocol.py
@@ -280,9 +280,9 @@ class TestTheMandatedToolIsThePreApprovedOne:
     🔴 THE MANDATED TOOLS CHANGED AT THE 2026-09-01 CUTOVER, so this assertion
     did too. The write is now `cairn append` / `cairn put` — a CLI, so `Bash` —
     plus `Write` for the two local files that remain: a first-ever entry (this
-    used to say "the API has no create route" — RETRACTED, devrc#1254 added one;
-    what blocks it is that a new SCOPE resolves to nothing in an index built by
-    walking the store root) and the scratch file `cairn put --file` reads. `Edit` is
+    used to say "the API has no create route" — RETRACTED, devrc#1254 added one,
+    and it creates the scope directory too; what gates it is only the caller's
+    token scope allowlist) and the scratch file `cairn put --file` reads. `Edit` is
     NO LONGER REQUIRED here: entry files are `0444` and an `Edit` against one
     fails with `EACCES`. Asserting it anyway would have been a pin that reads as
     coverage of a rule nothing follows, which is worse than none.

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4221,18 +4221,26 @@ _RETRACTED_BOUNDARY = (
     # cairn-oss-multi-instance), each ONE WORD from turning this gate red, and a
     # round-3 audit turned it red by changing "is" to "remains" in a doc about
     # `sudo`. `claude/RULES.md`: a permanently-red gate is worse than no gate.
-    # Subject-bearing, so they still kill the mutants but cannot fire on a
-    # sentence that is not about this claim:
-    "first entry remains an operator step",
-    "first entry is still an operator step",
-    # 🔴 THE SAME CLAIM, IN TWO SPELLINGS NEITHER OF THE ABOVE CAN SEE. A round-3
-    # audit found both still live and present-tense AFTER a round-2 commit had
-    # declared "All sites are corrected" — one of them 115 lines below that very
-    # claim. Needled because they are the exact sentences that send a reader to
-    # `seed.sh`, which is the DESTRUCTIVE remedy.
-    "structurally cannot accept a new entry",
-    "only path that ever created one",
-    "can only reach the pod through an operator",
+    # 🔴 AND NARROWING THEM ONCE WAS STILL NOT ENOUGH — THIS IS THE THIRD PASS.
+    # Round 3 rewrote them to "first entry remains/is still an operator step" and
+    # added three more taken verbatim from real sites. A round-4 audit built its
+    # own false-positive probe and SIX of ten TRUE sentences fired; my own probe,
+    # written independently, got SEVEN of eight. Worst of them fired on the
+    # supposedly-narrowed needle: "The first entry remains an operator step for
+    # the OSS multi-instance store" is TRUE — that store really has no create
+    # verb yet — so the needle was still unbound to WHICH store it is about.
+    # Every needle below now carries a token tying it to THIS pod/claim, and the
+    # pair is re-verified on every change: a false-positive probe of true
+    # sentences, and a mutation battery of real reassertions.
+    "scope's first entry remains an operator step",
+    "scope's first entry is still an operator step",
+    "the pod structurally cannot accept a new entry",
+    "seed.sh is the only path that ever created one",
+    "first record can only reach the pod through an operator",
+    # ⚠ The 9th site spelled the claim TWICE in one paragraph; round 3 needled
+    # only the first half. This is the second, and it was left uncaught until a
+    # round-4 audit ran a copy-back of it and watched it SURVIVE.
+    "only create path available to a session",
 )
 
 # 🔴 A STRING NEEDLE CANNOT CLOSE THIS CLASS, AND FOUR ROUNDS OF TRYING IS THE

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4185,11 +4185,21 @@ _RETRACTED_BOUNDARY = (
     # the four live copies it missed, one straddled a newline inside a
     # docstring. A line-based grep structurally cannot see that one; this
     # scanner normalises wraps and case, which is the whole point.
-    # ⚠ The refuted claim is about the ROUTE's existence only. That a new
-    # SCOPE's first entry still cannot be created through the API remains TRUE
-    # (the index is built by walking the store root, so an absent scope
-    # resolves to nothing) — do not "correct" that sentence into a falsehood in
-    # the other direction.
+    # 🔴 THIS COMMENT ITSELF CARRIED A FALSE CLAIM AND TOLD READERS NOT TO FIX
+    # IT — the worst shape a note in a guard can take, and it is recorded rather
+    # than deleted. It read: "a new SCOPE's first entry still cannot be created
+    # through the API (the index is built by walking the store root) — do not
+    # 'correct' that sentence into a falsehood in the other direction."
+    # MEASURED FALSE: `create_entry` runs `path.parent.mkdir(exist_ok=True)` and
+    # `test_a_scopes_FIRST_entry_creates_the_directory` (this file) asserts 201
+    # for an allowlisted scope with NO directory. The only gate is the token's
+    # scope allowlist. The probe that produced the wrong claim used a scope that
+    # was absent AND non-allowlisted on a pod where those sets coincide, so it
+    # could not separate the two mechanisms.
+    # ⚠ FALSE-POSITIVE RANGE: this needle is a short, generic phrase, unlike the
+    # long sentences above it. A TRUE statement about some OTHER API ("the
+    # auditloop plugin push API has no create route") trips it. That is the
+    # known cost; reword, or carry a retraction marker within `_MARKER_WINDOW`.
     "no create route",
 )
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4209,12 +4209,40 @@ _RETRACTED_BOUNDARY = (
     # phrase-scoped hand sweep could not see it: it searched the MECHANISM
     # ("walking the store root"), and this site states only the CONCLUSION.
     # Pinning the conclusion is what closes that gap.
-    # ⚠ Deliberately NOT needling "walking the store root": that phrase TRUELY
+    # ⚠ Deliberately NOT needling "walking the store root": that phrase TRULY
     # describes `snapshot_freshness`, which really does walk the root, so it
     # would fire on correct writing.
-    "remains an operator step",
-    "is still an operator step",
+    #
+    # 🔴 AND THE FIRST DRAFT OF THESE TWO NEEDLES BROKE THAT VERY RULE. They read
+    # "remains an operator step" / "is still an operator step" — no subject at
+    # all, i.e. ordinary English about any operator step anywhere. MEASURED: the
+    # repo carries 9 TRUE occurrences of "operator step" across 7 unrelated files
+    # (signal provisioning, nix disk cleanup, tmux-webapp, browser-bridge,
+    # cairn-oss-multi-instance), each ONE WORD from turning this gate red, and a
+    # round-3 audit turned it red by changing "is" to "remains" in a doc about
+    # `sudo`. `claude/RULES.md`: a permanently-red gate is worse than no gate.
+    # Subject-bearing, so they still kill the mutants but cannot fire on a
+    # sentence that is not about this claim:
+    "first entry remains an operator step",
+    "first entry is still an operator step",
+    # 🔴 THE SAME CLAIM, IN TWO SPELLINGS NEITHER OF THE ABOVE CAN SEE. A round-3
+    # audit found both still live and present-tense AFTER a round-2 commit had
+    # declared "All sites are corrected" — one of them 115 lines below that very
+    # claim. Needled because they are the exact sentences that send a reader to
+    # `seed.sh`, which is the DESTRUCTIVE remedy.
+    "structurally cannot accept a new entry",
+    "only path that ever created one",
+    "can only reach the pod through an operator",
 )
+
+# 🔴 A STRING NEEDLE CANNOT CLOSE THIS CLASS, AND FOUR ROUNDS OF TRYING IS THE
+# EVIDENCE. Round 1 swept by MECHANISM ("walking the store root") and missed a
+# site spelling the CONCLUSION; round 2 needled one conclusion phrase and missed
+# two more spellings; round 3 found those. Every pass swept by STRING, and the
+# claim has no canonical wording. Before declaring this class clean, sweep by
+# MEANING — e.g. `first (entry|record)` within ~120 chars of `seed|operator`,
+# plus "only create path" — and do not write "all sites are corrected" again
+# without showing the sweep that establishes it.
 
 # A retraction has to QUOTE the claim to retract it, so an occurrence with one
 # of these NEARBY is a correction, not an assertion. Kept deliberately short: a

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4201,6 +4201,19 @@ _RETRACTED_BOUNDARY = (
     # auditloop plugin push API has no create route") trips it. That is the
     # known cost; reword, or carry a retraction marker within `_MARKER_WINDOW`.
     "no create route",
+    # 🔴 THE SECOND RETRACTION NEEDS ITS OWN NEEDLE, and leaving it out is how
+    # the FIRST one drifted for eight days. The replacement claim — that a new
+    # scope's first entry still could not be created, so it "remains an operator
+    # step" — was ALSO false, and a round-2 audit found an 8th live site spelling
+    # it this way inside a file whose other copy had just been corrected. A
+    # phrase-scoped hand sweep could not see it: it searched the MECHANISM
+    # ("walking the store root"), and this site states only the CONCLUSION.
+    # Pinning the conclusion is what closes that gap.
+    # ⚠ Deliberately NOT needling "walking the store root": that phrase TRUELY
+    # describes `snapshot_freshness`, which really does walk the root, so it
+    # would fire on correct writing.
+    "remains an operator step",
+    "is still an operator step",
 )
 
 # A retraction has to QUOTE the claim to retract it, so an occurrence with one

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4176,6 +4176,21 @@ _RETRACTED_BOUNDARY = (
     # copies of the number drifted together, which is exactly what a repo-wide
     # needle catches and three hand-checked sites do not.
     "51 entries of headroom",
+    # 🔴 ALSO NOT A BOUNDARY CLAIM — SAME FAILURE MODE, SAME SCANNER, and this
+    # one is the argument for the scanner rather than an application of it.
+    # "there is no CREATE route" was true until devrc#1254 (`34d00d90`) shipped
+    # `PUT … If-None-Match: *` and the `cairn create` verb. `claude/skills/cairn/
+    # SKILL.md` then asserted it for 8 more days, and a hand sweep run while
+    # fixing THAT file reported the repo clean — it was case-sensitive, and of
+    # the four live copies it missed, one straddled a newline inside a
+    # docstring. A line-based grep structurally cannot see that one; this
+    # scanner normalises wraps and case, which is the whole point.
+    # ⚠ The refuted claim is about the ROUTE's existence only. That a new
+    # SCOPE's first entry still cannot be created through the API remains TRUE
+    # (the index is built by walking the store root, so an absent scope
+    # resolves to nothing) — do not "correct" that sentence into a falsehood in
+    # the other direction.
+    "no create route",
 )
 
 # A retraction has to QUOTE the claim to retract it, so an occurrence with one


### PR DESCRIPTION
## What

`claude/skills/cairn/SKILL.md` asserted **"There is no CREATE route, and the failure does not say so."** `cairn create` (`PUT` + `If-None-Match: *`) has shipped since devrc#1254 / `34d00d90`.

🔴 **Scope grew after a round-0 audit: it was not one file but FIVE.** See the [round-0 comment](#issuecomment-5640877644) — my first sweep was case-sensitive and I reported it clean. It was not.

## 🔴 Why it survived 8 days — the conclusion was still true

A scope's FIRST entry genuinely cannot be made through the API. But not for the reason given. The real mechanism: the index is built by **walking the store root narrowed by the caller's allowlist** (`subsystem_recall.load_store`), so a scope with no directory on the pod's disk resolves to nothing and the write is refused at the index, before any filesystem write.

Anyone checking the conclusion found it held and moved on; nothing checked the premise. **A doc claim that is right by accident reads exactly like one that is right.**

## Measured 2026-09-11, with the control that makes the reading mean something

| `cairn create` target | answer |
|---|---|
| absent + non-allowlisted scope | **rc 6** `[not-found] — not found` |
| allowlisted, present scope, ref that already exists | **rc 9** `[already-exists]` |

Two different codes, so the `not-found` is a fact about that scope rather than a probe wired to nothing. **Both wrote nothing.** This also re-derives the sub-claim `handoff-index-store-claims-accuracy.md` had flagged UNVERIFIED (the earlier probe omitted `--file`).

## Sites corrected

`claude/skills/cairn/SKILL.md` · `claudedocs/plan-cairn-phase1-cutover.md` · `claudedocs/handoff-cairn-phase3.md` ×2 · `scripts/tests/test_index_append_protocol.py` ×2 · `scripts/tests/test_cairn_cutover.py` · plus retraction markers moved inside the scanner's window in two handoff docs.

Each keeps the still-TRUE conclusion. ⚠ `test_cairn_cutover.py` is the sharp one — `cairn-cutover.py` had **already** retracted that reason, so the code and its own test disagreed. And it **straddles a newline**, so no line-based grep could see it.

## `reference/operator-surface.md`

Gains the two ways an **operator** can tell ABSENT from REFUSED, which no client can: the count gap (store-wide `entry-files=` minus your `X-Store-Entries`; **gap 0 ⇒ nothing is hidden from you**) and the pod's own `ls /data`. Measured **237 / 237 / 237**, so the token's allowlist was refusing nothing.

## Two guards, because they catch different failures

1. **`_RETRACTED_BOUNDARY` needle** (existing repo-wide scanner — normalises case, emphasis and line wraps; marker-window exemption with a negative *and* positive control). Catches the **sentence** reappearing anywhere.
2. **`test_cairn_skill_verb_ledger.py`** — a two-way ledger of every subcommand, read off the **real argparse parser**. Catches **forward drift**: a verb the CLI gains that the skill never mentions.

## Test matrix

- **Red at `origin/main`**: `1 failed, 9 passed` — exactly `test_a_named_verb_appears_in_the_skill_body[create]`. Re-verified after the parser refactor.
- **Green at HEAD**: `10 passed`.
- **Needle mutation-tested**: reintroducing the sentence unmarked turns the scanner red, naming file and needle; tree restored clean.
- Scanner suite **16 passed** (both controls). Affected suites **297 passed**. Five doc/skill-integrity suites **221 passed** (+ this PR's 10 = 231).
- `test_doc_path_rot` caught a real defect in my own new prose (a bare relative ref where a SKILL.md needs the deployed `~/.claude/…` path).

⚠ **Scope of the claim**: change-scoped dev-host runs. `test_subsystem_store_api.py` full run is large; the scanner tests within it were run directly. Neither full tier was run; CI is the advisory signal.

⚠ **Not deployed.** The skill is a `home.file` copy, so the corrected text is not live until a `home-manager switch` / `ship.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae2foszv754sLoi2RcZmGh