### PR TITLE
feat(audit-pr): report the churn no audit-claims block range covers — and it is 655 interior, 3,727 tail

### DIFF
--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -241,6 +241,28 @@ Bold is wrong. Three lessons, and every one of them was shipped as a rule before
   diff, so on shape A it reports every upstream line as this round's work.
 - **D** is the positive control. A form that gets D wrong is not measuring churn at all.
 
+### 🔴 The range form above measures ONE round. It does not measure whether the rounds CHAIN.
+
+`scripts/ladder-range-coverage.py` is the other half, and it exists because that distinction
+was missed for as long as churn has been measured here. Every block range can be individually
+correct while the ladder still has churn **no range contains** — three routes, all real:
+
+- a round posts **no block** and a later round anchors past it (#1233's round 3, 524 lines);
+- churn lands **after the last block** (11 of 20 devrc ladders; 3,727 lines);
+- a block carries a **bare `audited=<sha>`**, which names no range at all (#958's round 1).
+
+🔴 **Run it before quoting any per-round churn table as complete**, and read the INTERIOR total
+rather than the sum: the tail conflates post-last-block fixes with development that continued
+after the ladder ended, and nothing in the ranges separates them. It refuses a zero it cannot
+tell from a broken run (a block's own range must measure non-zero first), and it shares
+`measure_range_churn` with `audit-dispatch.py` so the command cannot drift from the one the
+skill body tells an auditor to run. Mutants:
+`scripts/tests/mutants-ladder-range-coverage.sh`.
+
+⚠ **The earlier measurement's instrument is GONE** — `claudedocs/audit-ladder-review-2026-09-04.md`
+says its churn tool "was written for this review", in a scratchpad, so not one of its numbers
+can be re-derived from the tree. That is why this one is committed.
+
 ---
 
 ## Mutation variants that delete NOTHING

--- a/claudedocs/audit-ladder-review-2026-09-04.md
+++ b/claudedocs/audit-ladder-review-2026-09-04.md
@@ -440,6 +440,31 @@ Both directions, and they do not cancel.
   of my table. #958 has the same shape (a 12-round ladder with 9 ranged blocks) but its ranges
   still chain end-to-end, so nothing is lost there. #1108 and #1219 both start at round 2, so
   their round-1 churn is likewise outside every range.
+  🔴 **NOW MEASURED, 2026-09-11, and the hole was WIDER AND NARROWER THAN THIS BULLET SAYS —
+  `scripts/ladder-range-coverage.py` over these same 20 ladders.** Three corrections, each
+  re-derivable by re-running it:
+  - **A SECOND interior gap existed and is named nowhere above: #998, round 1 → round 2,
+    `34265904..0aecdbf2`, 2 commits / 131 lines.** So the interior hole — the unambiguous kind,
+    where a round posted a block, a later round anchored past it, and nobody audited between —
+    is **655 raw lines across 2 of 20 ladders** (#1233 524 + #998 131), not one ladder.
+  - 🔴 **A WHOLE CLASS THIS BULLET DOES NOT MENTION IS SIX TIMES LARGER: the TAIL.** Churn
+    after the LAST block is in no range either, and **11 of 20 ladders carry some — 3,727 raw
+    lines**, led by #1046 (1,105), #1000 (987) and #1209 (672). ⚠ **It must NOT be quoted as
+    unaudited ladder work.** It conflates fixes posted after the final block (which the ladder
+    should have seen) with development that simply continued after the ladder ended (which it
+    should not), and nothing in the ranges distinguishes them. The script prints interior and
+    tail as separate totals for exactly this reason; read the split, never the 4,382 sum.
+  - ⚠ **"9 ranged blocks" for #958 is 8.** Its round-1 block is a BARE `audited=<sha>`, which
+    names no range at all — the same hole by a third route, and one with no reportable size.
+  - ✅ **This bullet's claim about #958 otherwise HOLDS**: all 8 of its adjacencies are TIGHT,
+    0 uncovered. #1219, #1286, #1120, #1181, #1207 and #989 are likewise 0 — a real negative
+    control, since a dead detector would also print 0 for them.
+  ⚠ **All of the above is RAW lines.** The payload/scaffolding split below was made by hand per
+  PR and no pathspec can make it, so **this does not say the `19,230 / 32,393` figures are
+  short by 655** — it says the ranges they were computed over missed that much churn.
+  ⚠ **And three of the tail gaps are many commits at ZERO lines** (#1064 125 commits, #1274 10,
+  #1110 7): `--not <base>` correctly excluding an upstream bring-in. A commit count is not a
+  churn count — shape A of the reference file's range table, working.
 - **The waste audit is devrc-only.** Ladders ran in homelab-talos, civit-datapacket-talos,
   vetr, auditloop, civitai-gpu-fleet and naida-ai; none were churn-measured.
 
@@ -490,6 +515,17 @@ Both directions, and they do not cancel.
    hand. This is the only route to a *rate* for "ladders that stopped on a stated mechanism",
    and it is also how #1157's escape-hatch requirement gets checked. *Closes when* the
    terminal round's summary is classified for every carrier and the rate is published.
-5. **Fix the range-coverage hole.** Blocks that skip a round (#1233) leave churn in no
-   range. *Closes when* the measurement additionally reports, per ladder, the churn between
-   the first block's `from` and the head that no block's range covers.
+5. ~~Fix the range-coverage hole.~~ **CLOSED 2026-09-11** — `scripts/ladder-range-coverage.py`
+   reports it, per ladder, for the window `[first block's from, head]`, and was run over these
+   20: **interior 655 lines in 2 ladders, tail 3,727 in 11**, with the two kept as separate
+   totals because only the first is unambiguously unaudited ladder work. Findings are folded
+   into the CANNOT-SEE bullet above, including two this item did not anticipate — a second
+   interior gap (#998) and the tail class itself. The instrument is committed, with a mutation
+   battery (`scripts/tests/mutants-ladder-range-coverage.sh`), *because this review's own churn
+   instrument was a scratchpad variant that no longer exists* and none of its numbers can be
+   re-derived from the tree today.
+   ⚠ **Residual, which this item did NOT ask for and is NOT closed:** the window deliberately
+   excludes churn BEFORE the first block, so a ladder whose ledger starts at round 2 (#958,
+   #1108, #1219 here) still has its round-1 churn unmeasured. The script says so per ladder
+   rather than inventing a number, because what "round 1" means for a ledger that begins at 2
+   is a judgement about that PR, not arithmetic.

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -1257,11 +1257,94 @@ def anchor_is_head(anchor, head_check):
 # The ledger — the skill's own command, with the skill's own read rules
 # --------------------------------------------------------------------------- #
 
+RangeChurn = namedtuple("RangeChurn", "files added deleted commits reason")
+
+
+def measure_range_churn(runner, repo_dir, frm, to, base):
+    """`git log --numstat --format= --remerge-diff <frm>..<to> --not <base>`.
+
+    The COMMAND half of the ledger's read rules, for an ARBITRARY range.
+    Extracted from `measure_ledger` so its second caller —
+    `scripts/ladder-range-coverage.py`, which measures the churn BETWEEN two
+    blocks' ranges — cannot drift away from it. Enforced here, not assumed:
+    **rc 0 and silent stderr**, on both git calls.
+
+    🔴 THE "NON-EMPTY RANGE" RULE IS DELIBERATELY *NOT* HERE, and that is why
+    this is a separate function rather than a parameterised `measure_ledger`.
+    The two callers want OPPOSITE things from an empty range. For a DELTA ROUND
+    it is a broken question — the range cannot contain anything, a finding-free
+    audit over it reads as a clean round, and `measure_ledger` spends three
+    branches diagnosing which cause it was. For the GAP between two blocks'
+    ranges an empty range is the HEALTHY answer: it is exactly what a ladder
+    whose blocks chain end-to-end looks like. A shared core that refused an
+    empty range would report every well-formed ladder as unmeasurable, so that
+    rule stays with the caller that needs it.
+
+    A missing ref or a git without `--remerge-diff` exits 128 with empty output;
+    an unwritable object store makes `--remerge-diff` UNDER-count, exit 0 and
+    print a plausible number, announcing itself only on stderr. Each returns a
+    `reason` and NO number — a failed command is not a zero.
+    """
+    def fail(reason):
+        return RangeChurn(None, None, None, None, reason)
+
+    rc, out, err = runner(
+        ["git", "-C", repo_dir, "rev-list", "--count", f"{frm}..{to}"]
+    )
+    if rc != 0:
+        return fail(f"`git rev-list {frm}..{to}` exited {rc}: "
+                    f"{(err or out).strip() or 'no output'}")
+    if err.strip():
+        return fail(f"`git rev-list` wrote to stderr: {err.strip()}")
+    try:
+        commits = int(out.strip())
+    except ValueError:
+        return fail(f"`git rev-list --count` printed {out.strip()!r}, not a number")
+    if commits == 0:
+        # No commits ⇒ no churn, and no numstat call (which is also what this
+        # function's extraction preserved: `measure_ledger` never reached the
+        # numstat on an empty range either). The CALLER decides what it means.
+        return RangeChurn({}, 0, 0, 0, None)
+
+    rc, out, err = runner([
+        "git", "-C", repo_dir, "log", "--numstat", "--format=",
+        "--remerge-diff", f"{frm}..{to}", "--not", base,
+    ])
+    if rc != 0:
+        return fail(f"the numstat command exited {rc}: "
+                    f"{(err or out).strip() or 'no output'}")
+    if err.strip():
+        return fail(
+            "the numstat command exited 0 but wrote to STDERR, so its number is "
+            f"not trustworthy: {err.strip()}"
+        )
+
+    files, added, deleted = {}, 0, 0
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        a, d, path = parts[0], parts[1], parts[-1]
+        na = 0 if a == "-" else int(a) if a.isdigit() else 0
+        nd = 0 if d == "-" else int(d) if d.isdigit() else 0
+        cur = files.get(path, (0, 0))
+        files[path] = (cur[0] + na, cur[1] + nd)
+        added += na
+        deleted += nd
+    return RangeChurn(files, added, deleted, commits, None)
+
+
 def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
     """`git log --numstat --format= --remerge-diff <prev>..HEAD --not <base>`.
 
-    🔴 FOUR read rules are enforced here, not assumed: **the checkout's HEAD is
-    the PR's head, rc 0, silent stderr, and a non-empty range**.
+    🔴 FOUR read rules govern this answer, none of them assumed: **the
+    checkout's HEAD is the PR's head, rc 0, silent stderr, and a non-empty
+    range**. TWO OF THE FOUR ARE NOW ENFORCED ONE LEVEL DOWN, in
+    `measure_range_churn` — rc 0 and silent stderr — and this function enforces
+    the other two, because they are the two that are specific to a delta round:
+    `head_check` is meaningless without a PR, and an empty range is a DEFECT
+    here while being the healthy answer for that function's other caller. The
+    count is four either way; do not read the delegation as a relaxation.
 
     The fourth one came last and is the one that lets the other three pass while
     the answer is entirely wrong: `HEAD` is resolved in the operator's own
@@ -1287,19 +1370,14 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
             f"mean what this ledger would claim it means: {head_check.reason}"
         )
 
-    rc, out, err = runner(
-        ["git", "-C", repo_dir, "rev-list", "--count", f"{prev_sha}..HEAD"]
-    )
-    if rc != 0:
-        return fail(f"`git rev-list {prev_sha}..HEAD` exited {rc}: "
-                    f"{(err or out).strip() or 'no output'}")
-    if err.strip():
-        return fail(f"`git rev-list` wrote to stderr: {err.strip()}")
-    try:
-        commits = int(out.strip())
-    except ValueError:
-        return fail(f"`git rev-list --count` printed {out.strip()!r}, not a number")
-    if commits == 0:
+    # The rc-0 / silent-stderr rules and the numstat parse live in
+    # `measure_range_churn`; the FOURTH rule (head_check, above) and the
+    # empty-range diagnosis below are this caller's, because only a delta round
+    # treats an empty range as a defect. See that function's docstring.
+    churn = measure_range_churn(runner, repo_dir, prev_sha, "HEAD", base)
+    if churn.reason is not None:
+        return fail(churn.reason)
+    if churn.commits == 0:
         # 🔴 THREE causes, and TWO OF THEM ARE REFUTED BY `head_check` — which is
         # a parameter of this very function, already required `ok` twelve lines
         # above. The old text named "the fixes are not committed yet, or this
@@ -1334,32 +1412,9 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
             "live.)"
         )
 
-    rc, out, err = runner([
-        "git", "-C", repo_dir, "log", "--numstat", "--format=",
-        "--remerge-diff", f"{prev_sha}..HEAD", "--not", base,
-    ])
-    if rc != 0:
-        return fail(f"the numstat command exited {rc}: "
-                    f"{(err or out).strip() or 'no output'}")
-    if err.strip():
-        return fail(
-            "the numstat command exited 0 but wrote to STDERR, so its number is "
-            f"not trustworthy: {err.strip()}"
-        )
-
-    files, added, deleted = {}, 0, 0
-    for line in out.splitlines():
-        parts = line.split("\t")
-        if len(parts) < 3:
-            continue
-        a, d, path = parts[0], parts[1], parts[-1]
-        na = 0 if a == "-" else int(a) if a.isdigit() else 0
-        nd = 0 if d == "-" else int(d) if d.isdigit() else 0
-        cur = files.get(path, (0, 0))
-        files[path] = (cur[0] + na, cur[1] + nd)
-        added += na
-        deleted += nd
-    return LedgerReport(files, added, deleted, commits, None, None, None)
+    return LedgerReport(
+        churn.files, churn.added, churn.deleted, churn.commits, None, None, None
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -136,7 +136,8 @@ Adjacency = namedtuple(
 Ladder = namedtuple(
     "Ladder",
     "pr head base blocks_total blocks_used first_round adjacencies "
-    "control_churn uncovered_added uncovered_deleted reason malformed bare",
+    "control_churn uncovered_added uncovered_deleted interior tail "
+    "reason malformed bare",
 )
 
 
@@ -216,6 +217,7 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
     if not usable:
         return Ladder(
             pr, head, base, len(blocks), 0, None, [], None, None, None,
+            (0, 0), (0, 0),
             f"no `audit-claims` block carrying a TWO-SHA `audited=<from>..<to>` "
             f"({len(blocks)} block(s) parsed). A bare `audited=<sha>` names no "
             "range, so it cannot be chained and this report has nothing to "
@@ -224,6 +226,7 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
         )
 
     adjacencies, uncovered_a, uncovered_d = [], 0, 0
+    interior_a = interior_d = tail_a = tail_d = 0
     # THE POSITIVE CONTROL: a block's OWN range. A ladder's rounds changed
     # something by construction, so if every one of these measures empty the
     # commits are not here and the uncovered total below would be a zero from
@@ -249,13 +252,31 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
         if label == GAP:
             uncovered_a += added or 0
             uncovered_d += deleted or 0
+            # 🔴 INTERIOR AND TAIL ARE DIFFERENT CLAIMS AND MUST NOT BE SUMMED
+            # INTO ONE HEADLINE. An INTERIOR gap is unambiguous: a round posted a
+            # block, a later round posted one anchored past it, and the churn
+            # between them was audited by nobody — #1233's round 3. A TAIL gap is
+            # churn after the LAST block, which conflates two things this script
+            # cannot separate: fixes made after the final block was posted (which
+            # the ladder should have seen) and ordinary development that continued
+            # after the ladder ended (which it should not). Measured over the
+            # 2026-09-04 review's 20 ladders, the tail is 3,727 of 4,382 lines —
+            # so a single total would be quoted as an under-count it does not
+            # support.
+            if r_to is None:
+                tail_a += added or 0
+                tail_d += deleted or 0
+            else:
+                interior_a += added or 0
+                interior_d += deleted or 0
         adjacencies.append(
             Adjacency(label, frm, to, r_from, r_to, added, deleted, commits, reason)
         )
 
     return Ladder(
         pr, head, base, len(blocks), len(usable), usable[0].round_no,
-        adjacencies, control, uncovered_a, uncovered_d, None, malformed, bare,
+        adjacencies, control, uncovered_a, uncovered_d,
+        (interior_a, interior_d), (tail_a, tail_d), None, malformed, bare,
     )
 
 
@@ -322,6 +343,7 @@ def render(ladders, notes):
         out.append("")
 
     total_a = total_d = 0
+    int_a = int_d = tl_a = tl_d = 0
     measured = 0
     for L in ladders:
         out.append(f"### PR #{L.pr}  head={L.head[:8] or '?'}  base={L.base or '?'}")
@@ -374,19 +396,50 @@ def render(ladders, notes):
             else:
                 out.append(f"  {a.label}  {where}: {a.reason}")
         out.append(f"  UNCOVERED: {L.uncovered_added + L.uncovered_deleted} line(s)"
-                   f" (+{L.uncovered_added}/-{L.uncovered_deleted})")
+                   f" (+{L.uncovered_added}/-{L.uncovered_deleted})"
+                   f" = interior {sum(L.interior)} + tail {sum(L.tail)}")
         total_a += L.uncovered_added
         total_d += L.uncovered_deleted
+        int_a += L.interior[0]
+        int_d += L.interior[1]
+        tl_a += L.tail[0]
+        tl_d += L.tail[1]
         out.append("")
 
     out.append(f"TOTAL uncovered across {measured} measured ladder(s): "
                f"{total_a + total_d} line(s) (+{total_a}/-{total_d})")
+    out.append("")
+    out.append("🔴 READ THE SPLIT, NOT THE TOTAL — they are different claims and "
+               "only the first is")
+    out.append("   unambiguous:")
+    out.append(f"   INTERIOR  {int_a + int_d} line(s) (+{int_a}/-{int_d}) — a "
+               "round posted a block, a later")
+    out.append("             round anchored past it, and NOBODY audited the churn "
+               "between. This is")
+    out.append("             the #1233 defect, and it is the number the review's "
+               "table is short by.")
+    out.append(f"   TAIL      {tl_a + tl_d} line(s) (+{tl_a}/-{tl_d}) — churn "
+               "after the LAST block. This")
+    out.append("             conflates two things this script cannot separate: "
+               "fixes posted after the")
+    out.append("             final block (the ladder should have seen them) and "
+               "development that")
+    out.append("             continued after the ladder ended (it should not). "
+               "Do NOT quote it as")
+    out.append("             unaudited ladder work without reading the commits.")
+    out.append("")
     out.append("⚠ RAW lines, NOT split payload/scaffolding. That split was made "
                "BY HAND, per PR, in")
     out.append("  the 2026-09-04 review; no pathspec can make it (a docs PR's "
                "payload IS the `.md`). So")
     out.append("  this total is the SIZE of the hole, not the payload the review "
                "under-counted by.")
+    out.append("⚠ A COMMIT COUNT IS NOT A CHURN COUNT. A GAP of many commits and "
+               "0 lines is `--not")
+    out.append("  <base>` working: those commits are an upstream bring-in already "
+               "in the base, which is")
+    out.append("  shape A of the reference file's range table. Three of the 20 "
+               "ladders look like that.")
     return "\n".join(out)
 
 
@@ -441,6 +494,7 @@ def main(argv=None, runner=real_runner, out_stream=sys.stdout,
         if not f.get("head"):
             ladders.append(Ladder(
                 f.get("pr", "?"), "", base, 0, 0, None, [], None, None, None,
+                (0, 0), (0, 0),
                 "no head sha — the TAIL adjacency (last block → head) cannot be "
                 "measured, and that is where a ladder's final round's fixes sit",
                 [], [],

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Churn an audit ladder's `audit-claims` blocks do NOT cover — the hole in the
+churn measurement behind `claude/skills/audit-pr/`.
+
+    scripts/ladder-range-coverage.py 1233
+    scripts/ladder-range-coverage.py 958 1233 --repo innovation-upstream/devrc
+    scripts/ladder-range-coverage.py --facts-file <json>      # no `gh`, no network
+
+WHY THIS EXISTS
+---------------
+`claudedocs/audit-ladder-review-2026-09-04.md` measured each block's OWN
+`from..to` range, which is correct per the header semantics
+(`audit-dispatch.py::range_anchor`: `<from>` = the tip that round's audit READ,
+`<to>` = the head its FIXES produced) — but it only covers the churn the blocks
+CHAIN ACROSS. That review names the hole against itself:
+
+    #1233 posted blocks for rounds 1, 2 and 4. Its round-4 comment is titled
+    "rounds 3 and 4", and round 3's fixes sit in `1b5d2e43..eb947328`, which no
+    block's range contains. That churn is in no column of my table.
+
+It also names two more: #1108 and #1219 both start at round 2, so their round-1
+churn is outside every range. So the published `19,230 payload / 32,393
+scaffolding` is an UNDER-count by an unmeasured amount, and the fix is not a
+better eye — it is this report.
+
+🔴 THE REVIEW'S INSTRUMENT WAS A SCRATCHPAD VARIANT AND IS GONE. Its own text
+says a second instrument "was written for this review"; nothing committed
+measures per-block churn today (`scripts/ladder-depth-sweep.py` measures DEPTH,
+from transcripts, not churn from claims blocks). That is why this file exists as
+a script and not as a procedure: the repo's own record is that a measurement
+living in a scratchpad is a measurement nobody can re-derive.
+
+WHAT IT REPORTS
+---------------
+Per ladder, every ADJACENCY in the chain of block ranges, classified — and the
+classification is the finding, not a detail:
+
+  TIGHT      `to(N)` IS `from(N+1)`. The chain holds; nothing is uncovered.
+  GAP        `to(N)..from(N+1)` is non-empty ⇒ churn in NO block's range. The
+             #1233 shape. Its churn is what this script exists to print.
+  OVERLAP    `from(N+1)` is an ANCESTOR of `to(N)` ⇒ two ranges cover the same
+             commits, so the review's per-round columns DOUBLE-COUNT them.
+  UNRELATED  neither sha reaches the other. Not a gap with a size — a ladder
+             whose blocks do not describe one history (a rebase mid-ladder, or a
+             typed sha). Reported as UNMEASURABLE, never as 0.
+
+plus the TAIL adjacency `to(last)..<head>`, under the same four labels.
+
+🔴 THE WINDOW IS `[from(first), head]`, DELIBERATELY — it does NOT reach back to
+the base. Churn before the first block is the PR's ORIGINAL work, not ladder
+work, and counting it would turn every ordinary PR into a ladder with a huge
+hole. The consequence is stated rather than hidden: for a ladder whose first
+block is `round=2` (#1108, #1219) ROUND 1's FIXES ARE OUTSIDE THIS WINDOW TOO,
+so this script reports that ladder's first block round number and says the
+round-1 churn is out of scope. That is the review's third case, and it needs the
+operator to decide what round 1 of a ladder whose ledger starts at 2 even means
+— it is not a number this script should invent.
+
+READ RULES
+----------
+The churn command and its rc-0 / silent-stderr rules are NOT reimplemented here:
+they come from `audit_dispatch.measure_range_churn`, which was extracted from
+the ledger for this caller. Claims blocks are parsed by
+`audit_dispatch.parse_claims_blocks`. One rule, one place — a second copy of
+either would be a second thing to get wrong.
+
+🔴 A ZERO IS REFUSED WHEN IT CANNOT BE TOLD FROM A BROKEN RUN. "Every adjacency
+is TIGHT" and "none of this PR's commits are in this checkout" produce the same
+uncovered total — 0 — so before reporting one this script requires a POSITIVE
+CONTROL: at least one block's own `from..to` range must measure non-zero churn.
+A ladder whose every round measures empty is reported `UNMEASURABLE`, with the
+reason, at exit 4. The commits of a MERGED PR are the usual cause; `--fetch`
+(default on for `gh` mode) pulls `refs/pull/<n>/head` first, and says so.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOTHING_MEASURABLE = 3
+EXIT_REFUSED = 4
+
+# --------------------------------------------------------------------------- #
+# The shared core, imported rather than re-typed
+# --------------------------------------------------------------------------- #
+# `audit-dispatch.py` has a hyphen, so it is not importable by name. Loading it
+# by path is deliberate and is the whole point: `parse_claims_blocks`,
+# `same_commit` and `measure_range_churn` are the SAME code the briefs are built
+# from, so a change to the block grammar or the churn command cannot leave this
+# script reading an older dialect.
+
+
+def load_audit_dispatch(path=None):
+    here = Path(__file__).resolve().parent
+    target = Path(path) if path else here / "audit-dispatch.py"
+    if not target.exists():
+        raise SystemExit(
+            f"cannot find audit-dispatch.py at {target} — this script reuses its "
+            "claims-block parser and churn command rather than carrying a second "
+            "copy. Pass --audit-dispatch <path>."
+        )
+    spec = importlib.util.spec_from_file_location("audit_dispatch", target)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {target} as a module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Process boundary — ONE runner, injected, so every test is hermetic
+# --------------------------------------------------------------------------- #
+
+def real_runner(cmd, cwd=None):
+    """-> (rc, stdout, stderr). The only place this module spawns anything."""
+    p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    return p.returncode, p.stdout, p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+
+TIGHT, GAP, OVERLAP, UNRELATED = "TIGHT", "GAP", "OVERLAP", "UNRELATED"
+
+Adjacency = namedtuple(
+    "Adjacency", "label frm to from_round to_round added deleted commits reason"
+)
+Ladder = namedtuple(
+    "Ladder",
+    "pr head base blocks_total blocks_used first_round adjacencies "
+    "control_churn uncovered_added uncovered_deleted reason malformed bare",
+)
+
+
+def _is_ancestor(runner, repo_dir, a, b):
+    """-> True / False / None, where None means git could not answer.
+
+    🔴 `merge-base --is-ancestor` uses its EXIT CODE as the answer: 0 true,
+    1 false, anything else an error. Reading `rc != 0` as "false" folds an
+    unknown ref (128) into a confident False, which would relabel an
+    UNMEASURABLE adjacency as a GAP and give it a number.
+    """
+    rc, _out, err = runner(
+        ["git", "-C", repo_dir, "merge-base", "--is-ancestor", a, b]
+    )
+    if rc == 0:
+        return True
+    if rc == 1:
+        return False
+    # Any other rc is an ERROR, not a False. `_classify` turns None into
+    # UNMEASURABLE; collapsing it to False there would label the adjacency a GAP
+    # and hand it a size.
+    return None
+
+
+def _classify(ad, runner, repo_dir, frm, to, base):
+    """-> (label, RangeChurn|None, reason|None) for one adjacency."""
+    if ad.same_commit(frm, to):
+        return TIGHT, None, None
+
+    forward = _is_ancestor(runner, repo_dir, frm, to)
+    if forward is None:
+        return UNRELATED, None, (
+            f"`git merge-base --is-ancestor {frm} {to}` could not answer — one "
+            "of these shas is not in this checkout, so whether there is a hole "
+            "between them is UNKNOWN, not zero"
+        )
+    if not forward:
+        backward = _is_ancestor(runner, repo_dir, to, frm)
+        if backward is True:
+            return OVERLAP, None, (
+                f"`{to}` is an ANCESTOR of `{frm}`, so the next block's range "
+                "starts INSIDE this one — the two ranges cover some of the same "
+                "commits and a per-round table double-counts them"
+            )
+        return UNRELATED, None, (
+            f"neither `{frm}` nor `{to}` reaches the other, so these blocks do "
+            "not describe one history (a rebase mid-ladder, or a mistyped sha). "
+            "There is no gap SIZE to report"
+        )
+
+    churn = ad.measure_range_churn(runner, repo_dir, frm, to, base)
+    if churn.reason is not None:
+        return UNRELATED, None, churn.reason
+    if churn.commits == 0:
+        # Reachable, distinct shas with no commits between them. `from..to` is
+        # empty while the shas differ — which git produces for an empty-tree
+        # commit pair and for `to` being `frm`'s own alias. Not a hole.
+        return TIGHT, churn, None
+    return GAP, churn, None
+
+
+def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
+    """-> Ladder. Pure given `runner`; no `gh`, no network, no cwd dependence."""
+    blocks, malformed = ad.parse_claims_blocks(comment_texts)
+    usable = [b for b in blocks if b.audited_from and b.audited_to]
+    # 🔴 A BLOCK THAT DID NOT PARSE, AND A BARE `audited=<sha>`, ARE THE SAME
+    # HOLE BY ANOTHER ROUTE — that round contributes no range, so its churn is
+    # in nobody's column exactly as #1233's round 3 is. They are reported beside
+    # the adjacencies rather than folded into them, because neither has a SIZE:
+    # there is no second sha to measure to.
+    bare = [b.round_no for b in blocks if not (b.audited_from and b.audited_to)]
+    # Stable sort on the round number, so a duplicate round (#958 posted two
+    # `round=3` blocks) keeps the order it was seen in rather than being
+    # reordered by sha.
+    usable.sort(key=lambda b: b.round_no)
+
+    if not usable:
+        return Ladder(
+            pr, head, base, len(blocks), 0, None, [], None, None, None,
+            f"no `audit-claims` block carrying a TWO-SHA `audited=<from>..<to>` "
+            f"({len(blocks)} block(s) parsed). A bare `audited=<sha>` names no "
+            "range, so it cannot be chained and this report has nothing to "
+            "measure between",
+            malformed, bare,
+        )
+
+    adjacencies, uncovered_a, uncovered_d = [], 0, 0
+    # THE POSITIVE CONTROL: a block's OWN range. A ladder's rounds changed
+    # something by construction, so if every one of these measures empty the
+    # commits are not here and the uncovered total below would be a zero from
+    # nothing. Measured before any adjacency, so the refusal is cheap.
+    control = 0
+    for b in usable:
+        own = ad.measure_range_churn(runner, repo_dir, b.audited_from, b.audited_to, base)
+        if own.reason is None and own.commits:
+            control += own.added + own.deleted
+
+    pairs = [
+        (usable[i].audited_to, usable[i + 1].audited_from,
+         usable[i].round_no, usable[i + 1].round_no)
+        for i in range(len(usable) - 1)
+    ]
+    pairs.append((usable[-1].audited_to, head, usable[-1].round_no, None))
+
+    for frm, to, r_from, r_to in pairs:
+        label, churn, reason = _classify(ad, runner, repo_dir, frm, to, base)
+        added = churn.added if churn else None
+        deleted = churn.deleted if churn else None
+        commits = churn.commits if churn else None
+        if label == GAP:
+            uncovered_a += added or 0
+            uncovered_d += deleted or 0
+        adjacencies.append(
+            Adjacency(label, frm, to, r_from, r_to, added, deleted, commits, reason)
+        )
+
+    return Ladder(
+        pr, head, base, len(blocks), len(usable), usable[0].round_no,
+        adjacencies, control, uncovered_a, uncovered_d, None, malformed, bare,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Facts — `gh`, or a file so a test needs neither it nor a network
+# --------------------------------------------------------------------------- #
+
+def facts_from_gh(runner, repo, pr):
+    cmd = ["gh", "pr", "view", str(pr), "--json",
+           "comments,headRefOid,baseRefName,url"]
+    if repo:
+        cmd += ["--repo", repo]
+    rc, out, err = runner(cmd)
+    if rc != 0:
+        raise SystemExit(
+            f"`gh pr view {pr}` exited {rc}: {(err or out).strip() or 'no output'}"
+        )
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"`gh pr view {pr}` did not print JSON: {e}")
+    return {
+        "pr": pr,
+        "head": data.get("headRefOid") or "",
+        "base": data.get("baseRefName") or "",
+        "comments": [c.get("body", "") for c in data.get("comments") or []],
+        "url": data.get("url") or "",
+    }
+
+
+def fetch_pr_ref(runner, repo_dir, pr):
+    """`git fetch origin refs/pull/<n>/head` — a MERGED PR's commits are the
+    usual reason every range measures empty, and a squash merge leaves them
+    reachable from no local branch. Returns a one-line note, never raises: a
+    failed fetch is reported beside the refusal it causes, not instead of it.
+    """
+    rc, _out, err = runner([
+        "git", "-C", repo_dir, "fetch", "--quiet", "origin",
+        f"refs/pull/{pr}/head",
+    ])
+    if rc != 0:
+        return (f"fetch of refs/pull/{pr}/head FAILED (rc {rc}): "
+                f"{err.strip().splitlines()[-1] if err.strip() else 'no output'}")
+    return f"fetched refs/pull/{pr}/head"
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+def render(ladders, notes):
+    out = []
+    out.append("## ladder range coverage — churn that NO `audit-claims` block "
+               "range covers")
+    out.append("")
+    out.append("window per ladder: [first block's `from`, head]. Churn BEFORE the "
+               "first block is the PR's")
+    out.append("own work, not ladder work, and is deliberately out of scope — "
+               "see this script's docstring.")
+    out.append("")
+    for n in notes:
+        out.append(f"note: {n}")
+    if notes:
+        out.append("")
+
+    total_a = total_d = 0
+    measured = 0
+    for L in ladders:
+        out.append(f"### PR #{L.pr}  head={L.head[:8] or '?'}  base={L.base or '?'}")
+        for r in L.malformed:
+            out.append(f"  🔴 UNPARSED BLOCK — {r}")
+        if L.bare:
+            out.append(f"  🔴 BARE `audited=<sha>` on round(s) "
+                       f"{', '.join(str(r) for r in L.bare)} — one sha names no "
+                       "range, so that")
+            out.append("    round is in the chain's numbering and in nobody's "
+                       "coverage. No SIZE is reportable.")
+        if L.malformed or L.bare:
+            out.append("    Both are the #1233 hole by another route: a round "
+                       "that contributes no range.")
+        if L.reason:
+            out.append(f"  UNMEASURABLE — {L.reason}")
+            out.append("")
+            continue
+        out.append(f"  blocks: {L.blocks_used} usable of {L.blocks_total} parsed"
+                   f" · first ledgered round: {L.first_round}")
+        if L.first_round and L.first_round > 1:
+            out.append(f"  ⚠ this ladder's ledger STARTS at round {L.first_round},"
+                       f" so rounds 1..{L.first_round - 1} are outside the window")
+            out.append("    and their churn is NOT counted below. That is the "
+                       "#1108 / #1219 shape.")
+        if not L.control_churn:
+            out.append("  🔴 REFUSED — the positive control measured ZERO: not one "
+                       "block's own range")
+            out.append("    has any churn in this checkout, so an uncovered total "
+                       "of 0 here would be a zero")
+            out.append("    from nothing rather than a tight chain. The PR's "
+                       "commits are almost certainly not")
+            out.append("    present — see the fetch note above.")
+            out.append("")
+            continue
+        measured += 1
+        out.append(f"  positive control: {L.control_churn} line(s) of churn across "
+                   "the blocks' own ranges")
+        for a in L.adjacencies:
+            where = (f"round {a.from_round} `to` → round {a.to_round} `from`"
+                     if a.to_round is not None
+                     else f"round {a.from_round} `to` → head (TAIL)")
+            if a.label == TIGHT:
+                out.append(f"  TIGHT      {where}")
+            elif a.label == GAP:
+                out.append(f"  🔴 GAP     {where}: {a.frm[:8]}..{a.to[:8]} — "
+                           f"{a.commits} commit(s), "
+                           f"{(a.added or 0) + (a.deleted or 0)} line(s) "
+                           f"(+{a.added}/-{a.deleted}) in NO block's range")
+            else:
+                out.append(f"  {a.label}  {where}: {a.reason}")
+        out.append(f"  UNCOVERED: {L.uncovered_added + L.uncovered_deleted} line(s)"
+                   f" (+{L.uncovered_added}/-{L.uncovered_deleted})")
+        total_a += L.uncovered_added
+        total_d += L.uncovered_deleted
+        out.append("")
+
+    out.append(f"TOTAL uncovered across {measured} measured ladder(s): "
+               f"{total_a + total_d} line(s) (+{total_a}/-{total_d})")
+    out.append("⚠ RAW lines, NOT split payload/scaffolding. That split was made "
+               "BY HAND, per PR, in")
+    out.append("  the 2026-09-04 review; no pathspec can make it (a docs PR's "
+               "payload IS the `.md`). So")
+    out.append("  this total is the SIZE of the hole, not the payload the review "
+               "under-counted by.")
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+
+def main(argv=None, runner=real_runner, out_stream=sys.stdout,
+         err_stream=sys.stderr):
+    ap = argparse.ArgumentParser(
+        description="churn an audit ladder's claims-block ranges do not cover"
+    )
+    ap.add_argument("prs", nargs="*", type=int, help="PR number(s)")
+    ap.add_argument("--repo", help="owner/name (default: gh's own default)")
+    ap.add_argument("--repo-dir", default=".", help="the git checkout to measure in")
+    ap.add_argument("--base", help="override the base ref (default: origin/<the "
+                                   "PR's own baseRefName>)")
+    ap.add_argument("--facts-file", help="JSON object, or list of them, with "
+                                        "{pr, head, base, comments[]} — "
+                                        "consults no `gh` and no network")
+    ap.add_argument("--no-fetch", action="store_true",
+                    help="skip `git fetch origin refs/pull/<n>/head`")
+    ap.add_argument("--audit-dispatch", help="path to audit-dispatch.py")
+    args = ap.parse_args(argv)
+
+    if not args.prs and not args.facts_file:
+        ap.error("give at least one PR number, or --facts-file")
+
+    ad = load_audit_dispatch(args.audit_dispatch)
+
+    facts_list, notes = [], []
+    if args.facts_file:
+        try:
+            raw = json.loads(Path(args.facts_file).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"cannot read --facts-file: {e}", file=err_stream)
+            return EXIT_USAGE
+        facts_list = raw if isinstance(raw, list) else [raw]
+        notes.append("--facts-file mode: no `gh` was consulted, so nothing here "
+                     "was checked against the live PR")
+    else:
+        for pr in args.prs:
+            if not args.no_fetch:
+                notes.append(fetch_pr_ref(runner, args.repo_dir, pr))
+            facts_list.append(facts_from_gh(runner, args.repo, pr))
+
+    ladders = []
+    for f in facts_list:
+        base = args.base or f.get("base") or ""
+        # A bare branch name is not a ref this checkout can resolve; the review
+        # used `origin/main`, and the PR reports `main`.
+        if base and "/" not in base:
+            base = f"origin/{base}"
+        if not f.get("head"):
+            ladders.append(Ladder(
+                f.get("pr", "?"), "", base, 0, 0, None, [], None, None, None,
+                "no head sha — the TAIL adjacency (last block → head) cannot be "
+                "measured, and that is where a ladder's final round's fixes sit",
+                [], [],
+            ))
+            continue
+        ladders.append(measure_ladder(
+            ad, runner, args.repo_dir, f.get("pr", "?"), f["head"], base,
+            f.get("comments") or [],
+        ))
+
+    print(render(ladders, notes), file=out_stream)
+
+    if not ladders:
+        return EXIT_NOTHING_MEASURABLE
+    if all(L.reason for L in ladders):
+        return EXIT_NOTHING_MEASURABLE
+    if any(L.reason is None and not L.control_churn for L in ladders):
+        return EXIT_REFUSED
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/mutants-ladder-range-coverage.sh
+++ b/scripts/tests/mutants-ladder-range-coverage.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Mutation battery for `scripts/ladder-range-coverage.py` and the
+# `measure_range_churn` extraction it shares with `scripts/audit-dispatch.py`.
+#
+# Not run by CI. An author/reviewer instrument, kept IN THE TREE so
+# "mutation-verified" can be RE-DERIVED instead of believed.
+#
+#   nix develop ~/workspace/devrc -c bash \
+#     scripts/tests/mutants-ladder-range-coverage.sh
+#
+#   (a bare `bash …` works only where pytest is already on PATH; this host's
+#   `.envrc` is `use opencode`, which does not put it there.) Exit 0 only if
+#   every row is as expected.
+#
+# 🔴 CONVENTIONS COME FROM `mutants-audit-ladder.sh` — the assert-it-applied
+# driver, the named-killer rule, the harness floor, `PYTHONDONTWRITEBYTECODE=1`.
+# Read that file's header for WHY each exists; this one does not restate it.
+#
+# 🔴 THE ARTIFACT HERE IS CODE, NOT PROSE, so these are operator and branch
+# mutants rather than rewordings. The one thing they must prove is specific to
+# this script: its headline output is a ZERO for a healthy ladder, so "the GAP
+# detector works" and "the GAP detector is dead" are indistinguishable from the
+# report alone. Every row below breaks the detector on purpose and names the
+# test that must notice.
+#
+# 🔴 IT NEVER TOUCHES YOUR WORKING TREE. Everything is mutated inside a
+# `mktemp -d` copy built by naming FOUR INDIVIDUAL FILES. That selective copy,
+# not the assertion below it, is what keeps a `.git` out of the tree — this repo
+# is worked in WORKTREES, whose `.git` is a FILE pointing at the real git dir, so
+# a `cp -a "$SRC"` here would let a git command inside the copy act on the real
+# repository.
+#
+# COVERAGE IS DELIBERATELY PARTIAL. Not covered: the `gh` facts path (no network
+# in this battery — `facts_from_gh` is exercised only by `--facts-file`'s absence
+# in `main`), the renderer's exact wording beyond the tokens the tests assert,
+# and `fetch_pr_ref`. Those are the surfaces where a defect is LOUD; the rows
+# here are the ones where it would be silent and flattering.
+set -uo pipefail
+
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+SRC="$(cd "$D/../.." && pwd)"
+
+T="$(mktemp -d /tmp/ladder-range-mut-XXXXXX)"
+trap 'rm -rf "$T"' EXIT
+ROOT="$T/tree"
+
+mkdir -p "$ROOT/scripts/tests" "$ROOT/scripts/testlib"
+cp -a "$SRC/scripts/ladder-range-coverage.py"                "$ROOT/scripts/"
+cp -a "$SRC/scripts/audit-dispatch.py"                       "$ROOT/scripts/"
+cp -a "$SRC/scripts/tests/test_ladder_range_coverage.py"     "$ROOT/scripts/tests/"
+# The suite imports `testlib.hermetic_git` for its git fixtures; without it the
+# UNMUTATED baseline aborts at import and the battery runs ZERO rows while
+# reporting nothing the author touched.
+cp -a "$SRC/scripts/testlib/hermetic_git.py"                 "$ROOT/scripts/testlib/"
+# 🔴 THIS SCRIPT IS ITSELF A DEPENDENCY OF THE SUITE, and forgetting it is the
+# trap `mutants-audit-ladder.sh` records twice:
+# `test_the_batterys_floor_is_re_derived_from_this_modules_size` reads the
+# `MIN_TESTS` literal below out of this file, so without this line the baseline
+# aborts and every row goes unmeasured. Measured here on the first run — the
+# battery reported the unmutated suite red and ran ZERO rows. Assume the next
+# guard added to that module needs a line here too.
+cp -a "$SRC/scripts/tests/mutants-ladder-range-coverage.sh"  "$ROOT/scripts/tests/"
+[ -f "$SRC/scripts/testlib/__init__.py" ] && \
+  cp -a "$SRC/scripts/testlib/__init__.py"                   "$ROOT/scripts/testlib/"
+
+if [ -e "$ROOT/.git" ]; then
+  echo "🔴 the copy carries a .git — refusing to run"; exit 2
+fi
+find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
+
+SUITE="$ROOT/scripts/tests/test_ladder_range_coverage.py"
+LRC="$ROOT/scripts/ladder-range-coverage.py"
+DISP="$ROOT/scripts/audit-dispatch.py"
+cp -a "$LRC"  "$T/lrc.orig"
+cp -a "$DISP" "$T/disp.orig"
+restore() { cp -a "$T/lrc.orig" "$LRC"; cp -a "$T/disp.orig" "$DISP"; }
+
+FAILURES=0
+ROWS=0
+
+# 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
+# FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
+# mutant SURVIVED. The floor catches COLLAPSE, not growth; `run-tests.sh`'s own
+# formula is `m - min(50, max(1, m/20))`, which at m=19 is 18.
+# 🔴 IT ALREADY FIRED ONCE, BEFORE THIS FILE WAS COMMITTED: the module grew
+# 18 → 19 while this literal still said 17, and the pin failed with
+# `should be 18, not 17`. One growth was enough. That is the argument for pinning
+# it from the first commit rather than after the second silent widening.
+# 🔴 DO NOT maintain this by memory — `test_ladder_range_coverage.py::
+# test_the_batterys_floor_is_re_derived_from_this_modules_size` reads the literal
+# below, counts the module, and fails with the replacement value. Two instances
+# of a too-low floor silently widening have already been recorded in
+# `mutants-audit-ladder.sh`; this is pinned from the first commit instead.
+MIN_TESTS=18
+failing() {
+  local out n f total
+  out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
+    -q --no-header --tb=no -p no:cacheprovider 2>&1)"
+  if grep -q "No module named pytest" <<<"$out"; then
+    echo "__HARNESS_BROKE__ pytest is not on PATH — run it as" \
+         "\`nix develop ~/workspace/devrc -c bash" \
+         "scripts/tests/mutants-ladder-range-coverage.sh\`, not in a bare shell"
+    return
+  fi
+  n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
+  f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
+  total=$(( ${n:-0} + ${f:-0} ))
+  if [ "$total" -lt "$MIN_TESTS" ]; then
+    echo "__HARNESS_BROKE__ only $total test(s) ran (floor $MIN_TESTS)"
+    return
+  fi
+  sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p' <<<"$out" | sort -u
+}
+
+apply() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+old, new = sys.argv[2], sys.argv[3]
+if old not in t:
+    sys.exit(3)
+p.write_text(t.replace(old, new, 1))
+PY
+}
+
+run() { # run <name> <expect: test name | SURVIVES> <file> <old> <new>
+  local name="$1" want="$2" file="$3" old="$4" new="$5"
+  ROWS=$((ROWS+1))
+  if ! apply "$file" "$old" "$new"; then
+    printf '  🔴 %-52s MUTATION DID NOT APPLY — result meaningless\n' "$name"
+    FAILURES=$((FAILURES+1)); restore; return
+  fi
+  local killers; killers="$(failing)"
+  restore
+  if grep -q __HARNESS_BROKE__ <<<"$killers"; then
+    printf '  🔴 %-52s HARNESS BROKE — %s\n' "$name" "$killers"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if [ "$want" = SURVIVES ]; then
+    if [ -n "$killers" ]; then
+      printf '  🔴 %-52s KILLED but should SURVIVE: %s\n' \
+        "$name" "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')"
+      FAILURES=$((FAILURES+1)); return
+    fi
+    printf '  ok %-52s SURVIVES, as expected\n' "$name"; return
+  fi
+  if [ -z "$killers" ]; then
+    printf '  🔴 %-52s SURVIVED — no test failed\n' "$name"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  # 🔴 The named test must be AMONG the killers, reported in two steps so
+  # "your guard is dead, something else caught it" is never rendered as
+  # "the probe is no longer isolated". These rows are about whether THIS
+  # assertion executes.
+  if ! grep -qx "$want" <<<"$killers"; then
+    printf '  🔴 %-52s WRONG-KILLER: %s (wanted %s)\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')" "$want"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  printf '  ok %-52s killed by %s\n' "$name" \
+    "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')"
+}
+
+echo "== baseline (must be GREEN, or every row below is meaningless) =="
+BASE="$(failing)"
+if [ -n "$BASE" ]; then
+  echo "🔴 the UNMUTATED suite is not green: $(tr '\n' ',' <<<"$BASE")"
+  exit 2
+fi
+echo "  ok unmutated suite is green"
+
+echo
+echo "== the GAP detector itself =="
+# The single most flattering failure this script can have: report every ladder
+# as a tight chain. The uncovered total is then 0 everywhere, which is exactly
+# what a healthy corpus looks like.
+run "GAP can never be returned (collapse it to TIGHT)" \
+    test_the_1233_shape_reports_the_skipped_rounds_churn "$LRC" \
+    '    return GAP, churn, None' \
+    '    return TIGHT, churn, None'
+
+run "the tail adjacency is dropped from the chain" \
+    test_the_tail_after_the_last_block_is_its_own_gap "$LRC" \
+    '    pairs.append((usable[-1].audited_to, head, usable[-1].round_no, None))' \
+    '    pass  # tail dropped'
+
+run "uncovered churn is never accumulated" \
+    test_the_1233_shape_reports_the_skipped_rounds_churn "$LRC" \
+    '        if label == GAP:
+            uncovered_a += added or 0
+            uncovered_d += deleted or 0' \
+    '        if False:
+            uncovered_a += added or 0
+            uncovered_d += deleted or 0'
+
+# 🔴 The interior/tail split is the one number a reader will quote, and a mutant
+# that credits a tail gap to the interior bucket makes the unambiguous half look
+# 6x bigger than it is (3,727 tail vs 655 interior over the review's 20 ladders).
+run "a TAIL gap is credited to the INTERIOR bucket" \
+    test_interior_and_tail_gaps_are_reported_as_SEPARATE_totals "$LRC" \
+    '            if r_to is None:' \
+    '            if False:'
+
+run "the interior bucket never accumulates" \
+    test_interior_and_tail_gaps_are_reported_as_SEPARATE_totals "$LRC" \
+    '                interior_a += added or 0' \
+    '                interior_a += 0'
+
+echo
+echo "== the labels that must NOT become a sized GAP =="
+run "an OVERLAP is reported as a GAP instead" \
+    test_an_overlap_is_labelled_OVERLAP_and_given_no_size "$LRC" \
+    '        if backward is True:' \
+    '        if backward is None:'
+
+run "a git ERROR is read as a plain False (not UNMEASURABLE)" \
+    test_a_sha_git_cannot_resolve_is_UNMEASURABLE_not_a_gap "$LRC" \
+    '    # Any other rc is an ERROR, not a False. `_classify` turns None into
+    # UNMEASURABLE; collapsing it to False there would label the adjacency a GAP
+    # and hand it a size.
+    return None' \
+    '    return False'
+
+echo
+echo "== the refusal: a zero that cannot be told from a broken run =="
+run "the positive control is never consulted (render)" \
+    test_absent_commits_are_REFUSED_not_reported_as_zero "$LRC" \
+    '        if not L.control_churn:' \
+    '        if False:'
+
+run "the refusal never reaches the EXIT STATUS" \
+    test_exit_code_4_when_a_ladder_is_refused "$LRC" \
+    '    if any(L.reason is None and not L.control_churn for L in ladders):' \
+    '    if False:'
+
+echo
+echo "== holes with no size =="
+run "a bare audited=<sha> is not recorded as a hole" \
+    test_a_bare_audited_sha_is_reported_as_a_hole_with_no_size "$LRC" \
+    '    bare = [b.round_no for b in blocks if not (b.audited_from and b.audited_to)]' \
+    '    bare = []'
+
+run "malformed blocks are dropped instead of reported" \
+    test_an_unparsed_block_is_reported_rather_than_dropped "$LRC" \
+    '        for r in L.malformed:' \
+    '        for r in []:'
+
+run "a round-2-first ledger is not told round 1 is out of window" \
+    test_a_ledger_starting_at_round_2_says_round_1_is_out_of_window "$LRC" \
+    '        if L.first_round and L.first_round > 1:' \
+    '        if False:'
+
+echo
+echo "== the shared core, and the rule that must differ per caller =="
+# 🔴 THE POINT OF THE EXTRACTION. If the core starts refusing an empty range,
+# every TIGHT chain becomes unmeasurable; if `measure_ledger` STOPS refusing one,
+# a delta round's empty-by-construction range reads as a clean round. Both
+# directions have their own row, because one mutant cannot show both.
+run "the shared core starts refusing an empty range" \
+    test_measure_range_churn_does_NOT_refuse_an_empty_range "$DISP" \
+    '        return RangeChurn({}, 0, 0, 0, None)' \
+    '        return fail("the range is EMPTY")'
+
+run "measure_ledger stops refusing an empty range" \
+    test_measure_ledger_still_refuses_an_empty_range "$DISP" \
+    '    if churn.commits == 0:
+        # 🔴 THREE causes' \
+    '    if False:
+        # 🔴 THREE causes'
+
+run "the churn numbers are dropped on the way back out" \
+    test_measure_ledger_still_measures_a_real_range "$DISP" \
+    '    return LedgerReport(
+        churn.files, churn.added, churn.deleted, churn.commits, None, None, None
+    )' \
+    '    return LedgerReport(
+        churn.files, 0, 0, churn.commits, None, None, None
+    )'
+
+run "a failed git call becomes a zero instead of a reason" \
+    test_a_failed_git_call_is_a_reason_not_a_zero "$DISP" \
+    '    if rc != 0:
+        return fail(f"`git rev-list {frm}..{to}` exited {rc}: "
+                    f"{(err or out).strip() or '"'"'no output'"'"'}")' \
+    '    if rc != 0:
+        return RangeChurn({}, 0, 0, 0, None)'
+
+echo
+echo "== the anti-duplication guard (its own positive control) =="
+# The structural guard asserts this script does NOT carry a second copy of the
+# churn command. A guard that cannot fire reads as coverage and provides none,
+# so the mutant is the duplication it forbids.
+run "a second copy of the churn command is re-typed here" \
+    test_it_imports_the_churn_command_rather_than_carrying_a_copy "$LRC" \
+    'def real_runner(cmd, cwd=None):' \
+    'def _unused(runner, repo_dir, a, b, base):
+    return runner(["git", "-C", repo_dir, "log", "--numstat", "--format=",
+                   "--remerge-diff", f"{a}..{b}", "--not", base])
+
+
+def real_runner(cmd, cwd=None):'
+
+echo
+echo "== controls (must kill NOTHING) =="
+# A comment edit and a rename of a purely internal local must both survive. If
+# either goes red the suite is keyed to incidental text rather than behaviour.
+run "edit a comment nobody asserts on" SURVIVES "$LRC" \
+    '# --------------------------------------------------------------------------- #
+# Rendering' \
+    '# --------------------------------------------------------------------------- #
+# Rendering (the operator-facing half)'
+
+run "rename an internal local in the numstat loop" SURVIVES "$DISP" \
+    '    files, added, deleted = {}, 0, 0
+    for line in out.splitlines():
+        parts = line.split("\t")' \
+    '    files, added, deleted = {}, 0, 0
+    for raw_line in out.splitlines():
+        parts = raw_line.split("\t")'
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "✅ $ROWS row(s), all as expected"
+  exit 0
+fi
+echo "🔴 $FAILURES of $ROWS row(s) not as expected"
+exit 1

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -193,6 +193,38 @@ def test_the_tail_after_the_last_block_is_its_own_gap(lrc, ad, base_repo):
 # The three labels that must NOT become a GAP with a number
 # --------------------------------------------------------------------------- #
 
+def test_interior_and_tail_gaps_are_reported_as_SEPARATE_totals(lrc, ad,
+                                                                base_repo):
+    """🔴 The two gap kinds are different claims and must not share a headline.
+
+    An INTERIOR gap is unambiguous — a round's churn nobody audited. A TAIL gap
+    conflates post-last-block fixes with development that continued after the
+    ladder ended. Measured over the 2026-09-04 review's 20 ladders the tail is
+    3,727 of 4,382 lines, so a single total invites being quoted as an
+    under-count it does not support. This fixture has one of each, with
+    DELIBERATELY DIFFERENT sizes so a mutant that reports one in place of the
+    other cannot pass: an interior gap of 7 and a tail of 4 are distinct from
+    each other AND from their sum.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    skipped = _commit(repo, "interior.py", 7, "round 2's unledgered fix")
+    r3_to = _commit(repo, "c.py", 10, "round 3 fix")
+    tail = _commit(repo, "tail.py", 4, "after the last block")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 9, tail, "main",
+                           [_block(1, base, r1_to), _block(3, skipped, r3_to)])
+
+    assert sum(L.interior) == 7, [(a.label, a.to_round, a.added)
+                                  for a in L.adjacencies]
+    assert sum(L.tail) == 4
+    assert L.uncovered_added + L.uncovered_deleted == 11
+
+    rendered = lrc.render([L], [])
+    assert "INTERIOR  7 line(s)" in rendered
+    assert "TAIL      4 line(s)" in rendered
+
+
 def test_an_overlap_is_labelled_OVERLAP_and_given_no_size(lrc, ad, base_repo):
     """Two ranges covering the same commits double-count, which is the OPPOSITE
     error from a gap. Reporting it as a 0-line gap would hide it."""
@@ -429,6 +461,53 @@ def test_the_script_runs_and_its_usage_does_not_require_a_network():
                        capture_output=True, text=True, check=False)
     assert p.returncode == 0, p.stderr
     assert "--facts-file" in p.stdout
+
+
+def test_the_batterys_floor_is_re_derived_from_this_modules_size():
+    """🔴 `mutants-ladder-range-coverage.sh`'s `MIN_TESTS` must track THIS module.
+
+    That battery reads pytest's own count and calls anything below `MIN_TESTS`
+    a broken harness. A floor left behind as the module grows never complains —
+    it is invisible precisely because it only fires downward — and
+    `mutants-audit-ladder.sh` has recorded that happening TWICE, the second time
+    tolerating the silent loss of both guards the growth had added. So the number
+    is pinned here from this battery's first commit rather than maintained by
+    memory, and this test prints the replacement value on failure.
+
+    The formula is `run-tests.sh`'s own: `m - min(50, max(1, m // 20))`.
+    """
+    battery = SCRIPTS / "tests" / "mutants-ladder-range-coverage.sh"
+    assert battery.exists(), "the battery this floor belongs to is gone"
+
+    declared = None
+    for line in battery.read_text(encoding="utf-8").splitlines():
+        if line.startswith("MIN_TESTS="):
+            declared = int(line.split("=", 1)[1].strip())
+            break
+    assert declared is not None, "no MIN_TESTS= literal in the battery"
+
+    p = subprocess.run(
+        [sys.executable, "-m", "pytest", str(Path(__file__).resolve()),
+         "--collect-only", "-q", "--no-header", "-p", "no:cacheprovider"],
+        capture_output=True, text=True, check=False, cwd=str(REPO_ROOT),
+    )
+    assert p.returncode == 0, p.stdout[-2000:] + p.stderr[-2000:]
+    collected = len([
+        ln for ln in p.stdout.splitlines()
+        if "::" in ln and ln.startswith("scripts/tests/")
+    ])
+    # 🔴 A positive control on the COUNT, not just on the comparison: a parse
+    # that silently yields 0 would make any floor look generous.
+    assert collected > 5, (
+        f"--collect-only parsed {collected} test(s) from this module, which is "
+        f"not a credible count — the floor below would be vacuous.\n{p.stdout[-2000:]}"
+    )
+    expected = collected - min(50, max(1, collected // 20))
+    assert declared == expected, (
+        f"this module now collects {collected} test(s), so the battery's floor "
+        f"should be {expected}, not {declared}. Set `MIN_TESTS={expected}` in "
+        f"{battery.name} — do not compute it by hand."
+    )
 
 
 def test_it_imports_the_churn_command_rather_than_carrying_a_copy():

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Guards for `scripts/ladder-range-coverage.py` — the report that finds churn
+no `audit-claims` block range covers.
+
+WHY THESE ARE SHAPED THIS WAY
+-----------------------------
+The thing under test is a CLASSIFIER over real git reachability, so the fixtures
+are real repositories with real commits. A fake runner would let the classifier
+agree with a model of `merge-base --is-ancestor` that git does not share — and
+the whole defect this script addresses (#1233's round 3) is a reachability
+fact, not a parsing one.
+
+🔴 EVERY ASSERTION HERE HAS A CONTROL ON THE OTHER SIDE, because the headline
+number this script prints is a ZERO for a healthy ladder. "0 uncovered" and "the
+instrument is wired to nothing" are the same output, so:
+
+  * `test_a_tight_chain_reports_zero_uncovered` is only meaningful beside
+    `test_the_1233_shape_reports_the_skipped_rounds_churn`, which MUST produce a
+    non-zero count off a fixture built to contain one;
+  * `test_absent_commits_are_REFUSED_not_reported_as_zero` is the negative
+    control for the positive control itself.
+
+The `#1233` fixture is named for the real case in
+`claudedocs/audit-ladder-review-2026-09-04.md`: blocks for rounds 1, 2 and 4,
+round 3's fixes between `to(2)` and `from(4)`, in no block's range.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.hermetic_git import hermetic_git_env  # noqa: E402
+
+SCRIPT = SCRIPTS / "ladder-range-coverage.py"
+DISPATCH = SCRIPTS / "audit-dispatch.py"
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def lrc():
+    return _load(SCRIPT, "ladder_range_coverage")
+
+
+@pytest.fixture(scope="module")
+def ad():
+    return _load(DISPATCH, "audit_dispatch_under_test")
+
+
+# --------------------------------------------------------------------------- #
+# Fixture repositories
+# --------------------------------------------------------------------------- #
+
+def _git(repo, *args, check=True):
+    p = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, env=hermetic_git_env(), check=False,
+    )
+    if check:
+        assert p.returncode == 0, f"git {args} failed: {p.stderr or p.stdout}"
+    return p.stdout.strip()
+
+
+def _init(repo):
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "--quiet", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "T")
+    return repo
+
+
+def _commit(repo, path, lines, msg):
+    """Write `lines` lines into `path` and commit. Returns the new sha."""
+    f = repo / path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("\n".join(f"line {i}" for i in range(lines)) + "\n",
+                 encoding="utf-8")
+    _git(repo, "add", "--", path)
+    _git(repo, "commit", "--quiet", "-m", msg)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _block(round_no, frm, to, claim="a claim"):
+    return (f"```audit-claims round={round_no} audited={frm}..{to}\n"
+            f"1. {claim}\n"
+            "```\n")
+
+
+@pytest.fixture
+def base_repo(tmp_path):
+    """`main` at a base commit, plus a `feat` branch off it. The base branch is
+    `main`, so `--not main` matches the review's `--not origin/main` shape."""
+    repo = _init(tmp_path / "repo")
+    _commit(repo, "README.md", 3, "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "checkout", "--quiet", "-b", "feat")
+    return repo, base
+
+
+# --------------------------------------------------------------------------- #
+# The positive control — the #1233 shape MUST produce a number
+# --------------------------------------------------------------------------- #
+
+def test_the_1233_shape_reports_the_skipped_rounds_churn(lrc, ad, base_repo):
+    """Blocks for rounds 1, 2 and 4; round 3's fixes in NO block's range.
+
+    This is the whole point of the script, and it is the positive control for
+    every zero the other tests assert. If this ever reports 0, the instrument is
+    measuring nothing and the tight-chain tests below are vacuous.
+    """
+    repo, base = base_repo
+    r1_from = base
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    r2_to = _commit(repo, "b.py", 10, "round 2 fix")
+    # ── round 3's fixes: committed, and NO block will name them ──
+    r3_a = _commit(repo, "skipped_one.py", 7, "round 3 fix, part 1")
+    r3_b = _commit(repo, "skipped_two.py", 5, "round 3 fix, part 2")
+    r4_to = _commit(repo, "d.py", 4, "round 4 fix")
+
+    comments = [
+        _block(1, r1_from, r1_to),
+        _block(2, r1_to, r2_to),
+        _block(4, r3_b, r4_to),      # round 4 anchors AFTER round 3's commits
+    ]
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 1233, r4_to, "main",
+                           comments)
+
+    assert L.reason is None
+    assert L.blocks_used == 3
+    assert L.control_churn > 0, "positive control: the blocks' own ranges move"
+
+    gaps = [a for a in L.adjacencies if a.label == lrc.GAP]
+    assert len(gaps) == 1, [(a.label, a.from_round, a.to_round)
+                            for a in L.adjacencies]
+    gap = gaps[0]
+    assert (gap.from_round, gap.to_round) == (2, 4)
+    assert gap.commits == 2, "round 3 landed two commits"
+    # 7 + 5 added lines, nothing deleted. Asserted as a LITERAL, derived from
+    # the fixture's own arguments and never from the script's output.
+    assert (gap.added, gap.deleted) == (12, 0)
+    assert L.uncovered_added + L.uncovered_deleted == 12
+    assert r3_a  # the first skipped commit is inside the measured gap
+
+
+def test_a_tight_chain_reports_zero_uncovered(lrc, ad, base_repo):
+    """The negative control. Only meaningful beside the test above."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    r2_to = _commit(repo, "b.py", 10, "round 2 fix")
+    comments = [_block(1, base, r1_to), _block(2, r1_to, r2_to)]
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 1, r2_to, "main",
+                           comments)
+
+    assert L.reason is None
+    assert L.control_churn > 0
+    assert [a.label for a in L.adjacencies] == [lrc.TIGHT, lrc.TIGHT]
+    assert L.uncovered_added + L.uncovered_deleted == 0
+
+
+def test_the_tail_after_the_last_block_is_its_own_gap(lrc, ad, base_repo):
+    """A ladder's FINAL round's fixes land after its last block is posted, so
+    the tail is exactly where a terminal round's churn hides."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    tail = _commit(repo, "after.py", 6, "fixes posted after the last block")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 2, tail, "main",
+                           [_block(1, base, r1_to)])
+
+    assert [a.label for a in L.adjacencies] == [lrc.GAP]
+    tail_adj = L.adjacencies[0]
+    assert tail_adj.to_round is None, "the tail adjacency has no next round"
+    assert (tail_adj.added, tail_adj.deleted) == (6, 0)
+
+
+# --------------------------------------------------------------------------- #
+# The three labels that must NOT become a GAP with a number
+# --------------------------------------------------------------------------- #
+
+def test_an_overlap_is_labelled_OVERLAP_and_given_no_size(lrc, ad, base_repo):
+    """Two ranges covering the same commits double-count, which is the OPPOSITE
+    error from a gap. Reporting it as a 0-line gap would hide it."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    r2_to = _commit(repo, "b.py", 10, "round 2 fix")
+    # Round 2 claims to have audited `base` — BEFORE round 1's range ended.
+    comments = [_block(1, base, r1_to), _block(2, base, r2_to)]
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 3, r2_to, "main",
+                           comments)
+
+    labels = [a.label for a in L.adjacencies]
+    assert labels[0] == lrc.OVERLAP, labels
+    overlap = L.adjacencies[0]
+    assert overlap.added is None and overlap.commits is None
+    assert "ANCESTOR" in overlap.reason
+    assert L.uncovered_added + L.uncovered_deleted == 0
+
+
+def test_unrelated_histories_are_UNMEASURABLE_not_zero(lrc, ad, base_repo):
+    """A rebase mid-ladder leaves two shas neither of which reaches the other.
+    There is no gap SIZE; saying 0 would be a claim nobody measured."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    # An orphan branch: a real commit in this repo, reachable from nothing here.
+    _git(repo, "checkout", "--quiet", "--orphan", "other")
+    _git(repo, "rm", "-rf", "--quiet", ".")
+    orphan = _commit(repo, "z.py", 3, "unrelated history")
+    _git(repo, "checkout", "--quiet", "feat")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 4, r1_to, "main",
+                           [_block(1, base, orphan), _block(2, r1_to, r1_to)])
+
+    assert any(a.label == lrc.UNRELATED for a in L.adjacencies), \
+        [(a.label, a.reason) for a in L.adjacencies]
+    for a in L.adjacencies:
+        if a.label == lrc.UNRELATED:
+            assert a.added is None, "an unmeasurable adjacency carries no number"
+
+
+def test_a_sha_git_cannot_resolve_is_UNMEASURABLE_not_a_gap(lrc, ad, base_repo):
+    """Reaches `_is_ancestor`'s ERROR return, which no other test here does.
+
+    🔴 Written because the other UNRELATED case (two real but unrelated commits)
+    exercises the rc-1 path only, so `_is_ancestor`'s rc-128 branch was
+    UNREACHABLE from this suite — a guard a mutation sweep would score as
+    surviving while production hits it on every merged PR whose head is not
+    fetched. The discriminator: `frm` resolves, `to` does not, and they differ,
+    so the classifier cannot take the TIGHT short-circuit.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    unfetched_head = "9" * 40
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 8, unfetched_head,
+                           "main", [_block(1, base, r1_to)])
+
+    assert L.control_churn > 0, "the block's own range is real — not a refusal"
+    tail = L.adjacencies[-1]
+    assert tail.label == lrc.UNRELATED, (tail.label, tail.reason)
+    assert "could not answer" in tail.reason
+    assert tail.added is None and tail.commits is None
+    assert L.uncovered_added + L.uncovered_deleted == 0
+
+
+def test_absent_commits_are_REFUSED_not_reported_as_zero(lrc, ad, base_repo):
+    """The negative control for the positive control.
+
+    A merged PR's commits are routinely absent from a local checkout. Every
+    range then measures empty and the uncovered total is 0 — identical to a
+    perfect ladder. The script must refuse instead.
+    """
+    repo, base = base_repo
+    _commit(repo, "a.py", 10, "a commit that exists")
+    absent_a = "0" * 40
+    absent_b = "1" * 40
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 5, absent_b, "main",
+                           [_block(1, absent_a, absent_b)])
+
+    assert not L.control_churn, "the control must read zero for absent commits"
+    rendered = lrc.render([L], [])
+    assert "REFUSED" in rendered
+    assert "zero" in rendered.lower()
+    assert base  # the repo itself is fine; only the ladder's shas are absent
+
+
+def test_exit_code_4_when_a_ladder_is_refused(lrc, tmp_path, base_repo):
+    """The refusal must reach the EXIT STATUS, not only the text — a caller
+    piping this report would otherwise read a clean 0."""
+    repo, _base = base_repo
+    facts = tmp_path / "facts.json"
+    facts.write_text(json.dumps({
+        "pr": 5, "head": "1" * 40, "base": "main",
+        "comments": [_block(1, "0" * 40, "1" * 40)],
+    }), encoding="utf-8")
+
+    rc = lrc.main(
+        ["--facts-file", str(facts), "--repo-dir", str(repo)],
+        out_stream=open("/dev/null", "w"),
+    )
+    assert rc == lrc.EXIT_REFUSED
+
+
+# --------------------------------------------------------------------------- #
+# Holes with no size — the other two routes to #1233's shape
+# --------------------------------------------------------------------------- #
+
+def test_a_bare_audited_sha_is_reported_as_a_hole_with_no_size(lrc, ad,
+                                                               base_repo):
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    r2_to = _commit(repo, "b.py", 10, "round 2 fix")
+    comments = [
+        _block(1, base, r1_to),
+        f"```audit-claims round=2 audited={r2_to}\n1. a claim\n```\n",
+    ]
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 6, r2_to, "main",
+                           comments)
+
+    assert L.bare == [2]
+    assert L.blocks_used == 1
+    rendered = lrc.render([L], [])
+    assert "BARE" in rendered
+    assert "No SIZE is reportable" in rendered
+
+
+def test_an_unparsed_block_is_reported_rather_than_dropped(lrc, ad, base_repo):
+    """`parse_claims_blocks` reports a malformed block; dropping that report
+    would make an unreadable round look like a round that never happened."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    comments = [
+        _block(1, base, r1_to),
+        "```audit-claims round=2 audited=aaaaaaa..bbbbbbb\n1. never closed\n",
+    ]
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 7, r1_to, "main",
+                           comments)
+
+    assert L.malformed, "the unclosed fence must be reported"
+    assert "UNPARSED BLOCK" in lrc.render([L], [])
+
+
+def test_a_ledger_starting_at_round_2_says_round_1_is_out_of_window(lrc, ad,
+                                                                    base_repo):
+    """The #1108 / #1219 case. The window starts at the first block's `from`, so
+    round 1's churn is outside it — that must be SAID, not silently excluded."""
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix, never ledgered")
+    r2_to = _commit(repo, "b.py", 10, "round 2 fix")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 1108, r2_to, "main",
+                           [_block(2, r1_to, r2_to)])
+
+    assert L.first_round == 2
+    rendered = lrc.render([L], [])
+    assert "STARTS at round 2" in rendered
+    assert "outside the window" in rendered
+    assert base
+
+
+# --------------------------------------------------------------------------- #
+# The shared core — the extraction must not have changed `measure_ledger`
+# --------------------------------------------------------------------------- #
+
+def test_measure_range_churn_does_NOT_refuse_an_empty_range(ad, base_repo):
+    """The inverted read rule, asserted directly.
+
+    `measure_ledger` treats an empty range as a defect; the gap scanner needs
+    the opposite, and a shared core enforcing the delta round's rule would
+    report every TIGHT chain as unmeasurable.
+    """
+    repo, base = base_repo
+    _commit(repo, "a.py", 4, "one commit")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    rep = ad.measure_range_churn(
+        ad.real_runner, str(repo), head, head, "main")
+
+    assert rep.reason is None, "an empty range is NOT an error for this caller"
+    assert (rep.commits, rep.added, rep.deleted) == (0, 0, 0)
+    assert base
+
+
+def test_measure_ledger_still_refuses_an_empty_range(ad, base_repo):
+    """The delegation's behaviour control: the fourth read rule still lives in
+    the caller, so `measure_ledger` must still fail on a self-range."""
+    repo, base = base_repo
+    _commit(repo, "a.py", 4, "one commit")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    rep = ad.measure_ledger(ad.real_runner, str(repo), head, "main")
+
+    assert rep.reason is not None, "an empty delta range is still a defect"
+    assert "EMPTY" in rep.reason
+    assert rep.added is None and rep.commits is None
+    assert base
+
+
+def test_measure_ledger_still_measures_a_real_range(ad, base_repo):
+    """…and the positive control for that one: it must still return numbers."""
+    repo, base = base_repo
+    _commit(repo, "a.py", 9, "the fix")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    rep = ad.measure_ledger(ad.real_runner, str(repo), base, "main")
+
+    assert rep.reason is None, rep.reason
+    assert rep.commits == 1
+    assert rep.added == 9 and rep.deleted == 0
+    assert head
+
+
+def test_a_failed_git_call_is_a_reason_not_a_zero(ad, base_repo):
+    """rc != 0 must not become churn 0 — the rule the core exists to hold."""
+    repo, _base = base_repo
+
+    rep = ad.measure_range_churn(
+        ad.real_runner, str(repo), "no-such-ref", "HEAD", "main")
+
+    assert rep.reason is not None
+    assert rep.added is None and rep.commits is None
+
+
+# --------------------------------------------------------------------------- #
+# The script is reachable as a script, and reuses rather than re-implements
+# --------------------------------------------------------------------------- #
+
+def test_the_script_runs_and_its_usage_does_not_require_a_network():
+    p = subprocess.run([sys.executable, str(SCRIPT), "--help"],
+                       capture_output=True, text=True, check=False)
+    assert p.returncode == 0, p.stderr
+    assert "--facts-file" in p.stdout
+
+
+def test_it_imports_the_churn_command_rather_than_carrying_a_copy():
+    """🔴 A SECOND COPY OF THE CHURN COMMAND IS THE DEFECT THIS GUARDS.
+
+    The review's hole was found because the per-block measurement was correct
+    and incomplete. A re-typed `--remerge-diff` line here could drift from
+    `audit-dispatch.py`'s — which is the one the SKILL tells an auditor to run —
+    and the two would disagree silently. Asserted structurally: this script must
+    not contain the command, and must call the shared function.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    command_lines = [
+        ln for ln in src.splitlines()
+        if "--remerge-diff" in ln and not ln.lstrip().startswith("#")
+        and '"""' not in ln
+    ]
+    assert not command_lines, (
+        "this script re-types the churn command instead of importing it: "
+        f"{command_lines}"
+    )
+    assert "measure_range_churn" in src
+    assert "parse_claims_blocks" in src


### PR DESCRIPTION
Closes open item **5** of `claudedocs/audit-ladder-review-2026-09-04.md`, which is rank 10 of `claudedocs/handoff-audit-pr-ladder.md`. Claim: `audit-pr-ladder-10`.

## The hole

That review measured each `audit-claims` block's own `from..to` range — correct per the header semantics, and only able to see the churn the blocks **chain across**. It names the gap against itself:

> #1233 posted blocks for rounds 1, 2 and 4 … round 3's fixes sit in `1b5d2e43..eb947328`, which **no block's range contains**. That churn is in no column of my table.

Its closing condition: report, per ladder, the churn inside `[first block's from, head]` that no block's range covers.

🔴 **Its own churn instrument was a scratchpad variant and is gone** — the review says so in as many words, so not one of its numbers can be re-derived from the tree. Nothing committed measures per-block churn today (`ladder-depth-sweep.py` measures *depth*, from transcripts). That is why this is a script, not a procedure.

## What it found, over the review's own 20 ladders

| | lines | ladders |
|---|---|---|
| **INTERIOR** — a round posted a block, a later round anchored past it, nobody audited between | **655** | 2 of 20 |
| **TAIL** — churn after the LAST block | **3,727** | 11 of 20 |

🔴 **Read the split, not the 4,382 sum.** Only the interior half is unambiguously unaudited ladder work. The tail conflates fixes posted after the final block with development that simply continued after the ladder ended, and nothing in the ranges separates them — the renderer says this above the caveat.

Three findings for the review, **two of which it did not anticipate**:

- a **second interior gap** exists and is named nowhere: **#998 round 1 → 2, `34265904..0aecdbf2`, 131 lines**. The review named only #1233.
- the **tail class is absent from the review entirely**, and it is 6× larger.
- **#958's "9 ranged blocks" is 8** — its round-1 block is a bare `audited=<sha>`, which names no range at all. Same hole by a third route, with no reportable size.

And the review's claim that #958 *chains end-to-end* **holds**: all 8 adjacencies TIGHT, 0 uncovered, alongside #1219, #1286, #1120, #1181, #1207, #989.

## How it avoids being a zero from nothing

The headline output for a healthy ladder **is 0**, so "every adjacency is TIGHT" and "none of this PR's commits are in this checkout" print the same thing.

- **Positive control, enforced in code:** at least one block's own range must measure non-zero churn, or the ladder is `REFUSED` at **exit 4** with the reason. `--fetch` (default) pulls `refs/pull/<n>/head` first, since a merged PR's commits are the usual cause.
- **Reproduced symptom:** run against #1233 it prints the gap at `1b5d2e43..eb947328` — the exact range the review names — and sizes it for the first time at 524 lines.
- **Negative control on real data:** the seven clean ladders above.

Three of the tail gaps are many commits at **0 lines** (#1064 125, #1274 10, #1110 7) — `--not <base>` correctly excluding an upstream bring-in, shape A of the reference file's range table. A commit count is not a churn count; the report says so.

## Four labels, because only one of them has a size

`TIGHT` · `GAP` (measured) · `OVERLAP` (the *opposite* error — two ranges double-counting) · `UNRELATED` (neither sha reaches the other; a rebase mid-ladder). Reporting an overlap or an unresolvable sha as a 0-line gap would hide it, so neither is given a number.

## One rule, one place

`measure_range_churn` is **extracted** from `audit-dispatch.py::measure_ledger` and called by both, so this report cannot drift from the command the skill tells an auditor to run. A structural guard asserts this script does not re-type it.

The extraction keeps all four read rules at four: rc 0 and silent stderr move into the shared core; `head_check` and the non-empty-range rule stay in `measure_ledger` — **deliberately, because the two callers want opposite things from an empty range.** For a delta round it is a broken question; for the gap between two blocks it is the *healthy* answer, and a core enforcing the delta rule would report every well-formed ladder as unmeasurable. Both directions have their own mutant row.

`measure_ledger`'s docstring was corrected in the same commit — it claimed to enforce four rules here, and two moved.

## Scope and residual, stated

- **RAW lines.** The payload/scaffolding split in that review was made **by hand per PR** and no pathspec can make it. This measures the **size of the hole**, not the payload the review under-counted by.
- **The window excludes churn BEFORE the first block** — that is the PR's own work, not ladder work. So a ladder whose ledger starts at round 2 (#958, #1108, #1219) still has round-1 churn unmeasured. The script reports that per ladder rather than inventing a number; recorded as an open residual on item 5.
- Not covered by the battery: the `gh` facts path, `fetch_pr_ref`, renderer wording beyond the asserted tokens — the surfaces where a defect is loud.

## Verification

- `test_ladder_range_coverage.py` — **19 passed**. Every zero-asserting test has a non-zero control on the other side.
- `scripts/tests/mutants-ladder-range-coverage.sh` — **19 rows, all as expected**, each naming the test that must kill it, plus two `SURVIVES` controls (a comment edit, an internal rename) and a green unmutated baseline. Under `PYTHONDONTWRITEBYTECODE=1`.
  - The floor pin **fired on its first growth** (18 → 19 tests) and printed its replacement value, which is the argument for pinning it from commit one.
  - One guard was **unreachable** from the suite as first written (`_is_ancestor`'s rc-128 branch, which production hits on every unfetched head); a test was added to reach it before the sweep scored it.
- `scoped-tests.sh` → **170 passed** across `test_ladder_range_coverage.py`, `test_audit_dispatch.py`, `test_audit_ladder_stop_rule.py` — the existing `measure_ledger` pins still hold. ⚠ `SCOPE: SCOPED`, not a gate.
- Content + shebang gates: **236 passed**, re-run *after* staging, since they read `git ls-files` and were blind to the new files before that.

⚠ **No full tier was run** — CI is what evaluates that.

## Follow-on

This is the instrument ranks **8** (churn-measure the ladders outside devrc) and **9** (mine stop-rationale across all 42 carriers) consume. Running 8 before this landed would have carried the understatement into six more repos.

⚠ `claudedocs/handoff-audit-pr-ladder.md` is being rewritten concurrently by #1511, so rank 10's queue entry is **deliberately not touched here** — it needs to land after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)