### PR TITLE
fix(disk-accounting): the sha guard tested HEAD, exempted what it could not resolve, and missed two spellings

### DIFF
--- a/scripts/diagnose-disk-accounting.sh
+++ b/scripts/diagnose-disk-accounting.sh
@@ -229,13 +229,18 @@ _not_on_device() { sed -z -n "/^$1\t/!{s/^[0-9]*\t//;p;}"; }
 # 🔴 EVERYTHING ELSE THAT STOOD HERE WAS WRONG, and it is deleted rather than
 # re-measured, because a per-implementation table of byte counts and exit codes
 # is a claim nothing checks and everything invalidates. What it got wrong:
-#   - "`-print0` exits **0** … it needs no stat". FALSE for the form this
-#     function uses: `-xdev` needs each entry's st_dev, so it DOES stat, and it
-#     exits 1 on a directory it cannot read. (Without `-xdev` there is no stat
-#     and rc is 0 — which is how the wrong claim got written: the probe dropped
-#     the flag the function actually passes.) ⚠ That rc-0-without-`-xdev` half
-#     was measured on ONE implementation and does NOT generalise: GNU 4.11.0
-#     exits 1 either way. Name the binary or say nothing.
+#   - "`-print0` exits **0** … it needs no stat". FALSE — but so was the
+#     correction that replaced it, which blamed `-xdev`. 🔴 THE FLAG IS NOT THE
+#     DISCRIMINATOR. MEASURED, GNU findutils 4.11.0, mode-0400 base, each cell
+#     twice, WITH and WITHOUT `-xdev`:
+#         base holding 3 regular files      → rc 0, both ways
+#         base holding a SUBDIRECTORY       → rc 1, both ways
+#     So rc turns on whether the unreadable base contains a subdirectory find
+#     would otherwise consider descending into — not on `-xdev`, which changes
+#     nothing here. Two successive comments asserted a cause without varying the
+#     thing they blamed; the second was written by re-running with the flag added
+#     and reading the changed rc as the flag's doing, when the FIXTURE had changed
+#     too. Vary one thing.
 #   - "the byte counts AGREE across builds". FALSE — two implementations
 #     disagreed on one fixture. 🔴 NO FIGURE IS QUOTED NOW, because byte count is
 #     dominated by the fixture's PATH LENGTH: one implementation gave 122 B at a

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1605,9 +1605,24 @@ echo "== 13. UNTALLIED-DROP SITE LEDGER — pinned two-way =="
 # blind spot is asserting something, and the assertion needs checking like any
 # other. "No scan can do this" is the single easiest claim to get wrong.
 #
-# 🔴 THE REMAINING BLIND SPOT IS ONE, NOT TWO: a guard delegated to a HELPER
-# FUNCTION, because no textual scan follows a call. The window is 3 lines, so a
-# guard spread wider than that also escapes — the canary below pins the window.
+# 🔴 WHAT THIS SCAN COVERS, MEASURED — not "the remaining blind spot is one",
+# which is what stood here and was wrong by five. It finds a `[ -d ]` or
+# `[[ -d ]]` test whose line, joined with the next 3, reaches a `continue`. Each
+# of these meets the CRITERION and is MISSED (each measured in isolation, because
+# a shared fixture lets one line's `continue` mask another's absence — my first
+# attempt at this list was wrong for exactly that reason):
+#     test -d "$p" || continue        (no brackets)
+#     [ -e "$p" ] || continue         (different test operator)
+#     [ -f "$p" ] || continue
+#     [ -d "$p" ] || break            (different loop control)
+#     echo skip; [ -d "$p" ] || continue   (the `echo ` exclusion drops the line)
+# plus a guard delegated to a HELPER FUNCTION, since no textual scan follows a
+# call, and one spread wider than the 3-line window (pinned by a canary below).
+# 🔴 SO THE LEDGER'S COVERAGE IS NARROWER THAN THE CRITERION THE SCRIPT STATES,
+# and that gap is the honest position rather than a defect to hide: widening the
+# pattern costs false positives on prose, and each widening so far has found a
+# real over-match. What must NOT happen again is a sentence claiming the set is
+# closed when it is not — that has now been written, and refuted, three times.
 #
 # 🔴 COMMENTS **AND** `echo` LINES ARE EXCLUDED, and the `echo` half is not
 # hypothetical: widening the pattern immediately matched section 2's own banner,
@@ -1729,22 +1744,72 @@ if ! command -v git >/dev/null 2>&1; then
 elif ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
   pass "COULD NOT MEASURE: $ROOT is not a git checkout — sha reachability unchecked (expected in the sandbox tier)"
 else
-  sha_bad=""; sha_seen=0
-  for f in $sha_files; do
-    for h in $(grep -oE '\b[0-9a-f]{8,40}\b' "$f" | grep -E '[a-f]' | sort -u); do
-      git -C "$ROOT" cat-file -e "${h}^{commit}" 2>/dev/null || continue
-      sha_seen=$((sha_seen + 1))
-      git -C "$ROOT" merge-base --is-ancestor "$h" HEAD 2>/dev/null || sha_bad="$sha_bad $h"
-    done
+  # 🔴 THE MAINLINE REF, NOT `HEAD` — this was the first version's headline bug.
+  # A citation is AUTHORED on a feature branch, where HEAD is that branch's tip,
+  # so a sha from the same branch always passed. The guard was blind at exactly
+  # the moment a citation is written, and could only ever catch a reference to a
+  # DIFFERENT, already-dead branch. This repo squash-merges, so a branch sha is
+  # on no mainline the moment it lands — which is the whole defect.
+  sha_base=""
+  for cand in origin/main main origin/master master; do
+    if git -C "$ROOT" rev-parse --verify --quiet "${cand}^{commit}" >/dev/null 2>&1; then
+      sha_base="$cand"; break
+    fi
   done
-  # POSITIVE CONTROL: a run that resolved NO sha proves nothing. If the files
-  # cite none, that is itself the reportable state, not a pass.
-  if [ "$sha_seen" -eq 0 ]; then
-    fail "the sha ledger resolved ZERO commit-shas in these files — either the extraction broke or every citation was removed; a zero here is not a clean result"
-  elif [ -z "$sha_bad" ]; then
-    pass "all $sha_seen cited sha(s) are ancestors of HEAD — resolvable from a fresh clone"
+  if [ -z "$sha_base" ]; then
+    pass "COULD NOT MEASURE: no mainline ref (origin/main|main|origin/master|master) in this checkout — sha reachability unchecked"
   else
-    fail "cited sha(s) NOT reachable from HEAD:$sha_bad — a reader cannot resolve the number each one anchors, which is the defect the 'only with a sha' rule exists to stop. Re-anchor to a commit on the mainline, or delete the figure"
+    sha_bad=""; sha_unres=""; sha_seen=0
+    for f in $sha_files; do
+      # 🔴 CASE-INSENSITIVE AND FROM 7, because git accepts an UPPERCASE sha and
+      # a 7-character prefix, and the first version's `[0-9a-f]{8,40}` exempted
+      # both spellings.
+      # 🔴 NO EXAMPLE SHA IS WRITTEN HERE, and that is not fastidiousness: the
+      # first draft of THIS comment illustrated the two spellings with a real
+      # commit, which resolved only from a stray local ref and was not an
+      # ancestor of the mainline. The guard below failed on its own author's
+      # explanation, first run. Describe the SHAPE; never paste a sha into prose
+      # that is not itself a citation you intend a reader to resolve.
+      for h in $(grep -oE '\b[0-9a-fA-F]{7,40}\b' "$f" | tr 'A-F' 'a-f' | sort -u); do
+        case "$h" in
+          *[a-f]*)
+            # Contains a letter ⇒ it is a sha CITATION, not a decimal figure.
+            # 🔴 UNRESOLVABLE IS A FAILURE, NOT A SKIP. The first version did
+            # `cat-file -e … || continue`, so a sha this machine does not hold was
+            # silently EXEMPT — and the check then returned OPPOSITE verdicts on
+            # byte-identical files depending on which stray local refs happened to
+            # exist. Unresolvable here is exactly what the reader experiences.
+            sha_seen=$((sha_seen + 1))
+            if ! git -C "$ROOT" cat-file -e "${h}^{commit}" 2>/dev/null; then
+              sha_unres="$sha_unres $h"
+            elif ! git -C "$ROOT" merge-base --is-ancestor "$h" "$sha_base" 2>/dev/null; then
+              sha_bad="$sha_bad $h"
+            fi ;;
+          *)
+            # All digits: ambiguous with the decimal figures these files quote
+            # (block counts, inode counts). Count it ONLY if git resolves it as a
+            # commit — which is how an all-digit sha prefix (~1 in 43) gets
+            # checked instead of silently exempted, without an allowlist.
+            if git -C "$ROOT" cat-file -e "${h}^{commit}" 2>/dev/null; then
+              sha_seen=$((sha_seen + 1))
+              git -C "$ROOT" merge-base --is-ancestor "$h" "$sha_base" 2>/dev/null \
+                || sha_bad="$sha_bad $h"
+            fi ;;
+        esac
+      done
+    done
+    # POSITIVE CONTROL: a run that resolved NO sha proves nothing.
+    if [ "$sha_seen" -eq 0 ]; then
+      fail "the sha ledger found ZERO commit-sha citations in these files — either the extraction broke or every citation was removed; a zero here is not a clean result"
+    elif [ -n "$sha_unres" ] || [ -n "$sha_bad" ]; then
+      [ -n "$sha_unres" ] && fail "cited sha(s) this checkout cannot resolve at all:$sha_unres — a reader cannot look them up, which is the defect the 'only with a sha' rule exists to stop. Re-anchor to a commit on $sha_base, or delete the figure"
+      [ -n "$sha_bad" ] && fail "cited sha(s) NOT ancestors of $sha_base:$sha_bad — they resolve HERE but not from the mainline, so a fresh clone cannot check the number each one anchors. Re-anchor, or delete the figure"
+    else
+      # 🔴 SAY WHAT WAS CHECKED. The first version's pass line claimed the shas
+      # were "resolvable from a fresh clone" — an assertion it never tested, and
+      # measured FALSE in an actual fresh clone.
+      pass "all $sha_seen cited sha(s) resolve here AND are ancestors of $sha_base"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Round 7 **attacked** the two mechanisms round 6 built, rather than reviewing them — and **defeated one**. The window-edge canary held against every degradation constructed. The sha ledger did not: three measured bypasses, all fixed here.

## It tested `HEAD`, under a banner saying `main`

A citation is **authored on a feature branch**, where `HEAD` is that branch's tip — so a sha from the same branch always passed. This repo squash-merges, so that sha is on no mainline the moment it lands.

The guard was blind at exactly the moment a citation is written, and could only ever catch a reference to a *different, already-dead* branch — which is how it caught the three it did. It is also the description-wider-than-implementation shape this ladder has now found four times, and I wrote it while fixing the third.

Now resolves `origin/main` (then `main`, `origin/master`, `master`), and `COULD NOT MEASURE` if none exists.

## An unresolvable sha was silently exempt

`cat-file -e … || continue` skipped any sha the machine doesn't hold — so the check returned **opposite verdicts on byte-identical files** depending on which stray local refs happened to exist. After a `gc`, the two citations it had caught would have passed.

Unresolvable is now its own failure with its own message. That is exactly what the reader experiences.

## The pass line asserted something it never tested

It read *"resolvable from a fresh clone"* — measured **false** in an actual fresh clone. It now states what was checked: resolves here **and** is an ancestor of the mainline ref.

## The extraction missed spellings git accepts

Uppercase and 7-char prefixes were exempt, and the `[a-f]` filter that keeps decimal figures out also exempted an **all-digit sha prefix** (~1 in 43). Now case-insensitive from 7; an all-digit token counts only if git resolves it as a commit — covering that case without an allowlist.

## The guard failed on its own author, first run

My comment explaining the uppercase/7-char fix illustrated them with a **real commit reachable only from a stray local ref**. The examples are gone, and the rule is stated: describe the shape; never paste a sha into prose that isn't a citation you intend a reader to resolve.

## Two of my claims corrected against measurement

- **"THE REMAINING BLIND SPOT IS ONE, NOT TWO"** was wrong by five. `test -d`, `[ -e ]`, `[ -f ]`, `|| break`, and a line prefixed with `echo ` all meet the criterion and are missed. Each measured **in isolation** — a shared fixture lets one line's `continue` mask another's absence, which made my first list wrong. The ledger's coverage is narrower than the criterion, and that is now the stated position rather than a claim of closure.
- **`-xdev` is not the rc discriminator.** Measured, GNU 4.11.0, twice per cell:

| fixture | with `-xdev` | without |
|---|---|---|
| mode-0400 base, 3 regular files | rc 0 | rc 0 |
| same base holding a **subdirectory** | rc 1 | rc 1 |

Two successive comments blamed a cause without varying it — the second re-ran with the flag added and read the changed rc as the flag's doing, when the fixture had changed too.

## Verification

Suite: **231 assertions, 0 failures**. Every bypass re-tested inside a real checkout (a `cp -a` copy can't run this guard — it takes the `COULD NOT MEASURE` branch, which is how a mutation test of it once reported SURVIVED against a guard that never executed):

| bypass | old | new |
|---|---|---|
| branch-local sha | passed | **FAIL** |
| unresolvable sha | silently exempt | **FAIL** |
| UPPERCASE | exempt | **FAIL** |
| 7-char prefix | exempt | **FAIL** |
| 8-char non-ancestor (positive control) | FAIL | **FAIL** |
