### PR TITLE
docs(ci-flakes): retract "the escrow test is the worst flake" — it is not a flake, and #1458 never touched it

### DIFF
--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1808,6 +1808,29 @@ def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
     assert d.gets == [], "the store was opened before the precondition was checked"
 
 
+# 🔴 THIS TEST IS NOT A CI FLAKE — DO NOT RE-RANK IT AS ONE. Measured
+# 2026-09-11: it failed `tekton/devrc-pytests` 8 times, which for a while made it
+# look like this repo's most frequent intermittent. It is not intermittent. All 8
+# failures land inside ONE 14-hour window on 2026-09-08 (05:44Z..19:44Z) across 8
+# distinct PR heads, and every one of those runs reports `failed=7` or `failed=8`
+# — a whole-suite red hitting every open PR at once, not a per-run flake.
+#
+# The cause was a toolchain bump: nixpkgs moved `age` to 1.3.2, which changed its
+# tamper classification, and this test pins those verdict sentences by EXACT
+# string equality (that is the whole point of it). Re-keyed by #1392
+# (`94f82796`) and #1403 (`4f49f5dc`), both on 2026-09-08; #1409 (`50b384c0`)
+# followed. ⚠ It was briefly credited to #1458's tmpfs store siting (`ce9b55c3`,
+# 2026-09-10) purely because a CI count was split on that commit's timestamp.
+# That is impossible by mechanism: nothing in this file stands up the store
+# server — no `store_siting`, no `build_server`, an in-memory `FakeDownloader`
+# — so the in-request fsync that `ce9b55c3` removes is never on this path, and
+# `ce9b55c3`'s diff names this file zero times. Full retraction and the
+# flake-vs-environment discriminator: the comment block above
+# `HANG_TIMEOUT` in `scripts/tests/test_subsystem_store_api.py`.
+#
+# 🔴 What that means for a FUTURE red here: a red on this test is a claim about
+# the `age` binary, not about CI load. Check `age --version` against the
+# verdicts pinned below before treating it as anything else.
 def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
     """🔴 FOUR OWNED SENTENCES, BY EXACT EQUALITY, IN ONE PLACE.
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -146,13 +146,52 @@ ROOT = Path(__file__).resolve().parents[2]
 # Re-measure before deleting any of this, and do not upgrade the table into
 # "proven".
 #
-# ⚠ AND THIS TEST WAS NEVER THE WORST ONE, which matters because it was ranked and
-# worked as though it were. In the same pre-fix window
-# `test_every_decrypt_family_VERDICT_is_pinned_WHOLE`
-# (`test_analyze_service_index_escrow_verify.py`) failed 8 times to this test's 4 —
-# twice as often — and is also at 0 post-fix. A flake that is vivid because it has
-# a long diagnosis written about it is not thereby the most frequent one: COUNT
-# them before choosing which to chase.
+# 🔴 THE COMPARISON THAT USED TO SIT HERE WAS WRONG — RETRACTED 2026-09-11. It
+# read: `test_every_decrypt_family_VERDICT_is_pinned_WHOLE`
+# (`test_analyze_service_index_escrow_verify.py`) "failed 8 times to this test's
+# 4 — twice as often — and is also at 0 post-fix", concluding COUNT them before
+# choosing which to chase. The count was right; the conclusion was wrong. THAT
+# TEST IS NOT A FLAKE, AND `ce9b55c3` NEVER TOUCHED IT. Three measurements, same
+# instrument as the table above (200 PR heads, 2026-09-05..09-11, 197 terminal
+# verdicts):
+#
+#   * MECHANISM — it is not on this fix's path. That file imports no store
+#     server, no `store_siting`, no `build_server`; it drives `escrow-verify.py`
+#     against an in-memory `FakeDownloader`, so `_replace_bytes`'s in-request
+#     fsync is never reached. `ce9b55c3`'s diff names the file ZERO times, and
+#     the test runs in 1.71 s.
+#   * TIME — all 8 failures fall inside ONE 14-hour window on 2026-09-08
+#     (05:44Z..19:44Z) across 8 distinct heads, and EVERY run reports `failed=7`
+#     or `failed=8`: a whole-suite red hitting every open PR at once.
+#   * CAUSE — nixpkgs moved `age` to 1.3.2, and that test pins age's tamper
+#     verdicts by exact string equality. Re-keyed by #1392 (`94f82796`,
+#     09-08T18:26Z) and #1403 (`4f49f5dc`, 20:32Z) — TWO DAYS BEFORE `ce9b55c3`
+#     (09-10T20:56Z) existed. The two failures after 18:26Z are stale-base heads
+#     that had not yet picked up #1392.
+#
+# 🔴 SO COUNTING IS NOT THE RULE — COUNTING IS WHAT PRODUCED THE ERROR. A raw
+# verdict count ranked a one-day toolchain outage as this repo's worst flake.
+# Before a count means anything, split the population with two mechanical tests:
+#
+#   (a) SCATTER — a flake's failures spread across days; an environment red
+#       clusters in one window. THIS test: 5 failures on 5 distinct heads across
+#       4 separate days (09-06, 09-07, 09-08, 09-09 x2). The escrow one: 8 in 14
+#       hours. ⚠ That 5 is from the 200-head sample read 2026-09-11 and the
+#       table above says 4 from a differently-drawn one — which is the point:
+#       the SCATTER is the claim, not the count, because the count moves with
+#       the sample and the shape does not.
+#   (b) `failed=N` — a flake takes down ONE test (`failed=1`); an environment
+#       change takes down the same N>1 on every head at once.
+#
+# Only count what survives both.
+#
+# ⚠ AND EVERY COUNT HERE IS A LOWER BOUND — THE TABLE ABOVE INHERITS THIS.
+# GitHub truncates a status description at 138 characters, so only the FIRST
+# failing test is ever named; a run where a test failed behind an
+# alphabetically earlier one is invisible to this instrument. Bounded by
+# arithmetic on the same rows (`collected - passed - skipped`): of the 14
+# post-fix failures, 12 derive `failed=1`, one derives 2, and one is
+# unparseable — so at most two post-fix runs could be concealing anything.
 #
 #   * IT IS DISK LATENCY, NOT CPU. On run `devrc-ci-86zxj` (sha 5de43017) this
 #     suite's own classifier printed `MECHANISM = SERVER_BLOCKED_IN_FSYNC …


### PR DESCRIPTION
Closes rank 1 of `claudedocs/handoff-alert-recall-and-skill-consumers.md` (datapacket-talos) — by measurement, and the answer is that the rank's premise was wrong.

Rank 1 asked whether `test_every_decrypt_family_VERDICT_is_pinned_WHOLE` was fixed by #1458's tmpfs siting or merely quiet, and said plainly that "quiet" is not "fixed". **Neither.** It was never a flake, and `ce9b55c3` cannot have touched it.

## What #1512 left in the tree

A comment in `test_subsystem_store_api.py`:

> ⚠ AND THIS TEST WAS NEVER THE WORST ONE … `test_every_decrypt_family_VERDICT_is_pinned_WHOLE` … failed 8 times to this test's 4 — twice as often — and is also at 0 post-fix … **COUNT them before choosing which to chase.**

The count was right. The conclusion was wrong, and **counting is what produced it**.

## The three measurements

Instrument: the 200 most-recently-updated PR heads, newest `tekton/devrc-pytests` statuses, 2026-09-05..09-11 — **197 terminal verdicts** (121 success, 48 failure, 32 error).

**1. MECHANISM — it is not on #1458's path.** `test_analyze_service_index_escrow_verify.py` imports no store server, no `store_siting`, no `build_server`; it drives `escrow-verify.py` against an in-memory `FakeDownloader`. `server.py:_replace_bytes`'s in-request fsync — the one thing `ce9b55c3` removes — is never reached. `ce9b55c3`'s diff names the file **zero** times. The test runs in **1.71 s**.

**2. TIME — a deterministic red, not a flake.** All 8 failures fall inside **one 14-hour window on 2026-09-08** (05:44Z..19:44Z) across 8 distinct heads, and *every* run reports `failed=7` or `failed=8` — a whole-suite red hitting every open PR at once.

**3. CAUSE — fixed two days earlier, by someone else.** nixpkgs moved `age` to 1.3.2, changing its tamper classification; this test pins those verdict sentences by exact string equality. Re-keyed by **#1392 (`94f82796`, 09-08T18:26Z)** and **#1403 (`4f49f5dc`, 20:32Z)**. `ce9b55c3` landed **09-10T20:56Z**. The two failures after 18:26Z are stale-base heads that had not picked up #1392 — the handoff's own rank-4 phenomenon.

## The contrast, same instrument

The test #1458 *did* fix failed **5 times across 4 separate days** (09-06, 09-07, 09-08, 09-09 ×2) — scattered, which is what contention looks like. Versus 8 failures in 14 hours.

## What replaces "COUNT them"

A discriminator, because a raw verdict count ranked a one-day toolchain outage as this repo's worst flake:

- **(a) SCATTER** — a flake's failures spread across days; an environment red clusters in one window.
- **(b) `failed=N`** — a flake takes down ONE test (`failed=1`); an environment change takes down the same N>1 on every head at once.

Count only what survives both.

## The blind spot both counts inherit

GitHub truncates a status description at **138 characters**, so only the FIRST failing test is ever named — a run where a test failed behind an alphabetically earlier one is invisible to this instrument. **Every count here and in #1512 is a lower bound.** Bounded by arithmetic on the same rows (`collected - passed - skipped`): of the 14 post-fix failures, **12 derive `failed=1`, one derives 2, one is unparseable** — so at most two post-fix runs could be concealing anything.

## Scope / verification

Comment-only, two files, no behaviour change. The escrow test also gains its own delisting note, so the next flake hunt does not re-derive this: a red there is a claim about the `age` binary, not about CI load.

`scripts/scoped-tests.sh` at base `origin/main` `018e483b`, run inside the dev shell: `SCOPE: SCOPED (2 file(s) across 1 of 28 hermetic target(s) via --files)`, **`RESULT: PASS (exit=0)`**.

⚠ **That is not a gate and is not claimed as one** — `gate.sh` exits 91 (PARTIAL) off any run that is not `SCOPE: FULL`. Neither tier was run in full; a comment-only diff cannot reach executable behaviour, and CI is what evaluates the whole-target expectations this scoped run suspended (GUARD 2's skip TOTAL, GUARD 7's REQUIRED direction).

⚠ **No executable test coverage is added, deliberately.** The change is a retraction of a prose claim about CI history; there is nothing executable to guard. The mechanical version of this — classifying a red as inherited-vs-live — is what #1524 is already building, so it is not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWAGG1mTfkozfKa5MMjXuC
