### PR TITLE
feat(systemd): adopt the vetr.com DMARC watch timer into home-manager

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2924,6 +2924,86 @@ in
     };
   };
 
+  # ── vetr.com DMARC WATCH ─────────────────────────────────────────────────────
+  # Daily check for forged mail wearing the vetr.com domain, notifying on STATE
+  # CHANGE only. Context: a 2026-09-08 audit found an ACTIVE spoofing campaign —
+  # 95% of mail claiming to be vetr.com was forged — and `_dmarc.vetr.com` was
+  # moved to `p=quarantine` in response. This unit is what makes the campaign
+  # visible without a human running API calls. Full audit + the abuse report:
+  # ~/workspace/scratch/vetr/claudedocs/mail-dns-audit-2026-09-08.md
+  #
+  # These were hand-written under ~/.config/systemd/user and would not have
+  # survived a machine rebuild — which is the whole reason they are here.
+  #
+  # 🔴 THE INTERPRETER IS `pkgs.python3`, AND THAT IS A CORRECTION, NOT A
+  # TRANSCRIPTION. The hand-written unit hardcoded `~/.nix-profile/bin/python3`
+  # with a comment forbidding a `/nix/store/...` path as garbage-collectable.
+  # That reasoning held for a unit nothing referenced; it does NOT hold here.
+  # A `${pkgs.python3}` interpolation makes the store path a DEPENDENCY of the
+  # home generation, so it is a live gcroot and cannot be collected — while the
+  # profile symlink it replaces is repointed by any unrelated `nix profile`
+  # operation. Do not "restore" the profile path. (`dmarc-watch.py` and
+  # `dmarc-alert.py` import stdlib only — argparse/json/urllib/smtplib — so a
+  # bare python3 is sufficient; adding a dependency to either script means
+  # adding it here too.)
+  systemd.user.services.dmarc-watch = {
+    Unit = {
+      Description = "vetr.com DMARC watch — notify on FIRING/RESOLVED/BROKEN state change";
+      Documentation = [ "file://${workspace}/scratch/vetr/claudedocs/mail-dns-audit-2026-09-08.md" ];
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      # Catches the unit being UNABLE TO RUN (missing checkout, broken
+      # interpreter). It does NOT cover the monitor being broken while running:
+      # dmarc-alert.py deliberately exits 0 in every path and reports that state
+      # in-band as a "[BROKEN] vetr.com DMARC monitor is not working" email,
+      # precisely so a dead monitor cannot read as a clean result. Do not infer
+      # from a green unit that spoofing is being observed.
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        # A user unit inherits no login-shell PATH. libnotify supplies
+        # notify-send; the toast is best-effort (i3 is not systemd-integrated,
+        # so DBUS may not be reachable here) and EMAIL is the durable channel.
+        "PATH=${lib.makeBinPath [ pkgs.python3 pkgs.libnotify pkgs.coreutils ]}"
+        "DISPLAY=:0"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.python3}/bin/python3 ${workspace}/scratch/vetr/scripts/dmarc-alert.py";
+      TimeoutStartSec = 300;
+    };
+  };
+
+  # 🔴 GATED ON THE CHECKOUT EXISTING, and the failure mode is a SILENT DISABLE.
+  # The scripts and their credentials (~/.config/vetr/cloudflare-dns.env) live in
+  # a vetr working copy, not in this repo, so on a host without one the timer
+  # would fire daily into a missing file and toast a failure every morning — the
+  # permanently-red gate everyone learns to ignore. Gating trades that for the
+  # opposite hazard: MOVE OR DELETE THAT CHECKOUT AND THE MONITOR VANISHES WITH
+  # NO NOTICE. Nothing detects it. After relocating the vetr workspace, confirm
+  # with `systemctl --user list-timers dmarc-watch.timer`.
+  # The SERVICE above is emitted unconditionally so `systemctl --user start
+  # dmarc-watch` still works by hand (same idiom as handoff-index-sync).
+  systemd.user.timers.dmarc-watch = lib.mkIf
+    (builtins.pathExists "${workspace}/scratch/vetr/scripts/dmarc-alert.py")
+    {
+      Unit = {
+        Description = "Daily vetr.com DMARC spoofing check";
+      };
+      Timer = {
+        # Mid-morning local, so an alert is seen the same day. The spoofing
+        # bursts are day-scale, so anything more frequent is noise.
+        OnCalendar = "*-*-* 09:30:00";
+        RandomizedDelaySec = "15m";
+        # A missed run is an unobserved day; catch up after the host was off.
+        Persistent = true;
+      };
+      Install = {
+        WantedBy = [ "timers.target" ];
+      };
+    };
+
   # ── HANDOFF-DOC SECTION INDEX (scripts/lib/handoff_index.py) ─────────────────
   # Derives a SECTION-grained full-text index of the handoff corpus into
   # `initiatives.handoff_section` (re-measured 2026-09-01: devrc 94 docs / 968


### PR DESCRIPTION
The `dmarc-watch` service+timer were hand-written under `~/.config/systemd/user` and would not have survived a machine rebuild. They watch for forged mail wearing the vetr.com domain, after a 2026-09-08 audit found an active spoofing campaign (95% of mail claiming to be vetr.com was forged) and moved `_dmarc.vetr.com` to `p=quarantine`.

## Two deliberate departures from the hand-written units

**The interpreter is `pkgs.python3`, not `~/.nix-profile/bin/python3`.** The old comment forbade a `/nix/store` path as garbage-collectable. That holds for a unit nothing references, but a `${pkgs.python3}` interpolation is a dependency of the home generation and therefore a live gcroot, while the profile symlink is repointed by any unrelated `nix profile` operation. Do not "restore" the profile path.

This changes the interpreter 3.12.14 → 3.14.7, so the exit-code contract was measured at both points rather than assumed: `0` quiet / `1` alert / `2` monitor-broken observed under each. Both scripts import stdlib only — adding a dependency to either means adding it here too.

**The timer is gated on the vetr checkout existing, and that is a SILENT DISABLE.** Ungated, a host without that checkout would toast a failure every morning — the permanently-red gate everyone learns to ignore. Gated, moving or deleting `~/workspace/scratch/vetr` removes the monitor with no notice and nothing detects it. After relocating that workspace, re-check `systemctl --user list-timers dmarc-watch.timer`.

## Verification

Switched and verified live on nixos:

- `readlink -f ~/.config/systemd/user/dmarc-watch.service` terminates in `/nix/store` (this is the check that distinguishes the generated unit from the hand-written one it replaces)
- `systemctl --user list-timers dmarc-watch.timer` shows a NEXT
- `systemctl --user start dmarc-watch.service` → `Result=success`, journal `[ok] unchanged, no notification (rc=0)`
- exit-code contract `0 / 1 / 2` all three observed under the exact store interpreter the unit uses

⚠️ **`OnFailure` does NOT cover the monitor being broken.** `dmarc-alert.py` exits 0 in every path by design and reports breakage in-band as a `[BROKEN]` email, precisely so a dead monitor cannot read as a clean result. `OnFailure` catches only the unit being unable to run at all. A green unit is not evidence that spoofing is being observed — the standing control is a bogus-credential run returning `2`.

## On the gate

`nix flake check --impure` is **red on this branch and equally red on its merge base**: `10 failed, 13638 passed` on both, same 10 test names, all `ship.sh` SSH-probe tests unrelated to this change (one is literally `test_no_test_writes_a_usr_bin_env_shebang_at_runtime`, matching the `/usr/bin/env: bad interpreter` error the nix sandbox throws). This PR touches one file and adds no new failures. A `fix/unbreak-pytests-gate` branch already exists for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHTifVGu9vkfE8VPd3yVgj