### PR TITLE
fix(disk-accounting): the sha guard's false positives, its scope claim, and a note it falsified elsewhere

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4635,8 +4635,16 @@ SHELL_TESTS=(
   # returns before the root check, and the suite drives the pure transforms
   # against fixtures — an lsof header in two different column layouts, a
   # directory literally named `evil";echo PWNED-AS-$(id -un) >&2;"x`, and a
-  # ~17,500-entry tree sized from the live ARG_MAX. It reaches no launcher, no
-  # network and no git.
+  # ~17,500-entry tree sized from the live ARG_MAX. It reaches no launcher and no
+  # network. 🔴 IT DOES READ GIT, since section 14 — the sha-citation ledger —
+  # resolves refs and tests ancestry with `git -C "$ROOT"`. That sentence said "no
+  # git" for two commits after the reads landed: the change that added them
+  # touched only the two diagnose-disk files and never grepped for a note
+  # describing them. A property asserted in ONE file about code in ANOTHER goes
+  # stale silently, which is the whole reason this registry carries notes at all.
+  # The reads are all read-only (rev-parse/cat-file/merge-base), the target never
+  # fetches, and it degrades to COULD NOT MEASURE where there is no .git — which
+  # is why it still runs in the sandbox tier.
   # 🔴 THIS COMMENT HAS NOW CARRIED A WRONG LINE COUNT TWICE, in the commit
   # correcting the previous wrong one each time. It said "282 lines"; round 2
   # replaced that with "282 at the merge base (567 after round 1, 730 after

--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1720,8 +1720,15 @@ has "pinned site: section 5's per-PVC inode loop" \
     "$sites_ctx" 'for p in /var/lib/rancher/k3s/storage/*'
 
 # --------------------------------------------------------------------------- #
-echo "== 14. EVERY SHA THESE FILES CITE MUST BE REACHABLE FROM main =="
-# 🔴 THIS IS THE PROSE RULE, MACHINE-CHECKED. Both files carry the sentence "a
+echo "== 14. EVERY SHA THESE FILES CITE MUST BE REACHABLE FROM THE MAINLINE =="
+# 🔴 THIS IS HALF THE PROSE RULE, MACHINE-CHECKED — say which half.
+# The rule is "a positional or historical number is legal only with a sha a
+# reader can resolve". This checks the CONVERSE ONLY: that shas which ARE present
+# are reachable. It cannot see a number anchored to a branch name, a PR number, a
+# tag, a date, or a prose description of a commit — all of which are positional
+# anchors a reader cannot resolve, and all of which pass. An audit demonstrated
+# each. Closing that would mean parsing intent out of English, which is not a
+# thing a grep does; what is written here instead is the boundary. Both files carry the sentence "a
 # positional or historical number is legal only with a sha a reader can resolve".
 # That sentence is itself a claim nothing checked — which is the exact generator
 # five audit rounds were spent on. MEASURED: after the round that WROTE the rule,
@@ -1750,16 +1757,23 @@ else
   # the moment a citation is written, and could only ever catch a reference to a
   # DIFFERENT, already-dead branch. This repo squash-merges, so a branch sha is
   # on no mainline the moment it lands — which is the whole defect.
+  # 🔴 REMOTE-TRACKING ONLY, AND IT REFUSES RATHER THAN GUESSES. The first
+  # ladder fell back to a LOCAL `main`, and a local branch is not evidence of a
+  # mainline: measured, with `origin/main` deleted and the working branch named
+  # `main`, a commit on no mainline anywhere PASSED. That is round 7's headline
+  # bug reachable again — it is the same "any ref I happen to be on" error one
+  # level up. A local branch cannot be proven to be the mainline from inside the
+  # repo, so it is not used at all.
   sha_base=""
-  for cand in origin/main main origin/master master; do
-    if git -C "$ROOT" rev-parse --verify --quiet "${cand}^{commit}" >/dev/null 2>&1; then
-      sha_base="$cand"; break
+  for cand in origin/main origin/master; do
+    if git -C "$ROOT" rev-parse --verify --quiet "refs/remotes/${cand}^{commit}" >/dev/null 2>&1; then
+      sha_base="refs/remotes/$cand"; break
     fi
   done
   if [ -z "$sha_base" ]; then
-    pass "COULD NOT MEASURE: no mainline ref (origin/main|main|origin/master|master) in this checkout — sha reachability unchecked"
+    pass "COULD NOT MEASURE: no remote-tracking mainline (origin/main|origin/master) in this checkout — a LOCAL branch is deliberately not used as a substitute, because it cannot be shown to be the mainline from in here"
   else
-    sha_bad=""; sha_unres=""; sha_seen=0
+    sha_bad=""; sha_unres=""; sha_seen=0; sha_shallow=0
     for f in $sha_files; do
       # 🔴 CASE-INSENSITIVE AND FROM 7, because git accepts an UPPERCASE sha and
       # a 7-character prefix, and the first version's `[0-9a-f]{8,40}` exempted
@@ -1770,7 +1784,29 @@ else
       # ancestor of the mainline. The guard below failed on its own author's
       # explanation, first run. Describe the SHAPE; never paste a sha into prose
       # that is not itself a citation you intend a reader to resolve.
-      for h in $(grep -oE '\b[0-9a-fA-F]{7,40}\b' "$f" | tr 'A-F' 'a-f' | sort -u); do
+      # 🔴 THE FLOOR STAYS AT 7, AND THAT IS A MEASURED TRADE, NOT AN OVERSIGHT.
+      # An audit correctly observed that git's minimum abbreviation is 4, so a
+      # 4/5/6-char citation is exempt, and recommended lowering the floor. I
+      # MEASURED that fix: at 4 the scan sweeps up ordinary English words and
+      # figures that are valid hex — `added`, `feed`, `dead`, `512b`, `9999` were
+      # all reported as dead citations against these very files. A floor low
+      # enough to catch git's real minimum is unusable; one high enough to avoid
+      # English exempts short citations. No regex closes both, so the guard
+      # covers the realistic spelling (>=7) and this comment states what it does
+      # not cover rather than implying closure.
+      # 🔴 NOT `\b` THOUGH — a word boundary does not fire against `_`, so
+      # `commit_<sha>` was invisible. The delimiter class is `[^0-9a-zA-Z]`,
+      # which DOES include `_`. ⚠ The first attempt wrote `[^0-9a-zA-Z_]`, which
+      # EXCLUDES it — backwards, and it fixed nothing. I asserted in a commit
+      # message that both fixes worked before testing either; the test refuted
+      # both. Write the claim after the measurement.
+      # The `-g` rewrite runs on the FILE, before the match — as a post-filter on
+      # grep's output it could never fire, because grep had already failed to
+      # match the `g`-prefixed form at all.
+      for h in $(sed -E 's/-g([0-9a-fA-F]{7,40})/ \1/g' "$f" \
+                   | grep -oE '(^|[^0-9a-zA-Z])[0-9a-fA-F]{7,40}([^0-9a-zA-Z]|$)' \
+                   | sed -E 's/[^0-9a-fA-F]//g' \
+                   | tr 'A-F' 'a-f' | sort -u); do
         case "$h" in
           *[a-f]*)
             # Contains a letter ⇒ it is a sha CITATION, not a decimal figure.
@@ -1781,7 +1817,14 @@ else
             # exist. Unresolvable here is exactly what the reader experiences.
             sha_seen=$((sha_seen + 1))
             if ! git -C "$ROOT" cat-file -e "${h}^{commit}" 2>/dev/null; then
-              sha_unres="$sha_unres $h"
+              # 🔴 A SHALLOW CLONE CANNOT ANSWER THIS, and saying "delete the
+              # figure" to someone whose clone simply lacks the history is the
+              # permanently-red-gate shape: they would delete a CORRECT citation.
+              if [ "$(git -C "$ROOT" rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+                sha_shallow=1
+              else
+                sha_unres="$sha_unres $h"
+              fi
             elif ! git -C "$ROOT" merge-base --is-ancestor "$h" "$sha_base" 2>/dev/null; then
               sha_bad="$sha_bad $h"
             fi ;;
@@ -1802,13 +1845,24 @@ else
     if [ "$sha_seen" -eq 0 ]; then
       fail "the sha ledger found ZERO commit-sha citations in these files — either the extraction broke or every citation was removed; a zero here is not a clean result"
     elif [ -n "$sha_unres" ] || [ -n "$sha_bad" ]; then
-      [ -n "$sha_unres" ] && fail "cited sha(s) this checkout cannot resolve at all:$sha_unres — a reader cannot look them up, which is the defect the 'only with a sha' rule exists to stop. Re-anchor to a commit on $sha_base, or delete the figure"
-      [ -n "$sha_bad" ] && fail "cited sha(s) NOT ancestors of $sha_base:$sha_bad — they resolve HERE but not from the mainline, so a fresh clone cannot check the number each one anchors. Re-anchor, or delete the figure"
+      # 🔴 THESE MESSAGES NAME BOTH CAUSES AND INSTRUCT NEITHER. Each failure has
+      # two possible explanations — a dead citation, or a local checkout that
+      # cannot see a live one — and this guard cannot tell them apart without a
+      # fetch, which a test must not do. An earlier version said "delete the
+      # figure", which is actively wrong advice for the second case: an operator
+      # with a stale `origin/main` would delete a correct citation on its say-so.
+      # Report, and let the human pick.
+      [ -n "$sha_unres" ] && fail "cited sha(s) this checkout cannot resolve:$sha_unres — EITHER the citation is dead (re-anchor it, or delete the figure) OR this clone lacks the object (try: git fetch --all; git cat-file -e <sha>). This guard cannot distinguish the two without fetching, and does not fetch"
+      [ -n "$sha_bad" ] && fail "cited sha(s) NOT ancestors of $sha_base:$sha_bad — EITHER they are on no mainline (re-anchor, or delete the figure) OR your $sha_base is stale (try: git fetch origin). Same limitation: this guard reads refs, it does not refresh them"
     else
       # 🔴 SAY WHAT WAS CHECKED. The first version's pass line claimed the shas
       # were "resolvable from a fresh clone" — an assertion it never tested, and
       # measured FALSE in an actual fresh clone.
-      pass "all $sha_seen cited sha(s) resolve here AND are ancestors of $sha_base"
+      if [ "$sha_shallow" -eq 1 ]; then
+        pass "COULD NOT MEASURE some citation(s): this is a SHALLOW clone, so an unresolvable sha proves nothing about the citation. $sha_seen checked, the resolvable ones are ancestors of $sha_base"
+      else
+        pass "all $sha_seen cited sha(s) resolve here AND are ancestors of $sha_base"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
fix(disk-accounting): the sha guard's false positives, its scope claim, and a note it falsified elsewhere

Round 8 attacked the rebuilt sha ledger and defeated it again: four bypasses and
two false-positive modes. This fixes what is worth fixing and STATES the rest
rather than claiming closure a third time.

🔴 THE FALSE POSITIVES WERE THE REAL HARM, not the bypasses. On a SHALLOW clone,
and on a checkout whose origin/main is merely STALE, the guard failed correct
files and told the operator to "delete the figure" — which would delete a CORRECT
citation. That is the permanently-red-gate shape, and the advice was actively
wrong rather than merely unhelpful. Shallow is now detected and degrades to
COULD NOT MEASURE; both failure messages now NAME BOTH CAUSES (dead citation, or
a local checkout that cannot see a live one) and instruct NEITHER, because the
guard cannot tell them apart without fetching and a test must not fetch.

🔴 THE REF LADDER FELL BACK TO A LOCAL BRANCH, which is the same "any ref I
happen to be on" error that was round 7's headline bug, one level up. MEASURED:
with origin/main deleted and the working branch named `main`, a commit on no
mainline anywhere PASSED. A local branch cannot be shown to be the mainline from
inside the repo, so it is no longer used at all — remote-tracking only, and
COULD NOT MEASURE when there is none.

🔴 THE RECOMMENDED FIX FOR THE EXTRACTION WAS MEASURED AND REJECTED. The audit
correctly observed that git's minimum abbreviation is 4, so 4/5/6-char citations
are exempt, and recommended lowering the floor. I tried it: at 4 the scan
reported `added`, `feed`, `dead`, `512b` and `9999` as dead citations against
these very files — ordinary words and figures that are valid hex. A floor low
enough to catch git's minimum is unusable; one high enough to avoid English
exempts short citations. No regex closes both. The floor stays at 7 and the
comment records the measurement instead of implying the set is closed.

Two extraction fixes that ARE worth making, because they widen what is caught
without widening what is matched: `\b` does not fire against `_`, so
`commit_<sha>` was invisible, and `git describe`'s `v1.2-3-g<sha>` spelling was
never matched at all.

🔴 AND I GOT BOTH WRONG ON THE FIRST ATTEMPT, ASSERTING IN THIS MESSAGE THAT THEY
WORKED BEFORE TESTING EITHER. The delimiter class was written `[^0-9a-zA-Z_]`,
which EXCLUDES underscore — backwards, so it fixed nothing; and the `-g` strip
ran as a post-filter on grep's OUTPUT, which could never fire because grep had
already failed to match the g-prefixed form. Measured after the fact: both
spellings still passed, only the plain control failed. The delimiter is now
`[^0-9a-zA-Z]` and the `-g` rewrite runs on the FILE before the match; all three
now fail and the clean baseline passes. Write the claim after the measurement —
which is the thesis of this entire ladder, violated in the commit enforcing it.

🔴 THE BANNER AND THE SCOPE CLAIM BOTH OVERSTATED. The banner said "REACHABLE
FROM main" over an implementation that now names a remote-tracking ref; and "THIS
IS THE PROSE RULE, MACHINE-CHECKED" claims the whole rule while the code checks
only the converse half — that shas WHICH ARE PRESENT are reachable. A number
anchored to a branch name, PR number, tag, date, or a prose description of a
commit is a positional anchor a reader cannot resolve, and every one of them
passes. Closing that means parsing intent out of English, which a grep does not
do; the boundary is now written down instead.

🔴 AND THE CHANGE THAT ADDED THIS GUARD FALSIFIED A NOTE IN ANOTHER FILE.
scripts/run-tests.sh said this target "reaches no launcher, no network and no
git" — written before section 14 existed, false for two commits after its six
`git -C "$ROOT"` reads landed, because the change touched only the two
diagnose-disk files and never grepped for a note describing them. A property
asserted in ONE file about code in ANOTHER goes stale silently, which is the
entire reason that registry carries notes. Corrected, with what the reads
actually are (read-only, never fetches, degrades without .git).

⚠ MY OWN GREP SAID THERE WERE ZERO git READS while I was checking this — wrong
quoting, and I nearly filed it as "no issue". Grep's answer is a claim about
grep's view.

Suite: 231 assertions, 0 failures.
