### PR TITLE
feat(ci-signal): name the commit that already fixed a PR's inherited red

### DIFF
--- a/scripts/lib/ci_status.py
+++ b/scripts/lib/ci_status.py
@@ -1,0 +1,208 @@
+"""GitHub commit-status reading for this repo's `tekton/devrc-*` gate.
+
+🔴 ONE RULE, ONE PLACE. Every predicate here was open-coded in BOTH
+`scripts/main-status-watch.py` (live, every 10 minutes, on both hosts) and
+`scripts/stale-base-triage.py`, and the copies had ALREADY DIVERGED before
+anybody noticed — only the newer one stripped the `TOTAL` truncation fragment,
+and only the newer one folded statuses by timestamp instead of by array
+position. Consolidation is what made that disagreement audible; the divergence
+was the finding, not the tidiness.
+
+WHAT LIVES HERE, AND WHAT DELIBERATELY DOES NOT. This module owns the rules that
+are about GITHUB'S DATA and about the GATE'S OWN OUTPUT FORMAT — how a status row
+maps to a verdict class, how a commit's rows fold to a current answer, and how
+the `FAILING: … | TOTAL collected=… ` banner parses. It owns no policy: which
+CONTEXT to look at, whether a foreign context may speak, what to do about a red,
+and whether a named set is provably complete are each the CALLER'S decision and
+stay in the caller, because the two callers genuinely answer them differently.
+
+🔴 AND EACH CALLER KEEPS ITS OWN ROW-VALIDITY POLICY, WHICH IS NOT THE SAME
+POLICY. `main-status-watch.py` validates every decoded row is a dict in its walk
+and names the commit when one is not — so it must NEVER silently drop a row,
+because a dropped row could be the red it exists to catch. `stale-base-triage.py`
+has no such walk and skips a malformed row. `newest_per_context` below therefore
+skips non-dict rows: for the watcher that arm is UNREACHABLE (its caller already
+proved every row is a dict), and for the triage tool it is the existing
+behaviour. Neither caller's contract changes; see
+`test_newest_per_context_skips_a_malformed_row_rather_than_raising`.
+"""
+import re
+
+# ── status classification ─────────────────────────────────────────────────────
+# 🔴 ONLY `state == "failure"` IS A RED. Every non-code outcome this pipeline
+# reports — superseded, KILLED, NO GATE POD, clone rc 128 — arrives as
+# `state == "error"`. Treating `error` as red is the `/commits/{sha}/status`
+# roll-up mistake in a second spelling; treating it as GREEN would be worse
+# still, so an unrecognised state is classified as NOT-A-VERDICT and the caller
+# walks past it. That is the narrowest rule that can be wrong in one direction.
+#
+# ⚠ THE FINER CLASSES NEED A TEST THAT DRIVES THIS FUNCTION DIRECTLY. Both
+# callers fold `superseded`/`killed`/`no-gate-pod`/`error-other` together, so an
+# end-to-end test can only ever see "not a verdict" — measured, 35 of this
+# function's 60 enumerated mutants survived a fully green 61-test suite, and the
+# two fall-through `return "error-other"`s were reached by no fixture at all:
+# turning either into `return "green"` survived. That is a state GitHub adds
+# tomorrow folded into "main is green", closing a red episode.
+
+
+def classify(state, description):
+    """One status row -> a verdict class. Pure, and the tests drive it directly.
+
+    🔴 UNRECOGNISED MEANS `error-other`, WHICH MEANS NOT-A-VERDICT — never
+    `red`, and never `green`. Both fall-through returns below are the arm an
+    unknown `state` lands on, and "absence reads as green" is the single failure
+    the watcher that consumes this is built against.
+    """
+    desc = (description or "").strip()
+    if state == "success":
+        return "green"
+    if state == "failure":
+        return "red"
+    if state == "pending":
+        return "pending"
+    if state == "error":
+        if desc.startswith("superseded"):
+            return "superseded"
+        if desc.startswith("KILLED"):
+            return "killed"
+        if desc.startswith("NO GATE POD"):
+            return "no-gate-pod"
+        return "error-other"
+    return "error-other"
+
+
+def newest_per_context(rows):
+    """Fold status rows to the NEWEST row per context, by `created_at`.
+
+    A commit accumulates a `pending` row and then its verdict under the SAME
+    context, so folding by context is what turns the history into a current
+    answer. Without it a stale `pending` from 20 minutes ago outvotes the
+    verdict that replaced it.
+
+    🔴 NOT first-wins AND NOT last-wins — BY TIMESTAMP, so the array's order is
+    not an input at all. GitHub returns this list newest-first today, which
+    makes first-wins accidentally correct and last-wins catastrophically wrong:
+    an agent shipped last-wins and reported a known-green head as `pending`. The
+    max-`created_at` fold agrees with first-wins on the order GitHub uses today
+    AND stays right if that order ever changes, so the hazard is removed rather
+    than avoided. `test_newest_per_context_is_order_independent` feeds both
+    orders and pins that they agree.
+
+    ⚠ WITH NO `created_at` ANYWHERE — a shape GitHub does not produce, but a
+    fixture might — every stamp compares equal and the FIRST row per context
+    wins, which is exactly the previous behaviour. The fallback is the old rule,
+    never an arbitrary one.
+
+    Returns EVERY context it saw. Filtering to the contexts a caller is allowed
+    to believe is the caller's job, and `main-status-watch.py` does it in
+    `commit_verdict`: a foreign pipeline's green must not read as this gate's.
+    """
+    best = {}
+    for row in rows:
+        # See the module docstring: skipping is the triage tool's existing
+        # behaviour, and unreachable for the watcher, whose walk has already
+        # proved every row is a dict and named the commit if one was not.
+        if not isinstance(row, dict):
+            continue
+        ctx = row.get("context") or ""
+        if not ctx:
+            continue
+        stamp = row.get("created_at") or ""
+        if ctx not in best or stamp > best[ctx][0]:
+            best[ctx] = (stamp, row)
+    return {ctx: row for ctx, (_, row) in best.items()}
+
+
+# ── the gate's own banner ─────────────────────────────────────────────────────
+# The line `run-tests.sh` prints and the pipeline posts:
+#   FAILED: pytests — FAILING: a | b | TOTAL collected=N  passed=N  skipped=N
+#                                     failed=N  (floor: …)
+# GitHub caps a status description at 140 BYTES, so most real rows arrive cut.
+FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
+FAILED_COUNT_RE = re.compile(r"\bfailed=(\d+)\b")
+
+# The only fragments a cut can leave behind where `TOTAL` was starting.
+# Enumerated rather than pattern-matched: a `startswith` test would also eat a
+# real name, and every test in this repo begins `test_` or `Test`, neither of
+# which is a prefix of `TOTAL`.
+TOTAL_FRAGMENTS = ("T", "TO", "TOT", "TOTA")
+
+
+def parse_failing_names(description):
+    """The test names the description NAMES. May be INCOMPLETE — see the callers.
+
+    A description cut inside ` | TOTAL` leaves a trailing fragment of the word
+    TOTAL sitting where a name would be. Left in, it resolves to no file and the
+    PR is reported as a real red on the strength of a truncation artefact.
+
+    ⚠ THE FRAGMENT STRIP IS INERT FOR A COMPLETENESS SCREEN AND LOAD-BEARING FOR
+    A NAME->FILE LOOKUP, which is why the two copies could diverge unnoticed: a
+    row cut at `| TOTA` was necessarily cut before `failed=N` too, so a screen
+    that also demands the count refuses either way. Only a caller that RESOLVES
+    the names can be hurt by the fragment.
+    """
+    m = FAILING_RE.search(description or "")
+    if not m:
+        return []
+    names = [n.strip() for n in m.group(1).split("|") if n.strip()]
+    if names and names[-1] in TOTAL_FRAGMENTS:
+        names.pop()
+    return names
+
+
+def parse_failed_count(description):
+    """The banner's own `failed=N`, or None when the cap ate it.
+
+    It is the LAST field in the banner, so whether it survives is decided by the
+    failing test's NAME LENGTH. `derived_failure_upper_bound` is the route that
+    does not depend on that.
+    """
+    m = FAILED_COUNT_RE.search(description or "")
+    return int(m.group(1)) if m else None
+
+
+# 🔴 THE THREE FIELDS ARE MATCHED AS ONE ADJACENT, ORDERED GROUP, NOT SEPARATELY,
+# AND THAT IS A SOUNDNESS REQUIREMENT RATHER THAN TIDINESS. The hazard is a
+# number the 140-byte cap cut SHORT — `collected=22204` arriving as
+# `collected=2220` would read as a perfectly well-formed integer and make the
+# derived bound far too SMALL, which is the one direction that can certify a
+# completeness a row does not have. Requiring `passed=` and then `skipped=` to
+# follow proves `collected=` and `passed=` are complete numbers: the cap
+# truncates a SUFFIX, so a field with more banner text after it was not cut.
+# Only `skipped=` — the last of the three — can itself be short, and a short
+# `skipped` SUBTRACTS LESS and so inflates the bound, i.e. errs toward refusing.
+TOTALS_RE = re.compile(r"\bcollected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)")
+
+
+def derived_failure_upper_bound(description):
+    """An UPPER bound on the banner's own `failed=`, or None if underivable.
+
+    `scripts/run-tests.sh` GUARD 4 computes, per target,
+
+        collected = passed + skipped + failed + errors + xfailed + xpassed
+        TOT_FAILED += failed + errors          (the banner's `failed=` is f+e)
+
+    and accumulates each term into the TOTAL banner this description quotes. So
+
+        collected − passed − skipped == failed + xfailed + xpassed >= failed
+
+    🔴 THE INEQUALITY ONLY EVER POINTS ONE WAY. `xfailed`/`xpassed` are
+    non-negative, so this can equal `failed=` but never fall below it. That is
+    what makes it usable as a completeness proof: a caller comparing it against
+    a count of NAMES is comparing against a ceiling, and a ceiling that happens
+    to equal the number of names squeezes `failed` to that same number. An
+    under-count would instead certify completeness on a row that had more
+    failures than it named — the single error a triage tool must not make.
+
+    The coupling to `run-tests.sh` is pinned by
+    `test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned`.
+    """
+    m = TOTALS_RE.search(description or "")
+    if not m:
+        return None
+    collected, passed, skipped = (int(g) for g in m.groups())
+    derived = collected - passed - skipped
+    # Negative is arithmetically impossible under the definition above, so it
+    # means the banner is not the banner this derivation was written against.
+    # Refusing to answer is the only safe reading of a row we cannot parse.
+    return derived if derived >= 0 else None

--- a/scripts/lib/ci_status.py
+++ b/scripts/lib/ci_status.py
@@ -119,7 +119,25 @@ def newest_per_context(rows):
 #                                     failed=N  (floor: …)
 # GitHub caps a status description at 140 BYTES, so most real rows arrive cut.
 FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
-FAILED_COUNT_RE = re.compile(r"\bfailed=(\d+)\b")
+
+# 🔴 ANCHORED ON `TOTAL`, AND THE ANCHOR IS THE SOUNDNESS ARGUMENT, NOT TIDINESS.
+# `run-tests.sh` emits a PER-TARGET row for every target it ran —
+# `FAIL  <dir>  (collected=… passed=… skipped=… failed=… errors=…)` and
+# `PASS  <dir>  (collected=… passed=… skipped=… floor=…)` — and those rows come
+# BEFORE the TOTAL banner. `re.search` takes the FIRST match, so an unanchored
+# `\bfailed=(\d+)\b` reads ONE TARGET'S count and calls it the run's. Measured:
+# a description carrying an earlier `(collected=9 passed=6 skipped=1 failed=2
+# errors=0)` yields 2 where the banner's own `failed=` is 27 — an UNDER-count,
+# which is the single direction that certifies a completeness the row does not
+# have (see `derived_failure_upper_bound` below, and `names_provably_complete`
+# in `scripts/stale-base-triage.py`). Requiring the word `TOTAL` first makes the
+# first match the banner's, because `TOTAL` appears once and last.
+#
+# ⚠ NO REACHABLE EXPLOIT IS CLAIMED. What builds the description is the posting
+# pipeline, which lives in `homelab-talos` and cannot be pinned from this repo —
+# every row measured here carries the banner alone. This closes the parser's
+# side of a hazard whose other side is not ours to observe.
+FAILED_COUNT_RE = re.compile(r"\bTOTAL\b.*?\bfailed=(\d+)\b")
 
 # The only fragments a cut can leave behind where `TOTAL` was starting.
 # Enumerated rather than pattern-matched: a `startswith` test would also eat a
@@ -156,6 +174,11 @@ def parse_failed_count(description):
     It is the LAST field in the banner, so whether it survives is decided by the
     failing test's NAME LENGTH. `derived_failure_upper_bound` is the route that
     does not depend on that.
+
+    🔴 THE BANNER'S OWN — not the first `failed=` in the string. The anchor on
+    `FAILED_COUNT_RE` is what makes those the same thing; read the note there
+    before loosening it. Pinned by
+    `test_an_EARLIER_per_target_row_cannot_be_mistaken_for_the_TOTAL_banner`.
     """
     m = FAILED_COUNT_RE.search(description or "")
     return int(m.group(1)) if m else None
@@ -171,7 +194,15 @@ def parse_failed_count(description):
 # truncates a SUFFIX, so a field with more banner text after it was not cut.
 # Only `skipped=` — the last of the three — can itself be short, and a short
 # `skipped` SUBTRACTS LESS and so inflates the bound, i.e. errs toward refusing.
-TOTALS_RE = re.compile(r"\bcollected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)")
+#
+# 🔴 AND THE GROUP IS ANCHORED ON `TOTAL`, FOR THE SECOND HALF OF THE SAME
+# ARGUMENT — see `FAILED_COUNT_RE` above. Adjacency proves the three numbers were
+# not cut SHORT; the anchor proves they are the RUN'S three and not some single
+# target's. Without it `re.search` takes the first triple in the string, and a
+# per-target `(collected=9 passed=6 skipped=1 …)` derives a bound of 2 for a run
+# whose own `failed=` is 27 — again the under-count direction, and here it lands
+# directly on the completeness proof.
+TOTALS_RE = re.compile(r"\bTOTAL\s+collected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)")
 
 
 def derived_failure_upper_bound(description):

--- a/scripts/lib/ci_status.py
+++ b/scripts/lib/ci_status.py
@@ -117,7 +117,11 @@ def newest_per_context(rows):
 # The line `run-tests.sh` prints and the pipeline posts:
 #   FAILED: pytests — FAILING: a | b | TOTAL collected=N  passed=N  skipped=N
 #                                     failed=N  (floor: …)
-# GitHub caps a status description at 140 BYTES, so most real rows arrive cut.
+# A status description arrives cut at 140 BYTES, so most real rows are partial.
+# ⚠ WHO CUTS IT IS NOT DETERMINED — GitHub's own cap and the posting pipeline's
+# truncation are indistinguishable in everything sampled. The BOUNDARY is what
+# was measured; see `test_CONTROL_the_real_truncated_rows_land_on_the_BYTE_cap_
+# not_the_CHAR_cap`.
 FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
 
 # 🔴 ANCHORED ON `TOTAL`, AND THE ANCHOR IS THE SOUNDNESS ARGUMENT, NOT TIDINESS.

--- a/scripts/main-status-watch.py
+++ b/scripts/main-status-watch.py
@@ -104,7 +104,16 @@ from pathlib import Path
 # is involved. A run that lands in the instant between the two files arriving
 # fails to import and exits non-zero; this unit has no `OnFailure=` toast and the
 # next poll is 10 minutes away, so the cost of that window is one skipped poll.
-sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+#
+# 🔴 `append`, NEVER `insert(0, …)`. `scripts/lib/` is this repo's shared-module
+# dumping ground and grows freely; prepending it puts EVERY module in it ahead of
+# the standard library for every LATER import this process makes — including the
+# lazy `import traceback` on the unattended-crash path at the bottom of this
+# file, which is the one import that runs when something has already gone wrong.
+# Nothing there shadows a stdlib name today; `append` means nothing added
+# tomorrow can, and it costs nothing, because `ci_status` is not a name anything
+# else on the path defines.
+sys.path.append(str(Path(__file__).resolve().parent / "lib"))
 from ci_status import (classify, newest_per_context,  # noqa: E402
                        parse_failed_count, parse_failing_names)
 
@@ -211,7 +220,7 @@ def commit_verdict(rows):
 
 # ── the flake screen ──────────────────────────────────────────────────────────
 # 🔴 THIS SCREEN IS SOUND AND ALMOST NEVER SATISFIABLE, AND BOTH HALVES ARE THE
-# POINT. GitHub caps a status description at 140 characters and the pipeline's
+# POINT. GitHub caps a status description at 140 BYTES and the pipeline's
 # `FAILING: a | b | c | TOTAL …` line overruns it constantly. MEASURED on real
 # rows: one described `failed=7` while naming ONE test; one named NO test at all;
 # and the row that named the known flake was cut MID-WORD

--- a/scripts/main-status-watch.py
+++ b/scripts/main-status-watch.py
@@ -92,6 +92,22 @@ import sys
 import time
 from pathlib import Path
 
+# 🔴 ONE RULE, ONE PLACE. `classify`, `newest_per_context`, `parse_failing_names`
+# and `parse_failed_count` used to be open-coded HERE and again in
+# `scripts/stale-base-triage.py`, and the copies had already DIVERGED. They now
+# live in `scripts/lib/ci_status.py`; this file keeps only the POLICY — which
+# context prefix may speak, which names are known flakes, what to do about a red.
+#
+# ⚠ IMPORTED BY PATH, not as a package, and this unit runs the file straight out
+# of the CHECKOUT (`ExecStart=… %h/workspace/devrc/scripts/main-status-watch.py`),
+# so a `git pull` is the whole deploy for both files and no home-manager switch
+# is involved. A run that lands in the instant between the two files arriving
+# fails to import and exits non-zero; this unit has no `OnFailure=` toast and the
+# next poll is 10 minutes away, so the cost of that window is one skipped poll.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from ci_status import (classify, newest_per_context,  # noqa: E402
+                       parse_failed_count, parse_failing_names)
+
 RC_OK, RC_TRIGGERED, RC_UNMEASURED, RC_BLIND, RC_USAGE = 0, 10, 11, 12, 2
 
 # The context prefix the main-push pipeline posts under. Derived nowhere: this
@@ -137,77 +153,40 @@ def print_header():
 
 
 # ── classification ────────────────────────────────────────────────────────────
-# 🔴 ONLY `state == "failure"` IS A RED. Every non-code outcome the pipeline
-# reports — superseded, KILLED, NO GATE POD — arrives as `state == "error"`, and
-# each says "Not a code failure." in its own description. Treating `error` as red
-# is the roll-up mistake in a second spelling; treating it as GREEN would be
-# worse still, so it is classified as NOT-A-VERDICT and the walk continues past
-# it. That is the narrowest rule that can be wrong in only one direction.
+# 🔴 `classify` AND `newest_per_context` NOW LIVE IN `scripts/lib/ci_status.py`,
+# imported above. What they do and why is documented there; what stays HERE is
+# the policy they are applied under.
 #
 # ⚠ `commit_verdict` BRANCHES ON `green` AND `red` ONLY, WHICH IS WHY THE FINER
-# CLASSES NEEDED A TEST OF THEIR OWN. Downstream, `superseded`/`killed`/
+# CLASSES NEED A TEST OF THEIR OWN. Downstream, `superseded`/`killed`/
 # `no-gate-pod`/`error-other` are indistinguishable, so an end-to-end test can
-# only ever see "not a verdict" — measured, 35 of this function's 60 enumerated
+# only ever see "not a verdict" — measured, 35 of `classify`'s 60 enumerated
 # mutants survived a fully green 61-test suite, and the 25 that died were
 # exactly the ones that moved an answer INTO green-or-red. Worse, the two
-# fall-through `return "error-other"`s are reached by no fixture at all: turning
-# either into `return "green"` survived. That is a state GitHub adds tomorrow
-# folded into "main is green", closing a red episode. They are now pinned by
-# `test_classify_maps_a_row_to_its_documented_class`, which drives this function
-# directly — the only way to see a distinction the caller cannot make.
+# fall-through `return "error-other"`s were reached by no fixture at all:
+# turning either into `return "green"` survived. That is a state GitHub adds
+# tomorrow folded into "main is green", closing a red episode. They are pinned
+# by `test_classify_maps_a_row_to_its_documented_class`, which drives the shared
+# function directly — the only way to see a distinction the caller cannot make.
 # A tuple named NOT_A_VERDICT used to sit here enumerating the same classes;
 # nothing read it, so it was deleted rather than left reading as a contract it
 # could not enforce.
-
-
-def classify(state, description):
-    """One status row -> a verdict class. Pure, and the tests drive it directly.
-
-    🔴 UNRECOGNISED MEANS `error-other`, WHICH MEANS NOT-A-VERDICT — never green.
-    Both fall-through returns below are the arm an unknown `state` lands on, and
-    "absence reads as green" is the single failure this whole file is built
-    against.
-    """
-    desc = (description or "").strip()
-    if state == "success":
-        return "green"
-    if state == "failure":
-        return "red"
-    if state == "pending":
-        return "pending"
-    if state == "error":
-        if desc.startswith("superseded"):
-            return "superseded"
-        if desc.startswith("KILLED"):
-            return "killed"
-        if desc.startswith("NO GATE POD"):
-            return "no-gate-pod"
-        return "error-other"
-    return "error-other"
-
-
-def newest_per_context(rows):
-    """GitHub returns statuses newest-first; keep the first row per context.
-
-    A commit accumulates a `pending` row and then its verdict under the SAME
-    context, so folding by context is what turns the history into a current
-    answer. Without it a stale `pending` from 20 minutes ago outvotes the
-    verdict that replaced it.
-    """
-    # 🔴 NO isinstance GUARD HERE, DELIBERATELY — ONE RULE, ONE PLACE. A first
-    # draft had one, and a mutation sweep proved it UNREACHABLE: the walk already
-    # rejects a non-object row loudly, naming the commit, so this one could never
-    # execute. Worse, it `continue`d — silently DROPPING a row, and a dropped row
-    # could be the red. A guard that cannot run, and would hide evidence if it
-    # did, is worse than none: it reads as coverage and stops anyone looking.
-    seen = {}
-    for row in rows:
-        ctx = row.get("context", "")
-        if not ctx.startswith(CONTEXT_PREFIX):
-            continue
-        if ctx not in seen:
-            seen[ctx] = row
-    return seen
+#
+# 🔴 THE FOLD CHANGED WHEN IT MOVED, AND THE CHANGE IS DELIBERATE. This file
+# used to keep the FIRST row per context, which is right only because GitHub
+# returns the array newest-first — an assumption about someone else's response
+# ordering, load-bearing and unstated. The shared `newest_per_context` folds on
+# `max(created_at)` instead: it agrees with first-wins on the order GitHub uses
+# today and stays right if that order ever changes. Pinned by
+# `test_newest_per_context_is_ORDER_INDEPENDENT_which_first_wins_was_not`.
+#
+# 🔴 AND THE CONTEXT FILTER MOVED HERE, WHICH IS WHERE THE POLICY BELONGS. The
+# shared fold returns every context it saw; deciding that only
+# `tekton/devrc-main-*` may speak about main is this file's rule, not GitHub's.
+# It must be applied BEFORE the emptiness check below — a commit carrying only a
+# foreign pipeline's rows has NO verdict here, and reading one as green would
+# close an open red episode off another pipeline's answer. Pinned by
+# `test_a_commit_with_ONLY_FOREIGN_contexts_is_no_verdict_not_green`.
 
 
 def commit_verdict(rows):
@@ -217,7 +196,8 @@ def commit_verdict(rows):
     verdict unless at least one leg produced green-or-red — a commit whose legs
     were all superseded tells us nothing at all, and must not read as green.
     """
-    per_ctx = newest_per_context(rows)
+    per_ctx = {ctx: row for ctx, row in newest_per_context(rows).items()
+               if ctx.startswith(CONTEXT_PREFIX)}
     if not per_ctx:
         return "none", {}
     classes = {ctx: classify(r.get("state"), r.get("description")) for ctx, r in per_ctx.items()}
@@ -245,23 +225,28 @@ def commit_verdict(rows):
 # row, which triggers a confirmation run because its truncation makes
 # completeness unprovable. That is the correct answer, not a defect.
 #
-# It is kept because it costs 15 lines and encodes WHY name-matching cannot carry
-# the flake decision here, next to a ledger someone will otherwise be tempted to
-# grow. The flake decision is made by the deadman, by re-running.
-_FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
-_FAILED_COUNT_RE = re.compile(r"\bfailed=(\d+)\b")
-
-
-def parse_failing_names(description):
-    m = _FAILING_RE.search(description or "")
-    if not m:
-        return []
-    return [n.strip() for n in m.group(1).split("|") if n.strip()]
-
-
-def parse_failed_count(description):
-    m = _FAILED_COUNT_RE.search(description or "")
-    return int(m.group(1)) if m else None
+# It is kept because it costs a handful of lines and encodes WHY name-matching
+# cannot carry the flake decision here, next to a ledger someone will otherwise
+# be tempted to grow. The flake decision is made by the deadman, by re-running.
+#
+# 🔴 THE ZERO ABOVE IS NOT A PROPERTY OF THE IDEA — IT IS THIS SCREEN READING
+# ONLY `failed=N`, WHICH IS THE FIELD THE 140-BYTE CAP EATS. `failed=` is LAST
+# in the banner, so whether it survives is decided by the failing test's NAME
+# LENGTH. `scripts/stale-base-triage.py` derives the same completeness proof a
+# second way — `collected − passed − skipped` is an upper bound on `failed`, and
+# those three fields PRECEDE it, so they survive — and on the rows measured that
+# route turns 5/28 provably-complete into 18/28.
+#
+# ⚠ DELIBERATELY NOT ADOPTED HERE, AND THE REASON IS THE DIRECTION OF THE ERROR.
+# There, proving completeness makes the tool SPEAK; here it makes this file stay
+# SILENT about a red. A wider screen is a wider silence over the only automated
+# detector `main` has, and the screen's own argument is that the flake decision
+# belongs to the deadman's re-run rather than to a name match. Widening it is a
+# change to make on purpose, with its own measurement — not a free win inherited
+# from a sibling. (Handoff rank 6's open question, "is this screen inert?", now
+# has half an answer: it is inert for a REASON, and the reason is fixable.)
+# `parse_failing_names` / `parse_failed_count` are shared with that file via
+# `scripts/lib/ci_status.py`; only the decision below is local.
 
 
 def screen_all_known_flakes(descriptions):

--- a/scripts/main-status-watch.py
+++ b/scripts/main-status-watch.py
@@ -220,12 +220,18 @@ def commit_verdict(rows):
 
 # ── the flake screen ──────────────────────────────────────────────────────────
 # 🔴 THIS SCREEN IS SOUND AND ALMOST NEVER SATISFIABLE, AND BOTH HALVES ARE THE
-# POINT. GitHub caps a status description at 140 BYTES and the pipeline's
+# POINT. A status description arrives cut at 140 BYTES and the pipeline's
 # `FAILING: a | b | c | TOTAL …` line overruns it constantly. MEASURED on real
 # rows: one described `failed=7` while naming ONE test; one named NO test at all;
 # and the row that named the known flake was cut MID-WORD
 # (`…_CAN_see_the_dif`). So a description can prove "at least one test failed and
 # here is its name" — it can NEVER prove "these are all of them".
+# ⚠ WHOSE CUT IT IS — GitHub's own 140-byte cap, or the posting pipeline's own
+# truncation — IS NOT DETERMINED and must not be asserted either way: every row
+# sampled carries exactly one multi-byte character, so at 138 chars / 140 bytes
+# the two hypotheses are indistinguishable. What is measured is the BOUNDARY,
+# pinned by `test_CONTROL_the_real_truncated_rows_land_on_the_BYTE_cap_not_the_
+# CHAR_cap`.
 #
 # A screen that skipped on a name match would therefore skip real reds. This one
 # skips only when the description PROVES the named set is complete: every failing

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+# stale-base-triage — is this PR's red INHERITED from a stale base, and which
+# commit already fixed it?
+#
+# WHY THIS EXISTS, MEASURED. `tekton/devrc-pytests` is the only automated signal
+# on a PR in this repo and nothing blocks a merge on it, so its whole value is
+# whether a human believes a red. MEASURED 2026-09-11 over the post-#1458
+# window: of the SIX genuine `failure` verdicts, THREE — half — were the same
+# test (`test_the_SUMMARY_BANNER_names_the_real_selection_source`) on PRs 17, 40
+# and 40 commits behind `main`, all since merged, and that test passes on
+# current `main`. An earlier sample had 8 of 8 failing open PRs 5-42 commits
+# behind, with a rebase curing 4 outright. So roughly half the genuine-failure
+# signal on the only gate there is comes from PRs re-reporting a red that `main`
+# has already fixed, and a human triages a failure their diff cannot reach.
+#
+# 🔴 WHAT THIS IS, AND WHAT IT IS NOT. It is a REPORTER. It runs no tests, it
+# makes no claim that a rebase WILL fix anything, and by default it writes
+# nothing anywhere. What it does is assemble a deterministic evidence pair for
+# each failing test named in the status description:
+#
+#   (1) the PR head's copy of the file defining that test is byte-identical to
+#       the MERGE-BASE's copy — i.e. this PR never touched it; and
+#   (2) `origin/main` HAS moved that file since the merge-base, in commits that
+#       are demonstrably not in the PR head's history.
+#
+# Both halves are blob-OID and commit-list facts, so the verdict is reproducible
+# by hand from the lines it prints. It still says "LIKELY cured by rebase",
+# because a commit touching the test's file is a candidate fix, not a proof of
+# one — only re-running the suite on the merged tree proves that, and this
+# script deliberately does not pretend to.
+#
+# 🔴 WHY IT READS `/commits/{sha}/statuses` (PLURAL). `/commits/{sha}/status`
+# (singular) is the ROLL-UP, and it maps `error` onto `failure`. Every non-code
+# outcome this pipeline produces — `superseded by a newer run`, `KILLED: the
+# gate pod died`, `NO GATE POD`, `clone rc 128` — arrives as `error`, and over
+# 200 measured rows the roll-up turned 9 real failures into 48-49 red-looking
+# pushes. A triage tool built on it would spend all of its time explaining runs
+# that never ran. The list endpoint carries no roll-up field at all, so the
+# mistake is unavailable here rather than merely avoided. 🔴 Same family:
+# `/commits/{sha}/check-runs` returns NOTHING for these checks — that zero is an
+# instrument artefact, not an absence of checks.
+#
+# 🔴 AND THE LIST IS NEWEST-FIRST, which is the second half of the same trap: a
+# last-wins dict over it yields the OLDEST post per context. One agent shipped
+# that and reported a known-green head as `pending`. `newest_per_context` folds
+# by `max(created_at)` and does not depend on the array's order at all, so it is
+# correct whichever way GitHub decides to return it tomorrow.
+#
+# 🔴 `error` IS REPORTED SEPARATELY AND IS NEVER A CODE FAILURE. Only
+# `state == "failure"` is triageable. An `error` row means the gate broke, not
+# the change, and folding the two together is the roll-up mistake in a second
+# spelling.
+#
+# 🔴 COMPLETENESS IS THE HARD PART, AND IT IS WHY THIS TOOL SAYS "COULD NOT
+# MEASURE" MORE OFTEN THAN YOU WOULD LIKE. GitHub caps a status description at
+# 140 characters and the gate's `FAILING: a | b | TOTAL … failed=N …` line
+# overruns it constantly. MEASURED on this repo's own rows: one described
+# `failed=7` while naming ONE test; one named NO test at all; one was cut
+# MID-WORD inside a test name. So a description can prove "at least one test
+# failed and here is its name" — it can NEVER prove "these are all of them"
+# unless the `failed=N` count survived AND equals the number of names.
+# Dismissing a PR as INHERITED on an incomplete list would dismiss a real red,
+# which is the one error this tool must not make. So the PR-level verdict
+# requires provable completeness; the PER-TEST lines print either way, and a
+# `HINT:` line says when a rebase is worth trying anyway.
+#
+# EXIT CODES
+#   0   ran; no PR was classified INHERITED (the counts say what it DID find)
+#  10   at least one PR is INHERITED — likely cured by rebase
+#  11   COULD NOT MEASURE at all (no gh, no repo, no PRs read)
+#   2   usage
+#
+# ENV SEAMS (none is read anywhere else; the ledger is pinned two-way by
+# `test_every_env_var_the_code_reads_is_documented_in_the_header`)
+#   STALE_BASE_TRIAGE_GH            argv0 for the API reader (default: `gh`)
+#   STALE_BASE_TRIAGE_REPO          owner/name, overriding the origin remote
+#   STALE_BASE_TRIAGE_BUDGET        total wall-clock seconds for all API reads
+#   STALE_BASE_TRIAGE_COMMENT_MODE  off (default) | dry-run | on
+# ⚠ NOTHING ELSE IN THIS COMMENT MAY BEGIN A LINE WITH A KNOB NAME — the guard
+# reads the ledger above by matching `^#   STALE_BASE_TRIAGE_…`, so an ordinary
+# sentence wrapping onto a line that started with one would register as a ledger
+# entry for a knob that has none: a two-way pin satisfied by prose.
+#
+# 🔴 IT WRITES NOTHING BY DEFAULT, AND ARMING IT COSTS A VISIBLE LINE.
+# `COMMENT_MODE_DEFAULT` is the literal `"off"`, pinned by
+# `test_the_comment_mode_default_is_the_LITERAL_off` — asserting mere membership
+# in the legal set would let a one-character edit arm a bot that comments on
+# every open PR pass unnoticed. Change that literal in the arming commit; the
+# diff should say out loud that a writer went live.
+"""Triage a red PR: is the failure inherited from a stale base, and what fixed it?"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+RC_OK, RC_INHERITED, RC_UNMEASURED, RC_USAGE = 0, 10, 11, 2
+
+# The context this triage is about. A literal contract with the devrc-ci
+# pipeline; a typo here yields "no verdict found" forever, which is why an empty
+# read is reported as UNMEASURED and never as "nothing to triage".
+CONTEXT = "tekton/devrc-pytests"
+
+# 🔴 THE DEFAULT IS THE SAFETY CLAIM. See the header.
+COMMENT_MODE_DEFAULT = "off"
+COMMENT_MODES = ("off", "dry-run", "on")
+
+# The marker that makes a posted comment idempotent. Present in a comment body
+# => this PR head has already been told, and posting again is noise.
+COMMENT_MARKER = "<!-- stale-base-triage -->"
+
+TOTAL_BUDGET_S_DEFAULT = 300
+
+VERDICT_INHERITED = "INHERITED — likely cured by rebase"
+VERDICT_NOT_STALE = "NOT EXPLAINED BY STALENESS"
+VERDICT_UNMEASURED = "COULD NOT MEASURE"
+
+HEADER_SENTINEL = '"""Triage a red PR'
+
+
+# 🔴 UNDER --json, STDOUT CARRIES THE PAYLOAD AND NOTHING ELSE. Prose printed
+# beside it makes the output un-parseable in a way that looks fine by eye: a
+# first draft printed the comment-mode line after the object, and `json.loads`
+# on the whole stream raised `Extra data` — the caller's parse, not this
+# script's, is where that lands. So every human line goes to stderr instead.
+_JSON_MODE = False
+
+
+def say(msg=""):
+    print(msg, file=sys.stderr if _JSON_MODE else sys.stdout, flush=True)
+
+
+class Unmeasured(Exception):
+    """Raised for every reason the world could not be read. Never a verdict."""
+
+
+def print_header():
+    """Print the comment header — the part that documents the env knobs.
+
+    Bounded by the docstring's opening line rather than a hardcoded range: a
+    literal range silently truncates --help the moment the header grows, which
+    `main-green-check.sh` records having happened to it already.
+    """
+    src = Path(__file__).read_text(encoding="utf-8").splitlines()
+    end = next((i for i, ln in enumerate(src) if ln.startswith(HEADER_SENTINEL)), None)
+    if end is None:
+        say("stale-base-triage: cannot locate the end of the header")
+        return False
+    for line in src[1:end]:
+        say(line[2:] if line.startswith("# ") else line.lstrip("#"))
+    return True
+
+
+# ── status classification ─────────────────────────────────────────────────────
+def classify(state, description):
+    """One status row -> a verdict class. Pure; the tests drive it directly.
+
+    🔴 UNRECOGNISED MEANS `error-other`, WHICH MEANS NOT-A-VERDICT — never
+    `red`, and never `green`. Only `failure` is a code failure; every broken-gate
+    outcome this pipeline produces arrives as `error` and is reported under its
+    own name so a human can see it was the gate, not the change.
+    """
+    desc = (description or "").strip()
+    if state == "success":
+        return "green"
+    if state == "failure":
+        return "red"
+    if state == "pending":
+        return "pending"
+    if state == "error":
+        if desc.startswith("superseded"):
+            return "superseded"
+        if desc.startswith("KILLED"):
+            return "killed"
+        if desc.startswith("NO GATE POD"):
+            return "no-gate-pod"
+        return "error-other"
+    return "error-other"
+
+
+def newest_per_context(rows):
+    """Fold status rows to the NEWEST row per context, by `created_at`.
+
+    🔴 NOT first-wins and NOT last-wins. GitHub returns this array newest-first
+    today, so a last-wins dict yields the OLDEST post per context — an agent
+    shipped exactly that and reported a known-green head as `pending`. Folding
+    on `max(created_at)` is correct under either ordering, so the hazard is
+    removed rather than merely avoided; `test_newest_per_context_is_order_
+    independent` feeds both orders and pins that they agree.
+    """
+    best = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        ctx = row.get("context") or ""
+        if not ctx:
+            continue
+        stamp = row.get("created_at") or ""
+        if ctx not in best or stamp > best[ctx][0]:
+            best[ctx] = (stamp, row)
+    return {ctx: row for ctx, (_, row) in best.items()}
+
+
+# ── description parsing ───────────────────────────────────────────────────────
+_FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
+_FAILED_COUNT_RE = re.compile(r"\bfailed=(\d+)\b")
+# The only fragments a 140-char cut can leave behind where `TOTAL` was starting.
+# Enumerated rather than pattern-matched: a `startswith` test would also eat a
+# real name, and every test in this repo begins `test_` or `Test`, none of which
+# is a prefix of `TOTAL`. See `test_a_trailing_TOTAL_fragment_is_not_a_test_name`.
+_TOTAL_FRAGMENTS = ("T", "TO", "TOT", "TOTA")
+
+
+def parse_failing_names(description):
+    """The test names the description NAMES. May be incomplete — see the header.
+
+    A description cut inside ` | TOTAL` leaves a trailing fragment of the word
+    TOTAL sitting where a name would be. Left in, it resolves to no file and the
+    PR is reported as a real red on the strength of a truncation artefact.
+    """
+    m = _FAILING_RE.search(description or "")
+    if not m:
+        return []
+    names = [n.strip() for n in m.group(1).split("|") if n.strip()]
+    if names and names[-1] in _TOTAL_FRAGMENTS:
+        names.pop()
+    return names
+
+
+def parse_failed_count(description):
+    m = _FAILED_COUNT_RE.search(description or "")
+    return int(m.group(1)) if m else None
+
+
+def names_provably_complete(description):
+    """True only when the description PROVES the named set is the whole set.
+
+    Returns (complete, reason). False on any doubt: no names, no surviving
+    count, or a count that disagrees with the names. This is the guard that
+    stops an INHERITED verdict being handed out on a truncated row that named
+    one of seven failures.
+    """
+    names = parse_failing_names(description)
+    if not names:
+        return False, "the description names no failing test"
+    count = parse_failed_count(description)
+    if count is None:
+        return False, "the description was truncated before `failed=N`"
+    if count != len(names):
+        return False, f"the description says failed={count} but names {len(names)}"
+    return True, f"failed={count} and {len(names)} named"
+
+
+# ── test name -> defining file ────────────────────────────────────────────────
+_PARAM_SUFFIX_RE = re.compile(r"\[.*$")
+
+
+def normalise_test_name(raw):
+    """`Class.method[param-param]` -> (class_or_None, method).
+
+    🔴 THREE SHAPES, EACH MEASURED ON A REAL ROW OF THIS REPO'S OWN CI:
+      * bare              `test_no_test_writes_a_usr_bin_env_shebang_at_runtime`
+      * class-qualified   `TestAHungRoundTripSAYSWhichSideBlocked.test_a_stall…`
+      * parametrised      `test_a_FORGED_actor_in_the_body_is_DISCARDED[record0-…`
+    The parametrise brackets are stripped BEFORE the class split, because an id
+    can itself contain a dot and would otherwise be read as the class.
+    """
+    name = (raw or "").strip()
+    name = _PARAM_SUFFIX_RE.sub("", name).strip()
+    if not name:
+        return None, ""
+    if "." in name:
+        cls, _, method = name.rpartition(".")
+        return cls or None, method
+    return None, name
+
+
+def _git(repo, args, check=True, timeout=60):
+    try:
+        proc = subprocess.run(["git", "-C", str(repo), *args],
+                              capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        raise Unmeasured("git is not on PATH")
+    except subprocess.TimeoutExpired:
+        raise Unmeasured(f"git {' '.join(args[:2])} timed out after {timeout}s")
+    if check and proc.returncode != 0:
+        err = (proc.stderr or "").strip().splitlines()
+        raise Unmeasured(
+            f"git {' '.join(args[:3])} exited {proc.returncode}: "
+            f"{err[0] if err else '(no stderr)'}")
+    return proc
+
+
+def ref_exists(repo, ref):
+    return _git(repo, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+                check=False).returncode == 0
+
+
+def path_exists_at(repo, ref, path):
+    """🔴 `git cat-file -e <ref>:<path>`, NEVER `git diff --quiet <ref> -- <path>`.
+
+    The latter exits 0 when the path exists on NEITHER side, so used as a
+    freshness check it reports a reassuring "matches <ref>" for a file that has
+    never existed in that tree. A comparison against an absent operand reports
+    SAME, not MISSING — so existence is proved first, separately, here.
+    """
+    return _git(repo, ["cat-file", "-e", f"{ref}:{path}"], check=False).returncode == 0
+
+
+def blob_oid(repo, ref, path):
+    """The blob OID of `path` at `ref`, or None when the path is absent there."""
+    proc = _git(repo, ["rev-parse", f"{ref}:{path}"], check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _grep_files(repo, ref, pattern):
+    """`git grep -l -E <pattern> <ref> -- '*.py'` -> list of paths.
+
+    rc 0 means matches, rc 1 means none, anything else is a real error and must
+    not read as "none" — an unparseable grep is the same reassuring zero the
+    rules warn about, so it raises instead. The `<ref>:` prefix is stripped by
+    LENGTH rather than by splitting on `:`, because a ref can contain one.
+    """
+    proc = _git(repo, ["grep", "-l", "-E", pattern, ref, "--", "*.py"], check=False)
+    out = proc.stdout or ""
+    if proc.returncode == 1:
+        if out.strip():
+            raise Unmeasured("git grep reported no matches but printed output")
+        return []
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip().splitlines()
+        raise Unmeasured(f"git grep exited {proc.returncode}: "
+                         f"{err[0] if err else '(no stderr)'}")
+    prefix = f"{ref}:"
+    paths = []
+    for line in out.splitlines():
+        if not line.startswith(prefix):
+            raise Unmeasured(f"git grep printed an unexpected line: {line!r}")
+        paths.append(line[len(prefix):])
+    return sorted(set(paths))
+
+
+def resolve_test_file(repo, ref, raw_name):
+    """Map a failing test name to the ONE file that defines it, at `ref`.
+
+    🔴 THE MAPPING IS SEARCHED, NEVER GUESSED, and every way it can fail has its
+    own outcome rather than a silent fallback:
+      `ok`          exactly one file defines it
+      `ambiguous`   more than one does — naming a fix commit would be a coin flip
+      `not-found`   none does (a renamed or deleted test, or a name this parser
+                    mis-read); reported, never treated as "nothing changed"
+
+    TWO PHASES, and the order is the guard. Phase 1 requires the opening paren,
+    so a short name cannot match a longer one that starts with it — the way
+    test_foo would otherwise match test_foobar. Only when phase 1 finds NOTHING
+    does phase 2 drop the paren — which is the truncation case, and nothing
+    else: GitHub's 140-char cap lands mid-name often enough that this repo has
+    a real row ending `…_CAN_see_the_dif`. Running phase 2 unconditionally would
+    turn every short name into a false `ambiguous`; see
+    `test_a_COMPLETE_name_is_not_made_ambiguous_by_a_longer_sibling`.
+    """
+    cls, method = normalise_test_name(raw_name)
+    if not method:
+        return {"status": "not-found", "name": raw_name, "reason": "empty test name"}
+    esc = re.escape(method)
+    exact = _grep_files(repo, ref, rf"^[ \t]*(async +)?def {esc}\(")
+    files, truncated = exact, False
+    if not files:
+        files = _grep_files(repo, ref, rf"^[ \t]*(async +)?def {esc}")
+        truncated = bool(files)
+    if cls and len(files) > 1:
+        # A class-qualified name carries a second, independent discriminator.
+        # Only ever NARROWS: if it narrows to nothing the class hint is wrong,
+        # and the un-narrowed ambiguity is reported rather than an empty one.
+        narrowed = [p for p in files
+                    if p in _grep_files(repo, ref, rf"^[ \t]*class {re.escape(cls)}\b")]
+        if narrowed:
+            files = narrowed
+    if not files:
+        return {"status": "not-found", "name": raw_name,
+                "reason": f"no file at {ref} defines `{method}`"}
+    if len(files) > 1:
+        return {"status": "ambiguous", "name": raw_name, "files": files,
+                "reason": f"{len(files)} files define `{method}`: " + ", ".join(files)}
+    return {"status": "ok", "name": raw_name, "file": files[0],
+            "truncated_name": truncated}
+
+
+# ── the evidence ──────────────────────────────────────────────────────────────
+def commits_touching(repo, since_ref, until_ref, path):
+    """Commits in `since..until` that touched `path`, newest first."""
+    proc = _git(repo, ["log", "--format=%H%x09%s", f"{since_ref}..{until_ref}",
+                       "--", path])
+    out = []
+    for line in (proc.stdout or "").splitlines():
+        sha, _, subject = line.partition("\t")
+        if sha.strip():
+            out.append({"sha": sha.strip(), "subject": subject.strip()})
+    return out
+
+
+def is_ancestor(repo, maybe_ancestor, ref):
+    """🔴 USED ONLY TO ASK ABOUT THE PR HEAD, NEVER TO CONCLUDE "THIS MERGED".
+
+    A SQUASH merge never makes a branch head an ancestor of its base, so
+    ancestry answers "was this merged?" with a permanent, confident FALSE — this
+    repo squashes, so that reading is always wrong here. What ancestry DOES
+    answer correctly is "is commit C in the history this PR head was built on?",
+    which is a question about one commit and one head and involves no merge at
+    all. That is the only question asked of it. The claim that a fix LANDED is
+    made by CONTENT elsewhere in this file: the blob OIDs of the test's file at
+    the merge-base, at the head, and at main.
+    """
+    return _git(repo, ["merge-base", "--is-ancestor", maybe_ancestor, ref],
+                check=False).returncode == 0
+
+
+def prove_candidates(repo, candidates, main_ref, head_ref):
+    """Annotate each candidate with the evidence pair; keep those absent from the head.
+
+    🔴 THE PAIR IS COMPUTED AND PRINTED; ONLY ONE HALF IS A FILTER, AND THE
+    ASYMMETRY IS DELIBERATE. `on_main` is TRUE BY CONSTRUCTION for anything
+    `commits_touching` returns — it walks `merge-base..main`, so every candidate
+    is already an ancestor of main. Filtering on it would be a guard that can
+    never run, which reads as coverage and stops anyone looking; a mutation
+    sweep said exactly that (dropping it from the condition SURVIVED the whole
+    suite). It is measured and printed so a reader can VERIFY the claim rather
+    than trust it — never to gate on.
+
+    `not in_head` IS a filter, and it is a separate function precisely so it can
+    be REACHED: through `triage_one_test` the blob comparison rejects the shapes
+    that would produce a head-ancestor candidate before this line runs. It still
+    matters, because `git merge-base` returns ONE base while a criss-cross
+    history has several, so a candidate in the printed range can be in the head
+    after all — and must not be offered as a fix the head is missing.
+    """
+    proven = []
+    for c in candidates:
+        c["on_main"] = is_ancestor(repo, c["sha"], main_ref)
+        c["in_head"] = is_ancestor(repo, c["sha"], head_ref)
+        if not c["in_head"]:
+            proven.append(c)
+    return proven
+
+
+def triage_one_test(repo, main_ref, head_ref, merge_base, raw_name):
+    """One failing test -> its own verdict plus the evidence for it."""
+    res = resolve_test_file(repo, head_ref, raw_name)
+    if res["status"] != "ok":
+        return {"name": raw_name, "verdict": VERDICT_UNMEASURED,
+                "reason": res["reason"], "explained": False}
+    path = res["file"]
+    out = {"name": raw_name, "file": path, "explained": False,
+           "truncated_name": res["truncated_name"]}
+
+    # 🔴 EXISTENCE FIRST, ON EVERY SIDE WE ARE ABOUT TO COMPARE.
+    for label, ref in (("merge-base", merge_base), ("main", main_ref)):
+        if not path_exists_at(repo, ref, path):
+            out["verdict"] = VERDICT_UNMEASURED
+            out["reason"] = (f"`{path}` does not exist at {label} ({ref[:12]}) — "
+                             "a rename or a new file; a blob comparison against "
+                             "an absent operand would report SAME, not MISSING")
+            return out
+    base_blob = blob_oid(repo, merge_base, path)
+    head_blob = blob_oid(repo, head_ref, path)
+    main_blob = blob_oid(repo, main_ref, path)
+    out.update({"blob_merge_base": base_blob, "blob_head": head_blob,
+                "blob_main": main_blob})
+
+    if head_blob != base_blob:
+        out["verdict"] = VERDICT_NOT_STALE
+        out["reason"] = (f"the PR itself modifies `{path}` (head blob "
+                         f"{(head_blob or '?')[:12]} != merge-base "
+                         f"{(base_blob or '?')[:12]}) — the failing test's own "
+                         "file is part of this change, so staleness does not "
+                         "explain it")
+        return out
+    if main_blob == base_blob:
+        out["verdict"] = VERDICT_NOT_STALE
+        out["reason"] = (f"`{path}` is unchanged on main since the merge-base "
+                         f"(blob {(base_blob or '?')[:12]}) — nothing on main "
+                         "can have fixed this; treat it as a real red")
+        return out
+
+    candidates = commits_touching(repo, merge_base, main_ref, path)
+    if not candidates:
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = (f"`{path}` differs between the merge-base and main, but "
+                         "no commit in merge-base..main touched that path (a "
+                         "rename would do this)")
+        return out
+    proven = prove_candidates(repo, candidates, main_ref, head_ref)
+    if not proven:
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = ("every candidate failed the evidence pair (on main AND "
+                         "not in the PR head) — the refs may have moved under "
+                         "this run")
+        out["candidates"] = candidates
+        return out
+    out["verdict"] = VERDICT_INHERITED
+    out["explained"] = True
+    out["candidates"] = proven
+    out["reason"] = (f"`{path}` is byte-identical at the PR head and the "
+                     f"merge-base, and main has moved it in "
+                     f"{len(proven)} commit(s) absent from the head")
+    return out
+
+
+# ── per-PR triage ─────────────────────────────────────────────────────────────
+def triage_pr(repo, main_ref, pr, row):
+    """Fold one PR's newest pytests row into a verdict plus its evidence."""
+    out = {"number": pr["number"], "title": pr.get("title", ""),
+           "head": pr["head_sha"], "url": pr.get("url", "")}
+    if row is None:
+        out["state"] = "none"
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = f"no `{CONTEXT}` status on this head"
+        return out
+    klass = classify(row.get("state"), row.get("description"))
+    out["state"] = row.get("state")
+    out["class"] = klass
+    out["description"] = row.get("description") or ""
+    out["created_at"] = row.get("created_at") or ""
+    if klass != "red":
+        out["verdict"] = None          # nothing to triage; NOT a verdict
+        return out
+
+    head_ref = pr["head_sha"]
+    if not ref_exists(repo, head_ref):
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = (f"head {head_ref[:12]} is not in the local clone — "
+                         "re-run with --fetch, or fetch it by hand")
+        return out
+    merge_base = _git(repo, ["merge-base", main_ref, head_ref]).stdout.strip()
+    out["merge_base"] = merge_base
+    out["behind"] = int(_git(
+        repo, ["rev-list", "--count", f"{merge_base}..{main_ref}"]).stdout.strip() or 0)
+
+    names = parse_failing_names(out["description"])
+    complete, completeness_reason = names_provably_complete(out["description"])
+    out["names"] = names
+    out["complete"] = complete
+    out["completeness_reason"] = completeness_reason
+    out["tests"] = [triage_one_test(repo, main_ref, head_ref, merge_base, n)
+                    for n in names]
+
+    explained = [t for t in out["tests"] if t["explained"]]
+    unexplained = [t for t in out["tests"]
+                   if t["verdict"] == VERDICT_NOT_STALE]
+    out["any_explained"] = bool(explained)
+    if unexplained:
+        # 🔴 CONSERVATIVE BY CONSTRUCTION. One named test main cannot have fixed
+        # is enough to make this a real red; dismissing it would be the only
+        # error this tool must never make.
+        out["verdict"] = VERDICT_NOT_STALE
+        out["reason"] = (f"{len(unexplained)} named test(s) are not explained by "
+                         "staleness: " + "; ".join(t["name"] for t in unexplained))
+        return out
+    if not names:
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = completeness_reason
+        return out
+    if not all(t["explained"] for t in out["tests"]):
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = "; ".join(t["reason"] for t in out["tests"]
+                                  if not t["explained"])
+        return out
+    if not complete:
+        out["verdict"] = VERDICT_UNMEASURED
+        out["reason"] = (f"every NAMED failure is inherited, but {completeness_reason}"
+                         " — so the named set cannot be proven complete and other "
+                         "failures may remain")
+        return out
+    out["verdict"] = VERDICT_INHERITED
+    out["reason"] = (f"all {len(names)} failing test(s) are inherited from a base "
+                     f"{out['behind']} commits behind main")
+    return out
+
+
+# ── IO ────────────────────────────────────────────────────────────────────────
+_DEADLINE = None
+
+
+def _remaining():
+    return 60.0 if _DEADLINE is None else _DEADLINE - time.monotonic()
+
+
+def gh_json(path, args=(), timeout=60):
+    gh = os.environ.get("STALE_BASE_TRIAGE_GH", "gh")
+    left = _remaining()
+    if left <= 0:
+        raise Unmeasured(f"ran out of its API budget before reading {path}")
+    timeout = min(timeout, left)
+    try:
+        proc = subprocess.run([gh, "api", path, *args],
+                              capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        raise Unmeasured(f"{gh} is not on PATH")
+    except subprocess.TimeoutExpired:
+        raise Unmeasured(f"gh api {path} timed out after {timeout}s")
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip().splitlines()
+        raise Unmeasured(f"gh api {path} exited {proc.returncode}: "
+                         f"{err[0] if err else '(no stderr)'}")
+    try:
+        return json.loads(proc.stdout or "")
+    except json.JSONDecodeError as exc:
+        raise Unmeasured(f"gh api {path} returned unparseable JSON: {exc}")
+
+
+def resolve_repo(repo_path):
+    override = os.environ.get("STALE_BASE_TRIAGE_REPO", "").strip()
+    if override:
+        return override
+    proc = _git(repo_path, ["remote", "get-url", "origin"], check=False)
+    if proc.returncode != 0:
+        raise Unmeasured("cannot read origin remote (not a git checkout?)")
+    url = proc.stdout.strip()
+    m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
+    if not m:
+        raise Unmeasured(f"cannot parse owner/name out of origin url: {url!r}")
+    return m.group(1)
+
+
+def comment_mode(cli_value):
+    """off | dry-run | on — CLI wins over env, and anything unrecognised is off.
+
+    🔴 FAILS CLOSED. A typo in the env var must silently disarm the writer, not
+    silently arm it, and must never raise: this runs on the reporting path.
+    """
+    raw = (cli_value or os.environ.get("STALE_BASE_TRIAGE_COMMENT_MODE")
+           or COMMENT_MODE_DEFAULT).strip().lower()
+    return raw if raw in COMMENT_MODES else COMMENT_MODE_DEFAULT
+
+
+def comment_body(result):
+    lines = [COMMENT_MARKER,
+             f"**{VERDICT_INHERITED}** — this head is **{result['behind']}** "
+             f"commits behind `main`.", ""]
+    for t in result["tests"]:
+        for c in t.get("candidates", []):
+            lines.append(f"- `{t['name']}` is defined in `{t['file']}`, which "
+                         f"`main` moved in {c['sha'][:12]} (_{c['subject']}_) — "
+                         "a commit that is on `main` and not in this head.")
+    lines += ["", "The PR's own copy of each file above is byte-identical to the "
+              "merge-base, so this change did not cause these failures. Rebasing "
+              "on `main` is likely to clear them.",
+              "", "_Reported by `scripts/stale-base-triage.py`; it ran no tests._"]
+    return "\n".join(lines)
+
+
+def already_commented(repo_slug, number):
+    rows = gh_json(f"/repos/{repo_slug}/issues/{number}/comments?per_page=100")
+    if not isinstance(rows, list):
+        raise Unmeasured("comment listing was not a list")
+    return any(COMMENT_MARKER in (r.get("body") or "") for r in rows
+               if isinstance(r, dict))
+
+
+def post_comment(repo_slug, number, body):
+    gh = os.environ.get("STALE_BASE_TRIAGE_GH", "gh")
+    proc = subprocess.run(
+        [gh, "api", "-X", "POST", f"/repos/{repo_slug}/issues/{number}/comments",
+         "-f", f"body={body}"], capture_output=True, text=True, timeout=60)
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip().splitlines()
+        raise Unmeasured(f"posting a comment exited {proc.returncode}: "
+                         f"{err[0] if err else '(no stderr)'}")
+    return True
+
+
+# ── fetching ──────────────────────────────────────────────────────────────────
+# 🔴 EVERY REF THIS SCRIPT WRITES LIVES UNDER ITS OWN NAMESPACE. `refs/` is
+# repo-GLOBAL — it lives in the COMMON git dir, so a worktree gives zero
+# isolation and a concurrent session reads the same refs. Writing
+# `refs/remotes/origin/main` or a branch would reach into work this run knows
+# nothing about; `refs/stale-base-triage/*` cannot collide with a branch, a tag
+# or a remote-tracking ref.
+NS = "refs/stale-base-triage"
+
+
+def fetch_refs(repo, numbers):
+    specs = [f"+refs/heads/main:{NS}/main"]
+    specs += [f"+refs/pull/{n}/head:{NS}/pr-{n}" for n in numbers]
+    _git(repo, ["fetch", "--no-tags", "--quiet", "origin", *specs], timeout=300)
+
+
+# ── rendering ─────────────────────────────────────────────────────────────────
+def render(result):
+    n = result["number"]
+    say(f"── PR #{n}  {result['title'][:80]}")
+    say(f"   head {result['head'][:12]}   {result.get('url','')}")
+    klass = result.get("class")
+    # 🔴 THE THREE CASES ARE PRINTED APART, because an earlier draft folded the
+    # first into the third and printed `failure   posted ?` above a verdict that
+    # said "no status on this head" — a line asserting a red that was never
+    # posted. Measured on #359/#355/#612/#646 in the first live sweep.
+    if result.get("state") == "none" or klass is None:
+        say(f"   {CONTEXT}: no status on this head")
+    elif klass != "red":
+        say(f"   {CONTEXT}: {result['state']} ({klass}) — "
+            "🔴 NOT a code failure: the gate broke, not the change")
+        if result.get("description"):
+            say(f"       {result['description'][:140]}")
+    else:
+        say(f"   {CONTEXT}: failure   posted {result.get('created_at','?')}")
+    if result.get("verdict") is None:
+        say("   nothing to triage")
+        say()
+        return
+    if "behind" in result:
+        say(f"   base is {result['behind']} commits behind main "
+            f"(merge-base {result.get('merge_base','?')[:12]})")
+    if result.get("description"):
+        say(f"   description: {result['description'][:140]}")
+    for t in result.get("tests", []):
+        say(f"   • {t['name']}")
+        if t.get("file"):
+            say(f"       file: {t['file']}"
+                + ("   (name was truncated by GitHub's 140-char cap)"
+                   if t.get("truncated_name") else ""))
+        say(f"       {t['verdict']}: {t['reason']}")
+        for c in t.get("candidates", []):
+            say(f"       evidence: {c['sha'][:12]} {c['subject'][:70]}")
+            say(f"                 on main: {c['on_main']}   "
+                f"in this head: {c['in_head']}")
+        if t.get("blob_merge_base"):
+            say(f"       blobs: merge-base {t['blob_merge_base'][:12]}  "
+                f"head {(t.get('blob_head') or '-')[:12]}  "
+                f"main {(t.get('blob_main') or '-')[:12]}")
+    if result.get("completeness_reason"):
+        say(f"   completeness: {result['completeness_reason']}")
+    say(f"   VERDICT: {result['verdict']}")
+    if result.get("reason"):
+        say(f"            {result['reason']}")
+    if result["verdict"] != VERDICT_INHERITED and result.get("any_explained"):
+        say("   HINT: at least one named failure IS inherited — a rebase is "
+            "worth trying before debugging.")
+    say()
+
+
+def summarise(results, errors):
+    inherited = [r for r in results if r.get("verdict") == VERDICT_INHERITED]
+    not_stale = [r for r in results if r.get("verdict") == VERDICT_NOT_STALE]
+    unmeasured = [r for r in results if r.get("verdict") == VERDICT_UNMEASURED]
+    reds = inherited + not_stale + unmeasured
+    say("── SUMMARY")
+    say(f"   PRs read:               {len(results)}")
+    say(f"   red ({CONTEXT}):        {len(reds)}")
+    say(f"   INHERITED:              {len(inherited)}"
+        + ("  " + ", ".join(f"#{r['number']}" for r in inherited) if inherited else ""))
+    say(f"   NOT EXPLAINED:          {len(not_stale)}"
+        + ("  " + ", ".join(f"#{r['number']}" for r in not_stale) if not_stale else ""))
+    say(f"   COULD NOT MEASURE:      {len(unmeasured)}"
+        + ("  " + ", ".join(f"#{r['number']}" for r in unmeasured) if unmeasured else ""))
+    # 🔴 A BROKEN GATE IS NEVER A CODE FAILURE, so it is counted on its own line
+    # and never inside the red total. Folding it in is the roll-up mistake.
+    if errors:
+        say(f"   broken gate (`error`):  {len(errors)}  "
+            + ", ".join(f"#{r['number']}({r.get('class')})" for r in errors))
+    # 🔴 A ZERO HERE IS NOT AN ALL-CLEAR UNTIL IT IS SHOWN OBSERVABLE. The
+    # counts above are printed together for exactly that reason: `INHERITED: 0`
+    # beside `red: 0` says the population was empty, while `INHERITED: 0` beside
+    # `red: 7` says seven reds were examined and none was explained. Those are
+    # different claims and the summary must never collapse them.
+    if not reds:
+        say("   ⚠ no red heads in this population — an INHERITED count of 0 here "
+            "is an empty sample, not an all-clear.")
+    return len(inherited)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+def build_parser():
+    p = argparse.ArgumentParser(add_help=False, description=__doc__)
+    p.add_argument("--pr", type=int, action="append", default=[],
+                   help="triage this PR (repeatable)")
+    p.add_argument("--sweep", action="store_true", help="triage every open PR")
+    p.add_argument("--repo-path", default=str(Path(__file__).resolve().parents[1]))
+    p.add_argument("--main-ref", default=None,
+                   help="ref standing for main (default: origin/main, or the "
+                        "namespaced ref under --fetch)")
+    p.add_argument("--fetch", action="store_true",
+                   help=f"refresh {NS}/* from origin before measuring")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument("--comment-mode", choices=COMMENT_MODES, default=None,
+                   help=f"post a PR comment (default {COMMENT_MODE_DEFAULT})")
+    p.add_argument("-h", "--help", action="store_true")
+    return p
+
+
+def main(argv):
+    global _DEADLINE, _JSON_MODE
+    args = build_parser().parse_args(argv)
+    _JSON_MODE = bool(args.json)
+    if args.help:
+        return RC_OK if print_header() else RC_UNMEASURED
+    if not args.pr and not args.sweep:
+        say("usage: stale-base-triage.py [--pr N ...] [--sweep]  (--help for the header)")
+        return RC_USAGE
+    budget = os.environ.get("STALE_BASE_TRIAGE_BUDGET", "")
+    _DEADLINE = time.monotonic() + (int(budget) if budget.isdigit()
+                                    else TOTAL_BUDGET_S_DEFAULT)
+    repo = Path(args.repo_path)
+    mode = comment_mode(args.comment_mode)
+
+    try:
+        slug = resolve_repo(repo)
+        if args.sweep:
+            rows = gh_json(f"/repos/{slug}/pulls?state=open&per_page=100")
+            if not isinstance(rows, list):
+                raise Unmeasured("the pull-request listing was not a list")
+            prs = [{"number": r["number"], "title": r.get("title", ""),
+                    "head_sha": r["head"]["sha"], "url": r.get("html_url", "")}
+                   for r in rows]
+        else:
+            prs = []
+            for n in args.pr:
+                r = gh_json(f"/repos/{slug}/pulls/{n}")
+                prs.append({"number": r["number"], "title": r.get("title", ""),
+                            "head_sha": r["head"]["sha"],
+                            "url": r.get("html_url", "")})
+        if args.fetch:
+            fetch_refs(repo, [p["number"] for p in prs])
+        main_ref = args.main_ref or (f"{NS}/main" if args.fetch else "origin/main")
+        if not ref_exists(repo, main_ref):
+            raise Unmeasured(f"{main_ref} does not resolve in {repo}")
+    except Unmeasured as exc:
+        say(f"{VERDICT_UNMEASURED} — {exc}")
+        return RC_UNMEASURED
+
+    say(f"repo {slug}   main-ref {main_ref} "
+        f"({_git(repo, ['rev-parse', main_ref]).stdout.strip()[:12]})   "
+        f"comment-mode {mode}")
+    say()
+    results, errors = [], []
+    for pr in prs:
+        try:
+            rows = gh_json(f"/repos/{slug}/commits/{pr['head_sha']}/statuses?per_page=100")
+            row = newest_per_context(rows if isinstance(rows, list) else []).get(CONTEXT)
+            res = triage_pr(repo, main_ref, pr, row)
+        except Unmeasured as exc:
+            res = {"number": pr["number"], "title": pr.get("title", ""),
+                   "head": pr["head_sha"], "url": pr.get("url", ""),
+                   "verdict": VERDICT_UNMEASURED, "reason": str(exc)}
+        if res.get("class") in ("superseded", "killed", "no-gate-pod", "error-other"):
+            errors.append(res)
+        results.append(res)
+        if not args.json:
+            render(res)
+
+    if args.json:
+        print(json.dumps({"repo": slug, "main_ref": main_ref,
+                          "comment_mode": mode, "results": results}, indent=2),
+              flush=True)
+        n_inherited = len([r for r in results
+                           if r.get("verdict") == VERDICT_INHERITED])
+    else:
+        n_inherited = summarise(results, errors)
+
+    if mode == "off":
+        say(f"comment: mode=off (set --comment-mode on to arm it); "
+            f"{n_inherited} PR(s) would have been eligible")
+    else:
+        for r in results:
+            if r.get("verdict") != VERDICT_INHERITED:
+                continue
+            body = comment_body(r)
+            if mode == "dry-run":
+                say(f"comment: DRY-RUN would comment on #{r['number']}")
+                continue
+            try:
+                if already_commented(slug, r["number"]):
+                    say(f"comment: #{r['number']} already carries the marker")
+                    continue
+                post_comment(slug, r["number"], body)
+                say(f"comment: posted on #{r['number']}")
+            except Unmeasured as exc:
+                say(f"comment: COULD NOT POST on #{r['number']} — {exc}")
+
+    if not results:
+        return RC_UNMEASURED
+    return RC_INHERITED if n_inherited else RC_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -131,6 +131,19 @@ import sys
 import time
 from pathlib import Path
 
+# 🔴 ONE RULE, ONE PLACE. `classify` here was BYTE-IDENTICAL to
+# `main-status-watch.py`'s, and the parsers were duplicated AND already
+# divergent — only this copy stripped the `TOTAL` truncation fragment, only this
+# copy folded statuses by timestamp. They now live in `scripts/lib/ci_status.py`
+# and both files import them; the disagreement between the copies was the
+# finding, and consolidating is what made it audible. What stays here is POLICY:
+# which context, what completeness means, and what to do about a red.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from ci_status import (TOTALS_RE as _TOTALS_RE,  # noqa: E402
+                       classify, derived_failure_upper_bound,
+                       newest_per_context, parse_failed_count,
+                       parse_failing_names)
+
 RC_OK, RC_INHERITED, RC_UNMEASURED, RC_USAGE = 0, 10, 11, 2
 
 # The context this triage is about. A literal contract with the devrc-ci
@@ -188,130 +201,12 @@ def print_header():
     return True
 
 
-# ── status classification ─────────────────────────────────────────────────────
-def classify(state, description):
-    """One status row -> a verdict class. Pure; the tests drive it directly.
-
-    🔴 UNRECOGNISED MEANS `error-other`, WHICH MEANS NOT-A-VERDICT — never
-    `red`, and never `green`. Only `failure` is a code failure; every broken-gate
-    outcome this pipeline produces arrives as `error` and is reported under its
-    own name so a human can see it was the gate, not the change.
-    """
-    desc = (description or "").strip()
-    if state == "success":
-        return "green"
-    if state == "failure":
-        return "red"
-    if state == "pending":
-        return "pending"
-    if state == "error":
-        if desc.startswith("superseded"):
-            return "superseded"
-        if desc.startswith("KILLED"):
-            return "killed"
-        if desc.startswith("NO GATE POD"):
-            return "no-gate-pod"
-        return "error-other"
-    return "error-other"
-
-
-def newest_per_context(rows):
-    """Fold status rows to the NEWEST row per context, by `created_at`.
-
-    🔴 NOT first-wins and NOT last-wins. GitHub returns this array newest-first
-    today, so a last-wins dict yields the OLDEST post per context — an agent
-    shipped exactly that and reported a known-green head as `pending`. Folding
-    on `max(created_at)` is correct under either ordering, so the hazard is
-    removed rather than merely avoided; `test_newest_per_context_is_order_
-    independent` feeds both orders and pins that they agree.
-    """
-    best = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        ctx = row.get("context") or ""
-        if not ctx:
-            continue
-        stamp = row.get("created_at") or ""
-        if ctx not in best or stamp > best[ctx][0]:
-            best[ctx] = (stamp, row)
-    return {ctx: row for ctx, (_, row) in best.items()}
-
-
-# ── description parsing ───────────────────────────────────────────────────────
-_FAILING_RE = re.compile(r"FAILING:\s*(.+?)(?:\s*\|\s*TOTAL\b|$)")
-_FAILED_COUNT_RE = re.compile(r"\bfailed=(\d+)\b")
-# The only fragments a 140-char cut can leave behind where `TOTAL` was starting.
-# Enumerated rather than pattern-matched: a `startswith` test would also eat a
-# real name, and every test in this repo begins `test_` or `Test`, none of which
-# is a prefix of `TOTAL`. See `test_a_trailing_TOTAL_fragment_is_not_a_test_name`.
-_TOTAL_FRAGMENTS = ("T", "TO", "TOT", "TOTA")
-
-
-def parse_failing_names(description):
-    """The test names the description NAMES. May be incomplete — see the header.
-
-    A description cut inside ` | TOTAL` leaves a trailing fragment of the word
-    TOTAL sitting where a name would be. Left in, it resolves to no file and the
-    PR is reported as a real red on the strength of a truncation artefact.
-    """
-    m = _FAILING_RE.search(description or "")
-    if not m:
-        return []
-    names = [n.strip() for n in m.group(1).split("|") if n.strip()]
-    if names and names[-1] in _TOTAL_FRAGMENTS:
-        names.pop()
-    return names
-
-
-def parse_failed_count(description):
-    m = _FAILED_COUNT_RE.search(description or "")
-    return int(m.group(1)) if m else None
-
-
-# 🔴 THE THREE FIELDS ARE MATCHED AS ONE ADJACENT, ORDERED GROUP, NOT SEPARATELY,
-# AND THAT IS A SOUNDNESS REQUIREMENT RATHER THAN TIDINESS. The hazard is a
-# number the 140-char cap cut SHORT — `collected=22204` arriving as
-# `collected=2220` would read as a perfectly well-formed integer and make the
-# derived bound far too SMALL, which is the one direction that can certify a
-# completeness this row does not have. Requiring `passed=` and then `skipped=`
-# to follow proves that `collected=` and `passed=` are complete numbers: the cap
-# truncates a SUFFIX, so a field with more banner text after it was not cut.
-# Only `skipped=` — the last of the three — can itself be short, and a short
-# `skipped` SUBTRACTS LESS and so inflates the bound, i.e. errs toward
-# withholding. See `test_a_TRUNCATED_skipped_can_only_INFLATE_the_derived_bound`.
-_TOTALS_RE = re.compile(r"\bcollected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)")
-
-
-def derived_failure_upper_bound(description):
-    """An UPPER bound on the banner's own `failed=`, or None if underivable.
-
-    `scripts/run-tests.sh` GUARD 4 computes, per target,
-
-        collected = passed + skipped + failed + errors + xfailed + xpassed
-        TOT_FAILED += failed + errors          (the banner's `failed=` is f+e)
-
-    and accumulates each term into the TOTAL banner this description quotes. So
-
-        collected − passed − skipped == failed + xfailed + xpassed >= failed
-
-    🔴 THE INEQUALITY ONLY EVER POINTS ONE WAY. `xfailed`/`xpassed` are
-    non-negative, so this can equal `failed=` but never fall below it. That is
-    what makes it usable as a completeness proof: a caller comparing it against
-    a count of NAMES is comparing against a ceiling, and a ceiling that happens
-    to equal the number of names squeezes `failed` to that same number. An
-    under-count would instead certify completeness on a row that had more
-    failures than it named — the single error this tool must not make.
-    """
-    m = _TOTALS_RE.search(description or "")
-    if not m:
-        return None
-    collected, passed, skipped = (int(g) for g in m.groups())
-    derived = collected - passed - skipped
-    # Negative is arithmetically impossible under the definition above, so it
-    # means the banner is not the banner this derivation was written against.
-    # Refusing to answer is the only safe reading of a row we cannot parse.
-    return derived if derived >= 0 else None
+# ── status classification and description parsing ─────────────────────────────
+# 🔴 `classify`, `newest_per_context`, `parse_failing_names`, `parse_failed_count`
+# and `derived_failure_upper_bound` are IMPORTED from `scripts/lib/ci_status.py`
+# (see the import block). What each one does, and the trap it exists for, is
+# documented there. Re-declaring any of them here is refused by
+# `test_the_shared_predicates_are_NOT_re_declared_in_either_consumer`.
 
 
 def names_provably_complete(description):

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -51,18 +51,52 @@
 # the change, and folding the two together is the roll-up mistake in a second
 # spelling.
 #
-# 🔴 COMPLETENESS IS THE HARD PART, AND IT IS WHY THIS TOOL SAYS "COULD NOT
-# MEASURE" MORE OFTEN THAN YOU WOULD LIKE. GitHub caps a status description at
-# 140 characters and the gate's `FAILING: a | b | TOTAL … failed=N …` line
-# overruns it constantly. MEASURED on this repo's own rows: one described
-# `failed=7` while naming ONE test; one named NO test at all; one was cut
-# MID-WORD inside a test name. So a description can prove "at least one test
-# failed and here is its name" — it can NEVER prove "these are all of them"
-# unless the `failed=N` count survived AND equals the number of names.
+# 🔴 COMPLETENESS IS THE HARD PART. GitHub caps a status description at 140
+# characters and the gate's `FAILING: a | b | TOTAL … failed=N …` line overruns
+# it constantly. MEASURED on this repo's own rows: one described `failed=7`
+# while naming ONE test; one named NO test at all; one was cut MID-WORD inside a
+# test name. So a description can prove "at least one test failed and here is
+# its name"; it can NEVER prove "these are all of them" on the names alone.
 # Dismissing a PR as INHERITED on an incomplete list would dismiss a real red,
 # which is the one error this tool must not make. So the PR-level verdict
-# requires provable completeness; the PER-TEST lines print either way, and a
+# requires PROVABLE completeness; the PER-TEST lines print either way, and a
 # `HINT:` line says when a rebase is worth trying anyway.
+#
+# 🔴 AND THE OBVIOUS WAY TO PROVE IT — READ `failed=N` — FIRES ON ALMOST NOTHING,
+# BECAUSE `failed=` IS THE FIELD THE CAP EATS. It is last in the banner, so
+# whether it survives is a function of the FAILING TEST'S NAME LENGTH and
+# nothing else. MEASURED 2026-09-11 on the three PRs this tool was justified by
+# (#1454, #1462, #1499): all three carry `len(desc)=138`, all three are cut
+# inside `failed=`, and all three therefore resolved to COULD NOT MEASURE with
+# the correct answer already in hand. The verdict was a function of a test name.
+#
+# 🔴 SO COMPLETENESS IS ALSO DERIVED, AND THE DERIVATION IS A PROOF RATHER THAN
+# A HEURISTIC. `scripts/run-tests.sh` GUARD 4 computes, per target,
+#     collected = passed + skipped + failed + errors + xfailed + xpassed
+#     TOT_FAILED += failed + errors        (i.e. the banner's `failed=` is f+e)
+# and sums each term into the TOTAL banner. Therefore
+#     collected − passed − skipped  ==  failed + xfailed + xpassed  ≥  failed
+# and names are a subset of the failures, so `len(names) ≤ failed ≤ derived`.
+# When `derived == len(names)` the inequality is squeezed shut and completeness
+# is PROVEN. `collected=`, `passed=` and `skipped=` all precede `failed=` in the
+# banner, so they are exactly the fields that survive the cut.
+# 🔴 THE BOUND IS AN OVER-COUNT, NEVER AN UNDER-COUNT, and that direction is the
+# whole safety argument: an under-count would let this file certify a
+# completeness it does not have and dismiss a real red. `xfailed`/`xpassed` can
+# only inflate it, and a `skipped=` truncated short by the cap can only inflate
+# it further — both push toward WITHHOLDING. See `derived_failure_upper_bound`.
+# The coupling to `run-tests.sh` is pinned by
+# `test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned`.
+#
+# 🔴 PRIOR ART, AND WHAT THIS ADDS TO IT. `scripts/main-status-watch.py`'s
+# `screen_all_known_flakes` is the same completeness-proving screen in 15 lines,
+# and its comment records that it would have fired ZERO times on the 100 commits
+# measured. That zero is not a property of the idea — it is the `failed=N` route
+# above being eaten by the cap. This file's contribution is (a) the derived
+# route, which turns 0/3 into 3/3 on the justifying population, and (b) the
+# EVIDENCE half the screen has no equivalent of: blob OIDs and commit lists that
+# name WHICH commit on main already fixed the test. The completeness gate itself
+# is prior art and is cited as such; only the derivation and the evidence are new.
 #
 # EXIT CODES
 #   0   ran; no PR was classified INHERITED (the counts say what it DID find)
@@ -235,23 +269,102 @@ def parse_failed_count(description):
     return int(m.group(1)) if m else None
 
 
+# 🔴 THE THREE FIELDS ARE MATCHED AS ONE ADJACENT, ORDERED GROUP, NOT SEPARATELY,
+# AND THAT IS A SOUNDNESS REQUIREMENT RATHER THAN TIDINESS. The hazard is a
+# number the 140-char cap cut SHORT — `collected=22204` arriving as
+# `collected=2220` would read as a perfectly well-formed integer and make the
+# derived bound far too SMALL, which is the one direction that can certify a
+# completeness this row does not have. Requiring `passed=` and then `skipped=`
+# to follow proves that `collected=` and `passed=` are complete numbers: the cap
+# truncates a SUFFIX, so a field with more banner text after it was not cut.
+# Only `skipped=` — the last of the three — can itself be short, and a short
+# `skipped` SUBTRACTS LESS and so inflates the bound, i.e. errs toward
+# withholding. See `test_a_TRUNCATED_skipped_can_only_INFLATE_the_derived_bound`.
+_TOTALS_RE = re.compile(r"\bcollected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)")
+
+
+def derived_failure_upper_bound(description):
+    """An UPPER bound on the banner's own `failed=`, or None if underivable.
+
+    `scripts/run-tests.sh` GUARD 4 computes, per target,
+
+        collected = passed + skipped + failed + errors + xfailed + xpassed
+        TOT_FAILED += failed + errors          (the banner's `failed=` is f+e)
+
+    and accumulates each term into the TOTAL banner this description quotes. So
+
+        collected − passed − skipped == failed + xfailed + xpassed >= failed
+
+    🔴 THE INEQUALITY ONLY EVER POINTS ONE WAY. `xfailed`/`xpassed` are
+    non-negative, so this can equal `failed=` but never fall below it. That is
+    what makes it usable as a completeness proof: a caller comparing it against
+    a count of NAMES is comparing against a ceiling, and a ceiling that happens
+    to equal the number of names squeezes `failed` to that same number. An
+    under-count would instead certify completeness on a row that had more
+    failures than it named — the single error this tool must not make.
+    """
+    m = _TOTALS_RE.search(description or "")
+    if not m:
+        return None
+    collected, passed, skipped = (int(g) for g in m.groups())
+    derived = collected - passed - skipped
+    # Negative is arithmetically impossible under the definition above, so it
+    # means the banner is not the banner this derivation was written against.
+    # Refusing to answer is the only safe reading of a row we cannot parse.
+    return derived if derived >= 0 else None
+
+
 def names_provably_complete(description):
     """True only when the description PROVES the named set is the whole set.
 
-    Returns (complete, reason). False on any doubt: no names, no surviving
-    count, or a count that disagrees with the names. This is the guard that
-    stops an INHERITED verdict being handed out on a truncated row that named
-    one of seven failures.
+    Returns (complete, reason). False on any doubt. TWO independent routes, and
+    the DIRECT one is tried first because it is the stronger claim:
+
+      1. `failed=N` survived the 140-char cap and equals the number of names.
+      2. `failed=N` did not survive, but `collected − passed − skipped` did —
+         an upper bound on `failed` (see `derived_failure_upper_bound`) — and it
+         equals the number of names, squeezing `failed` to that number too.
+
+    Route 2 exists because route 1 fires on almost nothing: `failed=` is the
+    LAST field in the banner, so whether it survives is decided by the failing
+    test's name length. On the three PRs this tool was justified by, route 1
+    returned "could not measure" with the answer already in the row.
+
+    This is the guard that stops an INHERITED verdict being handed out on a
+    truncated row that named one of seven failures, so every arm that cannot
+    PROVE the set complete returns False.
     """
     names = parse_failing_names(description)
     if not names:
         return False, "the description names no failing test"
+    derived = derived_failure_upper_bound(description)
     count = parse_failed_count(description)
-    if count is None:
-        return False, "the description was truncated before `failed=N`"
-    if count != len(names):
-        return False, f"the description says failed={count} but names {len(names)}"
-    return True, f"failed={count} and {len(names)} named"
+    if count is not None:
+        # 🔴 CONSISTENCY TRIPWIRE, AND IT IS HONESTLY LABELLED: while
+        # `run-tests.sh`'s arithmetic holds, `derived >= count` is guaranteed
+        # and this arm CANNOT FIRE on a real row. It is here so that an
+        # arithmetic change upstream shows up as a refusal to answer rather than
+        # as a silently wrong bound, and it is reachable from a test only. The
+        # test-time half of the same coupling is
+        # `test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned`.
+        if derived is not None and derived < count:
+            return False, (f"the banner contradicts itself: failed={count} but "
+                           f"collected−passed−skipped={derived}, which cannot be "
+                           "smaller — the totals arithmetic this reads is not the "
+                           "one `run-tests.sh` documents")
+        if count != len(names):
+            return False, f"the description says failed={count} but names {len(names)}"
+        return True, f"failed={count} and {len(names)} named"
+    if derived is None:
+        return False, ("the description was truncated before `failed=N`, and "
+                       "collected/passed/skipped are not all readable either")
+    if derived != len(names):
+        return False, (f"the description was truncated before `failed=N`, and "
+                       f"collected−passed−skipped={derived} does not equal the "
+                       f"{len(names)} named")
+    return True, (f"`failed=N` was cut by the 140-char cap, but "
+                  f"collected−passed−skipped={derived} — an upper bound on the "
+                  f"failures — equals the {len(names)} named")
 
 
 # ── test name -> defining file ────────────────────────────────────────────────

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -165,7 +165,13 @@ from pathlib import Path
 # and both files import them; the disagreement between the copies was the
 # finding, and consolidating is what made it audible. What stays here is POLICY:
 # which context, what completeness means, and what to do about a red.
-sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+#
+# 🔴 `append`, NEVER `insert(0, …)` — see the same note in
+# `scripts/main-status-watch.py`. Prepending `scripts/lib/` puts every module in
+# it ahead of the standard library for every later import; appending removes the
+# shadowing class outright and costs nothing, since nothing else on the path
+# defines `ci_status`.
+sys.path.append(str(Path(__file__).resolve().parent / "lib"))
 from ci_status import (TOTALS_RE as _TOTALS_RE,  # noqa: E402
                        classify, derived_failure_upper_bound,
                        newest_per_context, parse_failed_count,

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -115,6 +115,25 @@
 # sentence wrapping onto a line that started with one would register as a ledger
 # entry for a knob that has none: a two-way pin satisfied by prose.
 #
+# 🔴 IT RUNS NO `git` SUBCOMMAND THAT WRITES — AT ALL, NOT MERELY "BY DEFAULT",
+# AND THAT IS NOW PINNED ABSOLUTELY. It used to carry `--fetch`, which wrote
+# `refs/stale-base-triage/*`, and the guard could then only say "the refs it
+# writes are namespaced" — a relative claim about a repo-GLOBAL surface (`refs/`
+# lives in the COMMON git dir, so a worktree gives zero isolation). `--fetch`
+# was DELETED after measuring that it bought nothing here: this repo's PRs are
+# same-repo branches and `origin`'s refspec is `+refs/heads/*`, so an ordinary
+# `git fetch origin` already brings every head — 58 of 58 open PR heads resolved
+# in the base clone with no `--fetch` anywhere. `test_no_git_subcommand_that_
+# WRITES_is_ever_invoked` now enumerates the read-only subcommands as an
+# ALLOWLIST, so an unknown one is a write by default.
+#
+# ⚠ `--json` WAS DELETED TOO, for having no consumer: `git grep` over the whole
+# repo found this script and its test file and nothing else. It cost a global
+# `_JSON_MODE`, a `say()` indirection on every human line, and a second exit
+# path. `--sweep` was KEPT and is now the primary mode — see the measurement in
+# the F2 note above: the sweep surfaces 7 eligible open reds where it surfaced
+# 4, including PRs 9 commits behind that are actively being worked.
+#
 # 🔴 IT WRITES NOTHING BY DEFAULT, AND ARMING IT COSTS A VISIBLE LINE.
 # `COMMENT_MODE_DEFAULT` is the literal `"off"`, pinned by
 # `test_the_comment_mode_default_is_the_LITERAL_off` — asserting mere membership
@@ -168,16 +187,8 @@ VERDICT_UNMEASURED = "COULD NOT MEASURE"
 HEADER_SENTINEL = '"""Triage a red PR'
 
 
-# 🔴 UNDER --json, STDOUT CARRIES THE PAYLOAD AND NOTHING ELSE. Prose printed
-# beside it makes the output un-parseable in a way that looks fine by eye: a
-# first draft printed the comment-mode line after the object, and `json.loads`
-# on the whole stream raised `Extra data` — the caller's parse, not this
-# script's, is where that lands. So every human line goes to stderr instead.
-_JSON_MODE = False
-
-
 def say(msg=""):
-    print(msg, file=sys.stderr if _JSON_MODE else sys.stdout, flush=True)
+    print(msg, flush=True)
 
 
 class Unmeasured(Exception):
@@ -540,7 +551,7 @@ def triage_pr(repo, main_ref, pr, row):
     if not ref_exists(repo, head_ref):
         out["verdict"] = VERDICT_UNMEASURED
         out["reason"] = (f"head {head_ref[:12]} is not in the local clone — "
-                         "re-run with --fetch, or fetch it by hand")
+                         "run `git fetch origin` and try again")
         return out
     merge_base = _git(repo, ["merge-base", main_ref, head_ref]).stdout.strip()
     out["merge_base"] = merge_base
@@ -680,22 +691,6 @@ def post_comment(repo_slug, number, body):
     return True
 
 
-# ── fetching ──────────────────────────────────────────────────────────────────
-# 🔴 EVERY REF THIS SCRIPT WRITES LIVES UNDER ITS OWN NAMESPACE. `refs/` is
-# repo-GLOBAL — it lives in the COMMON git dir, so a worktree gives zero
-# isolation and a concurrent session reads the same refs. Writing
-# `refs/remotes/origin/main` or a branch would reach into work this run knows
-# nothing about; `refs/stale-base-triage/*` cannot collide with a branch, a tag
-# or a remote-tracking ref.
-NS = "refs/stale-base-triage"
-
-
-def fetch_refs(repo, numbers):
-    specs = [f"+refs/heads/main:{NS}/main"]
-    specs += [f"+refs/pull/{n}/head:{NS}/pr-{n}" for n in numbers]
-    _git(repo, ["fetch", "--no-tags", "--quiet", "origin", *specs], timeout=300)
-
-
 # ── rendering ─────────────────────────────────────────────────────────────────
 def render(result):
     n = result["number"]
@@ -787,12 +782,8 @@ def build_parser():
                    help="triage this PR (repeatable)")
     p.add_argument("--sweep", action="store_true", help="triage every open PR")
     p.add_argument("--repo-path", default=str(Path(__file__).resolve().parents[1]))
-    p.add_argument("--main-ref", default=None,
-                   help="ref standing for main (default: origin/main, or the "
-                        "namespaced ref under --fetch)")
-    p.add_argument("--fetch", action="store_true",
-                   help=f"refresh {NS}/* from origin before measuring")
-    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument("--main-ref", default="origin/main",
+                   help="ref standing for main (default: origin/main)")
     p.add_argument("--comment-mode", choices=COMMENT_MODES, default=None,
                    help=f"post a PR comment (default {COMMENT_MODE_DEFAULT})")
     p.add_argument("-h", "--help", action="store_true")
@@ -800,9 +791,8 @@ def build_parser():
 
 
 def main(argv):
-    global _DEADLINE, _JSON_MODE
+    global _DEADLINE
     args = build_parser().parse_args(argv)
-    _JSON_MODE = bool(args.json)
     if args.help:
         return RC_OK if print_header() else RC_UNMEASURED
     if not args.pr and not args.sweep:
@@ -830,9 +820,7 @@ def main(argv):
                 prs.append({"number": r["number"], "title": r.get("title", ""),
                             "head_sha": r["head"]["sha"],
                             "url": r.get("html_url", "")})
-        if args.fetch:
-            fetch_refs(repo, [p["number"] for p in prs])
-        main_ref = args.main_ref or (f"{NS}/main" if args.fetch else "origin/main")
+        main_ref = args.main_ref
         if not ref_exists(repo, main_ref):
             raise Unmeasured(f"{main_ref} does not resolve in {repo}")
     except Unmeasured as exc:
@@ -856,17 +844,9 @@ def main(argv):
         if res.get("class") in ("superseded", "killed", "no-gate-pod", "error-other"):
             errors.append(res)
         results.append(res)
-        if not args.json:
-            render(res)
+        render(res)
 
-    if args.json:
-        print(json.dumps({"repo": slug, "main_ref": main_ref,
-                          "comment_mode": mode, "results": results}, indent=2),
-              flush=True)
-        n_inherited = len([r for r in results
-                           if r.get("verdict") == VERDICT_INHERITED])
-    else:
-        n_inherited = summarise(results, errors)
+    n_inherited = summarise(results, errors)
 
     if mode == "off":
         say(f"comment: mode=off (set --comment-mode on to arm it); "

--- a/scripts/stale-base-triage.py
+++ b/scripts/stale-base-triage.py
@@ -51,9 +51,17 @@
 # the change, and folding the two together is the roll-up mistake in a second
 # spelling.
 #
-# 🔴 COMPLETENESS IS THE HARD PART. GitHub caps a status description at 140
-# characters and the gate's `FAILING: a | b | TOTAL … failed=N …` line overruns
-# it constantly. MEASURED on this repo's own rows: one described `failed=7`
+# 🔴 COMPLETENESS IS THE HARD PART. A status description is capped at 140 and
+# the gate's `FAILING: a | b | TOTAL … failed=N …` line overruns it constantly.
+# ⚠ 140 BYTES, NOT CHARACTERS — measured, and it matters to anyone building a
+# fixture. Every real row sampled on this repo is 138 CHARACTERS long, which is
+# 140 bytes once the `—` in `FAILED: pytests —` is counted as the three UTF-8
+# bytes it is. Whether the byte cut is GitHub's or the posting pipeline's own
+# truncation is NOT determined here; every row sampled carries exactly one
+# multi-byte character, so the two hypotheses were never separated. What is
+# measured is the boundary, and a fixture has to land on it.
+#
+# MEASURED on this repo's own rows: one described `failed=7`
 # while naming ONE test; one named NO test at all; one was cut MID-WORD inside a
 # test name. So a description can prove "at least one test failed and here is
 # its name"; it can NEVER prove "these are all of them" on the names alone.
@@ -226,7 +234,7 @@ def names_provably_complete(description):
     Returns (complete, reason). False on any doubt. TWO independent routes, and
     the DIRECT one is tried first because it is the stronger claim:
 
-      1. `failed=N` survived the 140-char cap and equals the number of names.
+      1. `failed=N` survived the 140-byte cap and equals the number of names.
       2. `failed=N` did not survive, but `collected − passed − skipped` did —
          an upper bound on `failed` (see `derived_failure_upper_bound`) — and it
          equals the number of names, squeezing `failed` to that number too.
@@ -268,7 +276,7 @@ def names_provably_complete(description):
         return False, (f"the description was truncated before `failed=N`, and "
                        f"collected−passed−skipped={derived} does not equal the "
                        f"{len(names)} named")
-    return True, (f"`failed=N` was cut by the 140-char cap, but "
+    return True, (f"`failed=N` was cut by the 140-byte cap, but "
                   f"collected−passed−skipped={derived} — an upper bound on the "
                   f"failures — equals the {len(names)} named")
 
@@ -376,7 +384,7 @@ def resolve_test_file(repo, ref, raw_name):
     so a short name cannot match a longer one that starts with it — the way
     test_foo would otherwise match test_foobar. Only when phase 1 finds NOTHING
     does phase 2 drop the paren — which is the truncation case, and nothing
-    else: GitHub's 140-char cap lands mid-name often enough that this repo has
+    else: the 140-byte cap lands mid-name often enough that this repo has
     a real row ending `…_CAN_see_the_dif`. Running phase 2 unconditionally would
     turn every short name into a false `ambiguous`; see
     `test_a_COMPLETE_name_is_not_made_ambiguous_by_a_longer_sibling`.
@@ -723,7 +731,7 @@ def render(result):
         say(f"   • {t['name']}")
         if t.get("file"):
             say(f"       file: {t['file']}"
-                + ("   (name was truncated by GitHub's 140-char cap)"
+                + ("   (name was truncated by the 140-byte cap)"
                    if t.get("truncated_name") else ""))
         say(f"       {t['verdict']}: {t['reason']}")
         for c in t.get("candidates", []):

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -68,7 +68,12 @@ RC_OK, RC_TRIGGERED, RC_UNMEASURED, RC_BLIND, RC_USAGE = 0, 10, 11, 12, 2
 # hazard the flake screen turns on is only demonstrable with real ones — every
 # synthetic description anybody would write by hand is conveniently complete.
 #
-# The known flake, cut MID-WORD by GitHub's 140-char description cap:
+# The known flake, cut MID-WORD by GitHub's 140-BYTE description cap. BYTES, not
+# characters: the `—` in `FAILED: pytests —` is three UTF-8 bytes, which is why
+# every real row measured on this repo reads `len(desc)=138`. Anyone building a
+# fixture from a CHARACTER cap lands two bytes late and quietly leaves `failed=`
+# readable — see `cut_like_github` in `scripts/tests/test_stale_base_triage.py`.
+REAL_DESC_BYTE_CAP = 140
 REAL_FLAKE_DESC = (
     "FAILED: pytests — FAILING: TestARefusedWriteIsIndistinguishableFromAnAbsentOne"
     ".test_POSITIVE_CONTROL_the_APPEND_comparison_CAN_see_the_dif"
@@ -333,8 +338,33 @@ def test_a_foreign_context_is_ignored(h):
 # ══ THE FLAKE SCREEN ══════════════════════════════════════════════════════════
 # 🔴 THE COUNTERINTUITIVE HALF FIRST: the REAL known-flake row must TRIGGER.
 
+def test_CONTROL_the_real_truncated_rows_land_on_the_BYTE_cap_not_the_CHAR_cap():
+    """🔴 THE DISTINCTION THIS FILE'S PROSE HAD WRONG, MADE MACHINE-CHECKED.
+
+    The cap is 140 BYTES, and the two rows above that it actually cut are 138
+    CHARACTERS long, because the `—` in `FAILED: pytests —` is three UTF-8
+    bytes. A comment saying "140 characters" is an invitation to build a fixture
+    by slicing at `[:140]` — which lands two bytes late, quietly leaves `failed=`
+    readable, and turns a truncated row into a complete one. Every assertion
+    resting on that fixture then passes for the wrong reason.
+
+    ⚠ WHAT THIS DOES NOT RESOLVE, AND MUST NOT BE READ AS RESOLVING: whether the
+    cut is GitHub's or the posting pipeline's. Every sampled row carries exactly
+    one multi-byte character, so at 138 chars / 140 bytes the two are
+    indistinguishable. This pins the MEASUREMENT, not a mechanism.
+    """
+    for desc in (REAL_FLAKE_DESC, REAL_SEVEN_FAILED_ONE_NAMED):
+        assert len(desc.encode("utf-8")) == REAL_DESC_BYTE_CAP, desc
+        assert len(desc) == 138, (len(desc), desc)
+        assert len(desc) < REAL_DESC_BYTE_CAP, desc   # chars ≠ bytes, and that is the point
+    # POSITIVE CONTROL: a row that was NOT cut sits well inside the cap, so the
+    # equality above is a property of the truncated rows and not of every string
+    # in this file.
+    assert len(REAL_NO_NAME.encode("utf-8")) < REAL_DESC_BYTE_CAP, REAL_NO_NAME
+
+
 def test_the_REAL_known_flake_row_still_triggers_because_it_is_truncated(h):
-    """The row that named the known flake was cut MID-WORD at GitHub's 140-char
+    """The row that named the known flake was cut MID-WORD at GitHub's 140-BYTE
     cap, so it proves neither the full name nor that it was the only failure.
     Skipping on it would skip real reds hiding behind the truncation.
 
@@ -1756,6 +1786,14 @@ def test_every_test_this_script_names_actually_exists():
     a FUNCTION body stayed split and read as a name nobody defined. It failed on
     its own first run against a citation this very PR added, which is the
     cheapest possible way to learn that a pattern is narrower than its claim.
+
+    ⚠ SCOPED TO THIS SCRIPT FILE, AND THAT IS NOT THE WHOLE SURFACE. Citations
+    inside `scripts/lib/ci_status.py` — the module this file's script imports —
+    are checked by `test_stale_base_triage.py`, whose copy of this guard follows
+    its script's `scripts/lib` imports. That widening exists because the FIRST
+    citation written into `ci_status.py` dangled and neither copy, each scoped to
+    one script, could see it. One owner is enough for one file; what is NOT safe
+    is assuming this guard covers it.
     """
     src = SCRIPT.read_text(encoding="utf-8")
     joined = re.sub(r"_\n[ \t]*#[ \t]*", "_", src)

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -1079,6 +1079,84 @@ def _code_only():
     return "\n".join(out)
 
 
+_SPAWN_FUNCS = {"run", "Popen", "call", "check_output", "check_call", "system",
+                "execv", "execvp", "execve", "spawnv", "spawnvp"}
+
+# 🔴 WHAT THIS SET MEANS, ENTRY BY ENTRY, because two of the three are opaque on
+# purpose and an opaque entry is exactly where a launcher hides:
+#   git            — `git -C <repo> remote get-url origin`, a literal list.
+#   <computed>     — `[gh, "api", path]`; `gh` is the MAIN_STATUS_WATCH_GH seam,
+#                    which is what lets every test point it at a stub.
+#   <not-a-list>   — `subprocess.run(cmd, …)` in `trigger_deadman`, where `cmd`
+#                    is either the MAIN_STATUS_WATCH_TRIGGER override or the
+#                    systemctl literal. That literal is pinned separately and
+#                    exactly by `test_the_production_trigger_is_systemctl_start_
+#                    main_green_check`, which also refuses `--force`.
+# So this pin is not the whole story by itself, and does not pretend to be — it
+# is the half that catches a NEW literal spawn appearing.
+EXPECTED_ARGV0 = {"git", "<computed>", "<not-a-list>"}
+
+
+def _spawn_argv0_literals(path):
+    """Every literal argv[0] in a spawn-shaped call, from the SYNTAX TREE.
+
+    `<computed>` / `<not-a-list>` rather than a skip: a command built from a
+    variable is precisely how a literal-keyed ledger gets walked past, so it
+    must land in the set and fail loudly instead of leaving it.
+    """
+    tree = ast.parse(Path(path).read_text(encoding="utf-8"))
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if isinstance(first, (ast.List, ast.Tuple)) and first.elts:
+            head = first.elts[0]
+            found.add(head.value if isinstance(head, ast.Constant) else "<computed>")
+        else:
+            found.add("<not-a-list>")
+    return found
+
+
+def test_main_status_watch_SPAWNS_these_argv0_AND_NOTHING_ELSE():
+    """GROWS-OR-SHRINKS. A new binary is the hazard the `home-manager`
+    acknowledgement in `test_no_real_launchers.py` would otherwise hide; a
+    vanished one means that justification has stopped describing this file."""
+    assert _spawn_argv0_literals(SCRIPT) == EXPECTED_ARGV0
+
+
+def test_home_manager_is_MENTIONED_but_never_SPAWNED():
+    """🔴 THE PIN UNDER THIS FILE'S ROW IN `ACKNOWLEDGED_UNSTUBBED`.
+
+    `launcher_scan.hazard_hits` is a TEXT scan and says so, so a prose mention
+    is a hit. This file acquired one when the shared-module import landed: a
+    comment explaining that the unit runs out of the CHECKOUT, so a `git pull`
+    is the whole deploy and no home-manager switch is involved. That sentence is
+    the reason the import is safe, so it is re-justified rather than reworded to
+    dodge the scanner — which is this repo's stated convention.
+
+    Both halves of the acknowledgement's claim are asserted rather than left to
+    a reader of prose: the mention must still EXIST (or the table entry has
+    outlived the sentence it describes), and it must remain a MENTION.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert re.search(r"(?<![\w-])home-manager(?![\w-])", text), (
+        "the ACKNOWLEDGED_UNSTUBBED entry for this file exists BECAUSE it names "
+        "home-manager; if that is gone, remove the acknowledgement too")
+    assert "home-manager" not in _spawn_argv0_literals(SCRIPT), (
+        "main-status-watch.py now SPAWNS home-manager — the acknowledgement "
+        "covering it is an unreachability claim and is now FALSE")
+    # …and the name appears in NO executable line at all, comments and
+    # docstrings stripped. This is the assertion that would catch it reaching
+    # the binary through the trigger override's literal rather than through a
+    # spawn head.
+    assert "home-manager" not in _code_only(), (
+        "home-manager reached an executable line in main-status-watch.py")
+
+
 def test_code_only_really_strips_the_prose_it_claims_to():
     """The instrument behind four static guards, with both controls.
 

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -1092,7 +1092,13 @@ def test_code_only_really_strips_the_prose_it_claims_to():
     only_in_a_docstring = "Raised for every reason the world could not be read"
     assert only_in_a_docstring in raw, "fixture phrase moved; this guard is blind"
     assert only_in_a_docstring not in code, "docstring prose still reaches the guards"
-    assert "def classify(state, description):" in code, (
+    # ⚠ The positive-control phrase must be a line this file still EXECUTES.
+    # It used to be `def classify(state, description):`, which moved to
+    # `scripts/lib/ci_status.py` when the duplicated predicates were
+    # consolidated — at which point this control started asserting the absence
+    # of a function that is simply elsewhere, i.e. it would have failed for a
+    # reason that has nothing to do with `_code_only`.
+    assert "def commit_verdict(rows):" in code, (
         "_code_only stripped executable lines too — every guard reading it is vacuous"
     )
 
@@ -1297,8 +1303,17 @@ def test_a_MOVED_docstring_sentinel_REFUSES_rather_than_dumping_the_file(tmp_pat
     assert moved != src, "the docstring sentinel is not where this test thinks"
     copy = tmp_path / "moved-sentinel.py"
     copy.write_text(moved, encoding="utf-8")
+    # 🔴 THE COPY HAS NO SIBLING `lib/`, so the shared `ci_status` import must be
+    # satisfied explicitly. The script resolves it relative to its OWN file,
+    # which is right for production — the unit runs it out of the checkout — and
+    # is exactly why a copy-and-run test has to say where the module is. Without
+    # this the copy dies on ImportError and the assertions below would be
+    # measuring a missing module, not a moved sentinel.
+    env = dict(os.environ,
+               PYTHONPATH=os.pathsep.join(
+                   [str(ROOT / "scripts" / "lib"), os.environ.get("PYTHONPATH", "")]))
     proc = subprocess.run([sys.executable, str(copy), "--help"],
-                          capture_output=True, text=True, timeout=60)
+                          capture_output=True, text=True, timeout=60, env=env)
     assert proc.returncode == RC_USAGE, proc.stdout + proc.stderr
     assert "cannot locate the end of the header" in proc.stdout
     # and it must NOT fall back to dumping the source: a header knob name would
@@ -1362,6 +1377,97 @@ def test_an_unknown_argument_is_a_USAGE_error(h):
 )
 def test_classify_maps_a_row_to_its_documented_class(state, description, expected):
     assert _load().classify(state, description) == expected
+
+
+def test_newest_per_context_is_ORDER_INDEPENDENT_which_first_wins_was_not():
+    """🔴 THE BEHAVIOUR CHANGE THAT CAME WITH THE CONSOLIDATION, DRIVEN BOTH WAYS.
+
+    This file used to fold to the FIRST row per context. That is right only
+    because GitHub returns the array newest-first — an assumption about someone
+    else's response ordering, load-bearing, unstated, and untested. The shared
+    `newest_per_context` folds on `max(created_at)` instead.
+
+    The OLD rule is reimplemented below and shown to return the WRONG row on the
+    order it does not expect, beside the new one returning the right row on
+    BOTH. Without the old rule present in the test, "the new one is right" is a
+    claim about one implementation and says nothing about what changed.
+    """
+    mod = _load()
+    old = {"context": CTX_PY, "state": "pending", "description": "running",
+           "created_at": "2026-09-11T10:00:00Z"}
+    new = {"context": CTX_PY, "state": "failure", "description": REAL_NO_NAME,
+           "created_at": "2026-09-11T17:00:00Z"}
+
+    def first_wins(rows):                 # the rule this file used to carry
+        seen = {}
+        for row in rows:
+            if row["context"] not in seen:
+                seen[row["context"]] = row
+        return seen
+
+    newest_first, oldest_first = [new, old], [old, new]
+    # On GitHub's CURRENT ordering the two rules agree — which is exactly why
+    # the old one survived unnoticed.
+    assert first_wins(newest_first)[CTX_PY]["state"] == "failure"
+    # On the OTHER ordering the old rule reports the superseded `pending` row,
+    # i.e. a head whose gate has already failed reads as still running.
+    assert first_wins(oldest_first)[CTX_PY]["state"] == "pending"
+    # The shared fold is right on both, because the array's order is not an
+    # input to it at all.
+    for order in (newest_first, oldest_first):
+        assert mod.newest_per_context(order)[CTX_PY]["state"] == "failure", order
+    # …and a second context is kept independently rather than overwritten.
+    both = mod.newest_per_context(
+        [new, old, {"context": CTX_NODE, "state": "success",
+                    "description": REAL_SUCCESS,
+                    "created_at": "2026-09-11T17:00:00Z"}])
+    assert set(both) == {CTX_PY, CTX_NODE}
+
+
+def test_newest_per_context_returns_FOREIGN_contexts_and_the_POLICY_filters_them():
+    """🔴 THE FILTER MOVED OUT OF THE FOLD AND INTO `commit_verdict`, so pin
+    where it now lives. The shared fold is about GitHub's data and returns every
+    context; "only `tekton/devrc-main-*` may speak about main" is THIS file's
+    rule. If the filter were lost in the move, a foreign pipeline's green would
+    close an open red episode — `test_a_commit_with_ONLY_FOREIGN_contexts_is_no_
+    verdict_not_green` is the end-to-end half of the same guard."""
+    mod = _load()
+    rows = [_status("tekton/devrc-cairn-client-runs", "success", "all good elsewhere"),
+            _status(CTX_PY, "failure", REAL_NO_NAME)]
+    assert set(mod.newest_per_context(rows)) == {
+        "tekton/devrc-cairn-client-runs", CTX_PY}
+    verdict, reds = mod.commit_verdict(rows)
+    assert verdict == "red" and set(reds) == {CTX_PY}
+    # The foreign row ALONE is no verdict — never green.
+    assert mod.commit_verdict(rows[:1]) == ("none", {})
+
+
+def test_the_shared_predicates_are_NOT_re_declared_in_either_consumer():
+    """🔴 ONE RULE, ONE PLACE — ENFORCED, NOT ASSERTED IN PROSE. These four
+    predicates were open-coded in this file AND in `stale-base-triage.py`, and
+    the copies had already diverged before anybody noticed: only one stripped
+    the `TOTAL` truncation fragment, only one folded by timestamp. A comment
+    saying "shared" does not stop the next copy; a test that fails on a local
+    `def` does.
+    """
+    shared = ("classify", "newest_per_context", "parse_failing_names",
+              "parse_failed_count", "derived_failure_upper_bound")
+    consumers = [ROOT / "scripts" / "main-status-watch.py",
+                 ROOT / "scripts" / "stale-base-triage.py"]
+    lib = ROOT / "scripts" / "lib" / "ci_status.py"
+    lib_src = lib.read_text(encoding="utf-8")
+    for name in shared:
+        assert f"def {name}(" in lib_src, f"{name} is not defined in {lib}"
+    for path in consumers:
+        src = path.read_text(encoding="utf-8")
+        for name in shared:
+            assert f"\ndef {name}(" not in src, (
+                f"{path.name} re-declares `{name}` — it belongs to "
+                f"scripts/lib/ci_status.py")
+    # POSITIVE CONTROL on the scan itself: the pattern DOES match a real local
+    # definition, so the assertions above are not vacuous on a pattern that
+    # never matches anything.
+    assert "\ndef screen_all_known_flakes(" in consumers[0].read_text(encoding="utf-8")
 
 
 def test_an_UNRECOGNISED_state_is_never_green_end_to_end(h):

--- a/scripts/tests/test_main_status_watch.py
+++ b/scripts/tests/test_main_status_watch.py
@@ -68,11 +68,14 @@ RC_OK, RC_TRIGGERED, RC_UNMEASURED, RC_BLIND, RC_USAGE = 0, 10, 11, 12, 2
 # hazard the flake screen turns on is only demonstrable with real ones — every
 # synthetic description anybody would write by hand is conveniently complete.
 #
-# The known flake, cut MID-WORD by GitHub's 140-BYTE description cap. BYTES, not
+# The known flake, cut MID-WORD at the 140-BYTE description cap. BYTES, not
 # characters: the `—` in `FAILED: pytests —` is three UTF-8 bytes, which is why
 # every real row measured on this repo reads `len(desc)=138`. Anyone building a
 # fixture from a CHARACTER cap lands two bytes late and quietly leaves `failed=`
-# readable — see `cut_like_github` in `scripts/tests/test_stale_base_triage.py`.
+# readable — see `cut_at_the_byte_cap` in `scripts/tests/test_stale_base_triage.py`.
+# ⚠ WHOSE CUT IT IS — GitHub's cap or the posting pipeline's own truncation — is
+# NOT determined; the two are indistinguishable on every row sampled. The
+# boundary is the measurement, and it is the only claim made about it.
 REAL_DESC_BYTE_CAP = 140
 REAL_FLAKE_DESC = (
     "FAILED: pytests — FAILING: TestARefusedWriteIsIndistinguishableFromAnAbsentOne"
@@ -364,7 +367,7 @@ def test_CONTROL_the_real_truncated_rows_land_on_the_BYTE_cap_not_the_CHAR_cap()
 
 
 def test_the_REAL_known_flake_row_still_triggers_because_it_is_truncated(h):
-    """The row that named the known flake was cut MID-WORD at GitHub's 140-BYTE
+    """The row that named the known flake was cut MID-WORD at the 140-BYTE
     cap, so it proves neither the full name nor that it was the only failure.
     Skipping on it would skip real reds hiding behind the truncation.
 
@@ -1209,6 +1212,46 @@ def test_code_only_really_strips_the_prose_it_claims_to():
     assert "def commit_verdict(rows):" in code, (
         "_code_only stripped executable lines too — every guard reading it is vacuous"
     )
+
+
+def _sys_path_mutations(src):
+    """(lineno, method) for every `sys.path.<method>(…)` call in a source."""
+    out = []
+    for node in ast.walk(ast.parse(src)):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)):
+            continue
+        owner = node.func.value
+        if (isinstance(owner, ast.Attribute) and owner.attr == "path"
+                and isinstance(owner.value, ast.Name) and owner.value.id == "sys"):
+            out.append((node.lineno, node.func.attr))
+    return out
+
+
+def test_the_shared_lib_is_APPENDED_to_sys_path_and_never_PREPENDED():
+    """🔴 A 🔴-MARKED COMMENT IS NOT A GUARD. The paragraph above this script's
+    `sys.path.append` says `append`, NEVER `insert(0, …)`, and reverting it to
+    `sys.path.insert(0, …)` SURVIVED the whole suite.
+
+    `scripts/lib/` grows freely; prepending it puts EVERY module in it ahead of
+    the standard library for every LATER import this process makes — including
+    the lazy `import traceback` on the unattended-crash path at the bottom of
+    this file, which is the one import that runs when something has already gone
+    wrong.
+
+    ⚠ THIS FILE'S SCRIPT ONLY. `stale-base-triage.py` carries the same comment
+    and the same hazard; its copy is pinned by `test_stale_base_triage.py`,
+    which owns that file.
+    """
+    got = _sys_path_mutations(SCRIPT.read_text(encoding="utf-8"))
+    assert got, "the sys.path scan matched nothing — this guard is inert"
+    assert [m for _, m in got] == ["append"], got
+    # POSITIVE CONTROL: the scan CAN see the spelling this forbids, so the
+    # equality above is not a comparison against a scan wired to nothing.
+    assert _sys_path_mutations(
+        'import sys\nsys.path.insert(0, "x")\n') == [(2, "insert")]
+    # …and it does not fire on an unrelated `.append`.
+    assert _sys_path_mutations('rows = []\nrows.append(1)\n') == []
 
 
 def test_the_script_never_reads_the_rollup_status_endpoint():

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -391,7 +391,7 @@ ACKNOWLEDGED_UNSTUBBED = {
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "i3status-scratchpads",
          "keylog-spin-capture.sh",
-         "mention-open.py",
+         "main-status-watch.py", "mention-open.py",
          "notify-failure.sh", "playwright-nixos", "regen-known-repos.py",
          "resume-state.sh",
          "session-manager", "session-resolve", "ship.sh", "tmux-post-save.sh",
@@ -454,6 +454,29 @@ ACKNOWLEDGED_UNSTUBBED = {
         "set. Both controls watched: clean tree passes, an injected "
         "`subprocess.run([\"home-manager\", \"switch\"])` fails with that "
         "test's own message. "
+        "main-status-watch.py (added 2026-09-11 with the shared-predicate "
+        "module scripts/lib/ci_status.py) is the same PROSE-MENTION shape and "
+        "is re-justified, not reworded. Its SINGLE occurrence is one clause of "
+        "a comment on the import block, explaining that the systemd unit runs "
+        "this file straight out of the CHECKOUT (ExecStart names "
+        "%h/workspace/devrc/scripts/main-status-watch.py), so a `git pull` "
+        "delivers BOTH files and no switch is involved — which is the whole "
+        "reason importing a sibling module is safe here rather than a new "
+        "deploy dependency. Deleting the word would delete the reason the "
+        "import is safe. "
+        "🔴 THE PIN, because this entry would otherwise blind the guard: "
+        "test_main_status_watch.py::test_main_status_watch_SPAWNS_these_argv0_"
+        "AND_NOTHING_ELSE walks the AST and asserts the spawn argv[0] set is "
+        "exactly {git, <computed>, <not-a-list>}, grows-or-shrinks — and its "
+        "companion test_home_manager_is_MENTIONED_but_never_SPAWNED asserts "
+        "BOTH halves: the mention still EXISTS (or this row has outlived the "
+        "sentence it describes) and the name reaches NO executable line, "
+        "comments and docstrings stripped by AST. The two opaque argv[0] "
+        "entries are named rather than waved at: <computed> is [gh, 'api', "
+        "path] behind the MAIN_STATUS_WATCH_GH stub seam, and <not-a-list> is "
+        "trigger_deadman's `cmd`, whose production literal is pinned exactly — "
+        "and refused a --force — by "
+        "test_the_production_trigger_is_systemctl_start_main_green_check. "
         "tmux-scratch-slots.sh (added 2026-08-19) is the FOURTH of this shape "
         "and carries the STRONGEST form of the justification: the other three "
         "merely lack a call site, whereas this file has no executable "

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -798,7 +798,7 @@ def test_ONE_unexplained_name_makes_the_WHOLE_PR_a_real_red(repo):
 
 def test_an_inherited_name_on_a_TRUNCATED_row_is_UNMEASURED_not_INHERITED(repo):
     """🔴 THE COMPLETENESS GUARD AT PR LEVEL. Every NAMED failure is inherited,
-    but the count did not survive the 140-char cap, so other failures may remain
+    but the count did not survive the 140-byte cap, so other failures may remain
     and the PR must not be dismissed. The per-test line still says what it
     found, which is the useful half."""
     got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -233,6 +233,39 @@ def test_newest_per_context_is_order_independent():
     assert set(both) == {"tekton/devrc-pytests", "tekton/devrc-nodetests"}
 
 
+def test_newest_per_context_skips_a_malformed_row_rather_than_raising():
+    """🔴 THE CITED TEST THAT DID NOT EXIST, AND THE MUTANT THAT SURVIVED.
+
+    `scripts/lib/ci_status.py`'s module docstring names this test as the pin on
+    its row-validity policy, and it named nothing: deleting
+    `if not isinstance(row, dict): continue` SURVIVED the whole suite, because
+    no fixture anywhere fed the fold a non-dict row. A guard nothing reaches is
+    a guard that can be deleted by accident with a green suite.
+
+    It is REACHABLE here and the earlier checks do not pre-empt it: the skip is
+    the FIRST statement in the loop body, and each row below is a shape
+    `row.get` does not exist on — so removing the guard raises `AttributeError`
+    on the reporting path of a tool whose whole contract is to report rather
+    than crash.
+
+    WHICH POLICY THIS IS, because the two callers do not share one:
+    `stale-base-triage.py` has no row walk of its own and this skip is its
+    existing behaviour; `main-status-watch.py` validates every row in its own
+    walk first, so for that caller this arm is unreachable by construction. The
+    fold must therefore skip, not raise, and must not skip a VALID row.
+    """
+    good = {"context": "tekton/devrc-pytests", "state": "failure",
+            "created_at": "2026-09-11T17:00:00Z", "description": "FAILED"}
+    for junk in ([], "a string", 7, None, ("context", "x")):
+        got = M.newest_per_context([junk, good])
+        # POSITIVE CONTROL, in the same call: the valid row alongside the junk
+        # still folds, so "it did not raise" is not "it returned nothing".
+        assert set(got) == {"tekton/devrc-pytests"}, junk
+        assert got["tekton/devrc-pytests"]["state"] == "failure", junk
+    # …and a list of nothing BUT malformed rows is an empty fold, never a raise.
+    assert M.newest_per_context(["", 0, None]) == {}
+
+
 # ══ PURE: description parsing ═════════════════════════════════════════════════
 # REAL descriptions, copied from statuses THIS repo posted about its OWN tests.
 # No third-party text, no hostnames, no captured content — and they are here
@@ -265,7 +298,7 @@ def test_parse_failing_names_reads_the_names_and_stops_at_TOTAL():
 
 
 def test_a_trailing_TOTAL_fragment_is_not_a_test_name():
-    """🔴 A 140-CHAR CUT LANDING INSIDE ` | TOTAL` LEAVES A FRAGMENT WHERE A NAME
+    """🔴 A 140-BYTE CUT LANDING INSIDE ` | TOTAL` LEAVES A FRAGMENT WHERE A NAME
     WOULD BE. Left in, it resolves to no file and the PR is reported as a real
     red on the strength of a truncation artefact — the exact false negative this
     tool must not produce. Only the four proper prefixes of TOTAL are stripped,
@@ -466,6 +499,76 @@ def test_a_TRUNCATED_skipped_can_only_INFLATE_the_derived_bound():
     assert M.derived_failure_upper_bound(short) > M.derived_failure_upper_bound(full)
 
 
+def test_an_EARLIER_per_target_row_cannot_be_mistaken_for_the_TOTAL_banner():
+    """🔴 THE UNDER-COUNT DIRECTION, WHICH IS THE ONLY ONE THAT CERTIFIES.
+
+    `run-tests.sh` prints a row PER TARGET before the TOTAL banner, and those
+    rows carry the same field names:
+
+        FAIL  <dir>  (collected=… passed=… skipped=… failed=… errors=…)
+
+    Both parsers used `re.search` over an UNANCHORED pattern, so on a
+    description carrying such a row they read ONE TARGET'S numbers: the derived
+    bound came out 2 and `failed=` came out 2, where the run's own count is 27.
+    Two names would then be "provably complete" on a row with 27 failures — the
+    single error this tool must not make, and it is silent, because the verdict
+    it produces is a confident INHERITED rather than a refusal.
+
+    ⚠ NO REACHABLE EXPLOIT IS CLAIMED, AND THIS TEST DOES NOT DEMONSTRATE ONE.
+    What assembles the posted description is the pipeline in `homelab-talos`,
+    which cannot be pinned from this repo; every row measured here carries the
+    banner alone. This is the parser's half of the hazard, closed on its own.
+    """
+    # The per-target row's shape is READ OUT OF `run-tests.sh`, not imagined, so
+    # this fixture cannot quietly stop resembling what the gate emits.
+    runner = (ROOT / "scripts" / "run-tests.sh").read_text(encoding="utf-8")
+    assert re.search(r'collected=\$collected\s+passed=\$p\s+skipped=\$s', runner), (
+        "run-tests.sh no longer prints a per-target collected/passed/skipped "
+        "row — re-derive this fixture before trusting the assertions below")
+
+    per_target = "FAIL  scripts/tests  (collected=9 passed=6 skipped=1 failed=2 errors=0)"
+    banner = "TOTAL collected=900  passed=850  skipped=23  failed=27"
+    desc = f"FAILED: pytests — FAILING: test_x | {per_target} | {banner}"
+
+    # POSITIVE CONTROL on the fixture: the per-target triple really is readable
+    # and really does yield the wrong answer, so the assertions below are about
+    # which match is taken and not about a string nothing can parse.
+    assert re.search(r"\bcollected=(\d+)\s+passed=(\d+)\s+skipped=(\d+)",
+                     desc).groups() == ("9", "6", "1")
+    assert re.search(r"\bfailed=(\d+)\b", desc).group(1) == "2"
+
+    assert M.derived_failure_upper_bound(desc) == 27, desc     # NOT 9-6-1 = 2
+    assert M.parse_failed_count(desc) == 27, desc              # NOT the target's 2
+    # …and the verdict that rests on them REFUSES. Pinned as a whole string,
+    # because the failure mode being closed is a confident True: before the
+    # anchor this row returned `(True, "failed=2 and 2 named")` — certified
+    # complete, on a run with 27 failures. (The "2 named" is the per-target row
+    # itself being read as a second name by `FAILING:`; it is an artefact of
+    # this fixture and not part of what is pinned.)
+    ok, why = M.names_provably_complete(desc)
+    assert not ok, why
+    assert why == "the description says failed=27 but names 2", why
+    # The banner ALONE still answers, so the anchor did not simply disable both
+    # parsers on every row.
+    assert M.derived_failure_upper_bound(banner) == 27
+    assert M.parse_failed_count(banner) == 27
+
+    # 🔴 WHY `re.search` — FIRST match — NEEDS NO SEPARATE PIN ONCE ANCHORED,
+    # written down as a measurement rather than left as an unexplained
+    # surviving mutant. Rewriting `TOTALS_RE.search(…)` as a LAST-match fold
+    # still survives the suite, and it survives because the anchored pattern
+    # matches AT MOST ONCE on every banner this repo can post: `TOTAL` is
+    # printed once and last. Unanchored, first-vs-last was a live hazard —
+    # that is the whole finding above; anchored, the two are the same match.
+    # (Reachability was confirmed separately: breaking the same statement kills
+    # 39 tests, so the arm is executed and this is equivalence, not silence.)
+    for fixture in (desc, banner, REAL_ONE_NAMED_COMPLETE, REAL_NO_NAMES_AT_ALL,
+                    REAL_FIVE_FAILED_ONE_NAMED, REAL_CUT_BEFORE_THE_COUNT,
+                    *CUT_INSIDE_FAILED, synth_row("test_z", 10, 7, 1, 2)):
+        assert len(M._TOTALS_RE.findall(fixture)) <= 1, fixture
+    assert len(M._TOTALS_RE.findall(desc)) == 1, desc
+
+
 def test_the_derived_bound_refuses_a_row_it_cannot_read():
     """None, never a number and never a raise — an unreadable row must not
     become a bound of 0, which would certify every single-named row as
@@ -573,9 +676,14 @@ def test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned()
     banners = [ln for ln in src.splitlines() if "TOTAL collected=$TOT_COLLECTED" in ln]
     assert len(banners) >= 2, f"expected both TOTAL banners, found {len(banners)}"
     for ln in banners:
+        # 🔴 `TOTAL` IS PART OF THE SHAPE, NOT DECORATION AROUND IT. Both
+        # parsers anchor on that word, because `run-tests.sh` also prints a
+        # per-target `(collected=… passed=… skipped=… failed=…)` row and an
+        # unanchored pattern reads THAT one. So the guard pins the word's
+        # adjacency to the triple, not just the triple's internal order.
         ordered = re.search(
-            r"collected=\$TOT_COLLECTED\s+passed=\$TOT_PASSED\s+skipped=\$TOT_SKIPPED\s+"
-            r"failed=\$TOT_FAILED", ln)
+            r"TOTAL\s+collected=\$TOT_COLLECTED\s+passed=\$TOT_PASSED\s+"
+            r"skipped=\$TOT_SKIPPED\s+failed=\$TOT_FAILED", ln)
         assert ordered, f"banner does not print the fields in order: {ln.strip()}"
         # …and the regex this file parses with actually matches that shape.
         assert M._TOTALS_RE.search(
@@ -635,7 +743,7 @@ def test_a_class_qualified_name_narrows_an_otherwise_ambiguous_method(repo):
     assert got["file"] == BRAVO
 
 
-def test_a_name_TRUNCATED_by_the_140_char_cap_still_resolves(repo):
+def test_a_name_TRUNCATED_by_the_140_BYTE_cap_still_resolves(repo):
     """🔴 REAL: a status row ended `…_CAN_see_the_dif`, mid-word. Phase 2 drops
     the opening paren so a prefix can match — and runs ONLY when phase 1 found
     nothing, which is why the next test exists."""
@@ -930,8 +1038,17 @@ class Harness:
         # Records EVERY argv, then answers on the first argument that looks like
         # an API path. `-X POST` therefore lands in the receipt exactly like a
         # read does — which is what makes "no write happened" observable.
+        #
+        # 🔴 ONE RECEIPT LINE PER INVOCATION, WHICH IT WAS NOT. A comment BODY
+        # contains newlines, so `printf "%s\n" "$*"` split ONE `gh` call across
+        # a dozen lines and `calls()` returned prose fragments as if they were
+        # invocations. That was invisible while the only question asked of a
+        # line was whether it contained the word POST; a classifier that reads
+        # each line AS an argv needs the lines to be argvs. Newlines inside an
+        # argument are flattened to spaces.
         write_exec(self.gh,
-                   f'printf "%s\\n" "$*" >> "{self.receipt}"\n'
+                   f'printf "%s" "$*" | tr "\\n" " " >> "{self.receipt}"\n'
+                   f'printf "\\n" >> "{self.receipt}"\n'
                    'p=""\n'
                    'for a in "$@"; do case "$a" in /*) p="$a"; break;; esac; done\n'
                    f'f=$(printf "%s" "$p" | tr "/?&=" "____")\n'
@@ -1099,7 +1216,10 @@ def test_the_DEFAULT_run_makes_no_write_api_call_at_all(harness, repo):
     proc = harness.run(repo, "--pr", "7")
     assert proc.returncode == RC_INHERITED, proc.stdout
     assert harness.calls(), "the stub was never reached — this test proves nothing"
-    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    # 🔴 EVERY RECORDED CALL IS AN ENUMERATED READ — not "no line said POST".
+    # See `gh_write_calls`: the word-scan this replaces was satisfied by
+    # `-X PATCH`, `-X PUT`, `--method DELETE` and `gh pr comment` alike.
+    assert gh_write_calls(harness.calls()) == [], harness.calls()
     assert "mode=off" in proc.stdout
 
 
@@ -1107,17 +1227,60 @@ def test_POSITIVE_CONTROL_arming_it_DOES_reach_the_write_call(harness, repo):
     harness.serve_default(repo)
     proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
     assert proc.returncode == RC_INHERITED, proc.stdout + proc.stderr
-    posts = [c for c in harness.calls() if "POST" in c]
+    posts = gh_write_calls(harness.calls())
     assert len(posts) == 1, harness.calls()
     assert "/repos/o/r/issues/7/comments" in posts[0]
     assert "posted on #7" in proc.stdout
+
+
+def test_the_write_screen_SEES_the_shapes_the_word_POST_did_not(harness, repo):
+    """🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT. Four tests above
+    now conclude "no write happened" from `gh_write_calls(...) == []`, and that
+    conclusion is worth nothing until this classifier has been watched to go
+    both ways over realistic argv.
+
+    The rows are the disarm the word-scan actually had: `"POST" in <line>` is
+    False for every one of the six below, so each was a write that the previous
+    guard read as clean. `gh api -f` is the sharpest — it is a POST with no
+    method flag at all, so even a method-only screen calls it a read.
+    """
+    reads = ["api /repos/o/r/pulls/7",
+             "api /repos/o/r/commits/deadbeef/statuses?per_page=100",
+             "api -X GET /repos/o/r/x",
+             "api --method HEAD /repos/o/r/x"]
+    assert gh_write_calls(reads) == [], reads
+    writes = ["api -X PATCH /repos/o/r/issues/7",
+              "api -X PUT /repos/o/r/x",
+              "api --method DELETE /repos/o/r/x",
+              "api -XPOST /repos/o/r/x",
+              "api /repos/o/r/issues/7/comments -f body=hello",
+              "pr comment 7 --body hello"]
+    for w in writes:
+        assert "POST" not in w or w == "api -XPOST /repos/o/r/x", w
+        assert gh_write_calls([w]) == [w], w
+    # …and it is not simply "everything is a write": mixed in, only the write
+    # comes back, in order.
+    assert gh_write_calls(reads + writes) == writes
+
+    # POSITIVE CONTROL ON THE RECEIPT ITSELF, not on invented strings: a REAL
+    # armed run produces exactly one line this classifier calls a write, and the
+    # read-only run above produces none. Without this the table could be pinning
+    # a parser that never meets the format the harness actually writes.
+    harness.serve_default(repo)
+    harness.run(repo, "--pr", "7", "--comment-mode", "on")
+    recorded = harness.calls()
+    assert len(gh_write_calls(recorded)) == 1, recorded
+    # 🔴 ONE LINE PER INVOCATION: the comment body contains newlines, and the
+    # receipt must not split one call across several lines — every line has to
+    # be a real argv or the classifier is reading prose.
+    assert all(c.startswith("api ") for c in recorded), recorded
 
 
 def test_DRY_RUN_says_what_it_would_do_and_writes_nothing(harness, repo):
     harness.serve_default(repo)
     proc = harness.run(repo, "--pr", "7", "--comment-mode", "dry-run")
     assert "DRY-RUN would comment on #7" in proc.stdout
-    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    assert gh_write_calls(harness.calls()) == [], harness.calls()
 
 
 def test_an_already_commented_PR_is_not_commented_on_twice(harness, repo):
@@ -1126,7 +1289,7 @@ def test_an_already_commented_PR_is_not_commented_on_twice(harness, repo):
                   [{"body": f"{M.COMMENT_MARKER}\nsaid this yesterday"}])
     proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
     assert "already carries the marker" in proc.stdout
-    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    assert gh_write_calls(harness.calls()) == [], harness.calls()
 
 
 def test_a_NOT_INHERITED_PR_is_never_commented_on_even_when_armed(harness, repo):
@@ -1134,7 +1297,7 @@ def test_a_NOT_INHERITED_PR_is_never_commented_on_even_when_armed(harness, repo)
         "FAILED: pytests — FAILING: test_the_bravo_invariant_holds | TOTAL "
         "collected=9  passed=8  skipped=0  failed=1"))
     proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
-    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    assert gh_write_calls(harness.calls()) == [], harness.calls()
     assert proc.returncode == RC_OK, proc.stdout
 
 
@@ -1223,29 +1386,195 @@ def test_the_rollup_endpoint_and_check_runs_are_never_requested():
     assert "/statuses" in " ".join(paths)
 
 
-def _git_subcommands():
+# 🔴 SENTINELS, NOT SKIPS. An argument list the AST cannot constant-fold is
+# precisely how a literal-keyed ledger gets walked past, so it must LAND IN THE
+# SET and fail loudly rather than leave it. This is the shape
+# `test_main_status_watch.py`'s `_spawn_argv0_literals` already uses, 200 lines
+# away in the same change; the version here dropped what it could not read, so
+# its stated rule ("an unknown git subcommand is a write by default") described
+# something it did not enforce — the opaque case was ABSENT, not DENIED.
+SUB_COMPUTED = "<computed>"        # `_git(repo, [sub, …])` with `sub` a variable
+SUB_NOT_A_LIST = "<not-a-list>"    # `_git(repo, cmd)` — argv built elsewhere
+SUB_EMPTY = "<empty-argv>"         # `_git(repo, [])`
+SUB_MISSING = "<no-argv>"          # `_git(repo)` — no argv argument at all
+
+_SPAWN_FUNCS = {"run", "Popen", "call", "check_output", "check_call", "system",
+                "execv", "execvp", "execve", "spawnv", "spawnvp"}
+
+# Every git subcommand this tool is permitted to reach. ALLOWLIST, NOT DENYLIST:
+# anything not named here — including all four sentinels above — is a write.
+GIT_READ_ONLY = frozenset({"rev-parse", "cat-file", "grep", "log", "merge-base",
+                           "rev-list"})
+
+
+def _git_subcommands(src=SRC):
     """Every git subcommand the source actually INVOKES, read from the AST.
 
     🔴 STRUCTURAL, NOT SPELLED. A string scan over the whole file would match
     the comment that EXPLAINS the hazard — which is exactly what a first draft
     of the guard below did, failing on its own documentation. The AST sees the
     argument list and nothing else, so prose cannot satisfy it or break it.
+
+    🔴 AND IT DROPS NOTHING. The argv is read from the SECOND POSITIONAL of
+    `_git(repo, args)` — not "whichever argument happens to be a list" — and
+    every element that is not a string constant becomes `<computed>`, so a
+    subcommand assembled at runtime reaches the allowlist as an unknown rather
+    than disappearing from it.
     """
-    tree = ast.parse(SRC)
+    tree = ast.parse(src)
     subs = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        fn = node.func
+        fn = node.func if isinstance(node, ast.Call) else None
         if not (isinstance(fn, ast.Name) and fn.id == "_git"):
             continue
-        for arg in node.args:
-            if isinstance(arg, ast.List) and arg.elts:
-                head = arg.elts[0]
-                if isinstance(head, ast.Constant) and isinstance(head.value, str):
-                    subs.append([e.value for e in arg.elts
-                                 if isinstance(e, ast.Constant)])
+        if len(node.args) < 2:
+            subs.append([SUB_MISSING])
+            continue
+        argv = node.args[1]
+        if not isinstance(argv, (ast.List, ast.Tuple)):
+            subs.append([SUB_NOT_A_LIST])
+            continue
+        if not argv.elts:
+            subs.append([SUB_EMPTY])
+            continue
+        subs.append([e.value if isinstance(e, ast.Constant)
+                     and isinstance(e.value, str) else SUB_COMPUTED
+                     for e in argv.elts])
     return subs
+
+
+def _git_unenumerated(subs):
+    """The invocations the allowlist does NOT permit — the guard, as a function.
+
+    A predicate rather than a loop of asserts so that a test can drive it over
+    SYNTHETIC source and watch it reject; a guard only ever exercised on the
+    real file cannot be shown to reject anything.
+    """
+    bad = []
+    for a in subs:
+        if not a:
+            bad.append(a)
+        elif a[0] == "remote":
+            # `remote` has writing forms (`add`, `set-url`, `remove`); only the
+            # reading one is permitted, and it is checked by its ARGUMENT.
+            if a[:2] != ["remote", "get-url"]:
+                bad.append(a)
+        elif a[0] not in GIT_READ_ONLY:
+            bad.append(a)
+    return bad
+
+
+def _spawn_argv0(src=SRC):
+    """(lineno, argv0) for every spawn-shaped call, from the SYNTAX TREE.
+
+    Same sentinel discipline as `_git_subcommands`: a command built from a
+    variable lands in the set as `<computed>` rather than being skipped.
+    """
+    out = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if isinstance(first, (ast.List, ast.Tuple)) and first.elts:
+            head = first.elts[0]
+            out.append((node.lineno,
+                        head.value if isinstance(head, ast.Constant) and
+                        isinstance(head.value, str) else SUB_COMPUTED))
+        else:
+            out.append((node.lineno, SUB_NOT_A_LIST))
+    return out
+
+
+def _gh_argv_shapes(src=SRC):
+    """The constant argv head of every spawn whose argv0 is the `gh` seam.
+
+    Stops at the first non-constant element or the first `/`-prefixed path, so
+    what comes back is the VERB — `("api",)`, `("api", "-X", "POST")` — and not
+    the endpoint. That is the thing an enumerated ledger can pin.
+    """
+    shapes = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, (ast.List, ast.Tuple)) and first.elts):
+            continue
+        head = first.elts[0]
+        if not (isinstance(head, ast.Name) and head.id == "gh"):
+            continue
+        shape = []
+        for e in first.elts[1:]:
+            if not (isinstance(e, ast.Constant) and isinstance(e.value, str)):
+                break
+            if e.value.startswith("/"):
+                break
+            shape.append(e.value)
+        shapes.append(tuple(shape))
+    return shapes
+
+
+# 🔴 WHAT THIS SET MEANS, ENTRY BY ENTRY — a ledger whose entries are unexplained
+# is a ledger nobody can evaluate a new row against:
+#   ("api",)                 — `gh_json`: every READ this tool makes.
+#   ("api", "-X", "POST")    — `post_comment`: the ONE write, and it is reachable
+#                              only under `--comment-mode on`, whose default is
+#                              pinned to the literal "off" separately.
+# GROWS-OR-SHRINKS. `gh api -X PATCH`, `-X PUT`, `--method DELETE` and
+# `gh pr comment` each produce a shape that is not in here, which is exactly the
+# class the word-scan this replaces could not see.
+EXPECTED_GH_ARGV = {("api",), ("api", "-X", "POST")}
+
+# `gh api` is the only surface, and only these methods are reads.
+GH_READ_METHODS = frozenset({"GET", "HEAD"})
+_GH_FIELD_FLAGS = frozenset({"-f", "-F", "--field", "--raw-field", "--input"})
+
+
+def gh_write_calls(calls):
+    """Every RECORDED `gh` invocation that is not an enumerated read.
+
+    🔴 ASSERTS THE STATE, NEVER THE ABSENCE OF A WORD. The guard this replaces
+    was `"POST" not in the receipt line`, and `gh api -X PATCH`, `-X PUT`,
+    `--method DELETE` and `gh pr comment` all walk straight past it. The disarm
+    is complete in today's tree; this is about what the guard catches next time.
+
+    🔴 A MISSING `-X` IS NOT A READ. `gh api` with any field flag (`-f`, `-F`,
+    `--field`, `--raw-field`, `--input`) defaults to POST, so a write needs no
+    method flag at all — the one shape a method-only screen would call clean.
+
+    Anything whose first token is not `api` is reported as a write too: it is a
+    `gh` surface nobody enumerated, and an allowlist must fail on those.
+    """
+    writes = []
+    for c in calls:
+        toks = c.split()
+        if not toks or toks[0] != "api":
+            writes.append(c)
+            continue
+        method, fields, i = None, False, 0
+        while i < len(toks):
+            t = toks[i]
+            if t in ("-X", "--method") and i + 1 < len(toks):
+                method, i = toks[i + 1].upper(), i + 2
+                continue
+            if t.startswith("-X") and len(t) > 2:
+                method = t[2:].upper()
+            elif t.startswith("--method="):
+                method = t.split("=", 1)[1].upper()
+            elif t in _GH_FIELD_FLAGS or t.startswith(("--field=", "--raw-field=")):
+                fields = True
+            i += 1
+        if method is None:
+            if fields:
+                writes.append(c)
+        elif method not in GH_READ_METHODS:
+            writes.append(c)
+    return writes
 
 
 def test_path_existence_is_proved_with_cat_file_not_diff_quiet():
@@ -1266,11 +1595,56 @@ def test_every_env_var_the_code_reads_is_documented_in_the_header():
     assert read == ledgered, f"read={sorted(read)} ledgered={sorted(ledgered)}"
 
 
+def _script_and_its_shared_libs(script=SCRIPT):
+    """{filename: source} for the script AND every `scripts/lib/*.py` it imports.
+
+    🔴 THE CONSOLIDATION MOVED CODE OUT FROM UNDER THE GUARD BELOW, AND THE FIRST
+    CITATION WRITTEN INTO THE NEW MODULE DANGLED. `classify`, the folds and the
+    banner parsers now live in `scripts/lib/ci_status.py`; its docstring cited
+    `test_newest_per_context_skips_a_malformed_row_rather_than_raising`, which
+    existed nowhere. Both copies of the citation guard — this one and
+    `test_main_status_watch.py`'s — were scoped to ONE script file, so neither
+    could see it. A citation that resolves to nothing reads as authority and is
+    not one; a guard that cannot see where the prose went is worse, because it
+    reads as coverage.
+
+    The imports are FOLLOWED rather than enumerated, so a second shared module
+    is covered the day it appears instead of the day somebody notices.
+    """
+    src = Path(script).read_text(encoding="utf-8")
+    lib = Path(script).resolve().parent / "lib"
+    out = {Path(script).name: src}
+    for node in ast.walk(ast.parse(src)):
+        names = []
+        if isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            names.append(node.module)
+        elif isinstance(node, ast.Import):
+            names += [a.name for a in node.names]
+        for mod in names:
+            p = lib / (mod.replace(".", "/") + ".py")
+            if p.is_file():
+                out[p.name] = p.read_text(encoding="utf-8")
+    return out
+
+
 def test_every_test_this_script_names_actually_exists():
     """A citation that resolves to nothing reads as authority and is not one.
-    Names wrapped across a comment line-break are re-joined before looking."""
-    joined = re.sub(r"\n#\s*", "", SRC)
-    cited = set(re.findall(r"`(test_[A-Za-z0-9_]+)`", joined))
+    Names wrapped across a comment line-break are re-joined before looking.
+
+    🔴 THE SCRIPT **AND THE SHARED MODULES IT IMPORTS** — see
+    `_script_and_its_shared_libs` for why that widening exists.
+    """
+    sources = _script_and_its_shared_libs()
+    # POSITIVE CONTROL on the widening: the import-following really did reach a
+    # shared module. Without this a refactor that stops importing `ci_status`
+    # silently narrows this guard back to one file and nothing says so.
+    assert "ci_status.py" in sources, (
+        f"the import scan found no shared lib module — this widening is inert: "
+        f"{sorted(sources)}")
+    cited = set()
+    for name, text in sources.items():
+        joined = re.sub(r"\n#\s*", "", text)
+        cited |= set(re.findall(r"`(test_[A-Za-z0-9_]+)`", joined))
     assert cited, "the citation scan matched nothing — this guard is inert"
     # Repo-wide, because this script legitimately cites tests it does not own
     # (a real CI row names one, and the measurement in the header names
@@ -1300,21 +1674,105 @@ def test_no_git_subcommand_that_WRITES_is_ever_invoked():
     🔴 AN ALLOWLIST, NOT A DENYLIST — a git subcommand nobody enumerated is a
     write by default. A denylist of known writers passes silently the day
     someone reaches for one it does not name.
+
+    🔴 AND "UNENUMERATED" NOW INCLUDES "UNREADABLE". The scan used to DROP an
+    argument list it could not constant-fold, so `_git(repo, [sub, …])` with a
+    variable head was absent rather than denied and this docstring's rule was
+    wider than its implementation. The sentinels close that; the test below
+    drives the rejection over synthetic source rather than asserting it here.
     """
     subs = _git_subcommands()
     assert subs, "the AST scan found no git invocations — this guard is inert"
-    read_only = {"rev-parse", "cat-file", "grep", "log", "merge-base", "rev-list"}
-    for a in subs:
-        if a[0] == "remote":
-            # `remote` has writing forms (`add`, `set-url`, `remove`); only the
-            # reading one is permitted, and it is checked by its ARGUMENT.
-            assert a[:2] == ["remote", "get-url"], a
-            continue
-        assert a[0] in read_only, f"`git {a[0]}` is not an enumerated read: {a}"
+    assert _git_unenumerated(subs) == [], _git_unenumerated(subs)
     # POSITIVE CONTROL on the scan: it really does see the arguments, so the
     # allowlist above is not passing over an empty or opaque list.
     assert any(a[:2] == ["merge-base", "--is-ancestor"] for a in subs), subs
     assert any(a[0] == "remote" for a in subs), subs
+
+
+def test_a_COMPUTED_git_subcommand_is_DENIED_rather_than_VANISHING():
+    """🔴 THE GUARD ABOVE, DRIVEN OVER SOURCE THAT VIOLATES IT.
+
+    The allowlist's stated rule is "an unknown git subcommand is a write by
+    default", and before the sentinels that was false for every shape the AST
+    could not fold: a computed head, an argv built elsewhere, an empty list.
+    They were dropped by the scan, so the guard saw nothing and passed. Absent
+    is not denied — and the real file contains no such call, so no assertion
+    against the real file can tell those two apart.
+    """
+    synthetic = (
+        'def a(repo, sub):\n    _git(repo, [sub, "--hard"])\n'
+        'def b(repo, cmd):\n    _git(repo, cmd)\n'
+        'def c(repo):\n    _git(repo, [])\n'
+        'def d(repo):\n    _git(repo)\n'
+        'def e(repo):\n    _git(repo, ["rev-parse", "HEAD"])\n'
+    )
+    subs = _git_subcommands(synthetic)
+    assert sorted(a[0] for a in subs) == sorted(
+        [SUB_COMPUTED, SUB_NOT_A_LIST, SUB_EMPTY, SUB_MISSING, "rev-parse"]), subs
+    assert sorted(a[0] for a in _git_unenumerated(subs)) == sorted(
+        [SUB_COMPUTED, SUB_NOT_A_LIST, SUB_EMPTY, SUB_MISSING]), subs
+    # NEGATIVE CONTROL on the predicate: the enumerated read ALONE is accepted,
+    # so the four rejections above are about the opaque heads and not about a
+    # predicate that refuses whatever it is given.
+    assert _git_unenumerated(_git_subcommands(
+        'def e(repo):\n    _git(repo, ["rev-parse", "HEAD"])\n')) == []
+    # …and a real writer is rejected by NAME, which is the case the allowlist
+    # was written for in the first place.
+    assert _git_unenumerated(_git_subcommands(
+        'def f(repo):\n    _git(repo, ["push", "origin", "HEAD"])\n')) == [
+        ["push", "origin", "HEAD"]]
+
+
+def test_stale_base_triage_SPAWNS_these_argv0_AND_NOTHING_ELSE():
+    """🔴 GROWS-OR-SHRINKS, and the half `_git_subcommands` structurally cannot
+    see: a bare `subprocess.run(["git", "push", …])` never goes near `_git`, so
+    the subcommand allowlist is blind to it by construction.
+
+      git          — `["git", "-C", str(repo), *args]`, inside `_git` only.
+      <computed>   — `[gh, "api", …]`; `gh` is the STALE_BASE_TRIAGE_GH seam,
+                     which is what lets every test point it at a stub. Its own
+                     argv is enumerated by the `gh` guard below, so `<computed>`
+                     here is not an unexamined hole.
+    """
+    assert {a0 for _, a0 in _spawn_argv0()} == {"git", SUB_COMPUTED}
+
+
+def test_every_git_SPAWN_goes_through_the_one_helper():
+    """The `_git` allowlist is only a claim about this tool if `_git` is the
+    only way a git process starts. A second `subprocess.run(["git", …])`
+    anywhere in the file would be a git invocation no allowlist ever sees."""
+    helpers = [n for n in ast.walk(ast.parse(SRC))
+               if isinstance(n, ast.FunctionDef) and n.name == "_git"]
+    assert len(helpers) == 1, [h.lineno for h in helpers]
+    lo, hi = helpers[0].lineno, helpers[0].end_lineno
+    spawns = [ln for ln, a0 in _spawn_argv0() if a0 == "git"]
+    assert spawns, "no git spawn found at all — this guard is inert"
+    assert all(lo <= ln <= hi for ln in spawns), (spawns, lo, hi)
+    # POSITIVE CONTROL: the detector CAN see a git spawn outside the helper —
+    # otherwise `all(...)` over a set it never populates is a vacuous green.
+    outside = [ln for ln, a0 in _spawn_argv0(
+        'import subprocess\nsubprocess.run(["git", "push"])\n') if a0 == "git"]
+    assert outside == [2], outside
+
+
+def test_the_gh_invocations_are_an_ENUMERATED_set_not_an_ABSENCE_of_POST():
+    """🔴 THE `gh` HALF HAD NO STRUCTURAL PIN AT ALL. The git half has an AST
+    allowlist; the write path was held by `"POST" not in <receipt line>`, which
+    `-X PATCH`, `-X PUT`, `--method DELETE` and `gh pr comment` all satisfy.
+    This asserts the STATE — the set of `gh` verbs the source can reach — rather
+    than the absence of a word another verb can avoid spelling."""
+    shapes = _gh_argv_shapes()
+    assert shapes, "the gh scan found no invocations — this guard is inert"
+    assert set(shapes) == EXPECTED_GH_ARGV, shapes
+    # …and exactly ONE of them is the write, so arming is a single site.
+    assert sum(1 for s in shapes if s == ("api", "-X", "POST")) == 1, shapes
+    # POSITIVE CONTROL on the scan: it CAN see a shape that is not in the
+    # ledger, so the equality above is not a comparison against nothing.
+    assert _gh_argv_shapes(
+        'import subprocess\ngh = "gh"\n'
+        'subprocess.run([gh, "api", "-X", "PATCH", "/repos/o/r/x"])\n'
+    ) == [("api", "-X", "PATCH")]
 
 
 def test_the_deleted_flags_are_GONE_from_the_parser_not_merely_undocumented():

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -907,7 +907,7 @@ def test_a_head_that_is_not_in_the_local_clone_is_UNMEASURED(repo):
     got = M.triage_pr(repo.path, "main", meta, pr_row(
         "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL failed=1"))
     assert got["verdict"] == M.VERDICT_UNMEASURED
-    assert "--fetch" in got["reason"]
+    assert "git fetch origin" in got["reason"]
 
 
 def test_a_head_with_NO_pytests_row_is_UNMEASURED_never_green(repo):
@@ -1048,21 +1048,6 @@ def test_the_HINT_is_printed_when_only_SOME_of_the_red_is_inherited(harness, rep
     assert M.VERDICT_UNMEASURED in proc.stdout
     assert "HINT: at least one named failure IS inherited" in proc.stdout
     assert "commits behind main" in proc.stdout
-
-
-def test_json_mode_emits_the_same_verdict_as_the_rendered_run(harness, repo):
-    harness.serve_default(repo)
-    proc = harness.run(repo, "--pr", "7", "--json")
-    assert proc.returncode == RC_INHERITED, proc.stdout
-    # 🔴 THE WHOLE OF STDOUT, parsed in one go — not a slice. A payload that is
-    # only parseable after a human picks the object out of surrounding prose is
-    # not machine-readable, and the failure lands in the CALLER's parser.
-    payload = json.loads(proc.stdout)
-    assert payload["results"][0]["verdict"] == M.VERDICT_INHERITED
-    assert payload["comment_mode"] == "off"
-    # …and the human lines still exist, on stderr.
-    assert "mode=off" in proc.stderr
-    assert payload["results"][0]["tests"][0]["candidates"][0]["sha"] == repo.fix
 
 
 def test_help_prints_the_env_ledger_rather_than_a_truncated_header(harness, repo):
@@ -1299,11 +1284,70 @@ def test_every_test_this_script_names_actually_exists():
     assert cited <= here, f"dangling citations: {sorted(cited - here)}"
 
 
-def test_only_refs_under_its_own_namespace_are_ever_written():
-    """🔴 `refs/` LIVES IN THE COMMON GIT DIR — a worktree gives zero isolation,
-    so a fetch refspec that landed on `refs/remotes/origin/main` or a branch
-    would reach into a concurrent session's work."""
-    dests = re.findall(r'\+refs/[^:"]+:([^"\s]+)', SRC)
-    assert dests, "the refspec scan matched nothing — this guard is inert"
-    for d in dests:
-        assert d.startswith("{NS}/") or d.startswith("refs/stale-base-triage/"), d
+def test_no_git_subcommand_that_WRITES_is_ever_invoked():
+    """🔴 "IT WRITES NOTHING" IS THIS TOOL'S SAFETY CLAIM, SO IT IS PINNED
+    ABSOLUTELY RATHER THAN RELATIVELY.
+
+    This guard replaces one that said "every ref it writes is namespaced under
+    `refs/stale-base-triage/*`" — true, and a weaker claim than the one the tool
+    makes, because `refs/` lives in the COMMON git dir: a worktree gives zero
+    isolation there, so ANY ref write reaches a concurrent session's repo. The
+    `--fetch` flag that made those writes was deleted for buying nothing here
+    (this repo's PRs are same-repo branches and `origin` fetches
+    `+refs/heads/*`, so an ordinary `git fetch origin` already has every head),
+    which lets the claim be pinned at zero.
+
+    🔴 AN ALLOWLIST, NOT A DENYLIST — a git subcommand nobody enumerated is a
+    write by default. A denylist of known writers passes silently the day
+    someone reaches for one it does not name.
+    """
+    subs = _git_subcommands()
+    assert subs, "the AST scan found no git invocations — this guard is inert"
+    read_only = {"rev-parse", "cat-file", "grep", "log", "merge-base", "rev-list"}
+    for a in subs:
+        if a[0] == "remote":
+            # `remote` has writing forms (`add`, `set-url`, `remove`); only the
+            # reading one is permitted, and it is checked by its ARGUMENT.
+            assert a[:2] == ["remote", "get-url"], a
+            continue
+        assert a[0] in read_only, f"`git {a[0]}` is not an enumerated read: {a}"
+    # POSITIVE CONTROL on the scan: it really does see the arguments, so the
+    # allowlist above is not passing over an empty or opaque list.
+    assert any(a[:2] == ["merge-base", "--is-ancestor"] for a in subs), subs
+    assert any(a[0] == "remote" for a in subs), subs
+
+
+def test_the_deleted_flags_are_GONE_from_the_parser_not_merely_undocumented():
+    """A flag left in the parser is a flag someone can still reach. Both
+    deletions are pinned at the source so a revert has to be deliberate.
+
+    `--fetch` was the only git WRITE in a tool whose stated safety property is
+    that it writes nothing; `--json` had no consumer anywhere in the repo.
+    `--sweep` is deliberately NOT in this list — it is the mode the derived
+    completeness route made useful.
+
+    🔴 STRUCTURAL, NOT SPELLED. A first version of this guard was a string scan
+    over the whole file and it failed on the HEADER PARAGRAPH THAT EXPLAINS THE
+    DELETION — the same trap `_git_subcommands` is AST-based to avoid. The AST
+    sees declarations and string constants; prose satisfies neither.
+    """
+    tree = ast.parse(SRC)
+    flags = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add_argument"):
+            flags |= {a.value for a in node.args
+                      if isinstance(a, ast.Constant) and isinstance(a.value, str)}
+    assert flags, "the add_argument scan matched nothing — this guard is inert"
+    assert "--sweep" in flags, "--sweep was kept on purpose; see the header"
+    for gone in ("--fetch", "--json"):
+        assert gone not in flags, f"{gone} is still reachable in the parser"
+    # …and neither leaves a stub behind: no module-level `_JSON_MODE`, and no
+    # STRING CONSTANT naming the ref namespace `--fetch` used to write.
+    assigned = {t.id for n in ast.walk(tree) if isinstance(n, ast.Assign)
+                for t in n.targets if isinstance(t, ast.Name)}
+    assert "_JSON_MODE" not in assigned, assigned
+    consts = [n.value for n in ast.walk(tree)
+              if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+    assert not [c for c in consts if "refs/stale-base-triage" in c], (
+        "a ref-namespace literal survived the deletion of --fetch")

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -1,0 +1,950 @@
+"""`scripts/stale-base-triage.py` — is a PR's red inherited from a stale base?
+
+WHY THIS FILE EXISTS. Half the genuine `tekton/devrc-pytests` failures measured
+in the post-#1458 window were one already-fixed test re-reported by PRs 17-40
+commits behind `main`. The script under test assembles the deterministic
+evidence for that — blob OIDs and commit lists, no test execution — and these
+tests are what say the evidence is real.
+
+🔴 WHAT THESE TESTS ARE, HONESTLY LABELLED.
+
+  * CONTROLS first, because every assertion below is a reassuring green if the
+    harness cannot reach the script, cannot see a write, or can only ever
+    produce one verdict.
+  * PURE-FUNCTION CONTRACTS on the parsers and the classifier, driven directly,
+    because the end-to-end path folds several of their distinctions away and
+    cannot see them (a truncated name and a missing count both arrive at the
+    caller as "COULD NOT MEASURE").
+  * EVIDENCE CONTRACTS driven against a REAL temporary git repository. Nothing
+    about git is mocked here: the blob OIDs, the merge-base and the commit lists
+    are git's own answers about a tree this file builds. A mocked git would have
+    made the `git diff --quiet` and squash-ancestry traps untestable, which is
+    the whole reason they are the traps they are.
+  * WRITE-PATH guards, including the pinned `"off"` literal. The script is a
+    reporter; arming it must cost a visible line in a diff.
+  * STATIC guards pinning relationships no behavioural test can see — that the
+    roll-up endpoint is never requested, that the env-knob ledger is two-way,
+    and that every test the script cites by name exists.
+
+🔴 NO REAL GITHUB CALL IS MADE ANYWHERE IN THIS FILE. Every test points
+`STALE_BASE_TRIAGE_GH` at a stub that serves canned JSON from tmp_path and
+records its argv, so a POST in a test is a line in a receipt file and never a
+comment on anybody's PR.
+"""
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+SCRIPT = ROOT / "scripts" / "stale-base-triage.py"
+SRC_SCRIPT = SCRIPT.read_text(encoding="utf-8")
+
+RC_OK, RC_INHERITED, RC_UNMEASURED, RC_USAGE = 0, 10, 11, 2
+
+
+def _load():
+    """Import the script as a module so pure functions can be driven directly."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("sbt", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+M = _load()
+
+
+# ══ the fixture repository ════════════════════════════════════════════════════
+# 🔴 FIELD VALUES ARE PAIRWISE DISTINCT, AND DISTINCT FROM ANY CONSTANT THE
+# ASSERTIONS NAME. A fixture whose two files, two test names and two commit
+# subjects collide cannot see a mutant that hardcodes one of them — it survives
+# a fully green suite. So: two differently-named files, four differently-named
+# tests, and commit subjects that share no word.
+
+class Repo:
+    def __init__(self, path):
+        self.path = path
+        self.hooks = path.parent / "nohooks"
+        self.hooks.mkdir(parents=True, exist_ok=True)
+
+    def git(self, *args, check=True):
+        proc = subprocess.run(
+            ["git", "-C", str(self.path),
+             "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+             "-c", "commit.gpgsign=false", "-c", f"core.hooksPath={self.hooks}",
+             *args],
+            capture_output=True, text=True, timeout=60)
+        if check and proc.returncode != 0:
+            raise AssertionError(f"git {args}: {proc.stderr}")
+        return proc
+
+    def write(self, rel, body):
+        p = self.path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return rel
+
+    def commit(self, rel, subject):
+        self.git("add", "--", rel)
+        self.git("commit", "-m", subject)
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def sha(self, ref):
+        return self.git("rev-parse", ref).stdout.strip()
+
+
+ALPHA = "scripts/tests/test_alpha_module.py"
+BRAVO = "scripts/tests/test_bravo_module.py"
+
+ALPHA_V0 = (
+    "def test_the_alpha_invariant_holds():\n    assert 0\n\n\n"
+    "class TestTheAlphaSuite:\n"
+    "    def test_the_shared_method_name(self):\n        assert 0\n"
+)
+ALPHA_V1 = (
+    "def test_the_alpha_invariant_holds():\n    assert 1\n\n\n"
+    "class TestTheAlphaSuite:\n"
+    "    def test_the_shared_method_name(self):\n        assert 1\n"
+)
+ALPHA_V2 = (
+    "def test_the_alpha_invariant_holds():\n    assert 2\n\n\n"
+    "class TestTheAlphaSuite:\n"
+    "    def test_the_shared_method_name(self):\n        assert 2\n"
+)
+BRAVO_V1 = (
+    "def test_the_bravo_invariant_holds():\n    assert 1\n\n\n"
+    "def test_the_bravo_invariant_holds_under_load():\n    assert 1\n\n\n"
+    "class TestTheBravoSuite:\n"
+    "    def test_the_shared_method_name(self):\n        assert 1\n"
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """main and pr diverge at C0; main then FIXES the alpha file.
+
+        S ── C0(main: rewrite ALPHA) ── C1(main: rewrite ALPHA)   <- main
+                     └── P1(pr: rewrite BRAVO)                    <- pr
+
+    So `test_the_alpha_invariant_holds` is the INHERITED case (main moved its
+    file, the PR did not) and `test_the_bravo_invariant_holds` is the
+    NOT-EXPLAINED case (the PR's own change owns that file).
+
+    S exists so that a test can pass an OLDER merge-base on purpose and get a
+    candidate that IS already in the head — the case the `not in_head` filter
+    is for, and the one a single-merge-base history cannot otherwise produce.
+    """
+    r = Repo(tmp_path / "fixture")
+    r.path.mkdir(parents=True)
+    r.git("init", "-b", "main", "--quiet")
+    r.write(ALPHA, ALPHA_V0)
+    r.write(BRAVO, BRAVO_V1)
+    r.git("add", "--", ALPHA, BRAVO)
+    r.git("commit", "-m", "seed both modules")
+    r.seed = r.sha("HEAD")
+    r.write(ALPHA, ALPHA_V1)
+    r.pre = r.commit(ALPHA, "settle alpha before the branch point")
+    r.merge_base = r.sha("HEAD")
+    r.git("checkout", "--quiet", "-b", "pr")
+    r.write(BRAVO, BRAVO_V1.replace("assert 1", "assert 3"))
+    r.pr_head = r.commit(BRAVO, "the branch rewrites bravo")
+    r.git("checkout", "--quiet", "main")
+    r.write(ALPHA, ALPHA_V2)
+    r.fix = r.commit(ALPHA, "repair the alpha invariant on trunk")
+    return r
+
+
+def triage(r, name, main_ref="main", head_ref="pr"):
+    return M.triage_one_test(r.path, main_ref, head_ref, r.merge_base, name)
+
+
+# ══ CONTROLS ══════════════════════════════════════════════════════════════════
+
+def test_CONTROL_the_evidence_path_can_produce_ALL_THREE_verdicts(repo):
+    """🔴 THE FIRST THING TO DOUBT IS AN INSTRUMENT WITH ONE ANSWER.
+
+    Every assertion below reads as meaningful only if the function can actually
+    reach each arm. Three fixtures, three distinct verdicts, one assertion.
+    """
+    got = {
+        triage(repo, "test_the_alpha_invariant_holds")["verdict"],
+        triage(repo, "test_the_bravo_invariant_holds")["verdict"],
+        triage(repo, "test_a_name_no_file_in_this_tree_defines")["verdict"],
+    }
+    assert got == {M.VERDICT_INHERITED, M.VERDICT_NOT_STALE, M.VERDICT_UNMEASURED}
+
+
+def test_CONTROL_the_gh_stub_is_reached_and_its_argv_is_recorded(harness, repo):
+    """A write-path test that never reaches the stub proves nothing about
+    writes. This pins that the receipt file CAN move."""
+    harness.serve_default(repo)
+    before = harness.calls()
+    proc = harness.run(repo, "--pr", "7")
+    after = harness.calls()
+    assert len(after) > len(before), proc.stdout
+    assert any("/repos/o/r/pulls/7" in c for c in after), after
+
+
+# ══ PURE: status classification ═══════════════════════════════════════════════
+
+def test_classify_maps_a_row_to_its_documented_class():
+    """🔴 ONLY `failure` IS RED. Every broken-gate outcome arrives as `error`
+    and each keeps its own name, because the caller folds them together and an
+    end-to-end test can therefore only ever see "not a verdict"."""
+    assert M.classify("success", "TOTAL collected=1") == "green"
+    assert M.classify("failure", "FAILED: pytests") == "red"
+    assert M.classify("pending", "devrc gate running") == "pending"
+    assert M.classify("error", "superseded by a newer run") == "superseded"
+    assert M.classify("error", "KILLED: the gate pod died") == "killed"
+    assert M.classify("error", "NO GATE POD") == "no-gate-pod"
+    assert M.classify("error", "clone rc 128") == "error-other"
+    # 🔴 A state GitHub adds tomorrow must not fold into green.
+    assert M.classify("queued", "") == "error-other"
+    assert M.classify(None, None) == "error-other"
+
+
+def test_newest_per_context_is_order_independent():
+    """🔴 THE TRAP THIS EXISTS FOR: GitHub returns the array NEWEST-FIRST, so a
+    last-wins dict yields the OLDEST post per context — an agent shipped that
+    and reported a known-green head as `pending`. Folding on max(created_at) is
+    right under either order, so both orders are fed here and pinned to agree.
+    """
+    old = {"context": "tekton/devrc-pytests", "state": "pending",
+           "created_at": "2026-09-11T10:00:00Z", "description": "running"}
+    new = {"context": "tekton/devrc-pytests", "state": "failure",
+           "created_at": "2026-09-11T17:00:00Z", "description": "FAILED"}
+    for order in ([new, old], [old, new]):
+        got = M.newest_per_context(order)["tekton/devrc-pytests"]
+        assert got["state"] == "failure", order
+    # A second context is kept independently, not overwritten by the first.
+    both = M.newest_per_context([new, old, {"context": "tekton/devrc-nodetests",
+                                            "state": "success",
+                                            "created_at": "2026-09-11T17:00:00Z"}])
+    assert set(both) == {"tekton/devrc-pytests", "tekton/devrc-nodetests"}
+
+
+# ══ PURE: description parsing ═════════════════════════════════════════════════
+# REAL descriptions, copied from statuses THIS repo posted about its OWN tests.
+# No third-party text, no hostnames, no captured content — and they are here
+# because every synthetic description anybody writes by hand is conveniently
+# complete, so the truncation hazard is only demonstrable with real ones.
+REAL_ONE_NAMED_COMPLETE = (
+    "FAILED: pytests — FAILING: test_no_test_writes_a_usr_bin_env_shebang_at_runtime"
+    " | TOTAL collected=22100  passed=22097  skipped=2  failed=1")
+REAL_CUT_BEFORE_THE_COUNT = (
+    "FAILED: pytests — FAILING: test_each_ledgered_site_still_QUOTES_the_figure_"
+    "rather_than_ASSERTING_it | TOTAL collected=22148  passed=22145 ")
+REAL_FIVE_FAILED_ONE_NAMED = (
+    "FAILED: pytests — FAILING: test_agent_without_any_tab_is_untouched | TOTAL "
+    "collected=21036  passed=21028  skipped=3  failed=5  (floor: 184")
+REAL_NO_NAMES_AT_ALL = (
+    "FAILED: pytests — TOTAL collected=15464  passed=15461  skipped=2  failed=1"
+    "  (floor: 13732 = sum of 27 per-target floors)")
+REAL_CUT_MID_NAME = (
+    "FAILED: pytests — FAILING: TestARefusedWriteIsIndistinguishableFromAnAbsentOne"
+    ".test_POSITIVE_CONTROL_the_APPEND_comparison_CAN_see_the_dif")
+
+
+def test_parse_failing_names_reads_the_names_and_stops_at_TOTAL():
+    assert M.parse_failing_names(REAL_ONE_NAMED_COMPLETE) == [
+        "test_no_test_writes_a_usr_bin_env_shebang_at_runtime"]
+    assert M.parse_failing_names(REAL_NO_NAMES_AT_ALL) == []
+    assert M.parse_failing_names(
+        "FAILED: pytests — FAILING: test_one | test_two | TOTAL collected=3") == [
+        "test_one", "test_two"]
+
+
+def test_a_trailing_TOTAL_fragment_is_not_a_test_name():
+    """🔴 A 140-CHAR CUT LANDING INSIDE ` | TOTAL` LEAVES A FRAGMENT WHERE A NAME
+    WOULD BE. Left in, it resolves to no file and the PR is reported as a real
+    red on the strength of a truncation artefact — the exact false negative this
+    tool must not produce. Only the four proper prefixes of TOTAL are stripped,
+    and only in final position: every test in this repo begins `test_` or
+    `Test`, none of which is a prefix of `TOTAL`, so a real name cannot be eaten.
+    """
+    for frag in ("T", "TO", "TOT", "TOTA"):
+        assert M.parse_failing_names(f"FAILING: test_real_name | {frag}") == [
+            "test_real_name"], frag
+    # NOT stripped: a real name, and a fragment that is not in final position.
+    assert M.parse_failing_names("FAILING: TestTheThing") == ["TestTheThing"]
+    assert M.parse_failing_names("FAILING: TOT | test_real_name") == [
+        "TOT", "test_real_name"]
+
+
+def test_names_are_provably_complete_only_when_the_count_agrees():
+    """🔴 THE GUARD THAT STOPS A REAL RED BEING DISMISSED. A description can
+    prove "at least one test failed and here is its name"; it can never prove
+    "these are all of them" unless `failed=N` survived the cap AND equals the
+    number of names. All three failure shapes below are REAL rows."""
+    ok, why = M.names_provably_complete(REAL_ONE_NAMED_COMPLETE)
+    assert ok and "failed=1" in why
+    for desc, fragment in ((REAL_CUT_BEFORE_THE_COUNT, "truncated"),
+                           (REAL_FIVE_FAILED_ONE_NAMED, "failed=5"),
+                           (REAL_NO_NAMES_AT_ALL, "names no failing test")):
+        ok, why = M.names_provably_complete(desc)
+        assert not ok, desc
+        assert fragment in why, (desc, why)
+
+
+def test_normalise_test_name_handles_all_three_real_shapes():
+    assert M.normalise_test_name("test_plain") == (None, "test_plain")
+    assert M.normalise_test_name("TestSuite.test_method") == (
+        "TestSuite", "test_method")
+    # 🔴 The brackets come off BEFORE the class split: a parametrise id can
+    # itself contain a dot and would otherwise be read as the class name.
+    assert M.normalise_test_name("test_x[record0-a.b]") == (None, "test_x")
+    assert M.normalise_test_name("TestS.test_y[1517-1024]") == ("TestS", "test_y")
+
+
+# ══ EVIDENCE: the mapping from a test name to its file ════════════════════════
+
+def test_a_name_resolves_to_the_one_file_that_defines_it(repo):
+    got = M.resolve_test_file(repo.path, "pr", "test_the_alpha_invariant_holds")
+    assert got["status"] == "ok"
+    assert got["file"] == ALPHA
+    assert got["truncated_name"] is False
+
+
+def test_an_unknown_name_is_NOT_FOUND_and_never_a_silent_guess(repo):
+    got = M.resolve_test_file(repo.path, "pr", "test_this_name_exists_nowhere")
+    assert got["status"] == "not-found"
+    assert "test_this_name_exists_nowhere" in got["reason"]
+
+
+def test_a_name_defined_in_two_files_is_AMBIGUOUS(repo):
+    """Naming a fix commit off a coin-flip mapping is worse than saying nothing:
+    both fixtures define `test_the_shared_method_name`, in different files."""
+    got = M.resolve_test_file(repo.path, "pr", "test_the_shared_method_name")
+    assert got["status"] == "ambiguous"
+    assert sorted(got["files"]) == sorted([ALPHA, BRAVO])
+
+
+def test_a_class_qualified_name_narrows_an_otherwise_ambiguous_method(repo):
+    """The class is a second, independent discriminator, and it only ever
+    NARROWS — the same method name lives in both fixture files."""
+    got = M.resolve_test_file(repo.path, "pr",
+                              "TestTheBravoSuite.test_the_shared_method_name")
+    assert got["status"] == "ok"
+    assert got["file"] == BRAVO
+
+
+def test_a_name_TRUNCATED_by_the_140_char_cap_still_resolves(repo):
+    """🔴 REAL: a status row ended `…_CAN_see_the_dif`, mid-word. Phase 2 drops
+    the opening paren so a prefix can match — and runs ONLY when phase 1 found
+    nothing, which is why the next test exists."""
+    got = M.resolve_test_file(repo.path, "pr", "test_the_alpha_invariant_ho")
+    assert got["status"] == "ok"
+    assert got["file"] == ALPHA
+    assert got["truncated_name"] is True
+
+
+def test_a_COMPLETE_name_is_not_made_ambiguous_by_a_longer_sibling(repo):
+    """🔴 THE ORDER OF THE TWO PHASES IS THE GUARD. `test_the_bravo_invariant_
+    holds` is a strict prefix of `test_the_bravo_invariant_holds_under_load`.
+    Phase 1 requires the opening paren, so the exact name wins outright; running
+    the prefix phase unconditionally would report a false ambiguity for every
+    short name in the repo."""
+    got = M.resolve_test_file(repo.path, "pr", "test_the_bravo_invariant_holds")
+    assert got["status"] == "ok"
+    assert got["truncated_name"] is False
+
+
+# ══ EVIDENCE: the verdict and its two halves ══════════════════════════════════
+
+def test_an_INHERITED_red_names_the_commit_that_already_fixed_it(repo):
+    """The whole point of the tool, end to end through the evidence path."""
+    got = triage(repo, "test_the_alpha_invariant_holds")
+    assert got["verdict"] == M.VERDICT_INHERITED
+    assert got["file"] == ALPHA
+    shas = [c["sha"] for c in got["candidates"]]
+    assert shas == [repo.fix]
+    # 🔴 BOTH HALVES OF THE EVIDENCE PAIR, ASSERTED SEPARATELY.
+    assert got["candidates"][0]["on_main"] is True
+    assert got["candidates"][0]["in_head"] is False
+    assert got["candidates"][0]["subject"] == "repair the alpha invariant on trunk"
+    # …and the CONTENT half: the head's copy never moved, main's did.
+    assert got["blob_head"] == got["blob_merge_base"]
+    assert got["blob_main"] != got["blob_merge_base"]
+
+
+def test_a_test_whose_file_THIS_PR_MODIFIES_is_not_blamed_on_staleness(repo):
+    """🔴 THE DISCRIMINATOR THAT KEEPS THE TOOL HONEST. If the PR's own diff
+    contains the failing test's file, staleness does not explain the failure
+    whatever main has been doing — and this is the case a mapping-only tool
+    would happily call INHERITED."""
+    got = triage(repo, "test_the_bravo_invariant_holds")
+    assert got["verdict"] == M.VERDICT_NOT_STALE
+    assert "the PR itself modifies" in got["reason"]
+    assert got["blob_head"] != got["blob_merge_base"]
+
+
+def test_a_file_UNCHANGED_on_main_is_a_real_red_and_says_so(repo):
+    """main cannot have fixed a file it has not touched. Driven by moving the
+    main ref back to the merge-base, so main and the head agree exactly."""
+    got = triage(repo, "test_the_alpha_invariant_holds", main_ref=repo.merge_base)
+    assert got["verdict"] == M.VERDICT_NOT_STALE
+    assert "unchanged on main" in got["reason"]
+    assert "real red" in got["reason"]
+
+
+def test_a_file_ABSENT_on_one_side_is_UNMEASURED_not_SAME(repo):
+    """🔴 `git diff --quiet <ref> -- <path>` EXITS 0 WHEN THE PATH EXISTS ON
+    NEITHER SIDE — a comparison against an absent operand reports SAME, not
+    MISSING. Here the test is DELETED on main, which is exactly the shape (a
+    rename) that would otherwise read as "unchanged, therefore a real red"."""
+    repo.git("rm", "--quiet", "--", ALPHA)
+    repo.git("commit", "-m", "retire the alpha module entirely")
+    got = triage(repo, "test_the_alpha_invariant_holds")
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert "does not exist at main" in got["reason"]
+
+
+def test_path_existence_is_proved_directly(repo):
+    """The primitive the test above rests on, driven on its own: it must
+    distinguish present from absent, and a ref where the file never existed."""
+    assert M.path_exists_at(repo.path, "main", ALPHA) is True
+    assert M.path_exists_at(repo.path, "main", "scripts/tests/test_nothing.py") is False
+
+
+def test_a_candidate_ALREADY_IN_THE_HEAD_is_excluded(repo):
+    """🔴 THE HALF OF THE EVIDENCE PAIR THAT IS ACTUALLY A FILTER, driven with
+    an older merge-base so a candidate in the range IS in the head.
+
+    Measured: with the real merge-base, dropping `not in_head` from the
+    condition SURVIVED the whole suite, because `merge-base..main` cannot
+    contain a head ancestor when there is exactly ONE merge-base. `git
+    merge-base` returns one base and a criss-cross history has several, so the
+    case is real — and this is how it is made reachable.
+    """
+    # The candidate list is git's own answer over a range that STRADDLES the
+    # branch point, so it genuinely contains a commit the head already has.
+    raw = M.commits_touching(repo.path, repo.seed, "main", ALPHA)
+    assert sorted(c["sha"] for c in raw) == sorted([repo.fix, repo.pre]), raw
+    proven = M.prove_candidates(repo.path, raw, "main", "pr")
+    assert [c["sha"] for c in proven] == [repo.fix]
+    # POSITIVE CONTROL on the filter: the excluded commit was excluded for the
+    # stated reason, and it did satisfy the OTHER half.
+    excluded = [c for c in raw if c["sha"] == repo.pre][0]
+    assert excluded["in_head"] is True
+    assert excluded["on_main"] is True
+
+
+def test_the_on_main_half_is_measured_and_reported_even_though_it_cannot_gate(repo):
+    """`on_main` is TRUE BY CONSTRUCTION — `commits_touching` walks
+    `merge-base..main`. It is printed so a reader can verify the claim rather
+    than trust it, and deliberately NOT part of the filter: a guard that can
+    never run reads as coverage and stops anyone looking."""
+    got = triage(repo, "test_the_alpha_invariant_holds")
+    assert all(c["on_main"] is True for c in got["candidates"])
+    assert "if on_main and not" not in SRC_SCRIPT
+    # 🔴 AND IT IS MEASURED, NOT ASSUMED. Fed a commit that is genuinely NOT on
+    # main — the PR's own head — it must say so; without this the field could
+    # be hardcoded True and every test above would still pass.
+    fabricated = [{"sha": repo.pr_head, "subject": "a commit main never took"}]
+    M.prove_candidates(repo.path, fabricated, "main", "pr")
+    assert fabricated[0]["on_main"] is False
+    assert fabricated[0]["in_head"] is True
+
+
+def test_is_ancestor_answers_about_the_head_and_nothing_else(repo):
+    """🔴 ANCESTRY IS ASKED ABOUT ONE COMMIT AND ONE HEAD, NEVER "DID THIS
+    MERGE?" — this repo squashes, and a squash NEVER makes a branch head an
+    ancestor of its base, so the merged reading is a permanent confident FALSE.
+    What is pinned here is the question the script actually asks."""
+    assert M.is_ancestor(repo.path, repo.fix, "main") is True
+    assert M.is_ancestor(repo.path, repo.fix, "pr") is False
+    assert M.is_ancestor(repo.path, repo.merge_base, "pr") is True
+
+
+# ══ PR-LEVEL FOLDING ══════════════════════════════════════════════════════════
+
+def pr_row(desc, state="failure"):
+    return {"context": M.CONTEXT, "state": state, "description": desc,
+            "created_at": "2026-09-11T17:00:00Z"}
+
+
+def pr_meta(repo):
+    return {"number": 7, "title": "a fixture pull request",
+            "head_sha": repo.pr_head, "url": "https://example.invalid/7"}
+
+
+def test_a_PR_whose_only_named_failure_is_inherited_AND_complete_is_INHERITED(repo):
+    got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+        "collected=9  passed=8  skipped=0  failed=1"))
+    assert got["verdict"] == M.VERDICT_INHERITED
+    assert got["behind"] == 1
+    assert got["complete"] is True
+
+
+def test_ONE_unexplained_name_makes_the_WHOLE_PR_a_real_red(repo):
+    """🔴 CONSERVATIVE BY CONSTRUCTION, and this is the mutant that matters: a
+    fold that reported INHERITED when ANY name was explained would dismiss a PR
+    whose own change is broken. Two names, one of each kind."""
+    got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | "
+        "test_the_bravo_invariant_holds | TOTAL collected=9  failed=2"))
+    assert got["verdict"] == M.VERDICT_NOT_STALE
+    assert "test_the_bravo_invariant_holds" in got["reason"]
+    assert got["any_explained"] is True          # …and the hint still fires
+
+
+def test_an_inherited_name_on_a_TRUNCATED_row_is_UNMEASURED_not_INHERITED(repo):
+    """🔴 THE COMPLETENESS GUARD AT PR LEVEL. Every NAMED failure is inherited,
+    but the count did not survive the 140-char cap, so other failures may remain
+    and the PR must not be dismissed. The per-test line still says what it
+    found, which is the useful half."""
+    got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+        "collected=9  passed=8 "))
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert "truncated" in got["reason"]
+    assert got["any_explained"] is True
+    assert got["tests"][0]["verdict"] == M.VERDICT_INHERITED
+
+
+def test_a_count_that_EXCEEDS_the_names_is_UNMEASURED(repo):
+    """The real `failed=5 … one named` shape."""
+    got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+        "collected=9  passed=4  skipped=0  failed=5"))
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert "failed=5" in got["reason"]
+
+
+def test_a_GREEN_or_PENDING_head_is_not_a_verdict_at_all(repo):
+    for state, desc in (("success", "TOTAL collected=9  failed=0"),
+                        ("pending", "devrc gate running")):
+        got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(desc, state))
+        assert got["verdict"] is None, state
+        assert "tests" not in got
+
+
+def test_an_ERROR_row_is_reported_as_a_broken_gate_and_never_as_red(repo):
+    """🔴 `error` IS NOT `failure`. Every non-code outcome arrives as `error`,
+    and over 200 measured rows the roll-up endpoint's conflation turned 9 real
+    failures into 48 red-looking pushes."""
+    for desc, klass in (("superseded by a newer run", "superseded"),
+                        ("KILLED: the gate pod died", "killed"),
+                        ("NO GATE POD", "no-gate-pod"),
+                        ("COULD NOT RUN: pytests", "error-other")):
+        got = M.triage_pr(repo.path, "main", pr_meta(repo), pr_row(desc, "error"))
+        assert got["class"] == klass, desc
+        assert got["verdict"] is None, desc
+
+
+def test_a_head_that_is_not_in_the_local_clone_is_UNMEASURED(repo):
+    meta = dict(pr_meta(repo), head_sha="0" * 40)
+    got = M.triage_pr(repo.path, "main", meta, pr_row(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL failed=1"))
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert "--fetch" in got["reason"]
+
+
+def test_a_head_with_NO_pytests_row_is_UNMEASURED_never_green(repo):
+    got = M.triage_pr(repo.path, "main", pr_meta(repo), None)
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert got["state"] == "none"
+
+
+# ══ END TO END, and the write path ════════════════════════════════════════════
+
+class Harness:
+    def __init__(self, tmp_path):
+        self.tmp = tmp_path
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir(parents=True, exist_ok=True)
+        self.responses = tmp_path / "responses"
+        self.responses.mkdir(parents=True, exist_ok=True)
+        self.receipt = tmp_path / "gh-calls"
+        self.gh = self.bin / "fake-gh"
+        # Records EVERY argv, then answers on the first argument that looks like
+        # an API path. `-X POST` therefore lands in the receipt exactly like a
+        # read does — which is what makes "no write happened" observable.
+        write_exec(self.gh,
+                   f'printf "%s\\n" "$*" >> "{self.receipt}"\n'
+                   'p=""\n'
+                   'for a in "$@"; do case "$a" in /*) p="$a"; break;; esac; done\n'
+                   f'f=$(printf "%s" "$p" | tr "/?&=" "____")\n'
+                   f'if [ -f "{self.responses}/$f" ]; then cat "{self.responses}/$f"; exit 0; fi\n'
+                   'echo "no canned response for $p" >&2; exit 22\n')
+
+    def serve(self, path, payload):
+        name = "".join("_" if c in "/?&=" else c for c in path)
+        (self.responses / name).write_text(json.dumps(payload), encoding="utf-8")
+
+    def serve_default(self, repo, desc=None, state="failure"):
+        self.serve("/repos/o/r/pulls/7",
+                   {"number": 7, "title": "a fixture pull request",
+                    "head": {"sha": repo.pr_head},
+                    "html_url": "https://example.invalid/7"})
+        self.serve(f"/repos/o/r/commits/{repo.pr_head}/statuses?per_page=100",
+                   [pr_row(desc or ("FAILED: pytests — FAILING: "
+                                    "test_the_alpha_invariant_holds | TOTAL "
+                                    "collected=9  passed=8  skipped=0  failed=1"),
+                           state)])
+        # Two keys, because the READ is paginated and the WRITE is not — and
+        # the stub keys on the literal path. Serving only one of them makes the
+        # write path's own failure look like a canned-response gap.
+        self.serve("/repos/o/r/issues/7/comments?per_page=100", [])
+        self.serve("/repos/o/r/issues/7/comments", {"id": 1})
+
+    def calls(self):
+        if not self.receipt.exists():
+            return []
+        return [c for c in self.receipt.read_text(encoding="utf-8").splitlines() if c]
+
+    def run(self, repo, *args, env=None):
+        e = dict(os.environ)
+        e.pop("STALE_BASE_TRIAGE_COMMENT_MODE", None)
+        e.update({"STALE_BASE_TRIAGE_GH": str(self.gh),
+                  "STALE_BASE_TRIAGE_REPO": "o/r"})
+        e.update(env or {})
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--repo-path", str(repo.path),
+             "--main-ref", "main", *args],
+            capture_output=True, text=True, timeout=180, env=e)
+
+
+@pytest.fixture
+def harness(tmp_path):
+    return Harness(tmp_path / "harness")
+
+
+def test_end_to_end_an_inherited_PR_exits_10_and_names_the_fix(harness, repo):
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_INHERITED, proc.stdout + proc.stderr
+    assert M.VERDICT_INHERITED in proc.stdout
+    assert repo.fix[:12] in proc.stdout
+    assert "repair the alpha invariant on trunk" in proc.stdout
+    assert ALPHA in proc.stdout
+
+
+def test_end_to_end_a_real_red_exits_0_and_is_not_dismissed(harness, repo):
+    harness.serve_default(repo, desc=(
+        "FAILED: pytests — FAILING: test_the_bravo_invariant_holds | TOTAL "
+        "collected=9  passed=8  skipped=0  failed=1"))
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_OK, proc.stdout
+    assert M.VERDICT_NOT_STALE in proc.stdout
+    assert M.VERDICT_INHERITED not in proc.stdout
+
+
+def test_the_summary_never_prints_a_bare_zero_for_an_empty_population(harness, repo):
+    """🔴 A ZERO MUST CARRY ITS POPULATION. `INHERITED: 0` beside `red: 0` is an
+    empty sample; beside `red: 7` it is seven examined reds. The summary prints
+    both counts and says so outright when there were no reds at all."""
+    harness.serve_default(repo, desc="TOTAL collected=9  failed=0", state="success")
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_OK, proc.stdout
+    assert "INHERITED:              0" in proc.stdout
+    assert "empty sample, not an all-clear" in proc.stdout
+
+
+def test_a_head_with_NO_status_row_never_prints_a_failure_line(harness, repo):
+    """🔴 REGRESSION, MEASURED IN THE FIRST LIVE SWEEP. An earlier draft folded
+    "no row" into the red arm and printed `failure   posted ?` directly above a
+    verdict reading "no status on this head" — a line asserting a red that was
+    never posted, on #359, #355, #612 and #646."""
+    harness.serve("/repos/o/r/pulls/7",
+                  {"number": 7, "title": "a fixture pull request",
+                   "head": {"sha": repo.pr_head}, "html_url": "https://x.invalid/7"})
+    harness.serve(f"/repos/o/r/commits/{repo.pr_head}/statuses?per_page=100", [])
+    proc = harness.run(repo, "--pr", "7")
+    assert "no status on this head" in proc.stdout
+    assert "failure" not in proc.stdout, proc.stdout
+    assert proc.returncode == RC_OK, proc.stdout
+
+
+def test_a_broken_gate_is_counted_on_its_OWN_summary_line(harness, repo):
+    """🔴 `error` IS NEVER FOLDED INTO THE RED TOTAL. Folding it in is the
+    roll-up mistake in a second spelling, and it is the difference between 9
+    real failures and 48 red-looking heads."""
+    harness.serve_default(repo, desc="superseded by a newer run", state="error")
+    proc = harness.run(repo, "--pr", "7")
+    assert "broken gate (`error`)" in proc.stdout
+    assert "NOT a code failure" in proc.stdout
+    assert "red (tekton/devrc-pytests):        0" in proc.stdout
+    assert proc.returncode == RC_OK, proc.stdout
+
+
+def test_the_HINT_is_printed_when_only_SOME_of_the_red_is_inherited(harness, repo):
+    """The useful half of a COULD NOT MEASURE: the operator still learns that a
+    rebase is worth trying before they start debugging."""
+    harness.serve_default(repo, desc=(
+        "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+        "collected=9  passed=8 "))
+    proc = harness.run(repo, "--pr", "7")
+    assert M.VERDICT_UNMEASURED in proc.stdout
+    assert "HINT: at least one named failure IS inherited" in proc.stdout
+    assert "commits behind main" in proc.stdout
+
+
+def test_json_mode_emits_the_same_verdict_as_the_rendered_run(harness, repo):
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7", "--json")
+    assert proc.returncode == RC_INHERITED, proc.stdout
+    # 🔴 THE WHOLE OF STDOUT, parsed in one go — not a slice. A payload that is
+    # only parseable after a human picks the object out of surrounding prose is
+    # not machine-readable, and the failure lands in the CALLER's parser.
+    payload = json.loads(proc.stdout)
+    assert payload["results"][0]["verdict"] == M.VERDICT_INHERITED
+    assert payload["comment_mode"] == "off"
+    # …and the human lines still exist, on stderr.
+    assert "mode=off" in proc.stderr
+    assert payload["results"][0]["tests"][0]["candidates"][0]["sha"] == repo.fix
+
+
+def test_help_prints_the_env_ledger_rather_than_a_truncated_header(harness, repo):
+    """The header is bounded by the docstring sentinel, not a line number: a
+    literal range silently truncates --help the moment the header grows."""
+    proc = harness.run(repo, "--help")
+    assert proc.returncode == RC_OK, proc.stdout
+    for knob in ("STALE_BASE_TRIAGE_GH", "STALE_BASE_TRIAGE_COMMENT_MODE"):
+        assert knob in proc.stdout, knob
+    assert "EXIT CODES" in proc.stdout
+
+
+def test_the_comment_mode_default_is_the_LITERAL_off():
+    """🔴 PINNED TO THE LITERAL, because "it reports only" is a SAFETY CLAIM
+    this script makes, not a default it inherits.
+
+    Asserting mere membership in ("off", "dry-run", "on") would let the
+    one-character edit that arms a bot commenting on every open PR pass
+    unnoticed. So when you DO arm it, change this literal in the arming commit —
+    that is the point, not an obstacle: the diff should say out loud that a
+    writer went live.
+    """
+    assert M.COMMENT_MODE_DEFAULT == "off"
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert 'COMMENT_MODE_DEFAULT = "off"' in src
+    # …and the resolver returns it with nothing set anywhere.
+    assert M.comment_mode(None) == "off"
+
+
+def test_an_unrecognised_comment_mode_FAILS_CLOSED(monkeypatch):
+    """A typo in the env var must disarm the writer, never arm it, and never
+    raise — this is read on the reporting path."""
+    for spelling in ("ON", "yes", "true", "1", "", "   ", "dry_run"):
+        monkeypatch.setenv("STALE_BASE_TRIAGE_COMMENT_MODE", spelling)
+        assert M.comment_mode(None) in ("off", "on"), spelling
+    monkeypatch.setenv("STALE_BASE_TRIAGE_COMMENT_MODE", "garbage")
+    assert M.comment_mode(None) == "off"
+    # The three legal spellings survive, so the guard is not simply "always off".
+    for legal in M.COMMENT_MODES:
+        monkeypatch.setenv("STALE_BASE_TRIAGE_COMMENT_MODE", legal)
+        assert M.comment_mode(None) == legal
+
+
+def test_the_DEFAULT_run_makes_no_write_api_call_at_all(harness, repo):
+    """🔴 THE NEGATIVE HALF. Its positive control is the very next test: without
+    one, "no POST in the receipt" is indistinguishable from a receipt nobody
+    writes to."""
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_INHERITED, proc.stdout
+    assert harness.calls(), "the stub was never reached — this test proves nothing"
+    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    assert "mode=off" in proc.stdout
+
+
+def test_POSITIVE_CONTROL_arming_it_DOES_reach_the_write_call(harness, repo):
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
+    assert proc.returncode == RC_INHERITED, proc.stdout + proc.stderr
+    posts = [c for c in harness.calls() if "POST" in c]
+    assert len(posts) == 1, harness.calls()
+    assert "/repos/o/r/issues/7/comments" in posts[0]
+    assert "posted on #7" in proc.stdout
+
+
+def test_DRY_RUN_says_what_it_would_do_and_writes_nothing(harness, repo):
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7", "--comment-mode", "dry-run")
+    assert "DRY-RUN would comment on #7" in proc.stdout
+    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+
+
+def test_an_already_commented_PR_is_not_commented_on_twice(harness, repo):
+    harness.serve_default(repo)
+    harness.serve("/repos/o/r/issues/7/comments?per_page=100",
+                  [{"body": f"{M.COMMENT_MARKER}\nsaid this yesterday"}])
+    proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
+    assert "already carries the marker" in proc.stdout
+    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+
+
+def test_a_NOT_INHERITED_PR_is_never_commented_on_even_when_armed(harness, repo):
+    harness.serve_default(repo, desc=(
+        "FAILED: pytests — FAILING: test_the_bravo_invariant_holds | TOTAL "
+        "collected=9  passed=8  skipped=0  failed=1"))
+    proc = harness.run(repo, "--pr", "7", "--comment-mode", "on")
+    assert not [c for c in harness.calls() if "POST" in c], harness.calls()
+    assert proc.returncode == RC_OK, proc.stdout
+
+
+def test_no_arguments_is_a_usage_error_not_an_empty_clean_run(harness, repo):
+    proc = harness.run(repo)
+    assert proc.returncode == RC_USAGE, proc.stdout
+    assert "usage:" in proc.stdout
+
+
+def test_a_gh_that_cannot_answer_is_UNMEASURED_not_clean(harness, repo):
+    proc = harness.run(repo, "--pr", "7")          # nothing served
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert M.VERDICT_UNMEASURED in proc.stdout
+
+
+def test_an_UNREADABLE_grep_is_an_error_not_a_reassuring_zero(repo):
+    """🔴 THE ZERO THAT IS NOT AN ANSWER. `git grep` exits 1 for "no matches"
+    and 128 for "that ref does not exist"; folding the second into the first
+    would report "no file defines this test" for every PR whose head the clone
+    has never seen. Measured: treating rc!=0 as `[]` SURVIVED the suite before
+    this test existed."""
+    with pytest.raises(M.Unmeasured):
+        M._grep_files(repo.path, "refs/heads/a-ref-that-was-never-created",
+                      r"^def test_")
+    # POSITIVE CONTROL: the same call against a real ref DOES return rows, so
+    # the raise above is about the bad ref and not about a broken invocation.
+    assert M._grep_files(repo.path, "main", r"^def test_the_alpha") == [ALPHA]
+
+
+def test_a_directory_that_is_not_a_checkout_is_UNMEASURED(tmp_path, monkeypatch, repo):
+    """🔴 THE MESSAGE IS ASSERTED, NOT JUST THE RAISE. `resolve_repo` has TWO
+    raise sites — a failed `git remote` and an unparseable URL — and a bare
+    `pytest.raises` is satisfied by either, so a mutant deleting the first
+    SURVIVED: the empty stdout simply fell through to the second. A test killed
+    by a different guard's error is green for the wrong reason.
+    """
+    monkeypatch.delenv("STALE_BASE_TRIAGE_REPO", raising=False)
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    with pytest.raises(M.Unmeasured, match="cannot read origin remote"):
+        M.resolve_repo(plain)
+    # POSITIVE CONTROL: with a real origin it RESOLVES, so the raise above is
+    # about the missing remote and not about this function never working.
+    repo.git("remote", "add", "origin", "git@example.invalid:owner/name.git")
+    assert M.resolve_repo(repo.path) == "owner/name"
+
+
+def test_the_API_budget_is_enforced_rather_than_merely_documented(harness, repo):
+    """A budget nothing consults is a comment. With zero seconds left the first
+    read must report COULD NOT MEASURE instead of running unbounded."""
+    harness.serve_default(repo)
+    proc = harness.run(repo, "--pr", "7", env={"STALE_BASE_TRIAGE_BUDGET": "0"})
+    assert proc.returncode == RC_UNMEASURED, proc.stdout
+    assert "budget" in proc.stdout
+    assert not harness.calls(), harness.calls()
+
+
+def test_the_context_is_PINNED_to_the_literal_the_pipeline_posts():
+    """🔴 A LITERAL CONTRACT WITH `devrc-ci`, AND IT WAS UNPINNED. Every other
+    test in this file reads `M.CONTEXT` for both the fixture row and the
+    lookup, so they agree with each other whatever the constant says: a mutant
+    changing it to `tekton/devrc-NOPE` SURVIVED the entire suite — it was the
+    sweep's own POSITIVE CONTROL, and its survival is what found this.
+
+    A wrong context here reads as "no verdict found" on every PR forever, which
+    is indistinguishable from a quiet, healthy repo.
+    """
+    assert M.CONTEXT == "tekton/devrc-pytests"
+    assert 'CONTEXT = "tekton/devrc-pytests"' in SRC_SCRIPT
+
+
+# ══ STATIC guards — relationships no behavioural test can see ═════════════════
+
+SRC = SRC_SCRIPT
+
+
+def test_the_rollup_endpoint_and_check_runs_are_never_requested():
+    """🔴 `/commits/{sha}/status` (SINGULAR) maps `error` onto `failure`, and
+    `/check-runs` returns NOTHING for these checks. Both are reassuring,
+    plausible and wrong; neither may appear in a request path."""
+    paths = re.findall(r'f?"(/repos/[^"]*)"', SRC)
+    assert paths, "the request-path scan matched nothing — this guard is inert"
+    for p in paths:
+        assert not p.endswith("/status"), p
+        assert "check-runs" not in p, p
+    assert "/statuses" in " ".join(paths)
+
+
+def _git_subcommands():
+    """Every git subcommand the source actually INVOKES, read from the AST.
+
+    🔴 STRUCTURAL, NOT SPELLED. A string scan over the whole file would match
+    the comment that EXPLAINS the hazard — which is exactly what a first draft
+    of the guard below did, failing on its own documentation. The AST sees the
+    argument list and nothing else, so prose cannot satisfy it or break it.
+    """
+    tree = ast.parse(SRC)
+    subs = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Name) and fn.id == "_git"):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.List) and arg.elts:
+                head = arg.elts[0]
+                if isinstance(head, ast.Constant) and isinstance(head.value, str):
+                    subs.append([e.value for e in arg.elts
+                                 if isinstance(e, ast.Constant)])
+    return subs
+
+
+def test_path_existence_is_proved_with_cat_file_not_diff_quiet():
+    """🔴 `git diff --quiet <ref> -- <path>` EXITS 0 WHEN THE PATH EXISTS ON
+    NEITHER SIDE, so as an existence check it reports SAME for MISSING."""
+    subs = _git_subcommands()
+    assert subs, "the AST scan found no git invocations — this guard is inert"
+    assert any(a[:2] == ["cat-file", "-e"] for a in subs), subs
+    assert not [a for a in subs if a[0] == "diff"], subs
+
+
+def test_every_env_var_the_code_reads_is_documented_in_the_header():
+    """Two-way: an undocumented knob is a knob nobody can find, and one named
+    in the ledger but no longer read is a lie."""
+    read = set(re.findall(r'os\.environ\.get\(\s*"(STALE_BASE_TRIAGE_[A-Z_]+)"', SRC))
+    ledgered = set(re.findall(r"^#   (STALE_BASE_TRIAGE_[A-Z_]+) ", SRC, re.M))
+    assert read, "the reader scan matched nothing — this guard is inert"
+    assert read == ledgered, f"read={sorted(read)} ledgered={sorted(ledgered)}"
+
+
+def test_every_test_this_script_names_actually_exists():
+    """A citation that resolves to nothing reads as authority and is not one.
+    Names wrapped across a comment line-break are re-joined before looking."""
+    joined = re.sub(r"\n#\s*", "", SRC)
+    cited = set(re.findall(r"`(test_[A-Za-z0-9_]+)`", joined))
+    assert cited, "the citation scan matched nothing — this guard is inert"
+    # Repo-wide, because this script legitimately cites tests it does not own
+    # (a real CI row names one, and the measurement in the header names
+    # another). Scoping to this file alone would have forced those citations
+    # out of the prose rather than validated them.
+    here = set()
+    for path in sorted((ROOT / "scripts").rglob("test_*.py")):
+        here |= set(re.findall(r"^ *def (test_[A-Za-z0-9_]+)",
+                               path.read_text(encoding="utf-8", errors="replace"),
+                               re.M))
+    assert cited <= here, f"dangling citations: {sorted(cited - here)}"
+
+
+def test_only_refs_under_its_own_namespace_are_ever_written():
+    """🔴 `refs/` LIVES IN THE COMMON GIT DIR — a worktree gives zero isolation,
+    so a fetch refspec that landed on `refs/remotes/origin/main` or a branch
+    would reach into a concurrent session's work."""
+    dests = re.findall(r'\+refs/[^:"]+:([^"\s]+)', SRC)
+    assert dests, "the refspec scan matched nothing — this guard is inert"
+    for d in dests:
+        assert d.startswith("{NS}/") or d.startswith("refs/stale-base-triage/"), d

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -296,6 +296,263 @@ def test_names_are_provably_complete_only_when_the_count_agrees():
         assert fragment in why, (desc, why)
 
 
+# ══ PURE: the DERIVED completeness proof ══════════════════════════════════════
+# 🔴 WHY SYNTHETIC, AND WHY THEY STILL LAND ON THE REAL BOUNDARY. This repo is
+# PUBLIC, so the rows below are BUILT, not pasted. What is copied from the
+# measurement is only the SHAPE: a banner cut by GitHub's cap at 140 BYTES —
+# which is 138 CHARACTERS once the `—` in `FAILED: pytests —` is counted as the
+# three UTF-8 bytes it is, and that is exactly why every real row measured on
+# this repo reads `len(desc)=138` rather than 140. Cutting on bytes is what puts
+# a synthetic fixture on the same boundary a real one lands on; cutting on
+# characters would land two bytes late and quietly leave `failed=` readable,
+# which is the whole hazard these tests are about.
+GITHUB_DESCRIPTION_BYTE_CAP = 140
+
+
+def cut_like_github(desc):
+    """Truncate to the 140-BYTE cap, never splitting a character."""
+    raw = desc.encode("utf-8")[:GITHUB_DESCRIPTION_BYTE_CAP]
+    while raw:
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            raw = raw[:-1]
+    return ""
+
+
+def synth_row(name, collected, passed, skipped, failed):
+    """A `devrc-pytests` banner in the shape `run-tests.sh` + the pipeline post."""
+    return (f"FAILED: pytests — FAILING: {name} | TOTAL collected={collected}"
+            f"  passed={passed}  skipped={skipped}  failed={failed}"
+            "  (floor: 18000 = sum of 30 per-target floors)")
+
+
+# The three rows the tool's own requirement was measured on, reproduced at their
+# real shape with invented test names of the real lengths. Field values are
+# pairwise distinct so a mutant hardcoding one of them cannot survive. Each is
+# kept as the (uncut, cut) PAIR so the control below can prove the cap really
+# landed inside `failed=` rather than merely that the row is short.
+UNCUT_AND_CUT = [
+    (lambda d: (d, cut_like_github(d)))(synth_row(name, c, p, s, 1))
+    for name, c, p, s in (
+        ("test_the_alpha_invariant_holds_when_the_ledger_is_empty", 22021, 22018, 2),
+        ("test_the_delta_ledger_is_rebuilt_from_the_spool_on_boot", 21964, 21960, 3),
+        ("test_the_gamma_pill_reports_its_own_sample_population", 22081, 22076, 4),
+    )
+]
+CUT_INSIDE_FAILED = [cut for _, cut in UNCUT_AND_CUT]
+
+
+def test_CONTROL_the_synthetic_rows_land_on_the_real_140_BYTE_boundary():
+    """🔴 THE FIXTURE IS THE INSTRUMENT HERE, so it is validated before anything
+    is concluded from it. If these rows were not actually cut inside `failed=`,
+    every assertion below would be about the DIRECT route and the derived one
+    would never run — a green proving nothing.
+
+    "Inside `failed=`" is asserted against the UNCUT row: the cut string is a
+    strict prefix of a banner that did print `failed=N`, and what survived stops
+    short of a readable count. The real rows end `…skipped=2  faile` / `…  fa`,
+    so the tail is a fragment of the word and cannot be matched for directly.
+    """
+    for full, desc in UNCUT_AND_CUT:
+        assert "  failed=1" in full, full
+        assert full.startswith(desc) and len(desc) < len(full), (desc, full)
+        assert len(desc) == 138, (len(desc), desc)
+        assert len(desc.encode("utf-8")) == GITHUB_DESCRIPTION_BYTE_CAP, desc
+        # The cut landed AFTER `skipped=` and BEFORE a readable `failed=N`.
+        assert M._TOTALS_RE.search(desc) is not None, desc
+        assert M.parse_failed_count(desc) is None, desc
+        assert M.parse_failed_count(full) == 1, full
+        assert len(M.parse_failing_names(desc)) == 1, desc
+
+
+def test_a_row_CUT_INSIDE_failed_is_PROVEN_complete_by_the_derived_count():
+    """🔴 F2. `failed=` is the LAST field in the banner, so whether it survives
+    the cap is decided by the failing test's NAME LENGTH — and on the three PRs
+    this tool was justified by it did not survive, so the verdict was
+    COULD NOT MEASURE with the answer already in the row.
+
+    `collected`, `passed` and `skipped` all PRECEDE it and do survive, and
+    `run-tests.sh` defines `collected = passed + skipped + failed + errors +
+    xfailed + xpassed`, so `collected − passed − skipped >= failed >= len(names)`.
+    Equality squeezes that shut and PROVES completeness.
+    """
+    for desc in CUT_INSIDE_FAILED:
+        assert M.derived_failure_upper_bound(desc) == 1, desc
+        ok, why = M.names_provably_complete(desc)
+        assert ok, (desc, why)
+        assert "collected−passed−skipped=1" in why, why
+
+
+def test_SOUNDNESS_the_derived_bound_never_UNDER_counts_the_visible_failed():
+    """🔴 THE HALF THAT CAN BE WRONG IN THE DANGEROUS DIRECTION.
+
+    An OVER-count only ever makes this tool withhold a verdict. An UNDER-count
+    makes it certify a completeness it does not have and dismiss a real red —
+    the one error it must not make. So wherever BOTH values are readable they
+    are compared, and the bound must never fall below the banner's own count.
+
+    The table is built from full (uncut) banners so `failed=N` is visible, and
+    the three multi-failure rows are the ones that matter: an under-counting
+    bound would drag them down toward the single name and certify them.
+    """
+    table = [
+        # name, collected, passed, skipped, failed, xfail+xpass slack
+        ("test_one", 21076, 21072, 3, 1, 0),
+        ("test_two", 21476, 21471, 2, 3, 0),
+        ("test_six", 21036, 21028, 3, 5, 0),
+        ("test_fortyish", 21500, 21450, 11, 39, 0),
+        # …and one with xfailed/xpassed inflating `collected` above p+s+failed,
+        # which is exactly the case where the bound is a strict OVER-count.
+        ("test_xf", 21000, 20950, 7, 40, 3),
+    ]
+    seen = set()
+    for name, collected, passed, skipped, failed, slack in table:
+        desc = synth_row(name, collected + slack, passed, skipped, failed)
+        derived = M.derived_failure_upper_bound(desc)
+        count = M.parse_failed_count(desc)
+        assert count == failed, desc
+        assert derived is not None, desc
+        assert derived >= count, (desc, derived, count)      # 🔴 NEVER BELOW
+        if slack == 0:
+            assert derived == count, (desc, derived, count)  # …and EXACT here
+        seen.add((derived, count))
+    # The table actually exercised both relations, so "never below" is not a
+    # claim about five copies of one row.
+    assert any(d == c for d, c in seen) and any(d > c for d, c in seen), seen
+
+
+def test_a_genuine_MULTI_failure_red_is_STILL_could_not_measure():
+    """🔴 THE CONTROL ON THE NEW ROUTE. A row that names ONE test while the
+    totals prove 39 failed must NOT be certified complete — with or without
+    `failed=N` surviving. Both spellings are driven, because the derived route
+    is the one that could newly get this wrong."""
+    full = synth_row("test_the_alpha_invariant_holds_when_the_ledger_is_empty",
+                      21500, 21450, 11, 39)
+    cut = cut_like_github(full)
+    assert M.parse_failed_count(full) == 39
+    assert M.parse_failed_count(cut) is None, cut     # the row the cap produces
+    for desc in (full, cut):
+        assert M.derived_failure_upper_bound(desc) == 39, desc
+        ok, why = M.names_provably_complete(desc)
+        assert not ok, (desc, why)
+        assert "39" in why, why
+
+
+def test_the_DIRECT_route_still_wins_when_failed_N_survived():
+    """Route 1 is not replaced, and it is the stronger claim. Pinned by driving
+    a row where the two routes would disagree if the order were flipped: the
+    slack from an xpassed makes the bound 2 while `failed=1` is right there."""
+    desc = synth_row("test_only_one_named", 100, 96, 2, 1)   # collected 100 = 96+2+1+1
+    assert M.derived_failure_upper_bound(desc) == 2
+    assert M.parse_failed_count(desc) == 1
+    ok, why = M.names_provably_complete(desc)
+    assert ok and why == "failed=1 and 1 named", why
+
+
+def test_a_TRUNCATED_skipped_can_only_INFLATE_the_derived_bound():
+    """🔴 THE ONE FIELD THE CAP CAN CUT SHORT WITHOUT BEING NOTICED, and the
+    reason `_TOTALS_RE` demands the three fields ADJACENT AND IN ORDER.
+
+    `collected=` and `passed=` are each followed by more banner text, so a match
+    proves they were not truncated. `skipped=` is last of the three and CAN be
+    left short — `skipped=23` arriving as `skipped=2`. Subtracting less inflates
+    the bound, which errs toward WITHHOLDING; the opposite would certify.
+    """
+    full = "FAILED: pytests — FAILING: test_x | TOTAL collected=900  passed=850  skipped=23  failed=27"
+    short = full.replace("skipped=23", "skipped=2")
+    assert M.derived_failure_upper_bound(full) == 27
+    assert M.derived_failure_upper_bound(short) == 48        # inflated, never below
+    assert M.derived_failure_upper_bound(short) > M.derived_failure_upper_bound(full)
+
+
+def test_the_derived_bound_refuses_a_row_it_cannot_read():
+    """None, never a number — an unreadable row must not become a bound of 0,
+    which would certify every single-named row as complete."""
+    for desc in ("", None, "FAILED: pytests — FAILING: test_x | TOTAL collected=9 ",
+                 "FAILED: pytests — FAILING: test_x | TOTAL collected=9  passed=8 ",
+                 # out of order: the adjacency requirement is what proves the
+                 # earlier fields were not cut short, so this must not match.
+                 "TOTAL passed=8  collected=9  skipped=0",
+                 # arithmetically impossible, so not the banner we parse.
+                 "TOTAL collected=9  passed=8  skipped=5"):
+        assert M.derived_failure_upper_bound(desc) is None, desc
+    # POSITIVE CONTROL: the same parser DOES answer on a well-formed row, so the
+    # Nones above are about these rows and not about a parser wired to nothing.
+    assert M.derived_failure_upper_bound(
+        "TOTAL collected=9  passed=8  skipped=0") == 1
+
+
+def test_a_banner_that_CONTRADICTS_itself_is_refused_rather_than_believed():
+    """🔴 THE TRIPWIRE ON THE COUPLING, HONESTLY LABELLED. While `run-tests.sh`'s
+    arithmetic holds, `derived >= failed=N` is guaranteed and this arm cannot
+    fire on a real row — it is reachable from a test only. It exists so that an
+    arithmetic change upstream surfaces as a refusal to answer rather than as a
+    silently wrong bound; the test-time half is the source pin below."""
+    desc = "FAILED: pytests — FAILING: test_x | TOTAL collected=9  passed=8  skipped=0  failed=4"
+    assert M.derived_failure_upper_bound(desc) == 1
+    assert M.parse_failed_count(desc) == 4
+    ok, why = M.names_provably_complete(desc)
+    assert not ok
+    assert "contradicts itself" in why, why
+
+
+def test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned():
+    """🔴 THE DERIVATION IS A COUPLING TO ANOTHER FILE, SO IT IS PINNED THERE.
+
+    `derived_failure_upper_bound` is sound only because `scripts/run-tests.sh`
+    defines `collected` to INCLUDE `passed` and `skipped` and to include every
+    term the banner's `failed=` is built from. This reads those expressions out
+    of the shell source and checks the containment relation itself, rather than
+    asserting a literal string — so a rename of the shell locals is fine and a
+    change to WHAT IS SUMMED is not.
+
+    ⚠ WHAT IT CANNOT CHECK: that the remaining terms (`xfailed`, `xpassed`) are
+    non-negative counts. That is an arithmetic fact about pytest's summary line,
+    not a textual one, and it is stated rather than pinned.
+    """
+    src = (ROOT / "scripts" / "run-tests.sh").read_text(encoding="utf-8")
+
+    def terms(name):
+        m = re.search(rf"^\s*{name}=\$\(\(([^)]*)\)\)", src, re.M)
+        assert m, f"no `{name}=$((…))` assignment in run-tests.sh — guard is inert"
+        return set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", m.group(1))) - {name}
+
+    collected = terms("collected")
+    failed = terms("TOT_FAILED")
+    assert collected, "the collected scan matched nothing — this guard is inert"
+    assert failed, "the TOT_FAILED scan matched nothing — this guard is inert"
+    # The two fields the derivation SUBTRACTS must be summands of `collected`.
+    passed_term, = terms("TOT_PASSED")
+    skipped_term, = terms("TOT_SKIPPED")
+    assert passed_term in collected, (passed_term, collected)
+    assert skipped_term in collected, (skipped_term, collected)
+    # …and everything the banner's `failed=` is built from must survive the
+    # subtraction, which is precisely why the remainder is an UPPER bound.
+    assert failed <= collected - {passed_term, skipped_term}, (failed, collected)
+    # The accumulators the banner prints are the per-target terms summed.
+    assert re.search(r"TOT_COLLECTED\s*\+\s*collected", src)
+    # And the banner really does print the three fields ADJACENT AND IN ORDER,
+    # which is the assumption `_TOTALS_RE` encodes.
+    banner = re.search(
+        r"collected=\$TOT_COLLECTED\s+passed=\$TOT_PASSED\s+skipped=\$TOT_SKIPPED\s+"
+        r"failed=\$TOT_FAILED", src)
+    assert banner, "the TOTAL banner no longer prints collected/passed/skipped/failed in order"
+    assert M._TOTALS_RE.search(
+        "TOTAL " + re.sub(r"\$TOT_(\w+)", "7", banner.group(0))) is not None
+
+
+def test_the_prior_art_this_gate_rebuilds_is_CITED_and_still_exists():
+    """🔴 A 15-LINE VERSION OF THIS SCREEN ALREADY SHIPPED. Citing it is not
+    courtesy: its comment records that it would have fired ZERO times on 100
+    commits, and this file's derived route is the explanation for that zero. A
+    citation that resolves to nothing reads as authority and is not one."""
+    assert "main-status-watch.py" in SRC_SCRIPT
+    assert "screen_all_known_flakes" in SRC_SCRIPT
+    prior = (ROOT / "scripts" / "main-status-watch.py").read_text(encoding="utf-8")
+    assert "def screen_all_known_flakes(" in prior
+
+
 def test_normalise_test_name_handles_all_three_real_shapes():
     assert M.normalise_test_name("test_plain") == (None, "test_plain")
     assert M.normalise_test_name("TestSuite.test_method") == (
@@ -520,6 +777,68 @@ def test_a_count_that_EXCEEDS_the_names_is_UNMEASURED(repo):
         "collected=9  passed=4  skipped=0  failed=5"))
     assert got["verdict"] == M.VERDICT_UNMEASURED
     assert "failed=5" in got["reason"]
+
+
+ROW_CUT_INSIDE_FAILED = (
+    "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+    "collected=9  passed=7  skipped=1  faile")
+ROW_CUT_INSIDE_FAILED_MULTI = (
+    "FAILED: pytests — FAILING: test_the_alpha_invariant_holds | TOTAL "
+    "collected=9  passed=5  skipped=1  faile")
+
+
+def test_a_row_CUT_INSIDE_failed_now_reaches_INHERITED_at_PR_level(repo):
+    """🔴 F2 AT THE VERDICT. Before the derived route this row — the shape of
+    every one of the three PRs the tool was justified by — resolved to
+    COULD NOT MEASURE with the correct answer already in it. `failed=` is cut,
+    but `collected−passed−skipped = 9−7−1 = 1` equals the one name."""
+    got = M.triage_pr(repo.path, "main", pr_meta(repo),
+                      pr_row(ROW_CUT_INSIDE_FAILED))
+    assert M.parse_failed_count(ROW_CUT_INSIDE_FAILED) is None
+    assert got["verdict"] == M.VERDICT_INHERITED
+    assert got["complete"] is True
+    assert "collected−passed−skipped=1" in got["completeness_reason"]
+
+
+def test_a_row_CUT_INSIDE_failed_with_MORE_failures_than_names_is_withheld(repo):
+    """🔴 THE SAME ROW SHAPE, ONE FIELD DIFFERENT, AND THE ANSWER FLIPS. Without
+    this the test above is satisfied by a route that certifies every cut row.
+    Here `9−5−1 = 3` against ONE name: two failures are unaccounted for, the
+    named one IS inherited, and the PR must still not be dismissed."""
+    got = M.triage_pr(repo.path, "main", pr_meta(repo),
+                      pr_row(ROW_CUT_INSIDE_FAILED_MULTI))
+    assert got["verdict"] == M.VERDICT_UNMEASURED
+    assert got["complete"] is False
+    assert "collected−passed−skipped=3 does not equal the 1 named" in got["reason"]
+    assert got["any_explained"] is True          # …so the HINT still fires
+
+
+def test_end_to_end_a_row_cut_inside_failed_exits_10_and_names_the_fix(harness, repo):
+    """The whole F2 path through the real script: a description GitHub cut
+    inside `failed=` now produces the INHERITED exit code and the evidence."""
+    harness.serve_default(repo, desc=ROW_CUT_INSIDE_FAILED)
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_INHERITED, proc.stdout + proc.stderr
+    assert M.VERDICT_INHERITED in proc.stdout
+    assert repo.fix[:12] in proc.stdout
+    # …and the run SAYS which route proved it, so the claim is auditable.
+    assert "collected−passed−skipped=1" in proc.stdout
+
+
+def test_end_to_end_the_SAME_shape_with_extra_failures_does_NOT_exit_10(harness, repo):
+    """🔴 THE NEGATIVE CONTROL ON THE END-TO-END TEST ABOVE. Same script, same
+    fixture, same cut — one number different — and the exit code must move.
+
+    ⚠ HONESTLY LABELLED: this one is GREEN at the pre-change base too, because
+    the old code withheld every cut row. It is an INVARIANT guard on the new
+    route (it must not start dismissing multi-failure reds), NOT regression
+    coverage, and it is not counted as such in the red/green matrix.
+    """
+    harness.serve_default(repo, desc=ROW_CUT_INSIDE_FAILED_MULTI)
+    proc = harness.run(repo, "--pr", "7")
+    assert proc.returncode == RC_OK, proc.stdout + proc.stderr
+    assert M.VERDICT_UNMEASURED in proc.stdout
+    assert "HINT: at least one named failure IS inherited" in proc.stdout
 
 
 def test_a_GREEN_or_PENDING_head_is_not_a_verdict_at_all(repo):

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -467,13 +467,20 @@ def test_a_TRUNCATED_skipped_can_only_INFLATE_the_derived_bound():
 
 
 def test_the_derived_bound_refuses_a_row_it_cannot_read():
-    """None, never a number — an unreadable row must not become a bound of 0,
-    which would certify every single-named row as complete."""
+    """None, never a number and never a raise — an unreadable row must not
+    become a bound of 0, which would certify every single-named row as
+    complete, and must not crash the reporting path either."""
     for desc in ("", None, "FAILED: pytests — FAILING: test_x | TOTAL collected=9 ",
                  "FAILED: pytests — FAILING: test_x | TOTAL collected=9  passed=8 ",
-                 # out of order: the adjacency requirement is what proves the
-                 # earlier fields were not cut short, so this must not match.
+                 # out of order: the three fields are read as ONE ordered group,
+                 # which is what proves the earlier ones were not cut short.
                  "TOTAL passed=8  collected=9  skipped=0",
+                 "TOTAL collected=9  skipped=0  passed=8",
+                 # 🔴 CUT EXACTLY ON THE `=`. `skipped=` with NO digits is the
+                 # shape a cap landing one character early produces; a `\\d*`
+                 # spelling of the group matches it and then `int("")` RAISES on
+                 # the reporting path. Refusal is the only safe reading.
+                 "TOTAL collected=9  passed=8  skipped=",
                  # arithmetically impossible, so not the banner we parse.
                  "TOTAL collected=9  passed=8  skipped=5"):
         assert M.derived_failure_upper_bound(desc) is None, desc
@@ -481,6 +488,28 @@ def test_the_derived_bound_refuses_a_row_it_cannot_read():
     # Nones above are about these rows and not about a parser wired to nothing.
     assert M.derived_failure_upper_bound(
         "TOTAL collected=9  passed=8  skipped=0") == 1
+
+
+def test_an_UNDERIVABLE_row_says_WHICH_route_failed_not_merely_that_one_did():
+    """🔴 THE REASON IS THE PRODUCT HERE, so it is pinned as a whole string.
+
+    Two different refusals reach the operator as COULD NOT MEASURE — "the count
+    was cut AND the totals are unreadable" and "the totals say there are more
+    failures than were named" — and they call for different next steps. A
+    mutant replacing the first with a bound of 0 produces the SAME verdict on
+    every input (names are non-empty by the time this runs, so 0 can never
+    equal them) and is invisible to a verdict-only assertion; only the text
+    distinguishes it.
+    """
+    ok, why = M.names_provably_complete("FAILED: pytests — FAILING: test_x | TOTAL collected=9 ")
+    assert not ok
+    assert why == ("the description was truncated before `failed=N`, and "
+                   "collected/passed/skipped are not all readable either"), why
+    ok, why = M.names_provably_complete(
+        "FAILED: pytests — FAILING: test_x | TOTAL collected=9  passed=5  skipped=1  fa")
+    assert not ok
+    assert why == ("the description was truncated before `failed=N`, and "
+                   "collected−passed−skipped=3 does not equal the 1 named"), why
 
 
 def test_a_banner_that_CONTRADICTS_itself_is_refused_rather_than_believed():
@@ -529,17 +558,28 @@ def test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned()
     assert skipped_term in collected, (skipped_term, collected)
     # …and everything the banner's `failed=` is built from must survive the
     # subtraction, which is precisely why the remainder is an UPPER bound.
+    # ⚠ CONTAINMENT, NOT EQUALITY, AND DELIBERATELY SO: `run-tests.sh` SHRINKING
+    # what it sums into `failed=` keeps the bound an upper bound and is
+    # therefore safe — a mutation sweep confirmed that variant survives this
+    # guard, correctly. Only a term LEAVING `collected` breaks the derivation.
     assert failed <= collected - {passed_term, skipped_term}, (failed, collected)
     # The accumulators the banner prints are the per-target terms summed.
     assert re.search(r"TOT_COLLECTED\s*\+\s*collected", src)
-    # And the banner really does print the three fields ADJACENT AND IN ORDER,
-    # which is the assumption `_TOTALS_RE` encodes.
-    banner = re.search(
-        r"collected=\$TOT_COLLECTED\s+passed=\$TOT_PASSED\s+skipped=\$TOT_SKIPPED\s+"
-        r"failed=\$TOT_FAILED", src)
-    assert banner, "the TOTAL banner no longer prints collected/passed/skipped/failed in order"
-    assert M._TOTALS_RE.search(
-        "TOTAL " + re.sub(r"\$TOT_(\w+)", "7", banner.group(0))) is not None
+    # 🔴 EVERY banner line, not merely SOME line. `run-tests.sh` prints TWO —
+    # a full-run one and a SCOPED one — and a first version of this guard
+    # searched the whole file, so reordering the fields in one of them was
+    # satisfied by the other and SURVIVED the sweep. The order is the assumption
+    # `_TOTALS_RE` encodes, and it has to hold on every row that can be posted.
+    banners = [ln for ln in src.splitlines() if "TOTAL collected=$TOT_COLLECTED" in ln]
+    assert len(banners) >= 2, f"expected both TOTAL banners, found {len(banners)}"
+    for ln in banners:
+        ordered = re.search(
+            r"collected=\$TOT_COLLECTED\s+passed=\$TOT_PASSED\s+skipped=\$TOT_SKIPPED\s+"
+            r"failed=\$TOT_FAILED", ln)
+        assert ordered, f"banner does not print the fields in order: {ln.strip()}"
+        # …and the regex this file parses with actually matches that shape.
+        assert M._TOTALS_RE.search(
+            re.sub(r"\$TOT_(\w+)", "7", ordered.group(0))) is not None, ln
 
 
 def test_the_prior_art_this_gate_rebuilds_is_CITED_and_still_exists():

--- a/scripts/tests/test_stale_base_triage.py
+++ b/scripts/tests/test_stale_base_triage.py
@@ -332,19 +332,25 @@ def test_names_are_provably_complete_only_when_the_count_agrees():
 # ══ PURE: the DERIVED completeness proof ══════════════════════════════════════
 # 🔴 WHY SYNTHETIC, AND WHY THEY STILL LAND ON THE REAL BOUNDARY. This repo is
 # PUBLIC, so the rows below are BUILT, not pasted. What is copied from the
-# measurement is only the SHAPE: a banner cut by GitHub's cap at 140 BYTES —
-# which is 138 CHARACTERS once the `—` in `FAILED: pytests —` is counted as the
-# three UTF-8 bytes it is, and that is exactly why every real row measured on
+# measurement is only the SHAPE: a banner cut at 140 BYTES — which is 138
+# CHARACTERS once the `—` in `FAILED: pytests —` is counted as the three UTF-8
+# bytes it is, and that is exactly why every real row measured on
 # this repo reads `len(desc)=138` rather than 140. Cutting on bytes is what puts
 # a synthetic fixture on the same boundary a real one lands on; cutting on
 # characters would land two bytes late and quietly leave `failed=` readable,
 # which is the whole hazard these tests are about.
-GITHUB_DESCRIPTION_BYTE_CAP = 140
+# ⚠ WHO DOES THE CUTTING IS NOT DETERMINED — GitHub's own status-description cap
+# and the posting pipeline's truncation are indistinguishable in everything
+# sampled, because every row carries exactly one multi-byte character. These
+# names say BYTE CAP rather than naming an actor on purpose; the measurement is
+# the boundary and nothing else. See `test_CONTROL_the_real_truncated_rows_land_
+# on_the_BYTE_cap_not_the_CHAR_cap`.
+DESCRIPTION_BYTE_CAP = 140
 
 
-def cut_like_github(desc):
+def cut_at_the_byte_cap(desc):
     """Truncate to the 140-BYTE cap, never splitting a character."""
-    raw = desc.encode("utf-8")[:GITHUB_DESCRIPTION_BYTE_CAP]
+    raw = desc.encode("utf-8")[:DESCRIPTION_BYTE_CAP]
     while raw:
         try:
             return raw.decode("utf-8")
@@ -366,7 +372,7 @@ def synth_row(name, collected, passed, skipped, failed):
 # kept as the (uncut, cut) PAIR so the control below can prove the cap really
 # landed inside `failed=` rather than merely that the row is short.
 UNCUT_AND_CUT = [
-    (lambda d: (d, cut_like_github(d)))(synth_row(name, c, p, s, 1))
+    (lambda d: (d, cut_at_the_byte_cap(d)))(synth_row(name, c, p, s, 1))
     for name, c, p, s in (
         ("test_the_alpha_invariant_holds_when_the_ledger_is_empty", 22021, 22018, 2),
         ("test_the_delta_ledger_is_rebuilt_from_the_spool_on_boot", 21964, 21960, 3),
@@ -391,7 +397,7 @@ def test_CONTROL_the_synthetic_rows_land_on_the_real_140_BYTE_boundary():
         assert "  failed=1" in full, full
         assert full.startswith(desc) and len(desc) < len(full), (desc, full)
         assert len(desc) == 138, (len(desc), desc)
-        assert len(desc.encode("utf-8")) == GITHUB_DESCRIPTION_BYTE_CAP, desc
+        assert len(desc.encode("utf-8")) == DESCRIPTION_BYTE_CAP, desc
         # The cut landed AFTER `skipped=` and BEFORE a readable `failed=N`.
         assert M._TOTALS_RE.search(desc) is not None, desc
         assert M.parse_failed_count(desc) is None, desc
@@ -462,7 +468,7 @@ def test_a_genuine_MULTI_failure_red_is_STILL_could_not_measure():
     is the one that could newly get this wrong."""
     full = synth_row("test_the_alpha_invariant_holds_when_the_ledger_is_empty",
                       21500, 21450, 11, 39)
-    cut = cut_like_github(full)
+    cut = cut_at_the_byte_cap(full)
     assert M.parse_failed_count(full) == 39
     assert M.parse_failed_count(cut) is None, cut     # the row the cap produces
     for desc in (full, cut):
@@ -962,8 +968,9 @@ def test_a_row_CUT_INSIDE_failed_with_MORE_failures_than_names_is_withheld(repo)
 
 
 def test_end_to_end_a_row_cut_inside_failed_exits_10_and_names_the_fix(harness, repo):
-    """The whole F2 path through the real script: a description GitHub cut
-    inside `failed=` now produces the INHERITED exit code and the evidence."""
+    """The whole F2 path through the real script: a description cut at the byte
+    cap inside `failed=` now produces the INHERITED exit code and the
+    evidence."""
     harness.serve_default(repo, desc=ROW_CUT_INSIDE_FAILED)
     proc = harness.run(repo, "--pr", "7")
     assert proc.returncode == RC_INHERITED, proc.stdout + proc.stderr
@@ -1276,6 +1283,91 @@ def test_the_write_screen_SEES_the_shapes_the_word_POST_did_not(harness, repo):
     assert all(c.startswith("api ") for c in recorded), recorded
 
 
+def test_the_write_screen_reads_an_ARGUMENT_VALUE_as_DATA_not_as_A_FLAG():
+    """🔴 THE FIVE MEASURED ROWS, PLUS THE CONTROLS THEY NEED. The previous
+    version tokenised the whole flattened argv as flags and took the LAST method
+    it saw, so a `--method GET` or `-X GET` spelled inside a comment BODY turned
+    the real `-X POST` into a read. Same call shape as `post_comment`'s in the
+    write rows; the last five are reads, so the table can go both ways.
+
+    Reachable, not hypothetical: `comment_body` interpolates `c['subject']` —
+    an arbitrary `main` commit subject — and the harness receipt flattens one
+    argv to one space-joined line, so the body's words arrive as bare tokens.
+    The end-to-end half is the next test.
+    """
+    post = "api -X POST /repos/o/r/issues/7/comments"
+    rows = [
+        # (recorded argv line, is it a write)                    what it exercises
+        (f"{post} -f body=hello", True),                       # the control
+        (f"{post} -f body=switch to --method GET now", True),  # body says --method
+        (f"{post} -f body=use -X GET here", True),             # body says -X
+        ("api /repos/o/r/x --input=payload.json", True),       # attached --input=
+        ("api /repos/o/r/x -fbody=hello", True),               # attached -f
+        # 🔴 THE SHARPEST ROW: a POST with NO method flag at all, whose BODY
+        # spells a read method. Only stopping the method scan at the first field
+        # flag saves this one — first-wins alone reads it as a GET.
+        ("api /repos/o/r/issues/7/comments -f body=see -X GET for details", True),
+        # 🔴 THE CASE THAT RULES OUT "STOP AT THE FIRST `/`-PREFIXED POSITIONAL":
+        # a legal write whose METHOD comes after the endpoint.
+        ("api /repos/o/r/x -X POST", True),
+        # 🔴 THE ROW FIRST-WINS IS FOR, and the reason the body-stop alone is not
+        # enough: a field flag is not the only argument that carries a VALUE.
+        # `-H`'s does too, and it is scanned, so a read method spelled inside a
+        # header would overrule the real one under a last-wins rule.
+        ("api -X POST /repos/o/r/x -H X-Note: -X GET", True),
+        # NEGATIVE CONTROLS, so the table is not "everything is a write".
+        ("api /repos/o/r/pulls/7", False),
+        ("api /repos/o/r/commits/deadbeef/statuses?per_page=100", False),
+        ("api -X GET /repos/o/r/x", False),
+        ("api --method HEAD /repos/o/r/x", False),
+        ("api -X GET /repos/o/r/x?q=a-file-named--method-POST", False),
+    ]
+    for line, is_write in rows:
+        assert gh_write_calls([line]) == ([line] if is_write else []), line
+    # …and mixed together, exactly the writes come back, in order.
+    assert gh_write_calls([ln for ln, _ in rows]) == [ln for ln, w in rows if w]
+
+
+def test_EVERY_field_flag_is_seen_in_BOTH_spellings_gh_accepts():
+    """🔴 TWO-WAY, AND DERIVED RATHER THAN RETYPED. `_GH_FIELD_FLAGS` named five
+    flags while the screen recognised the attached form of only two of them, so
+    the ledger read as coverage it did not provide. Both spellings of every
+    entry are built here from the entry itself, so a sixth flag cannot be added
+    to the set and left half-handled.
+    """
+    for flag in sorted(_GH_FIELD_FLAGS):
+        attached = f"{flag}=k=v" if flag.startswith("--") else f"{flag}k=v"
+        for spelling in ([flag, "k=v"], [attached]):
+            line = " ".join(["api", "/repos/o/r/x", *spelling])
+            assert gh_write_calls([line]) == [line], (flag, line)
+    # NEGATIVE CONTROL on the derivation: a flag-shaped token that is NOT a
+    # field flag stays a read, so the sweep above is not passing because every
+    # `-`-prefixed token is treated as a body.
+    assert gh_write_calls(["api /repos/o/r/x --paginate"]) == []
+    assert gh_write_calls(["api /repos/o/r/x -q .name"]) == []
+
+
+def test_a_hostile_COMMIT_SUBJECT_reaching_the_BODY_is_still_seen_as_a_WRITE(
+        harness, repo):
+    """🔴 THE REACHABILITY HALF, THROUGH THE REAL SCRIPT. The rows above are
+    strings this file wrote; this drives the same hazard the only way it can
+    actually arrive — a `main` commit subject that spells a read method, copied
+    into the comment body by `comment_body` and flattened into the receipt.
+
+    Without this the table is a claim about the classifier and not about the
+    shape the harness really produces.
+    """
+    repo.git("commit", "--amend", "-m",
+             "repair alpha: prefer -X GET over --method POST when probing")
+    harness.serve_default(repo)
+    harness.run(repo, "--pr", "7", "--comment-mode", "on")
+    recorded = harness.calls()
+    # POSITIVE CONTROL: the hostile text really did reach the recorded argv, so
+    # a green below is not "the body never contained it".
+    assert any("--method POST" in c for c in recorded), recorded
+    assert len(gh_write_calls(recorded)) == 1, recorded
+
+
 def test_DRY_RUN_says_what_it_would_do_and_writes_nothing(harness, repo):
     harness.serve_default(repo)
     proc = harness.run(repo, "--pr", "7", "--comment-mode", "dry-run")
@@ -1488,6 +1580,38 @@ def _spawn_argv0(src=SRC):
     return out
 
 
+def _computed_spawn_heads(src=SRC):
+    """(lineno, name) for every spawn whose argv0 is NOT a string constant.
+
+    🔴 THE HOLE `_spawn_argv0` CANNOT SEE. It folds every computed head into the
+    ONE set member `<computed>`, so a SECOND computed spawn — `binary = "git"`
+    then `subprocess.run([binary, "push"])` — leaves the argv0 set unchanged and
+    still equal to its pin. The pin's docstring justifies that member as
+    `[gh, "api", …]` and points at the `gh` ledger; but `_gh_argv_shapes` only
+    ever sees heads that are the Name `gh`, so the justification was WIDER than
+    the implementation and the extra spawn was covered by neither.
+
+    A head that is not a plain Name at all (`self.gh`, `cmds[0]()`) comes back
+    as `<not-a-name>` rather than being dropped — same sentinel discipline.
+    """
+    out = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name not in _SPAWN_FUNCS:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, (ast.List, ast.Tuple)) and first.elts):
+            continue
+        head = first.elts[0]
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            continue
+        out.append((node.lineno,
+                    head.id if isinstance(head, ast.Name) else "<not-a-name>"))
+    return out
+
+
 def _gh_argv_shapes(src=SRC):
     """The constant argv head of every spawn whose argv0 is the `gh` seam.
 
@@ -1532,7 +1656,19 @@ EXPECTED_GH_ARGV = {("api",), ("api", "-X", "POST")}
 
 # `gh api` is the only surface, and only these methods are reads.
 GH_READ_METHODS = frozenset({"GET", "HEAD"})
+# The five flags that give `gh api` a REQUEST BODY, and therefore a POST with or
+# without a method flag. `gh` takes each one's value ATTACHED as well as
+# separated, and the first version of this screen knew only three of the ten
+# spellings — `--input=…` and `-fbody=…` both read as clean. The two collections
+# are pinned against each other by
+# `test_EVERY_field_flag_is_seen_in_BOTH_spellings_gh_accepts`.
 _GH_FIELD_FLAGS = frozenset({"-f", "-F", "--field", "--raw-field", "--input"})
+_GH_FIELD_PREFIXES = ("-f", "-F", "--field=", "--raw-field=", "--input=")
+
+
+def _gh_is_field_flag(tok):
+    """Either spelling of any of the five body-carrying flags."""
+    return tok in _GH_FIELD_FLAGS or tok.startswith(_GH_FIELD_PREFIXES)
 
 
 def gh_write_calls(calls):
@@ -1544,8 +1680,33 @@ def gh_write_calls(calls):
     is complete in today's tree; this is about what the guard catches next time.
 
     🔴 A MISSING `-X` IS NOT A READ. `gh api` with any field flag (`-f`, `-F`,
-    `--field`, `--raw-field`, `--input`) defaults to POST, so a write needs no
-    method flag at all — the one shape a method-only screen would call clean.
+    `--field`, `--raw-field`, `--input`, in either spelling) defaults to POST,
+    so a write needs no method flag at all — the one shape a method-only screen
+    would call clean.
+
+    🔴 THE ARGUMENT **VALUES** ARE DATA, NOT FLAGS, AND THE RECEIPT CANNOT SAY SO.
+    The harness flattens one argv to one space-joined line, so a comment BODY
+    arrives as bare tokens indistinguishable from flags — and the body here
+    interpolates `c['subject']`, an arbitrary `main` commit subject. Measured on
+    the previous version, same call shape as the real write:
+
+        -f body=switch to --method GET now   -> read   (a later method WON)
+        -f body=use -X GET here              -> read   (a later method WON)
+
+    So the method is FIRST-WINS and is scanned only up to the first field flag:
+    everything from there on is body text, and a method spelled inside it must
+    not overrule the one the caller actually passed. Field flags ARE scanned to
+    the end, because `gh api /repos/… -f k=v` puts the body after the endpoint.
+
+    ⚠ WHY NOT "STOP AT THE FIRST `/`-PREFIXED POSITIONAL", which is the shape
+    `_gh_argv_shapes` uses: `gh api /repos/o/r/x -X POST` is legal and puts the
+    METHOD after the endpoint, so a scan that stopped at the path would read
+    that real write as clean — a regression in the one direction that matters.
+    The body, by contrast, can only ever begin at a field flag.
+
+    The residual error is in the safe direction: `gh api -f k=v -X GET /…` (a
+    read whose fields precede its method) is reported as a write. This tool
+    emits no such call, and a false write fails loudly rather than quietly.
 
     Anything whose first token is not `api` is reported as a write too: it is a
     `gh` surface nobody enumerated, and an allowlist must fail on those.
@@ -1556,18 +1717,22 @@ def gh_write_calls(calls):
         if not toks or toks[0] != "api":
             writes.append(c)
             continue
-        method, fields, i = None, False, 0
+        method, fields, body, i = None, False, False, 1
         while i < len(toks):
             t = toks[i]
-            if t in ("-X", "--method") and i + 1 < len(toks):
-                method, i = toks[i + 1].upper(), i + 2
+            if _gh_is_field_flag(t):
+                fields, body = True, True
+                i += 1
                 continue
-            if t.startswith("-X") and len(t) > 2:
-                method = t[2:].upper()
-            elif t.startswith("--method="):
-                method = t.split("=", 1)[1].upper()
-            elif t in _GH_FIELD_FLAGS or t.startswith(("--field=", "--raw-field=")):
-                fields = True
+            if not body:
+                if t in ("-X", "--method") and i + 1 < len(toks):
+                    method = toks[i + 1].upper() if method is None else method
+                    i += 2
+                    continue
+                if t.startswith("-X") and len(t) > 2:
+                    method = t[2:].upper() if method is None else method
+                elif t.startswith("--method=") and method is None:
+                    method = t.split("=", 1)[1].upper()
             i += 1
         if method is None:
             if fields:
@@ -1584,6 +1749,47 @@ def test_path_existence_is_proved_with_cat_file_not_diff_quiet():
     assert subs, "the AST scan found no git invocations — this guard is inert"
     assert any(a[:2] == ["cat-file", "-e"] for a in subs), subs
     assert not [a for a in subs if a[0] == "diff"], subs
+
+
+def _sys_path_mutations(src):
+    """(lineno, method) for every `sys.path.<method>(…)` call in a source."""
+    out = []
+    for node in ast.walk(ast.parse(src)):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)):
+            continue
+        owner = node.func.value
+        if (isinstance(owner, ast.Attribute) and owner.attr == "path"
+                and isinstance(owner.value, ast.Name) and owner.value.id == "sys"):
+            out.append((node.lineno, node.func.attr))
+    return out
+
+
+def test_the_shared_lib_is_APPENDED_to_sys_path_and_never_PREPENDED():
+    """🔴 A 🔴-MARKED COMMENT IS NOT A GUARD. This script and
+    `main-status-watch.py` each carry a paragraph saying `append`, NEVER
+    `insert(0, …)` — and reverting either one to `sys.path.insert(0, …)`
+    SURVIVED the whole suite.
+
+    `scripts/lib/` is this repo's shared-module dumping ground and grows freely;
+    prepending it puts EVERY module in it ahead of the standard library for
+    every LATER import the process makes, including the lazy ones that only run
+    once something has already gone wrong. Appending removes the shadowing class
+    outright and costs nothing.
+
+    ⚠ THIS FILE'S SCRIPT ONLY. `main-status-watch.py`'s copy is pinned by
+    `test_main_status_watch.py`, which owns that file — see the note there.
+    """
+    got = _sys_path_mutations(SRC)
+    assert got, "the sys.path scan matched nothing — this guard is inert"
+    assert [m for _, m in got] == ["append"], got
+    # POSITIVE CONTROL: the scan CAN see the spelling this forbids, so the
+    # equality above is not a comparison against a scan wired to nothing.
+    assert _sys_path_mutations(
+        'import sys\nsys.path.insert(0, "x")\n') == [(2, "insert")]
+    # …and it does not fire on an unrelated `.append`, so a future
+    # `results.append(…)` in the script cannot satisfy it by accident.
+    assert _sys_path_mutations('rows = []\nrows.append(1)\n') == []
 
 
 def test_every_env_var_the_code_reads_is_documented_in_the_header():
@@ -1734,8 +1940,83 @@ def test_stale_base_triage_SPAWNS_these_argv0_AND_NOTHING_ELSE():
                      which is what lets every test point it at a stub. Its own
                      argv is enumerated by the `gh` guard below, so `<computed>`
                      here is not an unexamined hole.
+
+    🔴 THAT LAST SENTENCE USED TO BE WIDER THAN WHAT WAS ENFORCED. A set member
+    is not a count: every computed head folds into the ONE `<computed>` entry,
+    so a second one — `binary = "git"; subprocess.run([binary, "push"])` —
+    passed this pin, the `gh` ledger, the `_git` allowlist and the
+    literal-`git`-outside-the-helper check, all four, unchanged. So the computed
+    heads are now asserted BY NAME AND BY COUNT, which is what makes the
+    justification above true rather than merely stated.
     """
     assert {a0 for _, a0 in _spawn_argv0()} == {"git", SUB_COMPUTED}
+    computed = _computed_spawn_heads()
+    assert computed, "no computed spawn found at all — this half is inert"
+    assert {n for _, n in computed} == {"gh"}, computed
+    # 🔴 AND BY COUNT, CROSS-CHECKED AGAINST THE OTHER SCAN. `_gh_argv_shapes`
+    # counts exactly the spawns whose head is the Name `gh`, so these two
+    # disagree the moment a computed spawn is built from anything else — which
+    # is the case a SET of argv0 sentinels absorbs without moving.
+    assert len(computed) == len(_gh_argv_shapes()), (computed, _gh_argv_shapes())
+
+
+def test_a_SECOND_computed_spawn_cannot_HIDE_INSIDE_the_computed_member():
+    """🔴 THE GUARD ABOVE, DRIVEN OVER SOURCE THAT VIOLATES IT — and the four
+    guards it walked past, each re-run here on the same source so the claim is a
+    measurement rather than a summary of one.
+
+    The violation is two lines appended to the REAL file, which is what makes
+    the four greens below meaningful: the argv0 SET is unchanged because
+    `<computed>` already has a member, the `gh` shape ledger is unchanged
+    because the new head is not the Name `gh`, the `_git` allowlist is unchanged
+    because the call never goes near `_git`, and the literal-`git`-outside-the-
+    helper check is unchanged because the head is a variable, not `"git"`.
+    """
+    hidden = SRC + '\nbinary = "git"\nsubprocess.run([binary, "push"])\n'
+    # The four that stay green — the finding, restated as assertions.
+    assert {a0 for _, a0 in _spawn_argv0(hidden)} == {"git", SUB_COMPUTED}
+    assert _gh_argv_shapes(hidden) == _gh_argv_shapes()
+    assert _git_unenumerated(_git_subcommands(hidden)) == []
+    helpers = [n for n in ast.walk(ast.parse(hidden))
+               if isinstance(n, ast.FunctionDef) and n.name == "_git"]
+    lo, hi = helpers[0].lineno, helpers[0].end_lineno
+    assert all(lo <= ln <= hi for ln, a0 in _spawn_argv0(hidden) if a0 == "git")
+    # …and the one that goes red. Source order, so the appended spawn is last.
+    assert [n for _, n in sorted(_computed_spawn_heads(hidden))] == (
+        [n for _, n in sorted(_computed_spawn_heads())] + ["binary"])
+    # NEGATIVE CONTROL on the new scan: the unmodified file's computed heads are
+    # ALL the `gh` seam, so the rejection above is about the appended spawn and
+    # not about a scan that reports every spawn it sees.
+    assert {n for _, n in _computed_spawn_heads()} == {"gh"}
+    # …and a head that is not a plain Name lands as a sentinel rather than
+    # raising or vanishing.
+    assert [n for _, n in _computed_spawn_heads(
+        'import subprocess\nsubprocess.run([self.gh, "api"])\n')] == ["<not-a-name>"]
+
+
+def test_a_spawn_whose_ARGV_IS_NOT_A_LIST_is_a_SENTINEL_rather_than_a_SKIP():
+    """🔴 THE NET FOR `os.system("git push")` AND ANY argv BUILT ELSEWHERE, and
+    it was never exercised: the mutant replacing `out.append((node.lineno,
+    SUB_NOT_A_LIST))` with `pass` SURVIVED the whole suite. The real file
+    contains no such call, so no assertion against the real file can tell ABSENT
+    from DENIED — the same reason `_git_subcommands`' sentinels are driven over
+    synthetic source rather than asserted in place.
+    """
+    for src, lineno in (
+            ('import os\nos.system("git push --force")\n', 2),      # a bare string
+            ('import subprocess\ncmd = ["git", "push"]\n'
+             'subprocess.run(cmd)\n', 3),                           # built elsewhere
+            ('import subprocess\nsubprocess.run([])\n', 2)):        # an empty argv
+        assert _spawn_argv0(src) == [(lineno, SUB_NOT_A_LIST)], src
+    # NEGATIVE CONTROL: a literal list head is NOT the sentinel, so the three
+    # above are about the unreadable argv and not about a scan that labels
+    # everything it sees.
+    assert _spawn_argv0('import subprocess\nsubprocess.run(["git", "push"])\n') == [
+        (2, "git")]
+    # …and the sentinel really does REJECT at the ledger that consumes it, which
+    # is what makes it a guard rather than a label.
+    assert {a0 for _, a0 in _spawn_argv0('import os\nos.system("git push")\n')
+            } != {"git", SUB_COMPUTED}
 
 
 def test_every_git_SPAWN_goes_through_the_one_helper():


### PR DESCRIPTION
## Why

**MEASURED:** of the **6** genuine `tekton/devrc-pytests` failures in the whole post-#1458 window, **3 — half — were the same test** on PRs **17, 40 and 40** commits behind `main`, all since merged, and that test passes on current `main`. An earlier sample had 8 of 8 failing open PRs 5–42 commits behind, with a rebase curing 4 outright.

Nothing blocks a merge here, so the gate's only value is whether a human *believes* a red — and half the genuine reds are already-fixed failures a human then debugs against a diff that cannot reach them. `strict: true` is deliberately off and correctly so, so this attacks the *triage* cost rather than the staleness.

## What

`scripts/stale-base-triage.py --pr N` / `--sweep`. It **runs no tests** and **writes nothing anywhere**. For each failing test named in the newest `tekton/devrc-pytests` status it emits a deterministic evidence pair:

1. the PR head's copy of the file defining that test is **byte-identical to the merge-base's** — so this change never touched it; and
2. `origin/main` **HAS moved that file** since the merge-base, in commits **absent from the head**.

Verdict per PR: `INHERITED — likely cured by rebase` (naming the commit and the test) · `NOT EXPLAINED BY STALENESS` · `COULD NOT MEASURE` with a reason.

---

## 🔴 Round 0 found the headline verdict fired on 0 of the 3 cases that justified it. Fixed.

`names_provably_complete` could prove completeness only by reading `failed=N` out of the status description. `failed=` is the **last** field in the gate's banner and a status description is capped at **140 BYTES** (measured: every real row sampled is 138 *characters*, which is 140 bytes once the `—` in `FAILED: pytests —` counts as three — ⚠ whether that byte cut is GitHub's or the posting pipeline's own truncation is **not** determined here, because every row sampled carries exactly one multi-byte character), so whether it survives is decided by **how long the failing test's name is**. On the three PRs this tool's requirement was measured on — #1454, #1462, #1499 — it did not survive. All three resolved to `COULD NOT MEASURE` **with the correct answer already in the row**.

**The fix is a second route, and it is a proof rather than a heuristic.** `scripts/run-tests.sh` GUARD 4 defines

```
collected   = passed + skipped + failed + errors + xfailed + xpassed
TOT_FAILED += failed + errors                    (the banner's failed= is f+e)
```

so `collected − passed − skipped == failed + xfailed + xpassed ≥ failed`, and names are a subset of the failures, so `len(names) ≤ failed ≤ derived`. When **`derived == len(names)`** the inequality is squeezed shut and completeness is **proven**. `collected=`, `passed=` and `skipped=` all *precede* `failed=`, so they are exactly the fields that survive the cut. The direct `failed=N` route is kept and still tried first, because it is the stronger claim.

### Yield, measured read-only on real status rows

| population | provably complete, before | after |
|---|---|---|
| 100 most-recently-updated closed PRs | 5 / 28 red heads | **18 / 28** |
| — the three justifying PRs #1454 #1462 #1499 | **0 / 3** | **3 / 3** |
| 58 open PRs | 4 / 26 red heads | **7 / 26** |
| — #1518, #1515 (9 commits behind, actively worked) | **0 / 2** | **2 / 2** |

### 🔴 The soundness control, because this is the half that can be wrong in the dangerous direction

An **over**-count only ever makes the tool withhold. An **under**-count would certify a completeness the row does not have and dismiss a real red — the one error this tool must not make.

- On the same real rows, **17 carried both a visible `failed=N` and a derivable bound. The two agreed exactly on all 17. Zero under-counts.**
- Genuine multi-failure reds stay withheld: **#1177** derives **39** against one name, **#1280** `failed=5`, **#1440** `failed=3` — all still `COULD NOT MEASURE`, with the `HINT:` line.
- The bound is structurally an over-count: `xfailed`/`xpassed` can only inflate it, and the three fields are matched as **one adjacent, ordered group** so a number the cap cut *short* cannot shrink it. `collected=` and `passed=` are proven intact by having matched banner text after them; `skipped=`, the only one that can be short, *subtracts less* and so errs toward refusing.

### The coupling is pinned mechanically, not asserted

`test_the_run_tests_collected_arithmetic_this_derivation_rests_on_is_pinned` reads the `collected=$((…))` and `TOT_FAILED=$((…))` expressions out of the shell source and checks the **containment relation** — so renaming the shell locals is fine, and changing *what is summed* is not. It also requires **every** `TOTAL` banner line to print the fields in order (there are two; a first version searched the whole file and was satisfied by the other one — the mutation sweep caught that). ⚠ What it *cannot* check — that `xfailed`/`xpassed` are non-negative counts — is **stated in the test, not asserted**.

### Verified against the original symptom, on live data

```
old code (5ad08e5a), --pr 1518:   VERDICT: COULD NOT MEASURE    rc 0
this tree,           --pr 1518:   VERDICT: INHERITED            rc 10
```

A four-PR read-only sweep returns `INHERITED` for #1518/#1515/#1450 naming the fix commits, and `COULD NOT MEASURE` for #1177.

---

## 🔴 Prior art, and what this adds to it — honestly

`scripts/main-status-watch.py`'s `screen_all_known_flakes` is **the same completeness-proving screen in 15 lines**, and it shipped first. Its own comment records that it would have fired **zero** times on the 100 commits measured. Round 0 was right that this PR rebuilt that gate and cited it nowhere. It now cites it, in the header, in both files.

**What this tool adds:**

1. **The derived route explains that zero.** The screen is not inert because the *idea* is unsatisfiable — it is inert because it reads only `failed=N`, the field the cap eats. That is a measurable answer to handoff rank 6's open question ("is that screen inert?", due 2026-10-11): **it is inert for a reason, and the reason is fixable.** On the rows measured the derived route moves provable completeness from 5/28 to 18/28.
2. **The evidence half, which the screen has no equivalent of.** The screen answers *may I stay silent about this red?* from a name ledger. This answers *which commit on `main` already fixed it?* from blob OIDs and commit lists — `resolve_test_file`'s two-phase search, the merge-base/head/main blob compare, `commits_touching`, `prove_candidates`. That is the ~150 lines round 0 kept, and it is where the value is.

**What it does not add, said plainly:** the completeness gate itself is prior art. It is not a new idea here, and the honest summary of the *gate's* contribution is "the same 15 lines, plus the derivation that makes them fire".

**The derived route is deliberately NOT back-ported to the live watcher, and the reason is the direction of the error.** In the triage tool, proving completeness makes it **speak**. In the watcher, it makes it stay **silent** about a red on `main`. Widening a silence over main's only automated detector is a change to make on purpose with its own measurement, not a free win inherited from a sibling. `main-status-watch.py` now says so where the screen is defined.

---

## 🔴 Report only by default

`COMMENT_MODE_DEFAULT` is the literal `"off"`, pinned by `test_the_comment_mode_default_is_the_LITERAL_off` **both as a value and as source text** — so arming the PR-comment writer costs a visible line in the arming commit. `dry-run` says what it would post; `on` posts once, behind an idempotence marker. **Nothing has been posted to GitHub at any point, and every live run in this work was read-only with `mode=off`.**

## One rule, one place (D6) — and the two copies had already diverged

`classify` here was **byte-identical** to `main-status-watch.py`'s; `_FAILING_RE`, `_FAILED_COUNT_RE`, `parse_failing_names` and `parse_failed_count` were duplicated **and already divergent**. All five now live in **`scripts/lib/ci_status.py`**, imported by both. Each divergence was reconciled deliberately, because `main-status-watch.py` is **live on both hosts every 10 minutes**:

- **The fold.** The live copy kept the *first* row per context, which is right only because GitHub returns the array newest-first — an assumption about someone else's response ordering, load-bearing and unstated. ⚠ *Correction to the round-0 framing:* first-wins over a newest-first array yields the **newest** row, not the oldest. The defect is order-**dependence**, not a wrong row today. It now folds on `max(created_at)`, which agrees with first-wins on GitHub's current ordering and stays right if that changes; with no `created_at` anywhere, first-wins is the fallback. `test_newest_per_context_is_ORDER_INDEPENDENT_which_first_wins_was_not` reimplements the old rule and shows it returning the superseded `pending` row on the order it does not expect.
- **The context filter** moved out of the fold into `commit_verdict`, where the policy belongs, and *before* the emptiness check — a commit carrying only a foreign pipeline's rows must have **no** verdict, never green.
- **The `isinstance` skip.** The live copy deliberately had none, arguing the arm was unreachable and that dropping a row could drop the red. The shared function keeps the triage tool's skip: still unreachable for the watcher (its walk validates every row first), unchanged for the triage tool.
- **The fragment strip** is now shared and is *provably inert* for the watcher: a row cut at `| TOTA` was necessarily cut before `failed=N` too.

Duplication is refused mechanically: `test_the_shared_predicates_are_NOT_re_declared_in_either_consumer` fails on a local `def` of any of the five, in either file, with a positive control so the scan cannot pass vacuously.

Two pre-existing tests broke, both for the right reason, both fixed rather than weakened: one used `def classify(...)` as its positive control for the docstring-stripper, and one copies the script to a tmp dir and runs it (no sibling `lib/`; it now passes `PYTHONPATH` and says why).

**Deployment:** the unit runs the script straight out of the checkout, so a `git pull` delivers both files and no home-manager switch is involved. ⚠ `X-Restart-Triggers` in `nix/home.nix` still names only `main-status-watch.py` and was deliberately **not** edited — for a timer-driven oneshot that re-reads the file every run it is cosmetic.

## Deletion pass, re-measured *after* F2 (D1–D5)

| candidate | decision | evidence |
|---|---|---|
| `--fetch` | **DELETE** | The only git subcommand here that **writes**, in a tool whose safety claim is that it writes nothing. Measured: this repo's PRs are same-repo branches and `origin` fetches `+refs/heads/*`, so **58 of 58 open PR heads already resolved in the base clone** with no `--fetch`. |
| `--json` | **DELETE** | No consumer. A whole-repo search for `stale-base-triage`/`STALE_BASE_TRIAGE` returns this script and its test file, nothing else. It cost a global `_JSON_MODE`, a `say()` indirection on every human line, and a second exit path. |
| `--sweep` | **KEEP** | Its rationale is exactly what F2 reversed: the sweep now surfaces **7** provably-complete open reds where it surfaced 4, and the three it gained are 9–94 commits behind and **actively worked** — not the 259/357/508-behind abandoned ones. |
| self-parsing `--help` | **KEEP** | What it prints is the `#` header — env ledger, exit codes, measured rationale — which argparse cannot see. The alternative is copying the ledger into an epilog, i.e. reintroducing the duplication D6 just removed. |
| the 3 env seams + ledger test | **KEEP** | `_GH`/`_REPO` are the seams the test harness points at a stub — they are *why* no test here can reach real GitHub. `_BUDGET` is the only way to drive the budget guard to zero. `_COMMENT_MODE` is the arming seam and fails closed across seven spellings. |
| duplicated predicates (D6) | **DONE** | Above. |

🔴 Deleting `--fetch` made the safety guard **stronger, not weaker**: `test_only_refs_under_its_own_namespace_are_ever_written` (a *relative* claim about a repo-**global** surface) is replaced by `test_no_git_subcommand_that_WRITES_is_ever_invoked`, which enumerates the read-only subcommands as an **allowlist** off the AST — so a subcommand nobody enumerated is a write by default.

## Traps handled, each pinned by a test

- `/commits/{sha}/status` (**singular**) maps `error` onto `failure` — never read. Only the plural list, which carries no roll-up field at all.
- The list is **newest-first** — folded on `max(created_at)`, so it is order-independent rather than merely order-lucky.
- `error` is a **broken gate, not a code failure** — its own summary line, never inside the red total.
- A **squash** merge never makes a head an ancestor of its base. Ancestry is asked only about the PR head; every "this landed" claim is made by **blob OID**.
- `git diff --quiet <ref> -- <path>` exits 0 when the path exists on **neither** side. Existence is proved with `git cat-file -e` first — pinned by an **AST scan** of the git invocations, because a string search would have been satisfied by the comment explaining the hazard.
- The **140-byte description cap**: `INHERITED` at PR level requires provable completeness by *either* route above. Deliberately conservative — the `HINT:` line still reports a partially-inherited red.
- The test-name → file mapping is **searched, never guessed**, with a distinct outcome for not-found, ambiguous, class-qualified, parametrised and cap-truncated names. Two phases, and the order is the guard.

## Testing

**Red/green for the F2 change:** **13 of the 14 new tests fail at the PR's previous head `5ad08e5a` and pass at HEAD.** The 14th is a negative control that is green at base too, and its docstring says so — it is an *invariant* guard, not regression coverage, and is not counted as such.

**Suites:** `test_stale_base_triage.py` 56 → **71**. `test_main_status_watch.py` 96 → **101**. Together with `test_no_real_launchers.py`: **252 passed.**

🔴 **A repo-wide guard went red, and the change-scoped mapping could not see it.** `test_no_real_launchers.py::test_every_hazardous_binary_the_scripts_reach_is_stubbed_or_acknowledged` failed on the D6 commit: `launcher_scan.hazard_hits` is a **text** scan over `scripts/` — a prose mention counts, deliberately and fail-closed — and the new import comment says "no home-manager switch is involved". **Re-justified, not reworded**, which is this repo's stated convention written into the table itself, and **pinned**, because that entry says in its own words that an acknowledgement "would otherwise blind the guard" (it has been blinded before: a real `home-manager switch` added to an already-acknowledged script once passed 54 guard tests). Two new tests carry the row — an AST argv[0] set that grows-or-shrinks, and a mention-exists-but-is-never-spawned pair. **Both controls watched, both directions:** injecting `subprocess.run(["home-manager", "switch"])` fails both new tests with *their own* messages; rewording the mention away fails the mention-must-exist half **and** the ledger's file-set pin. ⚠ Found only by running the whole `scripts/tests` target — `scoped-tests.sh` selected just the two suites named in the diff, and a change that adds only a *comment* can go red here.

**Mutation sweep on the new completeness logic**, `PYTHONDONTWRITEBYTECODE=1`, every edit verified to have changed the file, verdicts read from the runner's own result lines:

| round | mutants | killed | survived | negative control | positive control |
|---|---|---|---|---|---|
| 1 | 15 | 10 | 5 | GREEN | KILLED |
| 2 (delta) | 8 | 6 | 2, both argued **equivalent** | GREEN | KILLED |

Round 1's five survivors were **four real gaps in the tests** (fixed) and one equivalent mutant:

- **M14** — reordering `passed=`/`skipped=` in the `TOTAL` banner survived, because the pin searched the whole *file* and `run-tests.sh` prints **two** banners; mutating one was satisfied by the other.
- **M11** — `(\d*)` for the `skipped` group survived: no fixture fed a row cut exactly on the `=`, which makes `int("")` raise on the reporting path.
- **M10** — replacing the underivable-row refusal with a bound of 0 survived, because `names` is non-empty by then so the *verdict* is identical; only the operator-facing reason distinguishes them, and both reasons are now pinned as whole strings.
- **M5b** — the naive three-separate-searches spelling is now driven explicitly and is killed.

The two round-2 survivors are argued equivalent rather than fixed, and labelled as such in the source: **M5** (`.*` between the fields still requires the *order*, and a single-banner description has exactly one of each field) and **M13** (`run-tests.sh` *shrinking* what it sums into `failed=` keeps the bound an upper bound — the pin checks containment **on purpose**; **M15**, a term *leaving* `collected`, is killed by the same pin). Round 2 produced no new finding, so the ladder ends there.

## 🔴 This PR's own CI is red, and the tool in it triaged that red

`tekton/devrc-pytests` fails on `test_every_kill_server_call_site_in_the_repo_is_classified`. Run `stale-base-triage.py --pr 1524` against this head and it:

- resolves the name to `scripts/claude-hooks/tests/test_guard_core.py`, shows that blob is **byte-identical at the head and the merge-base** (`490ed52e57a3`) while `main` has moved it in two commits absent from the head, and
- **withholds the PR-level verdict anyway** — `collected − passed − skipped = 2` against **one** name, so `COULD NOT MEASURE` plus the `HINT:` line.

That is the conservative arm working on its author. And the withholding was **right**, which is the part worth reading: a locally built **merged tree** does *not* cure it, and a pristine `origin/main` worktree (`f3e27aa3`) **fails the same test on its own** — a second unclassified doc, `claudedocs/handoff-cairn-oss-multi-instance.md`, is missing from `_KILL_MENTION_LEDGER`. **`main` is red, independently of this PR.** Had the tool asserted `INHERITED — likely cured by rebase` here, it would have been wrong; it says "likely" and it declined to say even that.

**Attribution of the red, from this PR's own arithmetic:** previous head `collected=22204 passed=22200 skipped=2`; this head `collected=22224 passed=22220 skipped=2`. **+20 collected, +20 passed** — exactly the 15 + 5 tests added here, all passing — with the failure count unchanged at 2. My diff touches six files, all under `scripts/`, and no `claudedocs/` file at all. On the merged tree the three suites still report **252 passed**.

## Not verified

- **No gate tier was run locally** — neither `scripts/gate.sh` nor the `nix build` sandbox. A full `scripts/tests` target run was attempted twice and **produced no verdict either time**: the box was at load ~55 with six other full-target runs from another session, and it hit its 90-minute cap. Per the repo's own rule that is *could-not-vouch*, **not a pass**, and it is recorded that way. What did run to completion, on both the branch and the merged tree, is the three affected suites (**252 passed**) plus a 1,150-test subset covering every repo-wide scanner identifiable by grep — through the dev-shell pytest door, which bypasses GUARDs 7/8/9/10. **CI is the authoritative signal, and it is read above.**
- The tool says "**likely** cured by rebase" and means it: a commit touching the failing test's file is a *candidate* fix. Only re-running the suite on the merged tree proves one.
- The write path was exercised only against a stub `gh`. **No real comment has ever been posted.**
- `main-status-watch.py` was **not** exercised against live GitHub — only its 99 tests plus a `--help` smoke run. The deployed copy is untouched: this work happened in a worktree, and the live unit runs the base clone's `main`.
- The blob half of the verdict is unmeasured for #1454/#1462/#1499 specifically — their heads are not in the local clone. It **is** verified live on #1518, #1515, #1450 and #1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
