### PR TITLE
docs(scripts): the script index listed a file deleted 4 weeks ago, and a comment's positive controls had gone stale

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,7 +54,6 @@ Click actions for those blocks:
 | `tmux-scratch-picker.sh` | list/toggle/create `scratch-*` sessions |
 | `tmux-scratch-monitor.sh` | live HUD of the last N lines across all scratch sessions |
 | `tmux-scratch-status.sh` | RETIRED `status-left` scratch indicator — kept as a debugging renderer; the live legend is the bar block `i3status-scratchpads` |
-| `tmux-claude-counters.sh` | aggregate Claude-window counters for `status-right` |
 | `tmux-idle-update.sh` | batch-update window tab colours by idle time |
 | `tmux-pipe-activity.sh` | manage `pipe-pane` for background activity tracking |
 | `tmux-activity-emit.sh` | activity-telemetry shipper for tmux |

--- a/scripts/tmux-scratch-slots.sh
+++ b/scripts/tmux-scratch-slots.sh
@@ -6,11 +6,18 @@
 # Example: `Alt+Shift+V` -> tmux session `scratch4` -> codename `Vapor`.
 #
 # 🔴 The binding is tmux's ROOT key table, NOT i3. There is no i3 binding for any
-# slot — measured: `grep -rE 'mod\+Shift\+(V|G|P)' nix/i3/` -> 0, against 79 live
-# `bindsym` lines in nix/i3/config.nix, and 22 `M-<key>` entries in
-# `tmux list-keys -T root`. A previous version of this comment spelled the hotkey
-# `$mod+Shift+V` (i3 syntax); a reader following it presses a chord that is bound
-# to nothing.
+# slot — measured: `grep -rE 'mod\+Shift\+(V|G|P)' nix/i3/` -> 0. A previous
+# version of this comment spelled the hotkey `$mod+Shift+V` (i3 syntax); a reader
+# following it presses a chord that is bound to nothing.
+#
+# That ZERO is the claim, and it is only worth anything against a NON-EMPTY
+# corpus — otherwise it is indistinguishable from a grep wired to nothing. Two
+# positive controls, written as COMMANDS rather than as numbers so they cannot go
+# stale (an earlier revision hardcoded "79 bindsym lines" and "22 M-<key>
+# entries"; by 2026-09-11 the live counts were 84 and 26, and nothing had told
+# anyone):
+#     command grep -c bindsym nix/i3/config.nix          # i3 bindings that DO exist
+#     tmux list-keys -T root | grep -cE '^bind-key +-T root M-'   # the M- table
 #
 # 🔴 CASE IS SIGNIFICANT and is not a shift-modifier convention: `M-v` -> scratch3
 # (`violet`) and `M-V` -> scratch4 (`Vapor`) are DIFFERENT sessions. Never


### PR DESCRIPTION
Closing out the scratchpad-bar-legend arc (#1485). Both of these were flagged by that PR's round-2 audit and classified as **non-findings**; measuring them showed one is worse than that classification.

## 1. `scripts/README.md` indexed a file deleted four weeks ago

The table listed `tmux-claude-counters.sh`, which was **deleted 2026-08-14** in `059b7fbe` (#475). A reader looking a script up in the index goes hunting for a file that does not exist — which is something a reader *acts on*, not a cosmetic nit.

I measured the whole table rather than fixing only the row I already knew about:

```
72 rows checked, exactly 1 dangling
```

so the index is otherwise accurate. Row removed.

**Why nothing caught it:** `scripts/README.md` is not scanned by `test_doc_path_rot.py` — it has **0** entries in `doc-path-baseline.tsv`.

**The other live references to that script are correct and deliberate, and are left alone:**
- `claude/skills/devrc-dx/reference/config-stack.md` describes it in the **past tense** ("REMOVED 2026-08-14") and is baselined in `doc-path-baseline.tsv:110`.
- `scripts/drift-check.sh` and `scripts/lib/drift_phase2.py` name it as a **phase-2 reader to be deleted** — that is the ledger doing its job.
- Two `claudedocs/` files are dated historical records.

## 2. `scripts/tmux-scratch-slots.sh` — stale positive controls

The header's load-bearing claim is that **no i3 binding exists for any slot** (`grep -rE 'mod\+Shift\+(V|G|P)' nix/i3/` → 0). That zero is only worth something against a non-empty corpus, so the comment carried two counts as positive controls: "79 live `bindsym` lines" and "22 `M-<key>` entries".

Measured 2026-09-11 — the live counts are **84** and **26**. Nothing asserts on those numbers, so they drifted silently.

**Fixed the form, not the numbers.** Renumbering prose regenerates the same defect on the next drift. The controls are now the *commands* that re-derive them, and the comment states why the zero needs a non-empty corpus at all — a zero against an empty corpus is indistinguishable from a grep wired to nothing.

## Verification

The edited comment lives in a file with **three** readers, so all three were re-checked after the edit:

| reader | slots |
|---|---|
| bash `source` | 20 |
| Python legend parser (`i3status-scratchpads`) | 20 |
| nix `slot-table.nix` via `nix-instantiate --eval` | 20 |

`144 passed` across `test_scratchpads_block.py`, `test_doc_path_rot.py`, `test_runtime_shebangs.py`.

## Not done

No test was added pinning `scripts/README.md` rows to files that exist. That would have caught this and would catch the next one, but it is scope beyond the two claims being corrected — noting it rather than silently leaving the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpHAkviTvJNEybpsDFBHEJ
