### PR TITLE
fix(disk-accounting): the sha rule is declared in ONE file and is self-attributed, not in two

### DIFF
--- a/scripts/tests/test_diagnose_disk_accounting.sh
+++ b/scripts/tests/test_diagnose_disk_accounting.sh
@@ -1728,8 +1728,20 @@ echo "== 14. EVERY SHA THESE FILES CITE MUST BE REACHABLE FROM THE MAINLINE =="
 # tag, a date, or a prose description of a commit — all of which are positional
 # anchors a reader cannot resolve, and all of which pass. An audit demonstrated
 # each. Closing that would mean parsing intent out of English, which is not a
-# thing a grep does; what is written here instead is the boundary. Both files carry the sentence "a
-# positional or historical number is legal only with a sha a reader can resolve".
+# thing a grep does; what is written here instead is the boundary.
+# 🔴 THE RULE IS DECLARED IN ONE FILE — THIS ONE — AND IT IS SELF-ATTRIBUTED.
+# An earlier version of this paragraph read "Both files carry the sentence", which
+# asserted a second, INDEPENDENT declarer that does not exist and made the rule's
+# attribution look stronger than it is. MEASURED 2026-09-12:
+# `scripts/diagnose-disk-accounting.sh` does not carry that sentence and never has
+# — `git log -S'reader can resolve' -- scripts/diagnose-disk-accounting.sh` is
+# EMPTY across all history, while the same `-S` on THIS file returns three commits.
+# Positive control, so that zero is an absence and not a blind instrument:
+# `grep -c sha scripts/diagnose-disk-accounting.sh` -> 9 over 1,169 lines.
+# The only declarer is this file's own header, and it is correctly scoped there
+# ("legal IN THIS FILE only with a sha a reader can resolve") — a qualifier this
+# paragraph used to drop. So this file writes the rule, about itself, and then
+# checks it; nothing outside it asserts the rule at all.
 # That sentence is itself a claim nothing checked — which is the exact generator
 # five audit rounds were spent on. MEASURED: after the round that WROTE the rule,
 # THREE cited shas were not ancestors of main. Two survived in this very file,


### PR DESCRIPTION
Rank 6 of `claudedocs/handoff-audit-pr-ladder.md`. Comment-only.

Section 14's banner claimed **"Both files carry the sentence"** `a positional or historical number is legal only with a sha a reader can resolve`. That asserts a second, independent declarer which does not exist.

## Measured, with a positive control

| command | result |
|---|---|
| `git log -S'reader can resolve' -- scripts/diagnose-disk-accounting.sh` | **0 commits, all history** |
| `git log -S'reader can resolve' -- scripts/tests/test_diagnose_disk_accounting.sh` | 3 commits |
| `grep -c sha scripts/diagnose-disk-accounting.sh` | **9** over 1,169 lines |

The payload script has never carried the sentence, and the positive control proves grep can see that file — so the zero is an absence, not a blind instrument. The only declarer is this test file's own header, where the rule is correctly **scoped** (*"legal **in this file** only …"*) — the qualifier the banner dropped.

**So the rule is self-attributed:** this file writes it, about itself, then checks it. That is the weakest attribution class short of unattributed, and the comment concealed it — a maintainer asking whether section 14 should exist would read "both files" and conclude the payload script independently declares the rule.

## Why no new guard

The sibling `test_retracted_contention_figure.py` is ~282 lines keyed to literal digits for one figure. Equivalent machinery to pin one comment sentence is not justified; the remedy is to stop asserting the unestablished half. The retraction **quotes** the old wording deliberately, so a reader grepping for it lands on the correction — the same shape as that guard's three legitimate quoting sites.

## Verification

- Comment-only: **0** non-comment lines added or removed (`git diff -U0 | grep '^+' | grep -vcE '^\+\s*#'` → 0).
- `bash -n` clean.
- Target run at `4ded76cf`: **231 ok, 0 failures, exit 0**, `all checks passed`. Section 14 still reports `all 3 cited sha(s) resolve here AND are ancestors of refs/remotes/origin/main`.
- ⚠ The seven `fail` matches in that log are section 4b's own test **names**, each prefixed `ok:` — not failures. Stated because a bare `grep -ci fail` on the log looks alarming.
- ⚠ I did **not** run either gate tier. This is a comment-only change to one shell test; the claim above is about that target, named by path, not about the gate.

Found by a round-0 audit of #1523, re-verified twice independently and once more inside the worktree immediately before the edit.