### PR TITLE
fix(tests): classify handoff-tmux-scratchpad-bar-statusline in the kill-mention ledger

### DIFF
--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2524,6 +2524,7 @@ def test_tmux_kill_prefix_matches_both_wide_kills_and_neither_narrow_one():
 # classify it. Paths only — line numbers are what rotted last time.
 _KILL_MENTION_LEDGER = {
     "claudedocs/handoff-tmux-restore-chain.md": "prose: the incident write-up",
+    "claudedocs/handoff-tmux-scratchpad-bar-statusline.md": "prose: a gotcha warning AGAINST it — \"Never `kill-server`; that destroys every session\"",
     "scripts/claude-hooks/bash-guard.py": "prose: the guard's own ban list",
     "scripts/claude-hooks/guard_core.py": "prose: this check, its docstring and its message",
     "scripts/claude-hooks/tests/test_guard_core.py": "prose: these tests' fixtures + this ledger",


### PR DESCRIPTION
`main` is **red** and has been since that doc merged:

```
FAILED test_every_kill_server_call_site_in_the_repo_is_classified
  added:   ['claudedocs/handoff-tmux-scratchpad-bar-statusline.md']
  removed: []
```

The ledger is derived and fails when the tree grows a mention — which is the point of it — so a handoff doc that merely **names** a wide tmux kill trips it until somebody writes down what kind of site it is.

This one is prose warning **against** the kill: *"Never `kill-server`; that destroys every session."* Same class as the peer entry already in the ledger (`handoff-tmux-restore-chain.md: "prose: the incident write-up"`), and classified with the same shape.

Nothing about the guard's behaviour changes; this is the human classification the test exists to force.

**Not my PR's failure, and I checked rather than assumed:** reproduced on a pristine `origin/main` worktree with zero changes applied. Found because devrc#1516 (a docs-only change) inherited the red, and merging through a gate I'd already called meaningless is the thing not to do.

Verified: `1 passed, 1535 deselected` on this branch; the same invocation fails on `origin/main`.