### PR TITLE
docs(clickup): do not hand-file a ticket for work that already has a task

### DIFF
--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -109,6 +109,15 @@ HUMAN identity here, so an agent closing a ticket is indistinguishable from the 
 doing it. Two comments per task, never per turn. ⚠️ **Nothing enforces any of it** —
 there is no ClickUp hook; it is a convention, and the flow says so first.
 
+🔴 **Work that ALREADY has a `clawgate` task does not get a hand-filed ClickUp ticket —
+route it through the mirror's reverse-create instead.** Filing one here by hand writes no
+row in the mirror's ledger, so its next inbound run reads a ticket it has never seen. That
+no longer produces a SECOND task for the same work — an adoption guard now adopts the
+existing one — but adoption hands ClickUp ownership of that task's **title and body** from
+its next edit onward, replacing authored markdown with ClickUp's lossy `description`
+projection. Reverse-create seeds the ledger correctly and avoids both outcomes; this path
+does neither. ⚠️ Nothing enforces this one either.
+
 ## Going deeper — load ONE only when its trigger fires
 
 - **Credentials, `accounts.json`, multi-account, the JWT fields, first-time setup**


### PR DESCRIPTION
## What

One paragraph in the `clickup` skill's **Task hygiene** section: work that already has a `clawgate` task does not get a hand-filed ClickUp ticket — route it through the mirror's reverse-create instead.

## Why

The skill had **zero** awareness of the mirror's ledger — measured: 0 files under `claude/skills/clickup/` matched `task_map|clickup_mirror` against a positive control of 22 matching `clickup`. So nothing here ever told an agent that hand-filing has a downstream cost, and the hand-filed path kept being taken.

The mechanism: filing by hand writes no ledger row, so the mirror's next inbound run reads a ticket it has never seen.

- **Before:** that produced a SECOND clawgate task for work that already had one.
- **Now:** an adoption guard on the mirror side adopts the existing task instead of duplicating it.
- **Still a cost:** adoption hands ClickUp ownership of the adopted task's title and body from its next content change onward, replacing authored markdown with ClickUp's lossy `description` projection. That trade was accepted deliberately on the mirror side, but it is avoidable here.

Reverse-create seeds the ledger correctly and avoids both outcomes, which is why it is the route named.

## Verification

- `scripts/tests/test_doc_path_rot.py` + `scripts/tests/test_no_captured_text.py` → **177 passed**.
- 🔴 **The gate was validated before its green was trusted.** Running `test_doc_path_rot.py` as a script exits 0 with 0 bytes of output — it is a pytest suite with bare asserts, so invoking it directly collects nothing and the pass is vacuous. Under `python -m pytest` it collects 76 tests, and with a deliberately planted dead path it goes **red**, naming `claude/skills/clickup/SKILL.md:113` and the path. The plant was then removed and the suite re-run green.

## Scope

Prose only — no behaviour change, no code. Consistent with the section it joins, it ends by saying nothing enforces it: there is no ClickUp hook.

⚠️ This is a `home.file` store copy (`readlink -f` on the deployed skill lands in `/nix/store`), so merging does not make it live — each host needs a `home-manager switch`.
