### PR TITLE
fix(guard-core): main is RED — two handoff docs mention a wide tmux kill and were classified in NEITHER ledger

### DIFF
--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2542,6 +2542,15 @@ _KILL_MENTION_LEDGER = {
     # Prose about the event, not a call: that file executes no tmux kill.
     "scripts/tests/test_tmux_restore_trigger.py": "prose: why the service needs ConditionPathExists",
     "scripts/tests/test_waiting_windows.py": "prose: forbidden-verb list",
+    # Two handoff docs that landed on `main` unclassified, turning this guard
+    # RED for the whole repo. Both are prose in a write-up; neither file
+    # executes any tmux command at all.
+    "claudedocs/handoff-tmux-webapp.md":
+        "prose: incident write-up — a `tmux kill-window -t @58` that was READ "
+        "from a log, and a `tmux kill-session` recorded as BLOCKED by a guard",
+    "claudedocs/handoff-mention-system-repos.md":
+        "prose: a META-mention — it only quotes that the doc above 'landed "
+        "carrying `tmux kill-server` text', i.e. it is about this ledger",
 }
 
 # A tmux argv list that carries NO `-L` and is nevertheless fine, because it is
@@ -2670,6 +2679,13 @@ def test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny():
         "scripts/claude-hooks/tests/test_guard_core.py",
         "scripts/session-write-harness/real_pane_check.py",  # a docstring line
         "scripts/tests/test_tmux_restore_trigger.py",  # a docstring line; see the ledger
+        # The same two handoff docs as the ledger above, for the same reason:
+        # prose in a write-up, in files that execute nothing. 🔴 This allowlist
+        # and `_KILL_MENTION_LEDGER` are SEPARATE and both had to be updated —
+        # a file classified in one is still an offender to the other, which is
+        # how `main` stayed red on TWO tests for one root cause.
+        "claudedocs/handoff-tmux-webapp.md",
+        "claudedocs/handoff-mention-system-repos.md",
     }
     seen_in_allowlisted, offenders = 0, []
     for rel in _tracked_files():


### PR DESCRIPTION
🔴 **`main` is currently RED, and this un-reds it.** Not part of the arc I was working — found while investigating a red check on #1533 and run down rather than assumed.

## Measured, on `main` itself

A clean detached worktree of `origin/main` (`3161851b`), not a PR branch:

```
FAILED test_every_kill_server_call_site_in_the_repo_is_classified
FAILED test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny
2 failed, 1534 passed
```

**One root cause, two guards.** `claudedocs/handoff-tmux-webapp.md` and `claudedocs/handoff-mention-system-repos.md` landed carrying wide-tmux-kill prose and were entered in neither list. Both are prose in a write-up:

- `handoff-tmux-webapp.md` — a wide `kill-window -t @58` that was *read from a log*, and a session-kill recorded as **blocked by a guard**;
- `handoff-mention-system-repos.md` — a **meta-mention**: it only quotes that the doc above "landed carrying" such text, i.e. it is about this ledger.

Neither file executes any tmux command.

## 🔴 The two allowlists are separate, and both had to be updated

Classifying a file in `_KILL_MENTION_LEDGER` leaves it an offender to `quoting_is_the_point`. That is why one root cause held `main` red on **two** tests — and fixing only the first still left the module red, which is how I found the second. Worth noting as a "one rule, one place" smell: two ledgers over the same family, each of which must be edited for every new file.

## How I know it isn't #1533's fault

#1533's diff is a handoff doc and two audit-ladder files — it cannot reach `scripts/claude-hooks/`. The control that settled it: the same two tests **fail on a clean `origin/main` worktree** too. A red check is weak evidence on its own; this one reproduced independently of any PR.

## Positive control — because this PR adds entries to an allowlist

Adding to an allowlist is exactly the move that silences a guard, so:

| state | result |
|---|---|
| a tracked file carrying a real wide-kill command, in neither list | **2 failed** |
| after removing it | **2 passed** |

Both guards still catch a genuine offender. These additions **classify two documents**; they do not widen what the guard denies. The second test's own internal positive control (`seen_in_allowlisted > 0`) is untouched and still passing.

`scripts/claude-hooks/tests/test_guard_core.py`: **1536 passed**.

## Note for whoever owns those docs

Nothing here changes the docs. If either was meant to be neutered rather than classified, that is a different fix and this one should be reverted alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaeYxVr4aESJ7dWhgBRUtS
