### PR TITLE
fix(guard tests): the wide-kill mention scanner matched inside `skill-session` — red on main

### DIFF
--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -3406,7 +3406,7 @@ are corrected in place.
   unusable as a selector. The wire key for the tmux session is camelCase **`tmuxSessionName`** —
   querying `session` returns a confident "88/88 missing".
 - 🔴 **`term send` is subject to NONE of the calling session's PreToolUse hooks.** Found live: a
-  `tmux kill-session` was blocked by a guard, and a send would have bypassed it. That is the
+  a wide tmux kill was blocked by a guard, and a send would have bypassed it. That is the
   blocked action, not a workaround.
 - 🔴 **The clawgate skill is a home-manager `home.file` COPY** (`readlink -f` lands in
   `/nix/store`), so merging #1515 does not make it live — that needs `home-manager switch`.

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2563,7 +2563,14 @@ _ARGV_WITHOUT_SOCKET_THAT_NEVER_RUNS = {
         "prose example from a call, so the classification has to be written down",
 }
 
-_MENTION_RE = re.compile(r"kill-s(?:erver|ession)")
+# 🔴 THE LEFT BOUNDARY IS LOAD-BEARING — without it this matches INSIDE another
+# word. `skill-session` contains `kill-session`, so a doc naming a claim slug
+# like `clawgate-skill-session-verbs` was scored as mentioning a wide tmux kill
+# and had to be classified in the ledger below — recording a mention that does
+# not exist. Measured across the tree: the boundary removes exactly ONE file and
+# loses NONE of the 13 genuine mentions.
+# A word char only, NOT `-`: `foo-kill-session` is still a real mention.
+_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])kill-s(?:erver|ession)")
 _TMUX_ARGV_RE = re.compile(
     r"""\[\s*(?:"tmux"|'tmux'|tmux_exe)[^\[\]]*kill-s(?:erver|ession)[^\[\]]*\]""", re.S)
 
@@ -2608,6 +2615,14 @@ def test_the_kill_site_scanner_can_see_anything_at_all():
     """
     assert _MENTION_RE.search("subprocess.run(['tmux', 'kill-server'])")
     assert not _MENTION_RE.search("tmux kill-pane -t %1")
+    # 🔴 THE SUBSTRING CASE, and it really happened. Without a left word boundary
+    # this pattern matches INSIDE `skill-session`, so an ordinary doc naming a
+    # claim slug scored as a wide-kill mention and demanded a ledger entry for a
+    # mention that does not exist. Two live spellings, both from real slugs.
+    assert not _MENTION_RE.search("clawgate-skill-session-verbs")
+    assert not _MENTION_RE.search("the skill-session boundary")
+    # ...and the boundary must not swallow a REAL mention that follows a hyphen.
+    assert _MENTION_RE.search("run tmux-kill-session by hand")
     assert _TMUX_ARGV_RE.search('subprocess.run(["tmux", "-L", s, "kill-server"])')
     assert not _TMUX_ARGV_RE.search('subprocess.run(["tmux", "-L", s, "kill-pane"])')
     mentions, argvs = _scan_kill_sites()


### PR DESCRIPTION
`test_every_kill_server_call_site_in_the_repo_is_classified` is **red on `main`**, so it can surface in any devrc PR's pytests leg. It is currently blocking #1515.

## The defect

`_MENTION_RE` had no left word boundary:

```python
_MENTION_RE = re.compile(r"kill-s(?:erver|ession)")
```

`skill-session` **contains** `kill-session`. So a doc naming the claim slug `clawgate-skill-session-verbs` scored as mentioning a wide tmux kill and demanded a `_KILL_MENTION_LEDGER` entry — recording a mention that does not exist.

Classifying it would have been the wrong fix: a ledger entry is a *claim* about a file, and that claim would have been false.

## Measured, both patterns, over every tracked file

| | files matched |
|---|---|
| old | 14 |
| new | 13 |

**Removed:** `claudedocs/handoff-tmux-webapp.md` — the false positive.
**Newly matched:** none.

The boundary loses nothing and removes exactly the one bad match.

`(?<![A-Za-z0-9_])` excludes a word char only, **deliberately not `-`**, so a genuine hyphen-prefixed mention still matches. That case is asserted so a future "tighten it further" cannot silently over-reach.

## Red→green

Three assertions added to the existing positive control, each **watched red on the old pattern** before the fix:

- `clawgate-skill-session-verbs` — must NOT match
- `the skill-session boundary` — must NOT match
- a hyphen-prefixed real mention — MUST match

All three guards green after: the scanner control, the ledger test, and the shell-text test.

## The second change, and why it is different

One line of `claudedocs/handoff-tmux-webapp.md` is reworded. That was a **true** positive — the doc literally spelled the wide-kill command in prose and tripped `test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny`. The sentence does not need to spell it, so the fix is the wording rather than an allowlist entry.

Worth noting the guards are working as designed in both directions here: one caught a real thing I wrote, and the other had a false-positive bug. Only the second needed a code change.
