### PR TITLE
docs(store-api): the gate flake was fixed by #1458's tmpfs siting, and it was never the worst one

### DIFF
--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -127,6 +127,33 @@ ROOT = Path(__file__).resolve().parents[2]
 # reproduced ON THE DEV HOST in ~70 s; see `scripts/ci-repro/`. Two corrections
 # to the framing above, both measured:
 #
+# ✅ AND THEN IT DID STOP — but read WHY before trusting it, because the zero on
+# its own does not carry the claim. The fix was NOT this constant: `#1458`
+# (`ce9b55c3`, 2026-09-10 15:56) sited the 18 remaining store roots — this class's
+# among them — on TMPFS via the `sited_root` fixture, which removes the mechanism
+# rather than widening the bound, since an fsync to RAM cannot stall on a
+# contended disk. MEASURED 2026-09-11 over `tekton/devrc-pytests`, newest verdict
+# per PR head, split on that commit's timestamp:
+#
+#     window     verdicts  genuine failures  THIS test
+#     pre-fix         125                29          4
+#     post-fix         45                 6          0
+#
+# 🔴 THE POWER IS WEAK AND SAYING SO IS THE POINT. At the pre-fix per-verdict rate
+# (4/125 = 3.2%) the expected count in 45 verdicts is ~1.4, so P(observing 0) ≈
+# 0.23 — roughly a one-in-four coincidence. The zero is CONSISTENT with the fix
+# and does not establish it; what establishes it is that the mechanism is gone.
+# Re-measure before deleting any of this, and do not upgrade the table into
+# "proven".
+#
+# ⚠ AND THIS TEST WAS NEVER THE WORST ONE, which matters because it was ranked and
+# worked as though it were. In the same pre-fix window
+# `test_every_decrypt_family_VERDICT_is_pinned_WHOLE`
+# (`test_analyze_service_index_escrow_verify.py`) failed 8 times to this test's 4 —
+# twice as often — and is also at 0 post-fix. A flake that is vivid because it has
+# a long diagnosis written about it is not thereby the most frequent one: COUNT
+# them before choosing which to chase.
+#
 #   * IT IS DISK LATENCY, NOT CPU. On run `devrc-ci-86zxj` (sha 5de43017) this
 #     suite's own classifier printed `MECHANISM = SERVER_BLOCKED_IN_FSYNC …
 #     accept loop parked=True`. `server.py:_replace_bytes` fsyncs the file
@@ -7416,6 +7443,15 @@ class TestTheSpawnHarnessAndThePortRace:
     a connection REFUSED, not as a silent peer. Whether closing this race moves
     that intermittent's rate is UNKNOWN and is written down as unknown; do not
     let a later reader turn "ported alongside" into "caused by".
+
+    ✅ AND IT WAS SOMETHING ELSE, WHICH IS WHY THAT UNKNOWN WAS WORTH WRITING.
+    The intermittent was addressed by `#1458` siting the store on tmpfs — see the
+    measured before/after in the `HANG_TIMEOUT` block at the top of this file —
+    not by anything in this class. So this remains what its own first paragraph
+    says it is: an invariant guard on a mechanism that was live and unclosed, and
+    NOT regression coverage. 🔴 Had the two been merged into one story, the tmpfs
+    fix would have been credited to the port-race retry and the real mechanism
+    would still be in the request path.
 
     So: the retry is a hazard closed by construction, and the message is the
     instrument that makes the NEXT occurrence attributable. Ported from


### PR DESCRIPTION
Closes rank 3 of `claudedocs/handoff-gate-speed-and-ci-signal.md` — by measurement, not by fixing anything.

## What was actually wrong with rank 3

It read *"needs a diagnosis, not another ported retry."* It did not need a diagnosis. The suite's own classifier had already printed `MECHANISM = SERVER_BLOCKED_IN_FSYNC … accept loop parked=True` on run `devrc-ci-86zxj`: `server.py:_replace_bytes` fsyncs the file and then the parent dir **inside the request, before the response is written**, and fsync blocks in uninterruptible sleep. That is exactly the captured traceback (`TimeoutError` inside `socket.recv_into` — connection established, never answered).

**And it had already been fixed.** `#1458` (`ce9b55c3`, 2026-09-10 15:56) sited the 18 remaining store roots — including this class's — on **tmpfs** via `sited_root`. That removes the mechanism rather than widening a bound: an fsync to RAM cannot stall on a contended disk. Nothing recorded that the fix had landed, so the next session would have re-derived all of it.

## The measurement

`tekton/devrc-pytests`, newest verdict per PR head, split on `ce9b55c3`'s timestamp:

| window | verdicts | genuine failures | this test |
|---|---|---|---|
| pre-fix | 125 | 29 | **4** |
| post-fix | 45 | 6 | **0** |

`failure` and `error` counted separately throughout — `error` is a broken gate, not a bad change.

## Two things this PR refuses to overstate

**The power is weak, and the comment says so.** At the pre-fix per-verdict rate (4/125 = 3.2%), the expected count in 45 verdicts is ~1.4, so P(observing 0) ≈ 0.23 — roughly one in four. The zero is *consistent with* the fix and does not establish it. What establishes it is the mechanism being gone. Written in as not-proven so a later reader cannot upgrade the table into "proven".

**It was never the worst flake.** In the same pre-fix window, `test_every_decrypt_family_VERDICT_is_pinned_WHOLE` (`test_analyze_service_index_escrow_verify.py`) failed **8** times to this test's **4** — twice as often — and is also at 0 post-fix. This one got ranked and worked because it had a long diagnosis attached, not because it was frequent. The comment now says: count them before choosing which to chase.

## Also corrected

The port-race docstring still read as though that intermittent were live. Its own *"whether closing this race moves that rate is UNKNOWN"* was right, and is precisely why the two stayed separate — had they been merged into one story, the tmpfs fix would have been credited to the port-race retry and the real mechanism would still be sitting in the request path.

## Scope / verification

Comment-only, one file, no behaviour change. Full file re-run on this branch: **760 passed** (8m17s).

⚠ The remaining post-fix failures are all `test_the_SUMMARY_BANNER_names_the_real_selection_source`, on PRs **17–40 commits behind main** that have since merged — the handoff's rank 4 stale-base echo, not a live flake. That test passes on current main and `test_run_tests_targets.py` is claimed by another session, so it is deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQx16RMr8YQYBfsXaBEsSm