### PR TITLE
fix(guard): classify handoff-tmux-webapp's kill mention — main is red on BOTH kill guards, and CI showed only one

### DIFF
--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2524,6 +2524,10 @@ def test_tmux_kill_prefix_matches_both_wide_kills_and_neither_narrow_one():
 # classify it. Paths only — line numbers are what rotted last time.
 _KILL_MENTION_LEDGER = {
     "claudedocs/handoff-tmux-restore-chain.md": "prose: the incident write-up",
+    # The mention is one line of narrative — `tmux kill-session` was BLOCKED by
+    # this guard and a `send-keys` would have bypassed it. Prose about the guard
+    # working, not a call: that doc executes nothing.
+    "claudedocs/handoff-tmux-webapp.md": "prose: an incident where the guard held",
     "claudedocs/handoff-tmux-scratchpad-bar-statusline.md": "prose: a gotcha warning AGAINST it — \"Never `kill-server`; that destroys every session\"",
     "scripts/claude-hooks/bash-guard.py": "prose: the guard's own ban list",
     "scripts/claude-hooks/guard_core.py": "prose: this check, its docstring and its message",
@@ -2665,6 +2669,7 @@ def test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny():
     shell_text = re.compile(r"tmux(?:\s+-{1,2}[^\s'\"]+)*\s+kill-s[a-z-]*")
     quoting_is_the_point = {
         "claudedocs/handoff-tmux-restore-chain.md",
+        "claudedocs/handoff-tmux-webapp.md",  # narrative: the guard BLOCKED it; see the ledger
         "scripts/claude-hooks/bash-guard.py",
         "scripts/claude-hooks/guard_core.py",
         "scripts/claude-hooks/tests/test_guard_core.py",


### PR DESCRIPTION
`main` is red on **both** of `#1415`'s kill guards, and every open PR inherits it. A merged handoff doc mentions a wide tmux kill without being classified.

## 🔴 CI reported one failure and there were two

The status line named only `test_every_kill_server_call_site_in_the_repo_is_classified`, while the same line reads `collected=22167 passed=22163 skipped=2`. Arithmetic: **2 failed**. The 140-char GitHub status description truncated the second one.

That matters beyond this PR: fixing only the named failure leaves `main` red, and the next person reads the same truncated line and concludes the fix didn't work. I only found the second because I ran the file locally after fixing the first.

## The two guards, and why one entry wasn't enough

| guard | what it checks | needed |
|---|---|---|
| `test_every_kill_server_call_site_in_the_repo_is_classified` | two-directional census: the SET of files mentioning a wide kill must equal `_KILL_MENTION_LEDGER` | a ledger entry |
| `test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny` | scans tracked files for text this guard would deny, minus `quoting_is_the_point` | a second entry |

Two allowlists, one file — so a single classification leaves the suite red. Both are now populated.

## The mention is prose, verified before allowlisting

`claudedocs/handoff-tmux-webapp.md:3409` is a bulleted finding about `term send` bypassing PreToolUse hooks: the kill **was blocked by this guard**, and the point is that a send would have gone around it. No fenced command block in that file. That matches the four existing `claudedocs/` entries in the ledger, all classified `prose:`.

I checked this before adding the entries — allowlisting a real call site is the one way these guards fail silently.

## Red-before-green

Observed in this order, `__pycache__` cleared between runs, `PYTHONDONTWRITEBYTECODE=1`:

| tree | result |
|---|---|
| `origin/main` | census **RED**, naming `claudedocs/handoff-tmux-webapp.md` |
| + ledger entry | census green; shell-text scanner **RED** on the same file |
| + both entries | **1536 passed, 0 failed** |

The scanner carries its own positive control (`seen_in_allowlisted > 0`, asserting the pattern matched *something* in the files written to contain such text), so the clean result is not vacuous.

## Note on the commit message

It was written to a file and applied with `git commit -F`, because the guard being classified parses heredoc lines as real commands and **denied the commit that quoted it**. That is the remedy its own denial message prescribes — a fair demonstration that the guard works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4p3xnvfqhRRjAUGKLK96v
