### PR TITLE
fix(host-role): the probe reported every failure as silence, so a REFUSED HOST KEY read as a dead host

### DIFF
--- a/scripts/lib/host-role.sh
+++ b/scripts/lib/host-role.sh
@@ -124,6 +124,27 @@ remote_ssh_candidates_of() {
   esac
 }
 
+# probe_failure_state <stderr-text> -> untrusted-key | unreachable
+#
+# 🔴 WHY THIS EXISTS: "did not answer" was the ONE message every failure got,
+# and an empty result cannot distinguish the mechanisms that produce it. A host
+# that is powered off and a host whose key CHANGED — a reinstall, or a squatter
+# on the LAN address — were reported identically, so the second read as the
+# first and the operator went looking for a network fault. Ported from the
+# four-state reporting in PR #1287 (`scripts/workhost`), which was closed in
+# favour of keeping ONE mechanism; this is the part of it worth keeping.
+#
+# Classification is by ssh's own STDERR, not by exit status: ssh exits 255 for
+# every one of these, so the status cannot tell them apart.
+probe_failure_state() {
+  case "$1" in
+    *"REMOTE HOST IDENTIFICATION HAS CHANGED"*|*"Host key verification failed"*|\
+    *"differs from the key for the IP address"*|*"key for"*"has changed"*)
+      echo "untrusted-key" ;;
+    *) echo "unreachable" ;;
+  esac
+}
+
 # first_reachable_ssh <target>... -> the first target that answers, or empty.
 #
 # Probes with BatchMode (never prompts) and a bounded ConnectTimeout, running
@@ -132,16 +153,36 @@ remote_ssh_candidates_of() {
 # cleanly. Returns 1 when NOTHING answered — the caller must treat that as a
 # genuinely unreachable host, not as "use the first one anyway".
 #
+# 🔴 Each failing target is reported in ONE OF FOUR STATES, never collapsed:
+#   ok              answered (printed on stdout, nothing on stderr)
+#   unreachable     an address exists for this path, but it did not answer
+#   untrusted-key   it answered, and ssh refused the HOST KEY
+#   not-configured  no address exists for this path at all
+# `unreachable` deliberately keeps the original "did not answer" wording: it is
+# the common case, it is what the callers' own tests read, and re-spelling it
+# would have been churn. The state token is appended so the line is greppable.
+#
 # 🔴 $SSH_PROBE_CMD replaces the probe wholesale (it receives the target as $1
 # and signals reachability by exit status). It exists so the selection logic can
 # be tested without a network — a probe that always fails, or one that answers
-# only for a named address, is how the fallback is driven red.
+# only for a named address, is how the fallback is driven red. It signals
+# `untrusted-key` the same way ssh does, by PRINTING the refusal to stderr, so
+# that state is reachable in tests without a real changed key.
 first_reachable_ssh() {
-  local timeout="${SSH_PROBE_TIMEOUT:-5}" target
+  local timeout="${SSH_PROBE_TIMEOUT:-5}" target err
   for target in "$@"; do
-    [ -n "$target" ] || continue
+    if [ -z "$target" ]; then
+      echo "${SSH_PROBE_LOG_PREFIX:-ship}: no address configured for this path (not-configured)" >&2
+      continue
+    fi
     if [ -n "${SSH_PROBE_CMD:-}" ]; then
-      if "$SSH_PROBE_CMD" "$target"; then echo "$target"; return 0; fi
+      # 🔴 `2>&1 >/dev/null` IS THE ORDER THAT CAPTURES STDERR ALONE: stderr is
+      # dup'ed to the substitution pipe FIRST, then stdout is sent to /dev/null.
+      # Reversing it captures stdout instead and classification silently reads
+      # the wrong stream. Pinned by `test_the_classification_reads_STDERR_and_
+      # not_stdout`, which drives a probe that prints the host-key refusal on
+      # stdout and must still be classified `unreachable`.
+      err="$("$SSH_PROBE_CMD" "$target" 2>&1 >/dev/null)" && { echo "$target"; return 0; }
     # 🔴 ONE LINE, not a continuation. `test_drift_check.py`'s command extractor
     # reads the first token of each line as a command, so a wrapped invocation
     # makes it see the continuation's leading word (`target`) as a program and
@@ -163,7 +204,7 @@ first_reachable_ssh() {
     # the LAN address still fails the probe, and the run falls back rather than
     # trusting it. The cost is that a first-ever address is TOFU-adopted without
     # the operator being asked.
-    elif ssh -n -o BatchMode=yes -o ConnectTimeout="$timeout" -o StrictHostKeyChecking=accept-new "$target" true >/dev/null 2>&1; then
+    elif err="$(ssh -n -o BatchMode=yes -o ConnectTimeout="$timeout" -o StrictHostKeyChecking=accept-new "$target" true 2>&1 >/dev/null)"; then
       echo "$target"; return 0
     fi
     # 🔴 The prefix is the CALLER's, not a hardcoded "ship:". This lib is shared,
@@ -181,7 +222,15 @@ first_reachable_ssh() {
     # probing and defaulted DRIFT_SKIP_SSH_PROBE=1 in the fixture. Deleting the
     # default scored 594 passed against it. Cited here so nobody restores the
     # dead pointer.
-    echo "${SSH_PROBE_LOG_PREFIX:-ship}: $target did not answer" >&2
+    # 🔴 An `if`, NOT a `case`, and that is load-bearing: `test_drift_check.py`'s
+    # reverse-PATH guard reads the first token of every line as a command, so a
+    # `untrusted-key)` case LABEL is reported as an unaccounted-for program on
+    # the unit PATH. Measured — it failed exactly that way before this shape.
+    if [ "$(probe_failure_state "$err")" = "untrusted-key" ]; then
+      echo "${SSH_PROBE_LOG_PREFIX:-ship}: $target answered but ssh refused its HOST KEY — not trusting it (untrusted-key)" >&2
+    else
+      echo "${SSH_PROBE_LOG_PREFIX:-ship}: $target did not answer (unreachable)" >&2
+    fi
   done
   return 1
 }

--- a/scripts/tests/test_ship_ssh_fallback.py
+++ b/scripts/tests/test_ship_ssh_fallback.py
@@ -207,3 +207,124 @@ def test_the_secondary_targets_are_derived_from_the_ip_constants(tmp_path):
         "the ORIGINAL nebula address survived a renumber, so it is spelled "
         f"somewhere else too: {lines}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# The FOUR failure states -- ported from the closed PR #1287 (`scripts/workhost`)
+#
+# 🔴 WHY: until this landed, every failing target got the SAME line, "did not
+# answer". A powered-off host and a host whose key CHANGED (a reinstall, or a
+# squatter on the LAN address) were reported identically, so the second read as
+# the first. An empty result cannot distinguish the mechanisms that produce it;
+# these tests pin that each one is NAMED.
+# --------------------------------------------------------------------------- #
+
+def _probe_saying(tmp_path: Path, text: str, stream: str = "stderr") -> str:
+    """A prober that always FAILS, emitting `text` on the named stream.
+
+    ssh exits 255 for a refused host key and for a dead host alike, so the state
+    is carried by the message, not the status -- which is exactly why the stub
+    signals the same way rather than inventing a private exit code.
+    """
+    redirect = ">&2" if stream == "stderr" else ""
+    return str(write_exec(tmp_path / f"probe_{stream}.sh",
+                          'printf "%%s\\n" %s %s\nexit 255\n'
+                          % (repr(text).replace("'", '"'), redirect)))
+
+
+def _probe_stderr_of(tmp_path: Path, stub: str, targets: str) -> str:
+    env = {**os.environ, "SSH_PROBE_CMD": stub}
+    env.pop("REMOTE_SSH", None)
+    res = subprocess.run(
+        ["bash", "-c",
+         f'set -uo pipefail\nsource "{LIB}"\nfirst_reachable_ssh {targets}'],
+        capture_output=True, text=True, env=env,
+    )
+    return res.stderr
+
+
+def test_a_refused_host_key_is_reported_as_untrusted_key_not_as_silence(tmp_path):
+    """🔴 THE POINT OF THE PORT. `accept-new` refuses a CHANGED key by design,
+    and that refusal used to be indistinguishable from the host being off."""
+    stub = _probe_saying(tmp_path, "Host key verification failed.")
+    err = _probe_stderr_of(tmp_path, stub, LAPTOP_LAN)
+    assert "untrusted-key" in err, (
+        f"a refused host key was not named as such: {err!r}. This is the state "
+        "that reads as a network fault and sends the operator to the wrong place."
+    )
+    assert "did not answer" not in err, (
+        f"the refused key was ALSO reported as silence, so the states are still "
+        f"collapsed rather than distinguished: {err!r}"
+    )
+
+
+def test_a_changed_identification_banner_is_also_untrusted_key(tmp_path):
+    """The other spelling ssh uses -- a reinstalled host, not an unknown one."""
+    stub = _probe_saying(
+        tmp_path, "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!")
+    err = _probe_stderr_of(tmp_path, stub, LAPTOP_LAN)
+    assert "untrusted-key" in err, err
+
+
+def test_a_silent_address_is_still_named_unreachable(tmp_path):
+    """The common case keeps its wording AND gains its state token."""
+    stub = _probe_saying(tmp_path, "")
+    err = _probe_stderr_of(tmp_path, stub, LAPTOP_LAN)
+    assert "did not answer" in err, err
+    assert "unreachable" in err, (
+        f"the silent case lost its state token, so the four states are no longer "
+        f"greppable as a set: {err!r}"
+    )
+    assert "untrusted-key" not in err, (
+        f"a plain timeout was classified as a key problem: {err!r}"
+    )
+
+
+def test_an_unconfigured_path_is_NAMED_rather_than_skipped_in_silence(tmp_path):
+    """🔴 `not-configured` was previously a bare `continue`.
+
+    A path with no address produced no output at all, so "we never tried" and
+    "we tried and it was down" looked the same from the log.
+    """
+    stub = _probe_saying(tmp_path, "")
+    err = _probe_stderr_of(tmp_path, stub, '"" ')
+    assert "not-configured" in err, (
+        f"an empty target was skipped silently: {err!r}"
+    )
+
+
+def test_the_classification_reads_STDERR_and_not_stdout(tmp_path):
+    """🔴 PINS THE REDIRECTION ORDER. `2>&1 >/dev/null` captures stderr alone;
+    reversed, it captures stdout and classification reads the wrong stream.
+
+    A probe shouting the host-key banner on STDOUT is NOT a key problem -- ssh
+    writes that diagnostic to stderr. If this goes red with `untrusted-key`, the
+    redirection was flipped and every classification is now reading stdout.
+    """
+    stub = _probe_saying(
+        tmp_path, "Host key verification failed.", stream="stdout")
+    err = _probe_stderr_of(tmp_path, stub, LAPTOP_LAN)
+    assert "unreachable" in err, (
+        f"stdout was classified as if it were ssh's diagnostic: {err!r}"
+    )
+    assert "untrusted-key" not in err, (
+        f"the classifier read STDOUT -- the `2>&1 >/dev/null` order is flipped, "
+        f"so a target that merely prints on stdout is reported as a key "
+        f"refusal: {err!r}"
+    )
+
+
+def test_a_reachable_target_still_wins_and_says_nothing(tmp_path):
+    """The success path must stay quiet -- stdout is the winner, alone."""
+    stub = str(write_exec(tmp_path / "ok.sh", '[ "$1" = "%s" ]\n' % LAPTOP_NEBULA))
+    env = {**os.environ, "SSH_PROBE_CMD": stub}
+    env.pop("REMOTE_SSH", None)
+    res = subprocess.run(
+        ["bash", "-c",
+         f'set -uo pipefail\nsource "{LIB}"\nfirst_reachable_ssh {LAPTOP_LAN} {LAPTOP_NEBULA}'],
+        capture_output=True, text=True, check=True, env=env,
+    )
+    assert res.stdout.strip() == LAPTOP_NEBULA
+    assert LAPTOP_NEBULA not in res.stderr, (
+        f"the winning target was also reported as a failure: {res.stderr!r}"
+    )


### PR DESCRIPTION
Rank 14 of `claudedocs/handoff-audit-pr-ladder.md`, implementing the operator's decision of 2026-09-10.

## The defect

`first_reachable_ssh` emitted **one message for every failing target** — `<target> did not answer`. ssh exits 255 for a powered-off host and for a refused host key alike, so the two were indistinguishable in the log. A changed host key — a reinstalled machine, or a squatter on the LAN address — read as "the box is down" and sent the operator looking for a network fault.

`host-role.sh`'s own comment already said the probe *"does NOT accept a CHANGED key"*. It refuses correctly; it just never said so.

## The change

Four states, never collapsed:

| state | meaning |
|---|---|
| `ok` | answered — printed on stdout, nothing on stderr |
| `unreachable` | an address exists for this path, but it did not answer |
| `untrusted-key` | it answered, and ssh refused the HOST KEY |
| `not-configured` | no address exists for this path at all |

`unreachable` keeps the original "did not answer" wording (the common case, and what the callers' own tests read), with the state token appended so the set is greppable. `not-configured` was previously a bare `continue` — no output at all, so *"we never tried"* and *"we tried and it was down"* looked the same.

Classification reads ssh's own **stderr**, not its exit status, because the status cannot tell these apart.

## Where this came from

This is the one thing closed PR **#1287** (`scripts/workhost`, 1135 lines) did better than the live mechanism. The operator's decision was **one mechanism, not two**: keep `first_reachable_ssh` (merged in #1439, proven on both hosts) and port the four-state reporting. The full comparison is written on #1287. **Not ported:** parallel probing, the tailscale slot, `--json`, `--accept-key`, the standalone verb surface.

## Two shapes here are load-bearing — both measured, neither reasoned about

- **`2>&1 >/dev/null` captures stderr ALONE.** stderr is dup'ed to the substitution pipe first, *then* stdout is discarded. Reversed, it captures stdout and the classifier silently reads the wrong stream. Pinned by `test_the_classification_reads_STDERR_and_not_stdout`.
- **The dispatch is an `if`, not a `case`.** `test_drift_check.py`'s reverse-PATH guard reads the first token of every line as a command, and an `untrusted-key)` case LABEL fails it as an unaccounted-for program on the unit PATH. That is exactly how the first draft failed.

## Tests — both halves of the matrix

| | result |
|---|---|
| new tests over the **OLD** lib, at `cc278b7a` (`origin/main`) | **5 failed**, 12 passed |
| at HEAD | **17 passed** |

`test_a_reachable_target_still_wins_and_says_nothing` passed on **both** sides. It is an **invariant guard, not regression coverage**, and is labelled as one rather than counted.

**Mutation-controlled**, each isolated to the narrowest expression, lib restored byte-identical (`cp -a`, `cmp` clean) after each:

| mutant | outcome |
|---|---|
| discard both streams (the original shape) | 2 failed |
| capture STDOUT instead of stderr | 3 failed — including `test_the_classification_reads_STDERR_and_not_stdout` **with its own message**, which is what proves that test is reachable and specific rather than green for an unrelated reason |

## Scope of what I ran

`scripts/scoped-tests.sh` → `SCOPE: SCOPED` (3 files across 1 of 28 hermetic targets), `RESULT: PASS (exit=0)`, plus `test_ship_ssh_probe_wiring.py` and the two drift-check PATH guards by node id (28 passed together).

🔴 **That is not a gate and I am not quoting it as one.** I did not run either full tier. CI's `tekton/devrc-pytests` / `devrc-nodetests` are the automated signal — read them; note the measured ~42% red-noise rate before debugging any red against this diff.

## Blast radius

`scripts/lib/host-role.sh` is shared by `ship.sh` and `drift-check.sh`. Checked: **no non-test consumer parses the probe's per-target line** — the `did not answer` strings in `ship.sh:548` and `drift-check.sh:1083` are those scripts' own messages about `$REMOTE_SSH`, not reads of this one. The journal-cleanliness contract (`$SSH_PROBE_LOG_PREFIX`) is unchanged and still covered by `test_drift_checks_probe_output_is_journal_clean`.

Not deployed — `home-manager switch` / `ship.sh` is what makes a merged change live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaeYxVr4aESJ7dWhgBRUtS
