### PR TITLE
feat(audit-pr): enumerate the ladder carriers — and the interior hole is essentially a devrc phenomenon

### DIFF
--- a/claudedocs/audit-ladder-review-2026-09-04.md
+++ b/claudedocs/audit-ladder-review-2026-09-04.md
@@ -467,6 +467,42 @@ Both directions, and they do not cancel.
   churn count — shape A of the reference file's range table, working.
 - **The waste audit is devrc-only.** Ladders ran in homelab-talos, civit-datapacket-talos,
   vetr, auditloop, civitai-gpu-fleet and naida-ai; none were churn-measured.
+  ✅ **MEASURED 2026-09-11 — and the population outside devrc is LARGER than devrc's.**
+  `scripts/ladder-range-coverage.py --find-carriers` over each repo (limit 400, all states):
+
+  | repo | PRs scanned | carriers | measured | refused | INTERIOR | TAIL |
+  |---|---|---|---|---|---|---|
+  | homelab-talos | 400 ⚠ hit limit | 68 | 67 | 1 | **88** | 7,314 |
+  | civit-datapacket-talos | 400 ⚠ hit limit | 37 | 37 | 0 | **0** | 2,107 |
+  | vetr (api) | 152 | 13 | 11 | 2 | **0** | 115 |
+  | vetr (app) | 168 | 5 | 5 | 0 | **0** | 18 |
+  | civitai-gpu-fleet | 282 | 6 | 6 | 0 | **0** | 498 |
+  | naida-ai | 214 | **0** | — | — | UNMEASURABLE | — |
+  | auditloop | **0 PRs** | 0 | — | — | UNMEASURABLE | — |
+
+  **129 carriers outside devrc against 70 inside it** (devrc's newest 400 PRs, same command) —
+  so the repo this review measured holds about a third of the ladder work, and the other
+  two-thirds were unmeasured until now.
+  🔴 **THE HEADLINE FINDING INVERTS WHAT devrc SUGGESTS: the interior hole is essentially a
+  devrc phenomenon.** 655 uncovered interior lines across 20 devrc ladders, against **88
+  across 126 external ones** — and all 88 sit in a single repo (homelab-talos, 2 adjacencies).
+  Four of the five measured repos have **zero** interior gaps. The likely mechanism is a devrc
+  *authoring* habit rather than a property of the ladder: titling one comment "rounds N and
+  N+1" and posting a single block for both, which is exactly #1233's shape.
+  ⚠ **TAIL churn is large everywhere (10,052 lines externally) and is NOT a finding yet.** It
+  conflates post-final-block fixes with development that continued after the ladder ended;
+  nothing in the ranges separates them, and classifying it needs the commits read. Do not
+  quote it as unaudited ladder work.
+  ⚠ **Two repos are UNMEASURABLE, each for its own reason, and neither is a pass.** naida-ai
+  ran 214 PRs and posted **no ledger at all**, so there is nothing to measure coverage
+  against — "no ladders ran here" and "ladders ran without blocks" are the same observation
+  from this instrument, and so is "they were fine". auditloop has no PR history in scope.
+  ⚠ **Three caveats on the counts.** (a) Every carrier count is a **FLOOR** — `gh` does not
+  return REVIEW comments, so a block posted as a review is invisible, the same blind spot
+  `audit-dispatch.py` warns about. (b) Two repos **hit the 400-PR scan limit**, so their
+  carrier counts are partial and the real totals are higher. (c) This measures **ALL**
+  carriers, not this review's 2026-08-28 → 09-05 window, so it is a superset and not
+  comparable to the table above row-for-row.
 
 **Over-counts:**
 

--- a/claudedocs/handoff-ladder-range-coverage.md
+++ b/claudedocs/handoff-ladder-range-coverage.md
@@ -1,0 +1,201 @@
+# Handoff: ladder-range-coverage — 2026-09-11
+
+## Run this first — the index, one command
+```bash
+cairn recall --repo /home/zach/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+Measure the churn that an audit ladder's `audit-claims` blocks do NOT cover, in devrc and
+then outside it. Came in as ranks 10 and 8 of `handoff-audit-pr-ladder.md`; that doc has
+since renumbered and dropped both, so this is the durable home.
+
+## State now
+- **Branch:** `feat/ladder-carrier-enumerator` at `405c4b45`, pushed, **no PR yet**.
+  Worktree `/home/zach/workspace/devrc-ladder-find`, clean, branched off `058c90c2`.
+- ✅ **Rank 10 DONE and MERGED — `#1519` → squash `766c1295`**, verified by CONTENT on
+  `origin/main` (`scripts/ladder-range-coverage.py`, `scripts/tests/mutants-ladder-range-coverage.sh`,
+  and `measure_range_churn` all present), never by ancestry.
+  - `scripts/ladder-range-coverage.py` classifies every adjacency in a ladder's chain of
+    block ranges — TIGHT / GAP / OVERLAP / UNRELATED, plus the tail — and reports the
+    uncovered churn for the window `[first block's from, head]`.
+  - `measure_range_churn` was EXTRACTED from `audit-dispatch.py::measure_ledger` and is
+    shared, so the report cannot drift from the command the skill tells an auditor to run.
+  - Open item **5** of `claudedocs/audit-ladder-review-2026-09-04.md` is marked CLOSED in
+    that doc, with its residual stated.
+- ✅ **devrc measured (the review's own 20 ladders):** INTERIOR **655** lines in 2 ladders,
+  TAIL **3,727** in 11. Commands and per-ladder rows in the PR body of `#1519`.
+- ✅ **Rank 8 DONE — all six named repos churn-measured or UNMEASURABLE with a reason**, its
+  closing condition met. Results written into the `CANNOT-SEE` section of
+  `claudedocs/audit-ladder-review-2026-09-04.md` (uncommitted at time of writing; see ranked
+  item 1). **129 carriers outside devrc against 70 inside**; INTERIOR **88** total across 126
+  measured external ladders, TAIL 10,052. The per-repo table is in that doc, not repeated here.
+  ⚠ The raw per-repo reports were scratchpad files and are gone — re-run the commands in the
+  investigation block below rather than hunting for them.
+- **Deploy/verify status:** `766c1295` is merged and **NOT deployed** — no `ship.sh` run this
+  session. It adds a script and a test; nothing a consumer runs changed, and
+  `ladder-range-coverage.py` is invoked by path, not from `~/.claude`. `405c4b45` is pushed
+  only: not merged, not deployed.
+- ⚠ **No `clawgate-task:` field recorded.** `clawgate_handoff.sh resolve` exited **5**
+  (nothing resolved). An unknown session id answers 200 with an empty array, so that cannot
+  distinguish "this session touched no task" from "the id is wrong" — it is NOT a clean bill
+  of health, and no task was created to fill the blank.
+
+## Open investigations — live diagnosis state
+
+### The TAIL is 10,052 lines externally and nobody knows what it IS — the one open question
+- **Symptom + exact repro:** rank 8 is measured, but its largest number is uninterpretable.
+  Re-derive any repo with:
+  ```bash
+  nix develop /home/zach/workspace/devrc -c python3 \
+    /home/zach/workspace/devrc-ladder-find/scripts/ladder-range-coverage.py \
+    --find-carriers --repo <slug> --repo-dir <checkout> --limit 400
+  ```
+  Slugs → checkouts: `ZacxDev/homelab-infra` → `~/workspace/homelab-talos`;
+  `civitai/talos-infra` → `~/workspace/civit/datapacket-talos`;
+  `vetrllc/vetr-api` → `~/workspace/vetr-api`; `vetrllc/vetr-app` → `~/workspace/vetr-app`;
+  `civitai/gpu-fleet-infra` → `~/workspace/civit/civitai-gpu-fleet`.
+- **Observed (with values):** INTERIOR totals are 88 (homelab-talos, 2 adjacencies) and **0**
+  in all four other measured repos, against 655 across 20 devrc ladders. TAIL totals are
+  7,314 / 2,107 / 115 / 18 / 498 — **10,052 lines, and 126 of 129 external ladders measured**
+  (3 REFUSED on the positive control: their commits are not in the local checkout). Full
+  per-repo table in `claudedocs/audit-ladder-review-2026-09-04.md`.
+- **Ruled out:** *"the interior hole generalises outside devrc"* — it does not. 88 lines across
+  126 external ladders, all of it in one repo, versus 655 across 20 devrc ones. via: measurement
+- **Ruled out:** *"a zero carrier count means the repo is clean"* — naida-ai ran 214 PRs and
+  posted **no** ledger at all, so there is nothing to measure coverage against; the script
+  reports UNMEASURABLE with that reason rather than 0. via: measurement
+- **Ruled out:** *"TAIL churn is unaudited ladder work"* — NOT established, and the script
+  refuses to say so. It conflates fixes posted after the final block with development that
+  simply continued after the ladder ended. via: code (the `r_to is None` split in
+  `measure_ladder`, and the caveat `render` prints)
+- **Leading hypothesis:** most of the tail is ordinary post-ladder development, not missed
+  audit surface — which would mean the range-coverage hole is a real but SMALL defect (88
+  lines outside devrc) and the 10,052 is mostly noise. devrc's interior gaps are probably a
+  local *authoring* habit: titling one comment "rounds N and N+1" and posting one block for
+  both, which is exactly #1233's shape.
+- **Next probe:** read the COMMITS behind the three largest tail gaps (homelab-talos leads at
+  7,314 lines) and classify each as post-final-block FIXES vs ordinary development. That is
+  the one question the ranges cannot answer, and the whole reason interior and tail are
+  reported separately.
+
+### `main` is red on a gate that no diff can fix, and it is getting worse by itself
+- **Symptom + exact repro:** `tekton/devrc-pytests` fails on
+  `test_every_kill_server_call_site_in_the_repo_is_classified`.
+  ```bash
+  nix develop /home/zach/workspace/devrc -c python3 -m pytest \
+    scripts/claude-hooks/tests/test_guard_core.py -k kill_server_call_site -q
+  ```
+- **Observed (with values):** on a clean `origin/main` worktree at `50e8a71a` it fails with
+  `added: ['claudedocs/handoff-tmux-webapp.md']`; on a feature branch off `289c0193` it fails
+  with `added: ['claudedocs/handoff-tmux-scratchpad-bar-statusline.md']`. Different files,
+  same assertion: `set(mentions) == set(_KILL_MENTION_LEDGER)` in
+  `scripts/claude-hooks/tests/test_guard_core.py:2625`.
+- **Ruled out:** *"PR #1519 broke it"* — that diff never mentions `kill_server`
+  (`git diff origin/main...<branch> | grep kill_server` is empty) and the failure reproduces
+  on an unmodified `origin/main` checkout. via: measurement
+- **Leading hypothesis:** the ledger enumerates FILES that mention a wide tmux kill, so every
+  new handoff doc that mentions one is an unclassified entry. It is on track to be a
+  permanently-red gate, which `claude/RULES.md` rates worse than no gate.
+- **Next probe:** decide whether the ledger should enumerate `claudedocs/` at all — a doc
+  cannot execute a kill — or whether the scan should be scoped to executable paths. That is
+  the fix; adding each new doc to the ledger is the treadmill.
+
+## Next steps (ranked)
+1. **Land `feat/ladder-carrier-enumerator`** — `405c4b45` plus the uncommitted rank-8 table in
+   `claudedocs/audit-ladder-review-2026-09-04.md`, in worktree
+   `/home/zach/workspace/devrc-ladder-find`. **An unmerged pushed branch is invisible to
+   `ship.sh` and to the next `/resume`, and the rank-8 numbers exist ONLY in that working
+   tree** — `claude/RULES.md` calls that unsaved work one routine `checkout` from deletion.
+   Claim `audit-pr-ladder-8` is HELD by this session; release it when this lands.
+   forcing: regression — the measurement is uncommitted and its scratch reports are already gone
+2. **Classify the three largest TAIL gaps by reading their commits** — post-final-block fixes
+   vs ordinary development. Until this is done, the 3,727-line devrc tail and the
+   7,314-line homelab-talos one must NOT be quoted as unaudited ladder work, and the
+   range-coverage defect's real size is unknown (it may be as small as 88 lines externally).
+   forcing: none
+3. **Fix or rescope `_KILL_MENTION_LEDGER`** so a new handoff doc cannot red the gate. See the
+   investigation below for the two candidate fixes.
+   forcing: gate — `tekton/devrc-pytests` is red on `main` itself today, for every PR
+4. **Rank 9 — mine the stop-rationale prose across every carrier.** Now cheap: `--find-carriers
+   --list-only` produces the population that used to be hand-built (199 carriers across the
+   seven repos). Survives durably as open item **4** of
+   `claudedocs/audit-ladder-review-2026-09-04.md`.
+   forcing: none
+
+## Gotchas / decisions / dead-ends
+- 🔴 **THE RANKED LIST OF `handoff-audit-pr-ladder.md` WAS RENUMBERED AND THREE ITEMS
+  VANISHED — one of them while I held its claim.** That doc's preamble said *"Numbering is
+  STABLE — the rank is half a `claim-work` slug's identity"*; the rewrite (merged as
+  `bfcc3b20`, #1511) replaced ranks 1–16 with an unrelated 5-item list. Old **8**
+  (churn-measure outside devrc), **9** (stop-rationale) and **10** (range-coverage) have
+  **zero** traces in it — grepped for `range-coverage`, `Churn-measure the ladders OUTSIDE`,
+  `stop-rationale`, `42 block-carrying`. Old 14 and 16 were genuinely resolved and are
+  visible in its `State now`. **The slug namespace and the list drifted apart silently:** I
+  was holding `audit-pr-ladder-10` against a rank that no longer existed, and a stable-slug
+  promise is worth nothing without a guard. Recorded on #1511 as a comment.
+- 🔴 **RUNNING THE INSTRUMENT AGAINST A SECOND CORPUS IS WHAT FOUND ITS DEFECT.** The
+  zero-line-gap caveat shipped in `#1519` as the literal *"Three of the 20 ladders look like
+  that"* — the devrc figure — and then printed that sentence verbatim under a 5-ladder run of
+  `vetrllc/vetr-app`. A count in prose beside a measurement it is not computed from is the
+  exact class the report exists to find, committed inside the report. Now derived and pinned.
+  **A tool validated on one corpus is validated on one corpus.**
+- 🔴 **THE TWO CALLERS OF A SHARED CHURN CORE WANT OPPOSITE THINGS FROM AN EMPTY RANGE, and
+  that is why the extraction is a separate function rather than a parameter.** For a delta
+  round an empty range is a broken question (`measure_ledger` spends three branches
+  diagnosing it); for the gap between two blocks it is the HEALTHY answer. A core enforcing
+  the delta rule would report every well-formed ladder as unmeasurable. Both directions have
+  their own mutant row, because one mutant cannot show both.
+- 🔴 **A GAP OF MANY COMMITS AND ZERO LINES IS THE INSTRUMENT WORKING, NOT A BUG.** #1064
+  (125 commits), #1274 (10), #1110 (7) all measure 0 lines: `--not <base>` excluding an
+  upstream bring-in, shape A of `round-ladder-evidence.md`'s range table. **A commit count is
+  not a churn count** — and a reader who conflates them will "fix" the exclusion that is
+  doing its job.
+- 🔴 **INTERIOR AND TAIL MUST NOT SHARE A HEADLINE.** devrc: interior 655, tail 3,727.
+  homelab: 88 vs 7,314. A single total gets quoted as an under-count it does not support,
+  because only the interior half is unambiguously churn nobody audited.
+- **A CI red is weak evidence; the cheap control settles it in one command.** `#1519` went red
+  on a test in a file its diff never touched. Running that same test on a clean `origin/main`
+  worktree took under a minute and proved it inherited — against a documented ~42% noise rate
+  on this check, the control is always cheaper than the reasoning.
+- **`gh pr list --json comments` returns comment bodies, so the carrier scan is ONE call.**
+  Asking per PR is ~300 calls against a secondary rate limit, which is why the carrier
+  population had been hand-built twice. ⚠ It does **not** return REVIEW comments, so every
+  carrier count from it is a **FLOOR, not a census** — the same blind spot
+  `audit-dispatch.py` warns about when it cannot see a block a human can.
+- **The content gates read `git ls-files`, so they are blind to unstaged files.** I ran them
+  once before staging and once after; only the second run is evidence about the new files.
+  A green gate over files it could not see is not a green gate.
+- **A merged branch is gone from the remote, so follow-on work needs a fresh one.** `--delete-branch`
+  removed `fix/ladder-range-coverage`; branching the next change off its local tip would have
+  re-introduced the already-squashed commits as unmerged. Copied the three modified files
+  aside with `cp -a`, made a new worktree off `origin/main`, copied them in.
+- ⚠ **`--find-carriers` fetches `refs/pull/<n>/head` into the target checkout**, which for the
+  client repos means writing objects into shared clones. Additive only — it moves no ref and
+  touches no working tree — but it is a write, and two of those repos are client-owned.
+
+## How to verify
+```bash
+# the instrument's own guards
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  scripts/tests/test_ladder_range_coverage.py -q          # expect 20 passed
+nix develop ~/workspace/devrc -c bash \
+  scripts/tests/mutants-ladder-range-coverage.sh          # expect 20 row(s), all as expected
+
+# reproduce the original symptom: the gap the review named, sized
+nix develop ~/workspace/devrc -c python3 scripts/ladder-range-coverage.py 1233 \
+  --repo innovation-upstream/devrc --repo-dir ~/workspace/devrc
+# expect: 🔴 GAP round 2 `to` → round 4 `from`: 1b5d2e43..eb947328 — 524 line(s)
+
+# the negative control, on real data — a dead detector prints 0 for these too
+nix develop ~/workspace/devrc -c python3 scripts/ladder-range-coverage.py 958 1219 \
+  --repo innovation-upstream/devrc --repo-dir ~/workspace/devrc
+# expect: every adjacency TIGHT, UNCOVERED 0, positive control NON-zero
+```
+🔴 Read the `positive control:` line on every ladder. `UNCOVERED: 0` with a zero control is a
+REFUSAL (exit 4), not a clean ladder — the PR's commits are simply not in that checkout.

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -284,6 +284,66 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
 # Facts — `gh`, or a file so a test needs neither it nor a network
 # --------------------------------------------------------------------------- #
 
+def find_carriers(runner, repo, limit=300, state="all"):
+    """-> ([facts, …], note) for every PR in `repo` carrying an `audit-claims`
+    fence, newest first.
+
+    🔴 ONE ENUMERATOR, TWO CONSUMERS. Measuring the ladders in a repo and mining
+    their terminal-round prose are different tasks over the SAME population, and
+    that population has been built by hand twice — the 2026-09-04 review counted
+    "42 of 309 merged devrc PRs" in a scratchpad that no longer exists. A
+    hand-built list is also the one input nobody re-derives, so a repo added
+    later is silently out of scope.
+
+    🔴 IT IS ONE `gh` CALL, NOT ONE PER PR. `gh pr list --json comments` returns
+    the bodies, so the fence test is local. Asking per PR is ~300 calls against a
+    secondary rate limit and was the reason this stayed manual.
+
+    ⚠ THE BLIND SPOT IS INHERITED AND LOAD-BEARING: `gh` does not return REVIEW
+    comments here, so a block posted as a review is invisible — the same gap
+    `audit-dispatch.py` warns about when it cannot find a block a human can see.
+    A carrier count from this is therefore a FLOOR, never a census, and the note
+    it returns says so in the output rather than in this docstring alone.
+    """
+    cmd = ["gh", "pr", "list", "--repo", repo, "--state", state,
+           "--limit", str(limit), "--json",
+           "number,comments,headRefOid,baseRefName,title"]
+    rc, out, err = runner(cmd)
+    if rc != 0:
+        raise SystemExit(
+            f"`gh pr list --repo {repo}` exited {rc}: "
+            f"{(err or out).strip() or 'no output'}"
+        )
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"`gh pr list --repo {repo}` did not print JSON: {e}")
+
+    carriers = []
+    for pr in data:
+        bodies = [c.get("body", "") for c in pr.get("comments") or []]
+        if not any("audit-claims" in (b or "") for b in bodies):
+            continue
+        carriers.append({
+            "pr": pr.get("number"),
+            "head": pr.get("headRefOid") or "",
+            "base": pr.get("baseRefName") or "",
+            "comments": bodies,
+            "title": pr.get("title") or "",
+        })
+    note = (
+        f"{repo}: scanned {len(data)} PR(s) (state={state}, limit={limit}), "
+        f"{len(carriers)} carry an `audit-claims` fence. ⚠ A FLOOR, not a census "
+        "— `gh` does not return REVIEW comments, so a block posted as a review is "
+        "invisible here."
+    )
+    if len(data) >= limit:
+        note += (f" ⚠ The scan HIT ITS LIMIT ({limit}), so older PRs were not "
+                 "examined at all — raise --limit before reading this as the "
+                 "whole repo.")
+    return carriers, note
+
+
 def facts_from_gh(runner, repo, pr):
     cmd = ["gh", "pr", "view", str(pr), "--json",
            "comments,headRefOid,baseRefName,url"]
@@ -434,12 +494,24 @@ def render(ladders, notes):
                "payload IS the `.md`). So")
     out.append("  this total is the SIZE of the hole, not the payload the review "
                "under-counted by.")
-    out.append("⚠ A COMMIT COUNT IS NOT A CHURN COUNT. A GAP of many commits and "
-               "0 lines is `--not")
-    out.append("  <base>` working: those commits are an upstream bring-in already "
-               "in the base, which is")
-    out.append("  shape A of the reference file's range table. Three of the 20 "
-               "ladders look like that.")
+    # 🔴 DERIVED, NEVER A LITERAL. This line first shipped reading "Three of the
+    # 20 ladders look like that" — the figure from the devrc run it was written
+    # during — and then printed that sentence verbatim on a 5-ladder run of a
+    # different repo. A count in prose beside a measurement it is not computed
+    # from is the exact defect class this whole report exists to find, committed
+    # inside the report. Counted here instead.
+    zero_line_gaps = sum(
+        1 for L in ladders if L.reason is None
+        for a in L.adjacencies
+        if a.label == GAP and a.commits and not (a.added or 0) + (a.deleted or 0)
+    )
+    if zero_line_gaps:
+        out.append("⚠ A COMMIT COUNT IS NOT A CHURN COUNT. A GAP of many commits "
+                   "and 0 lines is `--not")
+        out.append("  <base>` working: those commits are an upstream bring-in "
+                   "already in the base, which is")
+        out.append(f"  shape A of the reference file's range table. "
+                   f"{zero_line_gaps} gap(s) in THIS run look like that.")
     return "\n".join(out)
 
 
@@ -460,11 +532,20 @@ def main(argv=None, runner=real_runner, out_stream=sys.stdout,
                                         "consults no `gh` and no network")
     ap.add_argument("--no-fetch", action="store_true",
                     help="skip `git fetch origin refs/pull/<n>/head`")
+    ap.add_argument("--find-carriers", action="store_true",
+                    help="enumerate every PR in --repo carrying an "
+                         "`audit-claims` fence and measure all of them")
+    ap.add_argument("--list-only", action="store_true",
+                    help="with --find-carriers: print the carriers and stop")
+    ap.add_argument("--limit", type=int, default=300,
+                    help="with --find-carriers: how many PRs to scan (default 300)")
     ap.add_argument("--audit-dispatch", help="path to audit-dispatch.py")
     args = ap.parse_args(argv)
 
-    if not args.prs and not args.facts_file:
-        ap.error("give at least one PR number, or --facts-file")
+    if not args.prs and not args.facts_file and not args.find_carriers:
+        ap.error("give at least one PR number, --facts-file, or --find-carriers")
+    if args.find_carriers and not args.repo:
+        ap.error("--find-carriers needs --repo owner/name")
 
     ad = load_audit_dispatch(args.audit_dispatch)
 
@@ -478,6 +559,30 @@ def main(argv=None, runner=real_runner, out_stream=sys.stdout,
         facts_list = raw if isinstance(raw, list) else [raw]
         notes.append("--facts-file mode: no `gh` was consulted, so nothing here "
                      "was checked against the live PR")
+    elif args.find_carriers:
+        facts_list, note = find_carriers(runner, args.repo, limit=args.limit)
+        notes.append(note)
+        if args.list_only:
+            print(note, file=out_stream)
+            for f in facts_list:
+                print(f"  #{f['pr']}  {f['title'][:88]}", file=out_stream)
+            return EXIT_OK if facts_list else EXIT_NOTHING_MEASURABLE
+        if not facts_list:
+            # 🔴 NOT a clean bill of health, and it is the answer rank 8 most
+            # often gets: "this repo ran no ladders with a ledger" and "nobody
+            # ever posted a block here" are the same observation, and neither is
+            # "the ladders here are fine".
+            print(note, file=out_stream)
+            print("\nUNMEASURABLE — this repo has NO PR carrying an "
+                  "`audit-claims` block in the scanned window, so there is no\n"
+                  "ledger to measure coverage against. That is a statement about "
+                  "the LEDGER, not about whether\nladders ran here: a ladder that "
+                  "ran without posting a block is invisible to every instrument\n"
+                  "in this family, including the review's.", file=out_stream)
+            return EXIT_NOTHING_MEASURABLE
+        if not args.no_fetch:
+            for f in facts_list:
+                notes.append(fetch_pr_ref(runner, args.repo_dir, f["pr"]))
     else:
         for pr in args.prs:
             if not args.no_fetch:

--- a/scripts/tests/mutants-ladder-range-coverage.sh
+++ b/scripts/tests/mutants-ladder-range-coverage.sh
@@ -81,17 +81,18 @@ ROWS=0
 # 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
 # FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
 # mutant SURVIVED. The floor catches COLLAPSE, not growth; `run-tests.sh`'s own
-# formula is `m - min(50, max(1, m/20))`, which at m=19 is 18.
-# 🔴 IT ALREADY FIRED ONCE, BEFORE THIS FILE WAS COMMITTED: the module grew
-# 18 → 19 while this literal still said 17, and the pin failed with
-# `should be 18, not 17`. One growth was enough. That is the argument for pinning
-# it from the first commit rather than after the second silent widening.
+# formula is `m - min(50, max(1, m/20))`, which at m=20 is 19.
+# 🔴 IT FIRED TWICE BEFORE THIS FILE WAS EVEN MERGED, which is the whole argument:
+# the module grew 18 → 19 (pin said 17, failed with `should be 18, not 17`), then
+# 19 → 20 one commit later (pin said 18, failed with `should be 19, not 18`).
+# Neither growth was a refactor — each was a single test added while fixing
+# something — and a hand-maintained floor would have silently tolerated both.
 # 🔴 DO NOT maintain this by memory — `test_ladder_range_coverage.py::
 # test_the_batterys_floor_is_re_derived_from_this_modules_size` reads the literal
 # below, counts the module, and fails with the replacement value. Two instances
 # of a too-low floor silently widening have already been recorded in
 # `mutants-audit-ladder.sh`; this is pinned from the first commit instead.
-MIN_TESTS=18
+MIN_TESTS=19
 failing() {
   local out n f total
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
@@ -205,6 +206,14 @@ run "the interior bucket never accumulates" \
     test_interior_and_tail_gaps_are_reported_as_SEPARATE_totals "$LRC" \
     '                interior_a += added or 0' \
     '                interior_a += 0'
+
+# 🔴 The regression row. This caveat shipped as a LITERAL ("Three of the 20
+# ladders") and printed that devrc figure under a 5-ladder run of another repo.
+# The mutant restores the literal; the guard must notice.
+run "the zero-line-gap caveat goes back to a literal" \
+    test_the_zero_line_gap_caveat_is_DERIVED_from_this_run "$LRC" \
+    '                   f"{zero_line_gaps} gap(s) in THIS run look like that.")' \
+    '                   "Three of the 20 ladders look like that.")'
 
 echo
 echo "== the labels that must NOT become a sized GAP =="

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -225,6 +225,42 @@ def test_interior_and_tail_gaps_are_reported_as_SEPARATE_totals(lrc, ad,
     assert "TAIL      4 line(s)" in rendered
 
 
+def test_the_zero_line_gap_caveat_is_DERIVED_from_this_run(lrc, ad, base_repo):
+    """🔴 Regression. That caveat shipped as the literal "Three of the 20 ladders
+    look like that" — the figure from the devrc run it was written during — and
+    then printed verbatim under a 5-ladder run of a different repo. A count in
+    prose beside a measurement it is not computed from is the defect class this
+    whole report exists to find.
+
+    The fixture makes a gap of real COMMITS with ZERO churn, which is what an
+    upstream bring-in looks like: commits that `--not <base>` excludes entirely.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    # Commits already in `main`, so `--not main` excludes every line of them:
+    # reachable from the branch, contributing no churn.
+    _git(repo, "checkout", "--quiet", "main")
+    upstream = _commit(repo, "upstream.py", 12, "an upstream commit")
+    _git(repo, "checkout", "--quiet", "feat")
+    _git(repo, "merge", "--quiet", "--no-edit", "main")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 10, head, "main",
+                           [_block(1, base, r1_to)])
+
+    tail = L.adjacencies[-1]
+    assert tail.label == lrc.GAP, (tail.label, tail.reason)
+    assert tail.commits and tail.commits > 0, "the gap has real commits"
+    assert (tail.added, tail.deleted) == (0, 0), \
+        "`--not main` must exclude the bring-in's lines"
+
+    rendered = lrc.render([L], [])
+    assert "1 gap(s) in THIS run look like that" in rendered
+    assert "the 20 ladders" not in rendered, \
+        "a hardcoded corpus figure is being printed for an unrelated run"
+    assert upstream
+
+
 def test_an_overlap_is_labelled_OVERLAP_and_given_no_size(lrc, ad, base_repo):
     """Two ranges covering the same commits double-count, which is the OPPOSITE
     error from a gap. Reporting it as a 0-line gap would hide it."""


### PR DESCRIPTION
Follow-on to #1519. Closes the 2026-09-04 review's CANNOT-SEE bullet *"the waste audit is devrc-only … none were churn-measured"* — the item that was rank 8 of `handoff-audit-pr-ladder.md` before that doc renumbered. Claim: `audit-pr-ladder-8`.

## The headline inverts what devrc suggested

| | devrc | outside devrc |
|---|---|---|
| ladders measured | 20 | **126** of 129 carriers |
| **INTERIOR** uncovered (unambiguous) | **655** lines, 2 ladders | **88** lines, 2 adjacencies, **all in one repo** |
| TAIL uncovered (not a finding) | 3,727 | 10,052 |

🔴 **The interior hole barely exists outside devrc.** Four of the five measured repos have **zero**. The likely mechanism is a devrc *authoring* habit rather than a property of the ladder: titling one comment "rounds N and N+1" and posting a single block for both — exactly #1233's shape. So the defect #1519 was built to find is **real and small**, and saying that plainly matters more than the larger number sitting next to it.

🔴 **And the review measured about a third of the work.** 129 carriers outside devrc against 70 inside, same command and limit.

Per-repo table, caveats included, lands in `claudedocs/audit-ladder-review-2026-09-04.md`. Two repos are **UNMEASURABLE** and neither is a pass: naida-ai ran 214 PRs and posted **no ledger at all**; auditloop has no PR history in scope. To this instrument "no ladders ran here", "ladders ran without blocks" and "they were fine" are one observation, so it says so instead of printing 0.

**TAIL is deliberately not a finding.** It conflates post-final-block fixes with development that continued after the ladder ended; nothing in the ranges separates them. Classifying it needs the commits read — that is the one open question, and it is ranked in the handoff.

## `--find-carriers`

The carrier population had been hand-built **twice** (the review counted "42 of 309 merged devrc PRs" in a scratchpad that no longer exists). A hand-built list is the one input nobody re-derives, and rank 9 — mining stop-rationale prose — needs the *same* list. So it is a mode, not a query I would have thrown away.

One `gh pr list --json comments` call, not one per PR: per-PR is ~300 calls against a secondary rate limit, which is why this stayed manual. Two honesty properties live in the **output**, not only a docstring: the count is a **FLOOR** (`gh` does not return REVIEW comments, the same blind spot `audit-dispatch.py` warns about), and **hitting `--limit` is reported** — two repos did, so their counts are partial.

## 🔴 A defect in what #1519 just shipped, found by the measurement itself

Its zero-line-gap caveat shipped as the literal **"Three of the 20 ladders look like that"** — the figure from the devrc run it was written during — and then printed that sentence **verbatim under a 5-ladder run of a different repo**.

A count in prose beside a measurement it is not computed from is the exact class this report exists to find, committed inside the report. **20 tests and a 20-row mutation battery were green throughout**: no assertion read the sentence and no mutant targeted it, because a literal in *output* is not a branch.

It is now derived from the ladders in hand, suppressed at zero, and pinned by `test_the_zero_line_gap_caveat_is_DERIVED_from_this_run` with a battery row that restores the literal.

**What caught it was pointing the tool at a second corpus** — not a round, not a sweep. A tool validated on one corpus is validated on one corpus, and that control is the one nobody schedules.

## Verification

- `test_ladder_range_coverage.py` — **20 passed**.
- `scripts/tests/mutants-ladder-range-coverage.sh` — **20 rows, all as expected**, each naming its killer, both `SURVIVES` controls green, baseline green, under `PYTHONDONTWRITEBYTECODE=1`.
- The floor pin fired a **second** time on growth (19 → 20) and named its replacement. Two firings before this file has merged, neither from a refactor — which is the argument for pinning it from commit one.
- Content, hostname, IP and shebang gates: **154 passed**, re-run after staging (they read `git ls-files`, so a pre-staging run is not evidence about new files).
- 3 of 129 ladders came back **REFUSED** rather than 0 — their commits are not in the local checkout. That is the positive control doing its job.

⚠ **No full tier was run.** CI evaluates that.
⚠ `tekton/devrc-pytests` is **red on `main` itself** on `test_every_kill_server_call_site_in_the_repo_is_classified` — `_KILL_MENTION_LEDGER` does not classify newly-added handoff docs. Reproduced on a clean `origin/main` worktree at `50e8a71a`. Unrelated to this diff, and ranked in the handoff: every new handoff doc mentioning a wide tmux kill reds it, so it is becoming a permanently-red gate.

## Also in this PR

`claudedocs/handoff-ladder-range-coverage.md` — a new handoff for this effort. Filed under its own topic **deliberately**: the parent `audit-pr-ladder` arc was closed out by its author in #1511, and its ranked list renumbered to unrelated work, **dropping old ranks 8, 9 and 10 with no closure note** — I was holding `audit-pr-ladder-10` against a rank that had ceased to exist. Recorded as a comment on #1511 so those items regain pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)