### PR TITLE
fix(audit-ladder): the floor pin read SOURCE TEXT, so any override the shell applied was invisible — and #1431's own prescribed fix did not close the case it named

### DIFF
--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -101,7 +101,7 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
 ## Next steps (ranked)
 
 1. **Round 0 trials 3-5, on ordinary PRs, dispatched BEFORE merge-readiness.** Ledger so far: `ran: 2 · changed the outcome: 2`. Both yielded, but trial 2's report landed *after* its PR merged, so the live question is whether round 0 is fast enough to matter, not whether it finds things. Delete the section if it ran and changed nothing. forcing: none
-2. **Decide the `scoped-tests.sh` trigger list with `#1445`'s author** — implement `gate-inventory-2026-09-08.md` §10 or decline it in the header. Measured first-hand, see the open investigation below. forcing: regression — a `testlib` change runs 1 of 331 test files while CLAUDE.md names this the iteration loop
+2. ✅ **DECIDED 2026-09-11 by the operator: IMPLEMENT §10. Shipped as `#1532`** (open, unmerged). A shared-surface diff now REFUSES to produce a scoped verdict (exit 4, naming the path and pointing at `scripts/gate.sh --tier both`) rather than under-running silently. Re-measured first-hand at `018e483b` — and **the doc's own headline figure was stale**: it said *"a `testlib` change runs 1 of 331 test files"*; the real range across all 24 `scripts/testlib/` modules is **0–10, median 1**. The substance was right and understated: `mockbin.py` selected **10** while **69** files across **7** targets reference it, and `gitenv.py` selected **2** while spanning **8**. 🔴 **The zero-select cases were already SAFE** (exit 4, verified) — the dangerous ones are the middle, because a run that executes *something* prints `RESULT: PASS`. ⚠ Deliberately NOT covered, flagged on the PR rather than silently added because it is outside the approved list: `scripts/scoped-tests.sh` itself is not a trigger, so a change to the mapper is still validated by the mapper. *Closes when* `#1532` merges. **Original item, for the record:** implement `gate-inventory-2026-09-08.md` §10 or decline it in the header. forcing: regression — a `testlib` change runs 1 of 331 test files while CLAUDE.md names this the iteration loop
 3. 🔴 **CLOSED — `ship.sh`'s laptop fallback WORKS; my own item was false.** I wrote "the nebula address is used to IDENTIFY the host and never as an SSH fallback" after hitting a LAN timeout early in this arc, and `#1439` had shipped the fallback by the time I wrote it down. Worse, I passed `LAPTOP_SSH=` as an override on BOTH later ship runs out of habit, so I never tested it. **Measured 2026-09-11 with the override removed** (`env -u LAPTOP_SSH ship.sh`): `ship: zach@192.168.50.155 did not answer — falling back to zach@10.42.0.100 for laptop`, then `VERIFIED`. `host-role.sh:120` emits both targets and `ship.sh:545` picks with `first_reachable_ssh`. A prior session had already struck this item; that session was right and I was about to re-assert it. **Do not re-open.** forcing: none
 4. **Track two — run the algorithm on `audit-pr/SKILL.md` itself** (~27 KB, almost entirely accreted from prior rounds' findings, i.e. the highest-scrutiny "requirements from smart people" class). Deferred by operator sequencing until the trial count resolves. forcing: none
 5. **`1e844f1e`** — another session's cairn handoff commit, pushed but unmerged, parked on `origin/feat/audit-pr-round-0-algorithm` (a branch named after this arc's feature). Not this arc's to merge; flagged so it is not mistaken for dead. forcing: none
@@ -1384,6 +1384,30 @@ were removed, not pinned. Its "Next probe" is spent; do not re-run it.
   `if [ -n "${QUICK:-}" ]; then MIN_TESTS=3; fi` — **1 passed** while the shell applies **3**.
   🔴 **The positive control is the load-bearing half:** without it, the green on the third row is
   indistinguishable from a guard that never ran.
+- ✅ **THE DEFECT IS NOW FIXED — `#1533`** (open, unmerged). The battery gained
+  `--print-min-tests`, emitted after every assignment and immediately before the run, and the
+  guard EXECUTES it instead of regexing the source. `#1431`'s stated closing condition is MET:
+  with the `QUICK` override present, `test_the_batterys_floor_is_re_derived_from_this_modules_size`
+  **was watched RED**. Control matrix, each mutant isolated, battery restored byte-identical:
+  baseline **1 passed**; `QUICK` conditional override **1 failed**; `MIN_TESTS=$LOW` **1 failed**;
+  floor drift `15`→`9` **1 failed**.
+- 🔴 **AND THE ISSUE'S OWN PRESCRIBED REMEDY WAS NOT SUFFICIENT — found only by RUNNING the
+  control it demanded, instead of assuming the fix satisfied it.** `#1431` proposed *"have the
+  battery print its effective `MIN_TESTS` and assert on that"* as the whole fix. Implemented
+  exactly as written, it closes `MIN_TESTS=$LOW` (the battery reports 4, the guard reddens) and
+  **leaves the `QUICK` case GREEN** — because `--print-min-tests` runs with `QUICK` unset, so the
+  effective floor honestly IS 15 for that invocation, while a `QUICK=1` run floors at 3.
+  **"Effective" is environment-dependent, and no probe can enumerate the environments.** The
+  closing half is therefore STRUCTURAL: exactly one `MIN_TESTS=` assignment anywhere in the file,
+  matched with `^\s*` rather than `^`. 🔴 **The old guard's column-0 anchor is the whole story of
+  why this slipped** — the issue itself recorded that a second numeric assignment "fires the
+  `len(literals) == 1` check", and it does, but only UNINDENTED; the override that beat it was
+  indented inside an `if`. **A remediation written into an issue is a HYPOTHESIS, not a spec.**
+- ⚠ **A mutation in this same run reported `MUTATION DID NOT APPLY (count=2)`** — the literal
+  `MIN_TESTS=15` had become non-unique because the COMMENT explaining the fix quotes it. The
+  `1 passed` printed alongside was meaningless, not a survivor. Re-run against a unique anchor it
+  came back **1 failed**. The battery's own `apply` refuses the same way; an inline mutator needs
+  the same assert or it manufactures false greens.
 
 ### The scoped mapper has no trigger list — a `testlib` change runs 1 test file of 331
 

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -284,6 +284,29 @@ run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
   FAILURES=$((FAILURES+1))
 }
 
+# --- report the EFFECTIVE floor, for the guard that pins it -------------------
+# 🔴 PLACED HERE ON PURPOSE: after every top-level assignment and immediately
+# before the run begins, so it reports the value `failing()` will actually
+# compare against. Moving it up to sit beside `MIN_TESTS=` would reintroduce
+# exactly the defect it closes.
+#
+# WHY IT EXISTS (devrc #1431): the guard used to pin this floor by regexing
+# `^MIN_TESTS=(\d+)` out of this file's SOURCE TEXT. Any override the shell
+# applies is invisible to that. MEASURED — with
+#     MIN_TESTS=15
+#     if [ -n "${QUICK:-}" ]; then MIN_TESTS=3; fi
+# the guard reported `1 passed` while the battery floored at 3. `MIN_TESTS=$LOW`
+# is the same hole. The issue was closed COMPLETED with the defect intact and
+# had to be reopened; this is the fix its closing condition names.
+#
+# The guard EXECUTES this rather than reading it, which is the whole point: a
+# value the shell computes is the only thing that can answer "what floor will
+# this run use".
+if [ "${1:-}" = "--print-min-tests" ]; then
+  printf '%s\n' "$MIN_TESTS"
+  exit 0
+fi
+
 echo "== baseline =="
 base="$(failing)"
 if grep -q __HARNESS_BROKE__ <<<"$base"; then

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -392,6 +392,7 @@ which proves that assertion executes rather than restating the pins beside it.
 
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -1175,14 +1176,64 @@ def test_the_batterys_floor_is_re_derived_from_this_modules_size():
         "re-point BATTERY_SH; if you deleted it, delete this guard in the same "
         "commit rather than leaving a pin on a file that no longer exists."
     )
-    battery = _read(BATTERY_SH)
-    literals = re.findall(r"^MIN_TESTS=(\d+)", battery, re.M)
-    assert len(literals) == 1, (
-        f"expected exactly one `MIN_TESTS=` assignment in {BATTERY_SH}, "
-        f"found {len(literals)}: {literals}. This guard reads the literal, so "
-        "a second assignment makes which one the battery uses ambiguous."
+    # 🔴 ASK THE BATTERY, DO NOT READ ITS SOURCE (devrc #1431). This used to be
+    # `re.findall(r"^MIN_TESTS=(\d+)", battery, re.M)`, which reads the source
+    # TEXT and is therefore blind to anything the SHELL applies. MEASURED — with
+    #     MIN_TESTS=15
+    #     if [ -n "${QUICK:-}" ]; then MIN_TESTS=3; fi
+    # that regex reported `1 passed` while the battery floored at 3, and
+    # `MIN_TESTS=$LOW` is the same hole: a non-numeric right-hand side simply
+    # does not match, so the guard silently pins nothing. `--print-min-tests`
+    # is emitted after every assignment and immediately before the run, so it
+    # is the value `failing()` will actually compare against.
+    proc = subprocess.run(
+        ["bash", str(BATTERY_SH), "--print-min-tests"],
+        capture_output=True, text=True,
     )
-    floor = int(literals[0])
+    assert proc.returncode == 0, (
+        f"`{BATTERY_SH.name} --print-min-tests` exited {proc.returncode}; this "
+        f"guard cannot read the effective floor, and an unreadable floor must "
+        f"NOT be treated as a passing one.\nstdout={proc.stdout!r}\n"
+        f"stderr={proc.stderr!r}"
+    )
+    reported = proc.stdout.strip()
+    assert re.fullmatch(r"\d+", reported), (
+        f"`{BATTERY_SH.name} --print-min-tests` printed {reported!r}, which is "
+        "not a bare integer. The handler must print the effective MIN_TESTS and "
+        "nothing else -- a guard that parses prose here is the source-reading "
+        "defect in a new costume."
+    )
+    floor = int(reported)
+
+    # 🔴 AND THE EFFECTIVE VALUE ALONE IS NOT ENOUGH -- MEASURED, and it is why
+    # this second half exists. #1431 proposed "print the effective MIN_TESTS and
+    # assert on that" as the whole fix. It closes `MIN_TESTS=$LOW` (the battery
+    # reports 4 and this guard goes red), but it does NOT close the CONDITIONAL
+    # override the issue actually names:
+    #     MIN_TESTS=15
+    #     if [ -n "${QUICK:-}" ]; then MIN_TESTS=3; fi
+    # `--print-min-tests` runs with QUICK unset, so the effective floor honestly
+    # IS 15 for that invocation, and the guard passes -- while a `QUICK=1` run
+    # floors at 3. "Effective" is environment-dependent, and no probe can
+    # enumerate the environments.
+    #
+    # So the environment-independence is asserted STRUCTURALLY instead: exactly
+    # one assignment, anywhere in the file. 🔴 `^\s*` and not `^` -- the old
+    # guard anchored at column 0, which is precisely why an INDENTED override
+    # inside an `if` was invisible to it while a second top-level one was
+    # caught. The issue even recorded that a second numeric assignment "fires
+    # the len(literals) == 1 check"; it does, but only unindented.
+    assignments = re.findall(r"^\s*MIN_TESTS=", _read(BATTERY_SH), re.M)
+    assert len(assignments) == 1, (
+        f"expected exactly ONE `MIN_TESTS=` assignment in {BATTERY_SH}, found "
+        f"{len(assignments)}. A second one -- including an indented override "
+        f"inside an `if`, which is the shape that slipped past the previous "
+        f"column-0 regex -- makes the floor depend on the environment, so no "
+        f"single number this guard reads can be the one a given run uses.\n\n"
+        f"If the battery genuinely needs a conditional floor, this guard has to "
+        f"be re-thought rather than relaxed: pin every branch, or have the "
+        f"battery refuse to run when the override is active."
+    )
 
     src = _read(SELF_PY)
     assert not re.search(r"^\s*@[\w.]*parametrize", src, re.M), (


### PR DESCRIPTION
Closes the defect behind **#1431** — the one that was closed `COMPLETED` with its condition unmet and had to be reopened yesterday.

## The defect

`test_the_batterys_floor_is_re_derived_from_this_modules_size` pinned the battery's floor by regexing `^MIN_TESTS=(\d+)` out of `mutants-audit-ladder.sh`. That reads the **source text**, so whatever the shell actually applied was never checked.

## The fix, in two halves — and the second is not in the issue

**1.** The battery gained `--print-min-tests`, emitted after every top-level assignment and immediately before the run begins, so it reports the value `failing()` will really compare against. The guard **executes** it instead of reading it.

**2.** 🔴 **That alone is not sufficient, and I only learned that by running the control #1431 demanded rather than assuming my fix satisfied it.**

The issue proposed *"have the battery print its effective `MIN_TESTS` and assert on that"* as the entire fix. Implemented exactly as written, it closes `MIN_TESTS=$LOW` — and **leaves the `QUICK` case green**, because `--print-min-tests` runs with `QUICK` unset, so the effective floor honestly *is* 15 for that invocation while a `QUICK=1` run floors at 3. **"Effective" is environment-dependent, and no probe can enumerate the environments.**

So environment-independence is asserted **structurally**: exactly one `MIN_TESTS=` assignment anywhere in the file, matched `^\s*` rather than `^`.

The old guard's column-0 anchor is the whole story of why this slipped. The issue itself records that a second numeric assignment *"fires the `len(literals) == 1` check"* — it does, but only **unindented**, and the override that beat it was indented inside an `if`.

**A remediation written into an issue is a hypothesis, not a spec.**

## Control matrix

`#1431`'s closing condition: *"with a `QUICK`-style conditional override present … this control **fails**. Until that control has been watched red, item 1 is open."* It was watched red. Each mutant isolated to the narrowest expression, battery restored byte-identical (`cmp` clean) after each:

| mutant | result |
|---|---|
| baseline (unmutated) | **1 passed** |
| `QUICK` conditional override | **1 failed** ← the stated closing condition |
| indirect assignment `MIN_TESTS=$LOW` | **1 failed** |
| floor drift `15` → `9` | **1 failed** |

⚠ One mutant first reported **`MUTATION DID NOT APPLY (count=2)`** — the literal `MIN_TESTS=15` stopped being unique because the comment explaining this fix quotes it. The `1 passed` printed alongside was **meaningless, not a survivor**; re-run against a unique anchor it came back `1 failed`. Recorded because an inline mutator without that assert manufactures false greens, which is the trap this battery exists to avoid.

**406 passed** across `test_audit_ladder_stop_rule.py` + `test_handoff_doc.py`. CI is the full signal.

## Doc

The `#1431` investigation block records the fix and the insufficiency finding. Rank 2 records the operator's §10 decision and #1532.

After this merges, **#1431's item 1 is closeable** — item 2 remains a written-dismissal item that only a human can satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaeYxVr4aESJ7dWhgBRUtS
