### PR TITLE
fix(guard): the wide-kill guard read only the command line, so a kill inside an executed script walked past it

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -2359,7 +2359,13 @@ _TMUX_KILL_DENY = (
     "own socket. "
     "🔴 AND IF A SHARED `kill-server` IS GENUINELY NEEDED, THE ESCAPE HATCH IS NOT YOURS: this "
     "hook gates the Bash TOOL, and the operator's own terminal is not hooked. Ask them to run "
-    "it. Do not go looking for a spelling that slips past this check."
+    # 🔴 THIS USED TO SAY "Do not go looking for a spelling that slips past this check", full
+    # stop — which read as a claim that none exists. It does: `cat x.sh | bash` reaches a shell
+    # through a pipe this parser does not model, and the blind-spot list in
+    # `check_tmux_kill_shared_server` names three more. An overclaiming deny message is worse
+    # than an honest one, because the first agent who finds a gap learns the guard lies.
+    "it. Gaps in this check exist and are listed in its source; using one is the same accident "
+    "as the incident above, not a workaround — the answer is still to ask the operator."
     + _QUOTING_ESCAPE_HATCH
 )
 
@@ -2508,42 +2514,130 @@ def check_tmux_kill_shared_server(cmd):
 # workflow, which `_IRREVERSIBLE_CHECKS` argues at length is worse than no gate
 # because it gets routed around AND reports safety.
 #
-# The narrow arm was measured on the same population: 135 real scripts across
-# `scripts/`, `githooks/`, `collector/`, `dl-router/` and `opencode/` — ZERO
-# denied — while the actual crash-1 body denies. That is the whole argument:
-# this arm is all upside on the tree as it stands. Widening it to another check
-# is an operator decision that must bring the same two numbers, not an
+# ⚠ THE "135 SCRIPTS, ZERO DENIED" FIGURE THAT USED TO SIT HERE WAS MEASURED ON
+# THE WRONG POPULATION AND WAS WRONG. The sweep walked five directories
+# NON-RECURSIVELY and missed 671 files under `scripts/` alone. Re-run
+# recursively, the arm as first written denied FIVE real files — `guard_core.py`
+# itself (mode 0755), `scripts/opencode/lib/oc_permissions.py`, two tests and a
+# `.pyc` — every one of them PYTHON, read as shell because the arm took any
+# path containing `/` as a script. Fixed by `_is_shell_program`: the INVOCATION
+# decides the interpreter.
+#
+# The honest figure, measured 2026-09-12 over a RECURSIVE walk of `scripts/` and
+# `githooks/`: 819 files, ZERO denied by direct execution, and ZERO denied by
+# `bash <file>` across the 86 of them that are shell programs — while the actual
+# crash-1 body denies. Widening this arm to another check is an operator
+# decision that must bring the same numbers from the same recursive walk, not an
 # assumption that more checks are more safety.
-_SCRIPT_TEXT_CHECKS = (check_tmux_kill_shared_server,)
+#
+# 🔴 EVERY ENTRY IS A (check, SENTINEL) PAIR, AND THE SENTINEL IS NOT OPTIONAL.
+# The sentinel is a substring that the check's OWN MATCHER makes NECESSARY for a
+# deny, and it is what keeps this arm off the hot path: a body that cannot
+# contain the sentinel cannot be denied, so it is never parsed. The pairing is
+# structural rather than a comment because a tuple of bare functions would make
+# the pre-gate silently WRONG the moment a second check joined — it would still
+# skip on the tmux sentinel while the new check's own spellings walked past.
+# `test_every_script_text_check_carries_a_sentinel_its_matcher_implies` fails if
+# an entry has no sentinel, and the implication itself is proved (not asserted)
+# by `test_the_tmux_sentinel_is_IMPLIED_by_the_matcher`.
+_SCRIPT_TEXT_CHECKS = (
+    # `_is_wide_kill_word` requires `tok.startswith(_TMUX_KILL_MANY_PREFIX)`, so
+    # EVERY spelling this check can deny carries that literal. Derived from the
+    # constant, never retyped, so the pre-gate cannot drift from the matcher.
+    (check_tmux_kill_shared_server, _TMUX_KILL_MANY_PREFIX),
+)
 
 # A script big enough to be a data file is not one an agent hand-wrote to run a
 # kill; the cap keeps a pathological read off the hot path of EVERY Bash call.
 _SCRIPT_READ_MAX_BYTES = 256 * 1024
 _SCRIPT_RECURSION_LIMIT = 3
 
+# 🔴 THE DESCENT CAP IS THE LATENCY FIX, AND IT IS A SEPARATE NUMBER FROM THE
+# READ CAP ON PURPOSE. MEASURED on the first shipped version of this arm, with
+# `evaluate()` timed in-process on the workbench:
+#
+#     scripts/claim-work.sh --list   960–1195 ms   (0.2 ms before this arm)
+#     scripts/drift-check.sh         552–820 ms
+#     bash scripts/gate.sh …          41–50 ms
+#
+# `claim-work.sh` is MANDATED by the resume skill, and this hook runs on every
+# Bash call in every session on both hosts. The cost is not the read (88 KiB is
+# ~0.5 ms); it is `commands()`, which took 187 ms on that body and was paid
+# TWICE — once by the check and once to find nested invocations — and then again
+# for every path-like token in its PROSE that happened to name a real file
+# (`claude/RULES.md`, `RULES-ARCHIVE.md`, `/etc/machine-id`, … all read).
+#
+# Two gates fix it, and they are different gates:
+#   * the SENTINEL pre-gate skips the check's parse when the body cannot be
+#     denied — no coverage loss, because the sentinel is implied by the matcher;
+#   * this cap skips the DESCENT parse for a body over 8 KiB. That one IS a
+#     coverage trade, stated plainly: a nested `bash <other>` inside a script
+#     larger than 8 KiB is not followed. The script itself is still read and
+#     still checked at any size up to the read cap. 8 KiB is where the parser
+#     costs ~5 ms; 16 KiB already costs ~34 ms and 88 KiB ~211 ms.
+# Agent-written scratch scripts — the population both 2026-09-11 incidents came
+# from — are a few hundred bytes, so multi-hop still works where it was needed.
+_SCRIPT_DESCEND_MAX_BYTES = 8 * 1024
+
 # 🔴 KNOWN GAP, AND A DELIBERATE ONE: `source x.sh` / `. x.sh` is NOT read.
 #
 # Sourcing runs in the CURRENT shell, so on danger alone it deserves reading
-# more than `bash <file>`, not less. It is excluded because of a DIFFERENT
-# invariant that outranks it here: `test_the_hot_path_reads_no_files_and_execs_
-# no_git` pins that this hook — which runs on EVERY Bash call on both hosts —
-# must not open files just because a command mentions one, and the dominant real
-# use of `.`/`source` is ENV FILES (`. wt.env; ls`), which the guard already
-# resolves through its own separately-gated path. Reading every sourced file
-# would put an open() on the hot path for the commonest shape there is.
+# more than `bash <file>`, not less.
 #
-# `bash <file>` is not that population: it is only the commands that actually
-# spawn a shell to RUN a script, which is both rare and exactly what the two
-# 2026-09-11 incidents did. So the arm covers the measured shape and declines
-# the one that would tax every call.
+# ⚠ THE REASON THIS BLOCK USED TO GIVE WAS FALSE, and the correction is the
+# point. It said `test_the_hot_path_reads_no_files_and_execs_no_git` "pins that
+# this hook must not open a file just because a command names one". That test
+# pins no such thing: it asserts only that THE SOURCED ENV FILE is not opened
+# for commands carrying no real `git … commit`, and it passed unchanged while
+# this very arm opened `ship.sh` for `evaluate('…/ship.sh --no-laptop')`. No
+# total open() count was pinned anywhere. Measured, not argued.
 #
-# What would close it without paying that cost: a cheap pre-gate that can tell
-# an env file from a program without reading it. There isn't one, so this is
-# recorded as open rather than papered over.
+# The reason that survives re-measurement is narrower, and it is about the
+# POPULATION rather than about an existing invariant: `. wt.env; ls` is the
+# commonest shape on this hook's hot path, an env file is not a program, and
+# reading every sourced file would put an open() on that shape on every Bash
+# call. `bash <file>` is not that population — it is only the commands that
+# spawn a shell to RUN a script, which is rare and is exactly what the two
+# 2026-09-11 incidents did.
+#
+# That claim is now PINNED by a test that actually constrains it:
+# `test_the_script_arm_opens_only_the_files_it_will_execute` asserts the exact
+# SET of paths opened for a realistic command mix — `. wt.env; ls` opens
+# nothing, `bash repro.sh` opens exactly `repro.sh` — with a positive control so
+# the assertion cannot pass by observing nothing.
 
 
-def _script_operand(argv):
-    """The path this argv would EXECUTE as a script file, or None.
+# Value-taking shell flags whose ARGUMENT is not the script. `-O`/`+O` and `+o`
+# were missing and each one was a live bypass: `bash -O extglob x.sh` returned
+# `extglob` as the script path (no such file → ALLOW), and `+`-prefixed tokens
+# were not recognised as flags at all, so `+O` itself was returned.
+_SHELL_VALUE_FLAGS = ("-o", "+o", "-O", "+O", "--rcfile", "--init-file")
+
+# A redirection token as this tokeniser hands it over: `>`, `2>`, `>>`, `&>`,
+# `<`, `<<EOF`, `2>&1`, `>/tmp/o.log`. Group 2 is the operator, group 3 whatever
+# was attached to it. Nothing that is not a redirection can match: an ordinary
+# operand would have to begin with digits followed by `<` or `>`.
+_REDIR_RE = re.compile(r"^(\d*)(<<-?|<&|>&|&>>?|<>|>>|>\||>|<)(.*)$")
+
+
+def _redirection(tok):
+    """`(kind, attached-target)` for a redirection token, else `(None, None)`.
+
+    `kind` is `"in"` only for a plain `<`, where the shell READS ITS PROGRAM
+    from the target — `bash < x.sh` and `bash -s < x.sh` execute `x.sh`, so the
+    redirect target IS the script. Every other operator redirects a stream the
+    shell does not interpret, so its target must be SKIPPED rather than read:
+    `bash 2>/dev/null x.sh` used to return `2>/dev/null` as the script path and
+    ALLOW the file that actually ran.
+    """
+    m = _REDIR_RE.match(tok)
+    if not m:
+        return (None, None)
+    return ("in" if m.group(2) == "<" else "other", m.group(3))
+
+
+def _script_operand(argv, _depth=0):
+    """`(path, executed_directly)` for the script this argv RUNS, or None.
 
     Two shapes, and deliberately no third:
       * `bash x.sh` / `sh -x x.sh`  — a shell with a FILE operand. `-c` is
@@ -2551,42 +2645,122 @@ def _script_operand(argv):
         this arm is for the case where the code is not in the command line.
       * `./x.sh` / `/abs/x.sh`      — executed directly.
 
-    Two gaps, both stated rather than papered over:
-      * `source`/`.` — see the block above; excluded to keep the hot-path
-        promise, not because it is safe.
+    🔴 THE SECOND ELEMENT IS LOAD-BEARING: THE INVOCATION DECIDES THE
+    INTERPRETER, NOT THE FILE. `bash x` means "read x as shell" whatever x
+    contains; `./x` means "run x the way its shebang says", which for a Python
+    file is not shell at all. Reading every directly-executed file as shell
+    denied FIVE real files in this repo — `scripts/claude-hooks/guard_core.py`
+    (mode 0755, so `./scripts/claude-hooks/guard_core.py` is a real invocation),
+    `scripts/opencode/lib/oc_permissions.py`, two tests and a `.pyc` — whose
+    bytes were never shell commands. See `_is_shell_program`.
+
+    KNOWN GAPS, stated rather than papered over, each pinned by a test in
+    section 16 of test_guard_core.py so it cannot close silently and then
+    reopen:
+      * `source`/`.` — see the block above.
       * a BARE `x.sh` resolved through `$PATH` — resolving it means guessing a
         PATH this process does not share with the command, and a wrong guess
         reads an unrelated file and denies on ITS contents.
+      * `cat x.sh | bash`, `tmux run-shell x.sh`, `tmux source-file x.sh`,
+        `make -f x.sh`, `python3 x.sh`, `watch bash x.sh`, `xargs … bash`,
+        `find -exec bash {} \\;`, `nix develop <dir> -c bash /abs/x.sh` — the
+        file reaches a shell through a program this parser does not model. Each
+        would need its own option-arity table, and getting one wrong is how a
+        check fails OPEN (see `_TMUX_VALUE_FLAGS`).
+      * `busybox busybox sh x.sh` — one applet hop is modelled, not two.
     """
     if not argv:
         return None
     base = os.path.basename(argv[0])
+    if base == "busybox":
+        # `busybox` is in `_SHELLS` because the binary can BE the shell, but the
+        # applet-dispatch spelling puts the real shell in argv[1] — and the flag
+        # scan below then returned `sh`, a path that never exists, so EVERY
+        # `busybox sh x.sh` was ALLOWED. That is the only way busybox is ever
+        # used as a shell here, so the missed spelling was the whole feature.
+        if _depth or len(argv) < 2:
+            return None
+        return _script_operand(argv[1:], _depth + 1)
     if base in _SHELLS:
-        skip_next = False
-        for tok in argv[1:]:
-            if skip_next:
-                skip_next = False
-                continue
+        i, force_operand = 1, False
+        while i < len(argv):
+            tok = argv[i]
+            if force_operand:
+                # After `--` the next token is the operand even when it looks
+                # like a flag: `bash -- -weird.sh` runs a file called
+                # `-weird.sh`. The old scan `continue`d past `--` and then
+                # skipped `-weird.sh` as a flag.
+                return (tok, False)
             if tok == "--":
+                force_operand = True
+                i += 1
                 continue
-            if tok.startswith("-"):
+            kind, attached = _redirection(tok)
+            if kind == "in":
+                if attached:
+                    return (attached, False)
+                return (argv[i + 1], False) if i + 1 < len(argv) else None
+            if kind == "other":
+                i += 1 if attached else 2
+                continue
+            if tok.startswith("-") or tok.startswith("+"):
                 # `-c` carries inline text, not a file; `_nested_shell_text` owns it.
-                if "c" in tok[1:] and not tok.startswith("--"):
+                if tok.startswith("-") and not tok.startswith("--") and "c" in tok[1:]:
                     return None
-                if tok in ("-o", "--rcfile", "--init-file"):
-                    skip_next = True
+                i += 2 if tok in _SHELL_VALUE_FLAGS else 1
                 continue
-            return tok
+            return (tok, False)
         return None
     # Direct execution. Require a path separator: a bare word here is either a
     # PATH lookup (see the docstring) or not a script at all.
     if "/" in argv[0]:
-        return argv[0]
+        return (argv[0], True)
     return None
 
 
-def _read_script(path, cwd):
-    """The file's text, or None when it is not a readable local regular file.
+def _is_shell_program(p, body):
+    """Would running `p` DIRECTLY execute `body` as shell commands?
+
+    Only asked of a directly-executed file (`./x`, `/abs/x`), never of a `bash
+    x` operand — there the invocation has already said "shell", and second-
+    guessing it from the file's own content would be a bypass: write a
+    `#!/usr/bin/env python3` line above a kill and run it with `bash`.
+
+    Three answers, in the order the kernel and the shell actually resolve them:
+      * a NUL byte near the start means a binary, not a text script;
+      * a `#!` line is authoritative — `execve` hands the file to THAT
+        interpreter, so a Python file is Python however it is named;
+      * no shebang at all means `execve` fails ENOEXEC and the calling shell
+        re-runs the file as a SHELL script — but only if it is executable in the
+        first place, because otherwise the invocation simply fails.
+    """
+    if "\x00" in body[:4096]:
+        return False
+    if body.startswith("#!"):
+        words = body.split("\n", 1)[0][2:].strip().split()
+        if not words:
+            return False
+        interp = os.path.basename(words[0])
+        if interp == "env":
+            # `#!/usr/bin/env -S VAR=1 bash` — the interpreter is the first word
+            # that is neither a flag nor an assignment.
+            interp = None
+            for w in words[1:]:
+                if w.startswith("-") or "=" in w:
+                    continue
+                interp = os.path.basename(w)
+                break
+            if interp is None:
+                return False
+        return interp in _SHELLS
+    try:
+        return bool(os.stat(p).st_mode & 0o111)
+    except OSError:
+        return False
+
+
+def _read_script(path, cwd, direct=False):
+    """The file's text, or None when it is not a shell program this can read.
 
     Never raises. A guard that throws on a weird path would fail the Bash call
     it was asked about, which is a worse outcome than the hole it is closing.
@@ -2596,14 +2770,83 @@ def _read_script(path, cwd):
             # Unexpanded glob/variable: this process cannot know what it names.
             return None
         p = path if os.path.isabs(path) else os.path.join(cwd or ".", path)
+        # 🔴 ANTI-HANG, NOT TIDINESS. `isfile` is False for a FIFO, and opening a
+        # FIFO that has no writer BLOCKS FOREVER — inside a hook that gates every
+        # Bash call in every session, i.e. it would wedge the operator's tool,
+        # not just this command. `bash /tmp/somefifo` is a real shape. It also
+        # rejects a directory and a dangling symlink.
         if not os.path.isfile(p):
             return None
         if os.path.getsize(p) > _SCRIPT_READ_MAX_BYTES:
             return None
         with open(p, encoding="utf-8", errors="replace") as fh:
-            return fh.read()
+            body = fh.read()
     except (OSError, ValueError):
         return None
+    if direct and not _is_shell_program(p, body):
+        return None
+    return body
+
+
+# Quoting characters deleted before the sentinel pre-gate runs. A shell token is
+# assembled from the text with these REMOVED, so `tmux 'kill-'server` and
+# `tmux kill\-server` both tokenise to `kill-server` while the raw bytes contain
+# no `kill-s`. Stripping them is what makes the pre-gate's implication hold over
+# TEXT and not merely over tokens.
+#
+# ⚠ Three `str.replace` passes, NOT `str.translate`. Measured on the 216 KiB
+# `scripts/drift-check.sh`: `translate` cost 20 ms — it is a per-character table
+# lookup in Python — against 0.6 ms for the replaces, and this runs on every
+# Bash call that names a script. The pre-gate must not become the cost it exists
+# to avoid.
+_UNQUOTE_CHARS = ("'", '"', "\\")
+
+
+def _unquote(body):
+    for ch in _UNQUOTE_CHARS:
+        body = body.replace(ch, "")
+    return body
+
+
+def _script_checks_for(body):
+    """The script-text checks whose sentinel appears in `body`.
+
+    🔴 THE PRE-GATE, and the reason it loses no coverage: each sentinel is a
+    substring the paired check's own matcher REQUIRES, so a body without it
+    cannot be denied by that check and parsing it would be pure cost. The body
+    is tested raw first (the common case, no copy) and then with quoting
+    stripped.
+
+    ⚠ RESIDUAL, declared: a line-continuation splice (`kill-\\` + newline +
+    `server`) still hides the sentinel, because deleting the backslash leaves
+    the newline between the halves. Pinned by
+    `test_a_line_continuation_splice_is_a_DECLARED_gap_in_the_pre_gate`.
+    """
+    stripped = None
+    for chk, sentinel in _SCRIPT_TEXT_CHECKS:
+        if sentinel in body:
+            yield chk
+            continue
+        if stripped is None:
+            stripped = _unquote(body)
+        if sentinel in stripped:
+            yield chk
+
+
+# 🔴 THIS ARM'S OWN REMEDY, because the inherited one is INVERTED here.
+# `_QUOTING_ESCAPE_HATCH` arrives inside `reason` and tells the caller to write
+# the text to a FILE — correct advice when a heredoc body is being parsed as a
+# command, and exactly backwards when what is denied is RUNNING a file. Writing
+# one is what the caller already did. So the tail says what actually clears it.
+_SCRIPT_ARM_REMEDY = (
+    " 🔴 AND IGNORE THE 'write the text to a file' NOTE ABOVE — it is inherited from the "
+    "checks that gate command TEXT and is backwards for this one: a file is what you just "
+    "ran. What clears this deny: (a) fix the SCRIPT — `tmux -L my-probe-$$ new-session -d …` "
+    "then `tmux -L my-probe-$$ kill-server`, or `kill-pane`/`kill-window` if you only meant "
+    "to remove what you named; (b) if the script only DOCUMENTS the command in a comment or a "
+    "heredoc, move that prose out of the executable file; (c) if a shared `kill-server` is "
+    "genuinely needed, ask the operator to run it in their own terminal."
+)
 
 
 @_wants_cwd
@@ -2614,9 +2857,18 @@ def check_executed_script_file(cmd, cwd=None):
     line does not contain the offending text and a bare "tmux kill-server is
     blocked" would read as a guard malfunction.
 
-    Bounded: recursion depth and a visited set, so a script that sources itself
-    (or a cycle between two) terminates instead of spinning a hook that runs on
-    every Bash call.
+    Bounded three ways, because this runs on every Bash call: a recursion depth,
+    a per-body descent cap (`_SCRIPT_DESCEND_MAX_BYTES`), and a visited set — so
+    a script that runs itself, or a cycle between two, terminates.
+
+    🔴 THE VISITED SET IS KEYED ON `(realpath, depth)`, NOT ON THE PATH. Keyed
+    on the path alone it was ORDER-DEPENDENT AND UNSOUND: `depth` is per-branch
+    but `seen` is global to the walk, so a file first reached at depth 3 (where
+    the next hop is over the limit) was then SKIPPED when the same file came up
+    again at depth 0, taking its whole subtree with it. Measured on a chain
+    `A→B→C→X→K` with the kill in `K`: `bash A.sh; bash X.sh` ALLOWED while
+    `bash X.sh; bash A.sh` DENIED — the same two commands, the same files, the
+    verdict decided by the order they appeared in.
     """
     seen = set()
 
@@ -2624,18 +2876,20 @@ def check_executed_script_file(cmd, cwd=None):
         if depth > _SCRIPT_RECURSION_LIMIT:
             return None
         for argv in commands(text):
-            path = _script_operand(argv)
-            if not path:
+            operand = _script_operand(argv)
+            if not operand:
                 continue
-            body = _read_script(path, cwd)
-            if body is None:
-                continue
-            key = os.path.realpath(
-                path if os.path.isabs(path) else os.path.join(cwd or ".", path))
+            path, direct = operand
+            key = (os.path.realpath(
+                path if os.path.isabs(path) else os.path.join(cwd or ".", path)),
+                depth)
             if key in seen:
                 continue
             seen.add(key)
-            for chk in _SCRIPT_TEXT_CHECKS:
+            body = _read_script(path, cwd, direct)
+            if body is None:
+                continue
+            for chk in _script_checks_for(body):
                 reason = chk(body)
                 if reason:
                     return (
@@ -2646,10 +2900,12 @@ def check_executed_script_file(cmd, cwd=None):
                         "Writing the command to a file and running the file is not "
                         "a way around this guard — it is the exact shape that "
                         "caused the incident. Fix the SCRIPT: give it its own "
-                        "server with `-L my-probe-$$` and kill that.")
-            nested = walk(body, depth + 1)
-            if nested:
-                return nested
+                        "server with `-L my-probe-$$` and kill that."
+                        + _SCRIPT_ARM_REMEDY)
+            if len(body) <= _SCRIPT_DESCEND_MAX_BYTES:
+                nested = walk(body, depth + 1)
+                if nested:
+                    return nested
         return None
 
     return walk(cmd, 0)

--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -2477,6 +2477,184 @@ def check_tmux_kill_shared_server(cmd):
     return None
 
 
+# --------------------------------------------------------------------------- #
+# THE SCRIPT-FILE ARM — the bypass that made the check above a paper guard.
+#
+# 🔴 MEASURED, TWICE, AFTER the check above was already deployed and correct.
+# 2026-09-11, the operator's tmux server died twice in one night, 52 and 53 live
+# Claude conversations each time. Both were this shape:
+#
+#     Write  -> /tmp/.../repro.sh   containing  TMUX_TMPDIR=… ; tmux kill-server
+#     Bash   -> bash /tmp/.../repro.sh
+#
+# `check_tmux_kill_shared_server` never saw the kill, because this hook gates the
+# Bash-tool TEXT and the text was `bash <path>`. Proven with a control pair: the
+# inline spelling DENIES, the identical bytes inside a file ALLOW at rc 0. The
+# guard's own docstring already said the thing that matters — "this hook gates
+# the Bash TOOL" — and the hole is that a file is not text the tool carries.
+#
+# Timing that pins it as cause rather than coincidence: 0.7s and 1.1s from exec
+# to the first `tmux-spawn-*.scope` teardown, and at each instant FOUR and THREE
+# UNRELATED sessions were interrupted simultaneously — a per-command denial
+# cannot do that; only the shared server dying can.
+#
+# 🔴 WHY ONLY THE TMUX CHECK RUNS OVER FILE CONTENTS, and why that is a floor
+# rather than timidity. The obvious design — run the whole policy over the file
+# — was MEASURED before being rejected: of 103 top-level `scripts/`, it denies
+# TWO, and they are `ship.sh` and `drift-check.sh`, i.e. the deploy command and
+# the drift deadman. Both are FALSE POSITIVES from prose (`ship.sh` explains
+# that it never stashes; the guard parses comment lines as commands). Denying
+# `bash scripts/ship.sh` would be a permanently-red gate on the repo's core
+# workflow, which `_IRREVERSIBLE_CHECKS` argues at length is worse than no gate
+# because it gets routed around AND reports safety.
+#
+# The narrow arm was measured on the same population: 135 real scripts across
+# `scripts/`, `githooks/`, `collector/`, `dl-router/` and `opencode/` — ZERO
+# denied — while the actual crash-1 body denies. That is the whole argument:
+# this arm is all upside on the tree as it stands. Widening it to another check
+# is an operator decision that must bring the same two numbers, not an
+# assumption that more checks are more safety.
+_SCRIPT_TEXT_CHECKS = (check_tmux_kill_shared_server,)
+
+# A script big enough to be a data file is not one an agent hand-wrote to run a
+# kill; the cap keeps a pathological read off the hot path of EVERY Bash call.
+_SCRIPT_READ_MAX_BYTES = 256 * 1024
+_SCRIPT_RECURSION_LIMIT = 3
+
+# 🔴 KNOWN GAP, AND A DELIBERATE ONE: `source x.sh` / `. x.sh` is NOT read.
+#
+# Sourcing runs in the CURRENT shell, so on danger alone it deserves reading
+# more than `bash <file>`, not less. It is excluded because of a DIFFERENT
+# invariant that outranks it here: `test_the_hot_path_reads_no_files_and_execs_
+# no_git` pins that this hook — which runs on EVERY Bash call on both hosts —
+# must not open files just because a command mentions one, and the dominant real
+# use of `.`/`source` is ENV FILES (`. wt.env; ls`), which the guard already
+# resolves through its own separately-gated path. Reading every sourced file
+# would put an open() on the hot path for the commonest shape there is.
+#
+# `bash <file>` is not that population: it is only the commands that actually
+# spawn a shell to RUN a script, which is both rare and exactly what the two
+# 2026-09-11 incidents did. So the arm covers the measured shape and declines
+# the one that would tax every call.
+#
+# What would close it without paying that cost: a cheap pre-gate that can tell
+# an env file from a program without reading it. There isn't one, so this is
+# recorded as open rather than papered over.
+
+
+def _script_operand(argv):
+    """The path this argv would EXECUTE as a script file, or None.
+
+    Two shapes, and deliberately no third:
+      * `bash x.sh` / `sh -x x.sh`  — a shell with a FILE operand. `-c` is
+        excluded because `_nested_shell_text` already recurses into that text;
+        this arm is for the case where the code is not in the command line.
+      * `./x.sh` / `/abs/x.sh`      — executed directly.
+
+    Two gaps, both stated rather than papered over:
+      * `source`/`.` — see the block above; excluded to keep the hot-path
+        promise, not because it is safe.
+      * a BARE `x.sh` resolved through `$PATH` — resolving it means guessing a
+        PATH this process does not share with the command, and a wrong guess
+        reads an unrelated file and denies on ITS contents.
+    """
+    if not argv:
+        return None
+    base = os.path.basename(argv[0])
+    if base in _SHELLS:
+        skip_next = False
+        for tok in argv[1:]:
+            if skip_next:
+                skip_next = False
+                continue
+            if tok == "--":
+                continue
+            if tok.startswith("-"):
+                # `-c` carries inline text, not a file; `_nested_shell_text` owns it.
+                if "c" in tok[1:] and not tok.startswith("--"):
+                    return None
+                if tok in ("-o", "--rcfile", "--init-file"):
+                    skip_next = True
+                continue
+            return tok
+        return None
+    # Direct execution. Require a path separator: a bare word here is either a
+    # PATH lookup (see the docstring) or not a script at all.
+    if "/" in argv[0]:
+        return argv[0]
+    return None
+
+
+def _read_script(path, cwd):
+    """The file's text, or None when it is not a readable local regular file.
+
+    Never raises. A guard that throws on a weird path would fail the Bash call
+    it was asked about, which is a worse outcome than the hole it is closing.
+    """
+    try:
+        if not path or any(c in path for c in "*?$`"):
+            # Unexpanded glob/variable: this process cannot know what it names.
+            return None
+        p = path if os.path.isabs(path) else os.path.join(cwd or ".", path)
+        if not os.path.isfile(p):
+            return None
+        if os.path.getsize(p) > _SCRIPT_READ_MAX_BYTES:
+            return None
+        with open(p, encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except (OSError, ValueError):
+        return None
+
+
+@_wants_cwd
+def check_executed_script_file(cmd, cwd=None):
+    """Run the script-file checks over the CONTENTS of any script this executes.
+
+    The deny names the FILE as well as the reason, because the caller's command
+    line does not contain the offending text and a bare "tmux kill-server is
+    blocked" would read as a guard malfunction.
+
+    Bounded: recursion depth and a visited set, so a script that sources itself
+    (or a cycle between two) terminates instead of spinning a hook that runs on
+    every Bash call.
+    """
+    seen = set()
+
+    def walk(text, depth):
+        if depth > _SCRIPT_RECURSION_LIMIT:
+            return None
+        for argv in commands(text):
+            path = _script_operand(argv)
+            if not path:
+                continue
+            body = _read_script(path, cwd)
+            if body is None:
+                continue
+            key = os.path.realpath(
+                path if os.path.isabs(path) else os.path.join(cwd or ".", path))
+            if key in seen:
+                continue
+            seen.add(key)
+            for chk in _SCRIPT_TEXT_CHECKS:
+                reason = chk(body)
+                if reason:
+                    return (
+                        f"`{path}` is executed by this command and CONTAINS a "
+                        f"blocked command. {reason}\n\n"
+                        "🔴 THIS IS THE BYPASS THAT KILLED THE OPERATOR'S TMUX "
+                        "SERVER TWICE ON 2026-09-11 (52 and 53 live conversations). "
+                        "Writing the command to a file and running the file is not "
+                        "a way around this guard — it is the exact shape that "
+                        "caused the incident. Fix the SCRIPT: give it its own "
+                        "server with `-L my-probe-$$` and kill that.")
+            nested = walk(body, depth + 1)
+            if nested:
+                return nested
+        return None
+
+    return walk(cmd, 0)
+
+
 # =========================================================================== #
 # POLICIES
 # =========================================================================== #
@@ -2603,6 +2781,11 @@ _CLAUDE_CODE_CHECKS = [
     # caller believed — and BEFORE the advisory checks for the usual "report the
     # more serious problem" reason.
     check_tmux_kill_shared_server,
+    # Immediately after the check it backstops, because it is the SAME finding
+    # reached through a file rather than through the command line — see
+    # `check_executed_script_file`, which carries the two incidents and the
+    # false-positive measurement that decided its narrow scope.
+    check_executed_script_file,
     check_heredoc_to_file,
     check_cd_then_git,
     check_private_key,

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -27,6 +27,7 @@ adapter end-to-end through a subprocess and is the regression suite for every
 raw-text bypass the original six checks close. It must stay green unchanged.
 """
 import itertools
+import os
 import re
 import sys
 from pathlib import Path
@@ -4591,10 +4592,24 @@ def test_a_SOURCED_script_is_a_KNOWN_GAP_and_stays_allowed(script, template, tmp
     and then reopen silently.
 
     Sourcing runs in the CURRENT shell, so on danger alone it deserves reading
-    MORE than `bash <file>`. It is excluded because a different invariant
-    outranks it here: `test_the_hot_path_reads_no_files_and_execs_no_git` pins
-    that this hook must not open a file merely because a command names one, and
-    `. wt.env; ls` is the commonest shape on that path.
+    MORE than `bash <file>`.
+
+    ⚠ THE REASON THIS DOCSTRING USED TO GIVE WAS FALSE. It said
+    `test_the_hot_path_reads_no_files_and_execs_no_git` pins "that this hook must
+    not open a file merely because a command names one". That test asserts only
+    `not [o for o in opened if str(env) in o]` — that THE SOURCED ENV FILE was
+    not opened — and it passed unchanged while this very arm opened `ship.sh`
+    for `evaluate('…/scripts/ship.sh --no-laptop')`. No total open() count was
+    pinned anywhere, by it or by
+    `test_the_hot_path_gate_is_the_same_walk_it_guards`.
+
+    The reason that survives re-measurement is about the POPULATION, not about
+    an existing invariant: `. wt.env; ls` is the commonest shape on this hook's
+    hot path, an env file is not a program, and reading every sourced file would
+    put an open() on that shape on every Bash call.
+    `test_the_script_arm_opens_only_the_files_it_will_execute` is what now
+    constrains that claim — it asserts the exact SET of paths opened, so `. env`
+    opening anything goes red.
 
     If someone finds a cheap way to tell an env file from a program without
     reading it, this test is the one to delete — deliberately, with the reason.
@@ -4606,7 +4621,14 @@ def test_a_SOURCED_script_is_a_KNOWN_GAP_and_stays_allowed(script, template, tmp
 
 
 def test_a_script_reached_through_ANOTHER_script_is_DENIED(script, tmp_path):
-    """One hop of indirection must not launder it."""
+    """Indirection must not launder it.
+
+    ⚠ This docstring used to say "One hop", and "one hop" is what the arm was
+    described as doing. `_SCRIPT_RECURSION_LIMIT = 3` gives THREE — measured,
+    hops 1-3 deny and hop 4 allows. The boundary is pinned on both sides by
+    `test_the_recursion_limit_is_THREE_hops_not_one`; this one stays as the
+    readable single-hop case.
+    """
     inner = script(_CRASH1_BODY, "inner.sh")
     outer = script('#!/usr/bin/env bash\necho hi\nbash ' + inner + '\n', "outer.sh")
     assert gc.evaluate(f"bash {outer}", "claude-code", str(tmp_path))
@@ -4752,28 +4774,679 @@ def test_bash_dash_c_is_still_handled_by_the_nested_text_arm(tmp_path):
 # nothing: the population is asserted non-empty first, and a known-bad script is
 # injected into the same sweep as a positive control, so a sweep wired to a
 # wrong path fails instead of reporting a reassuring zero.
+#
+# ⚠ IT USED TO WALK THE WRONG POPULATION AND REPORT A CLEAN ZERO ANYWAY. The
+# first version called `d.iterdir()` — NON-recursive — over five directories,
+# which missed 671 files under `scripts/` alone. Re-run with `rglob`, the SAME
+# guard denied FIVE real files: `scripts/claude-hooks/guard_core.py` (mode 0755,
+# so `./scripts/claude-hooks/guard_core.py` is a real invocation),
+# `scripts/opencode/lib/oc_permissions.py`, `scripts/tests/test_opencode_engine
+# .py`, `scripts/tests/test_opencode_config.py` and a `__pycache__/*.pyc`. Every
+# one is PYTHON: the arm was reading whatever a command named as shell. The fix
+# is `_is_shell_program` — the INVOCATION decides the interpreter — and this
+# sweep is the measurement that has to stay honest about it.
+#
+# BOTH invocation shapes are swept, because they take different paths through
+# `_read_script`: `{p}` (direct execution) consults the shebang, `bash {p}` does
+# not and must not — a shebang that overrode an explicit `bash` would be a
+# bypass. The `bash` half is restricted to files that ARE shell programs, which
+# is the only population where that spelling is a thing anyone types.
 # --------------------------------------------------------------------------- #
-def test_no_real_script_in_this_repo_is_denied_by_the_script_arm(tmp_path):
+def _repo_sweep_files():
     root = Path(__file__).resolve().parents[3]
-    dirs = [root / "scripts", root / "githooks", root / "scripts/collector",
-            root / "scripts/dl-router", root / "scripts/opencode"]
-    files = [p for d in dirs if d.is_dir() for p in sorted(d.iterdir())
-             if p.is_file() and p.suffix not in (".md", ".json", ".lock")]
+    files = []
+    for d in (root / "scripts", root / "githooks"):
+        if not d.is_dir():
+            continue
+        files += [p for p in sorted(d.rglob("*"))
+                  if p.is_file() and "__pycache__" not in p.parts
+                  and p.suffix not in (".md", ".json", ".lock")]
+    return root, files
 
-    assert len(files) > 80, (
-        f"the sweep found only {len(files)} scripts — a zero-denial result from "
-        "a population this small is a fact about the walk, not about the guard")
+
+def test_no_real_script_in_this_repo_is_denied_by_the_script_arm(tmp_path):
+    root, files = _repo_sweep_files()
+
+    # 🔴 THE FLOOR IS THE RECURSIVE COUNT, NOT THE OLD NON-RECURSIVE ONE.
+    # Measured 2026-09-12: 819 files. A floor of 80 was satisfied by the walk
+    # that missed 671 of them, so it could not have caught the bug it exists to
+    # catch. Raised to 600 — comfortably below today's count, far above anything
+    # a non-recursive walk can reach.
+    assert len(files) > 600, (
+        f"the sweep found only {len(files)} files — a zero-denial result from a "
+        "population this small is a fact about the walk, not about the guard. "
+        "(Non-recursive walks of these dirs reach ~150.)")
 
     denied = [str(p) for p in files
-              if gc.check_executed_script_file(f"bash {p}", str(root))]
+              if gc.check_executed_script_file(str(p), str(root))]
+    shellish = [p for p in files
+                if gc._is_shell_program(str(p), p.read_text(errors="replace"))]
+    assert len(shellish) > 40, (
+        f"only {len(shellish)} shell programs found — the `bash {{p}}` half of "
+        "this sweep has gone vacuous")
+    denied += [str(p) for p in shellish
+               if gc.check_executed_script_file(f"bash {p}", str(root))]
+
     assert denied == [], (
         "the script arm denies real scripts in this repo: " + ", ".join(denied)
         + ". A guard that fires on routine work is worse than no guard.")
 
-    # POSITIVE CONTROL, in the same sweep and the same call shape: if this does
-    # not deny, the loop above proved nothing.
+    # POSITIVE CONTROL, in the same sweep and both call shapes: if these do not
+    # deny, the loops above proved nothing.
     bad = tmp_path / "control.sh"
     bad.write_text(_CRASH1_BODY)
+    bad.chmod(0o755)
     assert gc.check_executed_script_file(f"bash {bad}", str(root)), (
         "the positive control was ALLOWED — this sweep is wired to nothing and "
         "its zero above is meaningless")
+    assert gc.check_executed_script_file(str(bad), str(root)), (
+        "the direct-execution positive control was ALLOWED")
+
+
+def test_a_directly_executed_PYTHON_file_is_not_read_as_shell(tmp_path):
+    """The F7 fix, stated as behaviour rather than as a sweep count.
+
+    `guard_core.py` is mode 0755 and contains the literal `kill-server` in its
+    own deny message and `"kill-s"` in `_TMUX_KILL_MANY_PREFIX`, so reading it as
+    shell denies it — and `./scripts/claude-hooks/guard_core.py` is a real thing
+    to type. Its shebang says `python3`; those bytes are never shell commands.
+
+    🔴 The second half is the anti-bypass: an EXPLICIT `bash <file>` must still
+    parse the file whatever its shebang says, or writing `#!/usr/bin/env python3`
+    above a kill and running it with `bash` would walk straight past.
+    """
+    root, _ = _repo_sweep_files()
+    real = root / "scripts/claude-hooks/guard_core.py"
+    assert real.is_file() and os.access(real, os.X_OK), (
+        "the fixture file moved or lost its exec bit — pick another 0755 "
+        "python file in the repo, or this test proves nothing")
+    assert gc.check_executed_script_file(str(real), str(root)) is None
+
+    lying = tmp_path / "lying.sh"
+    lying.write_text("#!/usr/bin/env python3\n" + _CRASH1_BODY)
+    lying.chmod(0o755)
+    assert gc.evaluate(str(lying), "claude-code", str(tmp_path)) is None, (
+        "direct execution must honour the shebang")
+    assert gc.evaluate(f"bash {lying}", "claude-code", str(tmp_path)), (
+        "🔴 BYPASS: an explicit `bash <file>` stopped parsing because of a "
+        "shebang. The INVOCATION decides the interpreter, not the file.")
+
+
+def test_a_no_shebang_file_executed_directly_is_still_read_as_shell(tmp_path):
+    """`execve` on a file with no `#!` fails ENOEXEC and the calling shell
+    re-runs it as a SHELL script — so a no-shebang executable IS shell, and
+    skipping it would open the obvious hole (write the kill, chmod, run it).
+
+    The negative half: a file with no shebang AND no exec bit cannot be executed
+    directly at all, so it is read once and then dropped — never PARSED. That is
+    what stopped `claude/RULES.md`, `RULES-ARCHIVE.md` and `/etc/machine-id`
+    being run through the shell parser because a script's PROSE named them.
+    (The parse, not the read, is what cost ~200 ms apiece.)
+    """
+    ex = tmp_path / "noshebang"
+    ex.write_text("tmux kill-server\n")
+    ex.chmod(0o755)
+    assert gc.evaluate(str(ex), "claude-code", str(tmp_path))
+
+    plain = tmp_path / "notes"
+    plain.write_text("tmux kill-server\n")
+    plain.chmod(0o644)
+    assert gc.evaluate(str(plain), "claude-code", str(tmp_path)) is None, (
+        "a non-executable file with no shebang cannot be run by `./x` — reading "
+        "it is pure cost")
+    # …and the gap that creates, stated rather than papered over: `chmod +x`
+    # earlier in the SAME command line happens after this guard reads the mode.
+    assert gc.evaluate(f"chmod +x {plain} && {plain}", "claude-code",
+                       str(tmp_path)) is None, (
+        "KNOWN GAP: chmod-then-run of a file with no shebang. If this starts "
+        "denying, that is an improvement — delete the assertion on purpose.")
+
+
+def test_a_binary_is_never_parsed_as_shell(tmp_path):
+    """Before `_is_shell_program`, `_script_operand` returned argv[0] for ANY
+    path containing `/` — binaries included — and the whole `commands()` parser
+    then ran over up to 256 KiB of machine code on the hot path of every Bash
+    call. A NUL byte is the cheap, sound tell."""
+    b = tmp_path / "mybin"
+    # 🔴 THE FIXTURE IS THE TEST. A first draft used
+    # `b"\\x7fELF\\x00\\x00\\x00tmux kill-server\\x00"` and a mutation sweep
+    # scored "drop the NUL sniff" as SURVIVED — because with the NULs glued to
+    # the word, the tokeniser produced argv[0] == '\\x7fELF\\x00\\x00\\x00tmux',
+    # which is not `tmux`, so the guard would have allowed it either way. The
+    # assertion was UNREACHABLE and the test passed for the wrong reason. The
+    # kill must sit on its own line, reachable, so only the sniff can stop it.
+    b.write_bytes(b"\x7fELF\x02\x01\x00\x00\x00\x00\n\ntmux kill-server\n\x00")
+    b.chmod(0o755)
+    body = b.read_text(errors="replace")
+    assert gc.check_tmux_kill_shared_server(body), (
+        "CONTROL: these bytes, read as shell, DO deny — so the assertion below "
+        "is about the binary sniff and not about an unreachable fixture")
+    assert gc._is_shell_program(str(b), body) is False
+    assert gc.evaluate(str(b), "claude-code", str(tmp_path)) is None
+
+
+# --------------------------------------------------------------------------- #
+# 16b. 🔴 THE SENTINEL PRE-GATE — the fix for a 1-SECOND hook on the hot path.
+#
+# MEASURED in-process on the first shipped version of this arm:
+#   scripts/claim-work.sh --list   1195 ms   (0.21 ms without the arm)
+#   scripts/drift-check.sh          820 ms   (0.18 ms)
+#   bash scripts/gate.sh …           50 ms   (0.36 ms)
+# `claim-work.sh` is MANDATED by the resume skill and this hook runs on EVERY
+# Bash call in every session on both hosts.
+#
+# The fix is a substring pre-gate that is IMPLIED BY THE MATCHER, so it loses no
+# coverage — proved below rather than asserted. After it, plus the descent cap
+# and the interpreter rule: 1.02 ms / 1.59 ms / 0.71 ms.
+# --------------------------------------------------------------------------- #
+def test_every_script_text_check_carries_a_sentinel_its_matcher_implies():
+    """🔴 THE LEDGER THAT STOPS THE PRE-GATE GOING SILENTLY WRONG.
+
+    A pre-gate keyed to ONE check's sentinel becomes incorrect the moment a
+    SECOND check joins `_SCRIPT_TEXT_CHECKS`: the walk would still skip on the
+    tmux sentinel while the new check's own spellings walked past, and nothing
+    would go red. So the pairing is structural — every entry is
+    `(check, sentinel)` — and this asserts the shape AND the membership by name,
+    two-way, the way `_CLAUDE_CODE_CHECKS` is pinned.
+
+    Adding a check here means choosing a substring its own matcher REQUIRES, and
+    proving that implication the way `test_the_tmux_sentinel_is_IMPLIED_by_the_
+    matcher` does below. If you cannot name one, the check does not belong in
+    this tuple — put it behind its own gate.
+    """
+    assert all(isinstance(e, tuple) and len(e) == 2 for e in gc._SCRIPT_TEXT_CHECKS), (
+        "an entry is not a (check, sentinel) pair — a bare function here means "
+        "the pre-gate skips bodies that check could have denied")
+    assert all(callable(c) and isinstance(s, str) and s
+               for c, s in gc._SCRIPT_TEXT_CHECKS), (
+        "a check with an empty sentinel would gate on `'' in body`, i.e. on "
+        "nothing — that is the pre-gate silently removed")
+    assert {c.__name__: s for c, s in gc._SCRIPT_TEXT_CHECKS} == {
+        "check_tmux_kill_shared_server": gc._TMUX_KILL_MANY_PREFIX}, (
+        "the script-text check ledger changed. Each entry runs over the CONTENTS "
+        "of a file on every Bash call that names a script, and its sentinel is "
+        "what keeps that off the hot path — say so in the PR body, and bring the "
+        "false-positive sweep numbers.")
+
+
+def test_the_tmux_sentinel_is_IMPLIED_by_the_matcher():
+    """🔴 THE PROOF THAT THE PRE-GATE LOSES NO COVERAGE, not the assertion.
+
+    `check_tmux_kill_shared_server` can only deny via `_tmux_argv_is_a_wide_kill`,
+    which requires `any(_is_wide_kill_word(tok))`, which requires
+    `tok.startswith(_TMUX_KILL_MANY_PREFIX)`. So every token that can produce a
+    deny carries the sentinel, and a body with no token carrying it cannot be
+    denied. Asserted at the matcher, where the implication actually lives —
+    checking a handful of command strings would only sample it.
+    """
+    sentinel = gc._TMUX_KILL_MANY_PREFIX
+    for tok in ("kill-server", "kill-session", "kill-ser", "kill-ses", "kill-s",
+                "kill-pane", "kill-window", "kill", "kill-server-test", "",
+                "new-session", "KILL-SERVER", "ki", "kill-", "list-sessions"):
+        if gc._is_wide_kill_word(tok):
+            assert sentinel in tok, (
+                f"{tok!r} denies WITHOUT carrying the sentinel {sentinel!r} — "
+                "the pre-gate would skip a body this matcher would have denied")
+    # …and the control that keeps that loop from being vacuous: at least one of
+    # those tokens must actually be a wide-kill word.
+    assert any(gc._is_wide_kill_word(t) for t in ("kill-server", "kill-ses"))
+    # The implication restated as the property the pre-gate relies on.
+    assert not gc._is_wide_kill_word("kill-pane")
+    assert not gc._is_wide_kill_word(sentinel[:-1])
+
+
+def test_the_pre_gate_survives_a_QUOTE_SPLIT_spelling(script, tmp_path):
+    """The sentinel test runs over TEXT while the matcher runs over TOKENS, and
+    quoting is what separates the two: `tmux 'kill-'server` tokenises to
+    `kill-server` while the raw bytes contain no `kill-s`. A naive
+    `sentinel in body` would skip it — a guard walkable by SPELLING.
+
+    So the body is also tested with quote characters deleted. Both spellings
+    below deny; the escape from that is `test_a_line_continuation_splice…`,
+    which is declared rather than claimed closed.
+    """
+    for body in ("#!/usr/bin/env bash\ntmux 'kill-'server\n",
+                 '#!/usr/bin/env bash\ntmux "kill-"server\n',
+                 "#!/usr/bin/env bash\ntmux kill\\-server\n"):
+        path = script(body, "q.sh")
+        assert gc.evaluate(f"bash {path}", "claude-code", str(tmp_path)), (
+            f"the pre-gate skipped a quote-split spelling: {body!r}")
+
+
+def test_a_line_continuation_splice_is_a_DECLARED_gap_in_the_pre_gate(script, tmp_path):
+    """🔴 NOT a passing grade. Deleting the backslash leaves the NEWLINE between
+    the halves, so `kill-\\<newline>server` still hides the sentinel.
+
+    It is recorded here because the pre-gate's whole claim is "implied by the
+    matcher", and this is the one place that implication is weaker over text
+    than over tokens. Closing it means normalising line continuations before the
+    substring test — cheap, but it has not been measured on the hot path, so it
+    is declared instead of guessed at.
+    """
+    path = script("#!/usr/bin/env bash\ntmux kill-\\\nserver\n", "splice.sh")
+    assert gc.evaluate(f"bash {path}", "claude-code", str(tmp_path)) is None, (
+        "the splice now denies — good; delete this test on purpose and say so")
+
+
+def test_the_arm_does_not_PARSE_a_body_that_cannot_be_denied(tmp_path, monkeypatch):
+    """🔴 THE LATENCY REGRESSION PIN, as a structural claim rather than a timing
+    one — a wall-clock assertion on a 24-core box shared with dozens of test
+    runs would be a flake generator.
+
+    What made the arm cost a second was `commands()`, run over the whole file
+    body TWICE (once by the check, once to find nested invocations). This counts
+    the calls: a big benign script must cost exactly ONE parse — the caller's own
+    command line — and a small one that CAN be denied must cost more, or the
+    counter is wired to nothing.
+    """
+    benign = tmp_path / "big.sh"
+    benign.write_text("#!/usr/bin/env bash\n"
+                      + "echo hello world; ls -la /tmp\n" * 900)
+    assert len(benign.read_text()) > gc._SCRIPT_DESCEND_MAX_BYTES
+    killer = tmp_path / "small.sh"
+    killer.write_text(_CRASH1_BODY)
+
+    calls = []
+    real = gc.commands
+    monkeypatch.setattr(gc, "commands", lambda t, *a, **k: (calls.append(t), real(t, *a, **k))[1])
+
+    assert gc.check_executed_script_file(f"bash {benign}", str(tmp_path)) is None
+    assert len(calls) == 1, (
+        f"a benign body was parsed {len(calls) - 1} extra time(s). The sentinel "
+        "pre-gate or the descent cap has been removed; this is the 1-second hook.")
+
+    calls.clear()
+    assert gc.check_executed_script_file(f"bash {killer}", str(tmp_path))
+    assert len(calls) > 1, (
+        "POSITIVE CONTROL FAILED: a body that IS denied was never parsed, so "
+        "the count above is a fact about the spy, not about the guard")
+
+
+def test_a_body_over_the_DESCENT_cap_is_still_checked_but_not_followed(tmp_path):
+    """The descent cap is a real coverage trade, so both of its arms are pinned.
+
+    ARM 1 — the file itself is still checked at any size up to the READ cap.
+    ARM 2 — a nested invocation inside an over-cap body is NOT followed. That is
+    the declared loss; the alternative was 211 ms of parsing per Bash call.
+    """
+    pad = "echo hello world; ls -la /tmp\n" * 900
+    big_killer = tmp_path / "bigkill.sh"
+    big_killer.write_text("#!/usr/bin/env bash\n" + pad + "tmux kill-server\n")
+    assert len(big_killer.read_text()) > gc._SCRIPT_DESCEND_MAX_BYTES
+    assert len(big_killer.read_text().encode()) < gc._SCRIPT_READ_MAX_BYTES
+    assert gc.evaluate(f"bash {big_killer}", "claude-code", str(tmp_path)), (
+        "a kill in an over-cap body must still deny — the cap is on the DESCENT, "
+        "not on the check")
+
+    inner = tmp_path / "inner.sh"
+    inner.write_text(_CRASH1_BODY)
+    big_caller = tmp_path / "bigcall.sh"
+    big_caller.write_text("#!/usr/bin/env bash\n" + pad + f"bash {inner}\n")
+    assert gc.evaluate(f"bash {big_caller}", "claude-code", str(tmp_path)) is None, (
+        "KNOWN GAP: a nested invocation inside a body over the descent cap. If "
+        "this starts denying, the cap changed — re-measure the hot path before "
+        "deleting this test.")
+    # Control: the SAME caller under the cap does deny, so the assertion above
+    # is about the cap and not about the nesting being broken outright.
+    small_caller = tmp_path / "smallcall.sh"
+    small_caller.write_text(f"#!/usr/bin/env bash\nbash {inner}\n")
+    assert gc.evaluate(f"bash {small_caller}", "claude-code", str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# 16c. 🔴 THE OPEN() LEDGER — what this arm reads, pinned as a SET.
+# --------------------------------------------------------------------------- #
+def test_the_script_arm_opens_only_the_files_it_will_execute(tmp_path, monkeypatch):
+    """🔴 THE TEST THE PR SAID IT ALREADY HAD, AND DID NOT.
+
+    `test_the_hot_path_reads_no_files_and_execs_no_git` and
+    `test_the_hot_path_gate_is_the_same_walk_it_guards` assert only
+    `not [o for o in opened if str(env) in o]` — that THE SOURCED ENV FILE was
+    not opened. Neither pins a total. Both passed while this arm opened
+    `scripts/ship.sh` for `evaluate('…/ship.sh --no-laptop')`, and a comment in
+    guard_core.py cited them as the reason `source` is excluded while
+    `bash <file>` is not. That sentence was false.
+
+    This pins the SET: for a realistic mix, the only files opened are the ones
+    the commands would actually execute. `. env; ls` opens nothing — which is
+    what genuinely constrains the `source` exclusion — and a plain `ls` opens
+    nothing either.
+    """
+    (tmp_path / "wt.env").write_text("WT=/tmp/whatever\n")
+    (tmp_path / "repro.sh").write_text(_CRASH1_BODY)
+    (tmp_path / "notes.md").write_text("run `bash repro.sh` to reproduce\n")
+    benign = tmp_path / "benign.sh"
+    benign.write_text("#!/usr/bin/env bash\necho hi\n")
+    benign.chmod(0o755)
+
+    opened = []
+    real_open = open
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1])
+
+    def opens_for(cmd):
+        opened.clear()
+        gc.check_executed_script_file(cmd, str(tmp_path))
+        return sorted({os.path.basename(o) for o in opened})
+
+    assert opens_for("ls -la") == []
+    assert opens_for(". wt.env; ls") == [], (
+        "the `source` exclusion is what this asserts — an env file on the hot "
+        "path must not be opened by THIS arm")
+    assert opens_for("cat notes.md") == [], (
+        "naming a file is not executing it")
+    assert opens_for("git -C /tmp status") == []
+    assert opens_for(f"bash {benign}") == ["benign.sh"], (
+        "a `bash <file>` must open exactly that file and nothing else")
+    assert opens_for(str(tmp_path / "notes.md")) == ["notes.md"], (
+        "⚠ A DIRECT execution of a path IS opened, exactly once. The shebang is "
+        "authoritative about what interprets the file and cannot be read without "
+        "opening it; the mode is consulted only when there is no shebang. So the "
+        "claim pinned here is ONE read and NO parse, not zero reads — "
+        "test_the_arm_does_not_PARSE_a_body_that_cannot_be_denied owns the parse "
+        "count, and parsing is what cost a second per Bash call.")
+
+    # 🔴 POSITIVE CONTROL: the spy must be able to observe an open at all, or
+    # every empty list above is a fact about the monkeypatch.
+    assert opens_for(f"bash {tmp_path / 'repro.sh'}") == ["repro.sh"]
+
+
+# --------------------------------------------------------------------------- #
+# 16d. 🔴 INVOCATION SHAPES THAT WERE MEASURED ALLOW, AND ARE NOW DENIED.
+#
+# Each row below was verified ALLOW against the arm as first written, with a
+# file containing the crash-1 body. They are not hypotheticals.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("template,why", [
+    ("busybox sh {p}",
+     "`busybox` IS in _SHELLS, so the flag scan returned `sh` as the script "
+     "path — a file that never exists. Applet dispatch is the ONLY way busybox "
+     "is used as a shell, so the missed spelling was the whole feature."),
+    ("busybox ash {p}", "same, other applet"),
+    ("bash -O extglob {p}",
+     "`-O` was missing from the value-flag skip set, so `extglob` was returned "
+     "as the script path"),
+    ("bash +O extglob {p}",
+     "`+`-prefixed tokens were not recognised as flags at all, so `+O` itself "
+     "was returned as the path"),
+    ("bash +o histexpand {p}", "same, `+o`"),
+    ("bash 2>/dev/null {p}",
+     "a redirect BEFORE the operand was returned as the path; after it, the "
+     "arm already denied"),
+    ("bash >/tmp/guard-probe.log {p}", "same, stdout"),
+    ("bash 2> /tmp/guard-probe.log {p}", "same, detached target token"),
+    ("bash < {p}",
+     "the shell READS ITS PROGRAM from a `<` redirect, so the target IS the "
+     "script"),
+    ("bash -s < {p}", "same, the documented stdin spelling"),
+    ("bash -- {p}", "`--` used to `continue` without forcing an operand"),
+    ("bash -o errexit {p}", "regression guard on the pre-existing skip set"),
+    ("sh -eu {p}", "clustered short flags"),
+])
+def test_shapes_that_were_MEASURED_allow_now_deny(script, template, why, tmp_path):
+    path = script(_CRASH1_BODY)
+    assert gc.evaluate(template.format(p=path), "claude-code", str(tmp_path)), (
+        f"ALLOWED: {template} — {why}")
+
+
+def test_a_dash_dash_operand_that_looks_like_a_flag_is_the_script(tmp_path):
+    """`bash -- -weird.sh` runs a file called `-weird.sh`. The old scan saw
+    `--`, `continue`d, then skipped `-weird.sh` as a flag and returned None."""
+    p = tmp_path / "-weird.sh"
+    p.write_text(_CRASH1_BODY)
+    assert gc.evaluate(f"bash -- {p}", "claude-code", str(tmp_path))
+    # A `bash` OPERAND is resolved against the command's cwd — the `$PATH`
+    # guessing gap is about a bare argv[0], which this is not.
+    assert gc.evaluate("bash -- -weird.sh", "claude-code", str(tmp_path))
+    assert gc._script_operand(["bash", "--", "-weird.sh"]) == ("-weird.sh", False)
+
+
+@pytest.mark.parametrize("template,why", [
+    ("cat {p} | bash",
+     "the file reaches a shell through a PIPE; this parser models argv, not "
+     "data flow between two commands"),
+    ("tmux run-shell {p}", "tmux runs it; no shell token appears in the argv"),
+    ("tmux source-file {p}", "same, and the file is tmux commands, not shell"),
+    ("make -f {p}", "make's own recipe lines reach a shell"),
+    ("python3 {p}", "not a shell; the INVOCATION decides, and this one says python"),
+    ("watch bash {p}", "`watch` is not in _WRAPPERS and takes its own options"),
+    ("xargs bash {p}", "same family: an exec-ing wrapper with its own arity"),
+    ("nix develop /some/dir -c bash {p}",
+     "`nix develop … -c` is an exec wrapper this parser does not model; adding "
+     "it means an option-arity table, and getting one wrong is how a check "
+     "fails OPEN"),
+    ("find . -name x -exec bash {p} ;", "same"),
+    ("bash -c repro.sh",
+     "`-c` takes a COMMAND STRING; `repro.sh` there is a PATH lookup, not this "
+     "file — and treating it as a file is exactly the mutant "
+     "test_bash_dash_c_names_a_COMMAND_not_a_file kills"),
+])
+def test_the_DECLARED_gaps_stay_declared(script, template, why, tmp_path):
+    """🔴 NOT a passing grade — a ledger of holes, pinned so each one cannot
+    close by accident and then silently reopen.
+
+    The deny message used to end "Do not go looking for a spelling that slips
+    past this check", full stop, while `cat x.sh | bash` worked. An overclaiming
+    guard teaches the first agent who finds a gap that the guard lies. The
+    message now says gaps exist and are listed in the source; this is that list,
+    executable.
+
+    Closing any row is an improvement — delete its entry deliberately, with the
+    measurement, rather than letting the assertion rot into a claim that the gap
+    is desirable.
+    """
+    path = script(_CRASH1_BODY)
+    assert gc.evaluate(template.format(p=path), "claude-code",
+                       str(tmp_path)) is None, (
+        f"{template} now DENIES — that is an improvement. Delete this row on "
+        f"purpose and say so in the PR body. (gap reason: {why})")
+
+
+def test_the_deny_message_does_not_claim_there_are_no_gaps(script, tmp_path):
+    """F3's honesty half, asserted rather than left to review."""
+    path = script(_CRASH1_BODY)
+    reason = gc.evaluate(f"bash {path}", "claude-code", str(tmp_path))
+    assert "Do not go looking for a spelling that slips past this check." not in reason, (
+        "the deny message claims no bypass exists while `cat x.sh | bash` works")
+    assert "Gaps in this check exist" in reason
+
+
+def test_the_script_arm_deny_carries_its_OWN_remedy(script, tmp_path):
+    """🔴 THE INHERITED ESCAPE HATCH IS INVERTED FOR THIS ARM.
+
+    `_QUOTING_ESCAPE_HATCH` arrives inside the wrapped reason and tells the
+    caller to "write the text to a file" — correct when a heredoc BODY is being
+    parsed as a command, and backwards when what is denied is RUNNING a file.
+    Writing one is what the caller just did. So this arm appends its own tail,
+    and the tail must say the inherited advice does not apply here.
+    """
+    path = script(_CRASH1_BODY)
+    reason = gc.evaluate(f"bash {path}", "claude-code", str(tmp_path))
+    assert gc._QUOTING_ESCAPE_HATCH in reason, (
+        "the inherited hatch went missing — the prose-in-a-script false positive "
+        "still needs a documented way out")
+    assert gc._SCRIPT_ARM_REMEDY in reason
+    assert "IGNORE THE 'write the text to a file' NOTE ABOVE" in reason
+    assert "-L my-probe-$$" in reason
+    assert reason.index(gc._QUOTING_ESCAPE_HATCH) < reason.index(gc._SCRIPT_ARM_REMEDY), (
+        "the correction must come AFTER the advice it corrects, or it reads as "
+        "two contradictory instructions")
+
+
+# --------------------------------------------------------------------------- #
+# 16e. 🔴 THE `seen` SET WAS ORDER-DEPENDENT — a SOUNDNESS bug, not a nit.
+# --------------------------------------------------------------------------- #
+def _chain(tmp_path, names):
+    """Write `names[0] → names[1] → … → kill`, return the paths in that order."""
+    paths = []
+    prev = None
+    for n in reversed(names):
+        p = tmp_path / f"{n}.sh"
+        p.write_text("#!/usr/bin/env bash\n"
+                     + (f"bash {prev}\n" if prev else "tmux kill-server\n"))
+        p.chmod(0o755)
+        prev = p
+        paths.append(p)
+    return list(reversed(paths))
+
+
+@pytest.mark.parametrize("order", [("A", "X"), ("X", "A")])
+def test_the_visited_set_does_not_swallow_a_kill_by_ORDER(tmp_path, order):
+    """🔴 MEASURED, BOTH DIRECTIONS, on the arm as first written.
+
+    `seen` was global to the walk while `depth` is per-branch, so a file entered
+    `seen` at whatever depth it was FIRST reached. With `A→B→C→X→K` and the kill
+    in `K`:
+        bash A.sh; bash X.sh   ->  ALLOW   (X seen at depth 3, skipped at 0)
+        bash X.sh; bash A.sh   ->  DENY
+    Same two commands, same five files, the verdict decided by which came first.
+    Keying on `(realpath, depth)` fixes it; both orders are asserted so a
+    revert to path-only keying goes red in at least one of them.
+    """
+    a, b, c, x, k = _chain(tmp_path, ["A", "B", "C", "X", "K"])
+    named = {"A": a, "X": x}
+    cmd = f"bash {named[order[0]]}; bash {named[order[1]]}"
+    assert gc.evaluate(cmd, "claude-code", str(tmp_path)), (
+        f"ALLOWED in order {order} — the visited set swallowed the kill in {k}")
+
+
+@pytest.mark.parametrize("hops,denies", [(1, True), (2, True), (3, True), (4, False)])
+def test_the_recursion_limit_is_THREE_hops_not_one(tmp_path, hops, denies):
+    """The PR body said "recursing one hop". `_SCRIPT_RECURSION_LIMIT = 3` gives
+    three, and the boundary is asserted on BOTH sides so the constant cannot
+    drift without a red test. Hop 4 is the declared cut-off: a chain that long
+    is not a shape anyone types, and an unbounded walk on a hook that runs on
+    every Bash call is how a guard becomes a hang."""
+    chain = _chain(tmp_path, [f"h{i}" for i in range(hops)] + ["K"])
+    assert bool(gc.evaluate(f"bash {chain[0]}", "claude-code", str(tmp_path))) is denies
+
+
+# --------------------------------------------------------------------------- #
+# 16f. 🔴 THE MUTATION TARGETS — one test per guard a sweep found SURVIVING.
+#
+# The PR body claimed "8/8 KILLED". A 13-mutant re-run found SIX survivors, each
+# one a guard some docstring in this arm claims to cover. These are the tests
+# that kill them; each was watched RED with its mutant applied.
+# --------------------------------------------------------------------------- #
+def test_a_bare_word_is_not_treated_as_a_script_path(tmp_path):
+    """M1 — deleting `if "/" in argv[0]` in `_script_operand`.
+
+    Without the separator test, EVERY argv[0] becomes a candidate path resolved
+    against the command's cwd — so `repro.sh` (a `$PATH` lookup, the documented
+    gap) would be read out of the cwd, and so would a token from prose. That is
+    the fanout that read `claude/RULES.md` and `/etc/machine-id`.
+    """
+    (tmp_path / "repro.sh").write_text(_CRASH1_BODY)
+    assert gc._script_operand(["repro.sh"]) is None
+    assert gc.evaluate("repro.sh", "claude-code", str(tmp_path)) is None, (
+        "a bare word was resolved as a local file — PATH is not this process's "
+        "to guess")
+    # POSITIVE CONTROL: the SAME file, the SAME cwd, one `./` added. If this did
+    # not deny, the `is None` above would be a fact about a broken fixture
+    # rather than about the separator test.
+    assert gc._script_operand(["./repro.sh"]) == ("./repro.sh", True)
+    assert gc.evaluate("./repro.sh", "claude-code", str(tmp_path))
+
+
+def test_bash_dash_c_names_a_COMMAND_not_a_file(tmp_path):
+    """M2 — deleting the `-c` early return.
+
+    `bash -c repro.sh` runs the STRING `repro.sh` as a command line, i.e. a
+    `$PATH` lookup; it does not execute the file in the cwd. Without the early
+    return the token after `-c` becomes the script path and the local file is
+    read and denied — a false positive on a command that never touches it.
+
+    ⚠ The pre-existing `test_bash_dash_c_is_still_handled_by_the_nested_text_arm`
+    does NOT kill this mutant: `bash -c "tmux kill-server"` denies either way,
+    via the nested-text arm. This one distinguishes them.
+    """
+    (tmp_path / "repro.sh").write_text(_CRASH1_BODY)
+    assert gc._script_operand(["bash", "-c", "repro.sh"]) is None
+    assert gc.evaluate("bash -c repro.sh", "claude-code", str(tmp_path)) is None
+    # Control: without `-c`, the same tokens DO reach the file.
+    assert gc.evaluate("bash repro.sh", "claude-code", str(tmp_path))
+
+
+def test_a_value_flags_ARGUMENT_is_not_the_script(tmp_path):
+    """M3 — deleting the `("-o", "--rcfile", "--init-file")` skip (and the
+    `-O`/`+O`/`+o` entries added with it).
+
+    `bash --rcfile rc.sh victim.sh` runs `victim.sh`; `rc.sh` is an argument.
+    Without the skip the scan returns `rc.sh`, checks the WRONG file, and the
+    kill in the real script is allowed.
+    """
+    rc = tmp_path / "rc.sh"
+    rc.write_text("#!/usr/bin/env bash\necho benign\n")
+    victim = tmp_path / "victim.sh"
+    victim.write_text(_CRASH1_BODY)
+    for flag in ("--rcfile", "--init-file", "-o", "-O", "+O", "+o"):
+        arg = "errexit" if flag in ("-o", "+o") else (
+            "extglob" if flag in ("-O", "+O") else str(rc))
+        assert gc._script_operand(["bash", flag, arg, str(victim)]) == (str(victim), False)
+        assert gc.evaluate(f"bash {flag} {arg} {victim}", "claude-code",
+                           str(tmp_path)), f"{flag} swallowed the script operand"
+
+
+def test_a_path_carrying_an_unexpanded_expansion_is_NEVER_read(tmp_path):
+    """M4 — deleting the `"*?$`"` rejection in `_read_script`.
+
+    ⚠ The pre-existing `test_an_unexpanded_variable_path_is_ALLOWED` is VACUOUS
+    against this mutant: `bash "$SCRIPT"` resolves to no file either way, so it
+    passes with the rejection deleted. This version creates files whose names
+    ARE those literals, so the mutant reads one and denies.
+
+    The rule being pinned: this process sees pre-expansion text, so `$SCRIPT`
+    and `repro*.sh` name something it cannot resolve. Guessing means reading an
+    unrelated file and denying on ITS contents.
+    """
+    for name in ("$SCRIPT", "repro*.sh", "who?.sh", "`cmd`.sh"):
+        (tmp_path / name).write_text(_CRASH1_BODY)
+        assert gc._read_script(name, str(tmp_path)) is None, (
+            f"{name!r} was read as a literal path")
+        assert gc.evaluate(f"bash '{name}'", "claude-code", str(tmp_path)) is None, (
+            f"{name!r} denied — the guard resolved an expansion it cannot see "
+            "through")
+    # POSITIVE CONTROL: a plain name in the same directory IS read, so the
+    # `is None` results above are about the rejection and not a broken fixture.
+    (tmp_path / "plain.sh").write_text(_CRASH1_BODY)
+    assert gc._read_script("plain.sh", str(tmp_path)) is not None
+    assert gc.evaluate("bash plain.sh", "claude-code", str(tmp_path))
+
+
+def test_a_FIFO_is_never_OPENED(tmp_path, monkeypatch):
+    """M5 — deleting `if not os.path.isfile(p)` in `_read_script`.
+
+    🔴 THIS IS THE ANTI-HANG GUARD, and it was neither commented nor tested.
+    `open()` on a FIFO with no writer BLOCKS FOREVER, inside a hook that gates
+    every Bash call in every session on both hosts — so the failure is not "this
+    command is denied", it is "the operator's primary tool stops".
+
+    Asserted by FORBIDDING the open rather than by timing it: a test that hangs
+    to prove a hang is a test that hangs. The stub raises `AssertionError`, which
+    `_read_script`'s `except (OSError, ValueError)` deliberately does not catch,
+    so the mutant fails loudly instead of wedging the suite.
+    """
+    fifo = tmp_path / "pipe.sh"
+    os.mkfifo(fifo)
+    real_open = open
+
+    def no_fifo(f, *a, **k):
+        assert str(f) != str(fifo), (
+            "🔴 the guard OPENED a FIFO — with no writer this blocks forever and "
+            "wedges every Bash call in every session")
+        return real_open(f, *a, **k)
+
+    monkeypatch.setattr("builtins.open", no_fifo)
+    assert gc._read_script(str(fifo), str(tmp_path)) is None
+    assert gc.evaluate(f"bash {fifo}", "claude-code", str(tmp_path)) is None
+    # …the same guard also rejects a directory and a dangling symlink.
+    assert gc._read_script(str(tmp_path), str(tmp_path)) is None
+    dangling = tmp_path / "gone.sh"
+    dangling.symlink_to(tmp_path / "nothing-here")
+    assert gc._read_script(str(dangling), str(tmp_path)) is None
+    # POSITIVE CONTROL: the stub lets a real file through, so the Nones above
+    # are the guard's doing and not the monkeypatch refusing everything.
+    real = tmp_path / "real.sh"
+    real.write_text(_CRASH1_BODY)
+    assert gc._read_script(str(real), str(tmp_path)) is not None

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -144,6 +144,19 @@ CLAUDE_CODE_EXPECTED = [
     # "two real uses" count over a tree that held four. It is DERIVED by
     # test_every_kill_server_call_site_in_the_repo_is_classified below.
     "check_tmux_kill_shared_server",
+    # 🔴 The SIXTEENTH check, added 2026-09-11 — and added because the
+    # FIFTEENTH turned out to be a paper guard. The operator's tmux server died
+    # TWICE that night, 52 and 53 live conversations, AFTER the check above was
+    # deployed and working: both times an agent wrote `tmux kill-server` into a
+    # scratch .sh and ran `bash <file>`, and this hook gates the Bash-tool TEXT,
+    # which contained only the wrapper. Proven with a control pair — the inline
+    # spelling denies, the identical bytes in a file allowed at rc 0.
+    # It runs IMMEDIATELY after the check it backstops because it is the same
+    # finding reached through a file. Scope is deliberately ONE check over file
+    # contents, not the whole policy: running the policy over file bodies denies
+    # `ship.sh` and `drift-check.sh` (measured, 2 of 103), which would be a
+    # permanently-red gate on the deploy command itself.
+    "check_executed_script_file",
     "check_heredoc_to_file",
     "check_cd_then_git",
     "check_private_key",
@@ -2053,10 +2066,22 @@ def test_commit_to_main_is_inherited_by_the_opencode_policy(tmp_path):
 def test_evaluate_passes_cwd_only_to_checks_that_want_it(tmp_path):
     """The dispatch is the seam between `evaluate` and a world-reading check. If
     it silently stopped passing cwd, the guard would fall back to the hook
-    process's own directory and quietly report on the wrong repo."""
-    assert gc.check_git_commit_to_main.wants_cwd is True
-    others = [c for c in gc.POLICIES["opencode"] if c is not gc.check_git_commit_to_main]
-    assert not any(getattr(c, "wants_cwd", False) for c in others)
+    process's own directory and quietly report on the wrong repo.
+
+    🔴 TWO checks read the world now, not one. `check_executed_script_file`
+    (2026-09-11) resolves a RELATIVE script path against the command's cwd, so
+    the same failure mode applies to it exactly: fall back to the hook process's
+    own directory and it reads a different file than the one about to run — and
+    then either misses a kill or denies on an unrelated file's contents.
+
+    Pinned as an exact SET rather than a per-check assertion, so a third
+    world-reading check cannot join the policy without this ledger saying so.
+    """
+    want_cwd = {c.__name__ for c in gc.POLICIES["opencode"]
+                if getattr(c, "wants_cwd", False)}
+    assert want_cwd == {"check_git_commit_to_main", "check_executed_script_file"}, (
+        f"the set of cwd-taking checks is {sorted(want_cwd)}. Adding one is a "
+        "check that reads the world on every Bash call — say so in the PR body.")
 
 
 def test_evaluate_without_cwd_falls_back_and_does_not_raise():
@@ -4477,3 +4502,278 @@ def test_positive_a_sourced_env_file_supplies_the_worktree_path(tmp_path):
     assert gc.check_git_commit_to_main(
         f'. {env}\ngit -C "$WT" commit -q -F - <<\'MSG\'\ndocs: a message\nMSG',
         str(repo)) is None
+
+
+# =========================================================================== #
+# 16. 🔴 check_executed_script_file — the bypass that made check 15 a paper guard
+#
+# 2026-09-11: the operator's tmux server died TWICE in one night, 52 and 53 live
+# Claude conversations, with `check_tmux_kill_shared_server` deployed and
+# correct throughout. Both were the same shape — Write the kill into a scratch
+# .sh, then `bash <file>` — and the hook gates Bash-tool TEXT, which held only
+# the wrapper.
+#
+# Attribution is not "it happened around then": exec-to-first-scope-teardown was
+# 0.7s and 1.1s, and at each instant FOUR and THREE UNRELATED sessions were
+# interrupted at once, which a per-command denial cannot cause and a dying
+# shared server can.
+# =========================================================================== #
+_CRASH1_BODY = (
+    '#!/usr/bin/env bash\n'
+    'set -u\n'
+    'S="$(dirname "$(readlink -f "$0")")"\n'
+    'export TMUX_TMPDIR="$S/tmuxtmp"\n'
+    'cleanup() {\n'
+    '  tmux kill-server 2>/dev/null\n'
+    '}\n'
+    'trap cleanup EXIT\n'
+    'tmux kill-server 2>/dev/null; sleep 0.3\n'
+    'tmux new-session -d -s work\n'
+)
+
+# Verbatim in shape from crash 2: the kill is in a "teardown" at the END, so a
+# guard that only read the first lines of a file would miss it.
+_CRASH2_BODY = (
+    '#!/usr/bin/env bash\n'
+    'ROOT=/tmp/probe-root\n'
+    'echo "=== (a) declared root ==="\n'
+    'TMUX_TMPDIR="$ROOT" python3 "$BLK" 2>&1 | head -c 300\n'
+    'echo "=== teardown ==="\n'
+    'TMUX_TMPDIR="$ROOT" tmux kill-server 2>&1\n'
+)
+
+
+@pytest.fixture
+def script(tmp_path):
+    """Write a script file and return its path as a string."""
+    def _make(body, name="repro.sh"):
+        p = tmp_path / name
+        p.write_text(body)
+        p.chmod(0o755)
+        return str(p)
+    return _make
+
+
+@pytest.mark.parametrize("body,label", [
+    (_CRASH1_BODY, "crash-1"),
+    (_CRASH2_BODY, "crash-2"),
+])
+def test_the_two_real_incident_scripts_are_DENIED(script, body, label, tmp_path):
+    """The regression. Both bodies are the real shapes from 2026-09-11."""
+    path = script(body, f"{label}.sh")
+    reason = gc.evaluate(f"bash {path}", "claude-code", str(tmp_path))
+    assert reason, f"{label}: the incident script was ALLOWED — this is the bypass"
+    assert path in reason, (
+        "the deny must NAME the file: the caller's command line does not contain "
+        "the offending text, so a bare reason reads as a guard malfunction")
+
+
+@pytest.mark.parametrize("template", [
+    "bash {p}",
+    "sh {p}",
+    "bash -x {p}",
+    "timeout 60 {p} /some/arg",
+    "{p}",
+    "cd /tmp && bash {p}",
+    "bash {p} && echo done",
+])
+def test_every_invocation_shape_that_runs_the_file_is_DENIED(script, template, tmp_path):
+    """Multi-spelling matrix, in this file's established style. A guard that
+    catches one spelling of `run this file` is not a guard."""
+    path = script(_CRASH1_BODY)
+    assert gc.evaluate(template.format(p=path), "claude-code", str(tmp_path)), (
+        f"ALLOWED: {template}")
+
+
+@pytest.mark.parametrize("template", [". {p}", "source {p}"])
+def test_a_SOURCED_script_is_a_KNOWN_GAP_and_stays_allowed(script, template, tmp_path):
+    """🔴 NOT a passing grade — this pins a hole so it cannot close by accident
+    and then reopen silently.
+
+    Sourcing runs in the CURRENT shell, so on danger alone it deserves reading
+    MORE than `bash <file>`. It is excluded because a different invariant
+    outranks it here: `test_the_hot_path_reads_no_files_and_execs_no_git` pins
+    that this hook must not open a file merely because a command names one, and
+    `. wt.env; ls` is the commonest shape on that path.
+
+    If someone finds a cheap way to tell an env file from a program without
+    reading it, this test is the one to delete — deliberately, with the reason.
+    """
+    path = script(_CRASH1_BODY)
+    assert gc.evaluate(template.format(p=path), "claude-code", str(tmp_path)) is None, (
+        "the sourced arm now DENIES — if that is intended, confirm the hot-path "
+        "open() count is still pinned and delete this test on purpose")
+
+
+def test_a_script_reached_through_ANOTHER_script_is_DENIED(script, tmp_path):
+    """One hop of indirection must not launder it."""
+    inner = script(_CRASH1_BODY, "inner.sh")
+    outer = script('#!/usr/bin/env bash\necho hi\nbash ' + inner + '\n', "outer.sh")
+    assert gc.evaluate(f"bash {outer}", "claude-code", str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# Negative cases — the reason this arm is ONE check wide and not the policy.
+#
+# The last two are the MEASURED false positives: running the full policy over
+# file bodies denies `ship.sh` and `drift-check.sh` (2 of 103), because both
+# name a banned command in PROSE while explaining that they never run it.
+# Denying the repo's own deploy command would be a permanently-red gate.
+# --------------------------------------------------------------------------- #
+# 🔴 These carry the literals ON PURPOSE. A fixture that merely paraphrased the
+# banned command would not trip the full policy either, so it would prove
+# nothing about the scope decision — the test would pass for the wrong reason.
+# These are the shapes `ship.sh` and `drift-check.sh` actually contain.
+_PROSE_SHIP = (
+    '#!/usr/bin/env bash\n'
+    '# It never stashes: `git stash` is repo-GLOBAL and would reach into\n'
+    '# other worktrees, so this script does not use it.\n'
+    'echo ship\n'
+)
+
+_PROSE_DRIFT = (
+    '#!/usr/bin/env bash\n'
+    '# READ-ONLY: never `git reset --hard`, never fixes, only reports.\n'
+    'echo drift\n'
+)
+
+
+def test_the_prose_fixtures_WOULD_trip_the_full_policy(script, tmp_path):
+    """The control that makes the two prose cases above meaningful.
+
+    If these bodies did not trip the full policy, `test_benign_and_prose_only_
+    scripts_stay_ALLOWED` would pass whether or not the arm is narrow, and the
+    scope decision would rest on nothing. So: assert the full policy DOES deny
+    them as raw text, which is exactly what a whole-policy file scan would do.
+    """
+    for body, label in ((_PROSE_SHIP, "ship"), (_PROSE_DRIFT, "drift")):
+        assert gc.evaluate(body, "claude-code", str(tmp_path)), (
+            f"the {label} fixture no longer trips the full policy, so the "
+            "negative test it supports has become vacuous — restore a literal "
+            "that a whole-policy file scan would deny")
+
+
+@pytest.mark.parametrize("body,why", [
+    ('#!/usr/bin/env bash\ntmux kill-pane -t %3\n',
+     "kill-pane destroys exactly what it names and is routine here"),
+    ('#!/usr/bin/env bash\ntmux -L my-probe-$$ kill-server\n',
+     "a server the caller made is the prescribed remedy"),
+    ('#!/usr/bin/env bash\ngit stash list\n',
+     "a read"),
+    (_PROSE_SHIP, "ship.sh's own comment"),
+    (_PROSE_DRIFT, "drift-check.sh's own comment"),
+])
+def test_benign_and_prose_only_scripts_stay_ALLOWED(script, body, why, tmp_path):
+    path = script(body)
+    assert gc.evaluate(f"bash {path}", "claude-code", str(tmp_path)) is None, (
+        f"denied a script that must stay allowed ({why}) — a guard that fires on "
+        "correct work gets routed around AND reports safety")
+
+
+def test_a_RELATIVE_script_path_is_resolved_against_the_COMMANDS_cwd(tmp_path):
+    """🔴 Found by a mutation sweep, not by review: making `_read_script` ignore
+    `cwd` entirely (`p = path`) SURVIVED a green suite, because every other test
+    here writes an absolute path into the command. So the cwd hop that
+    `test_evaluate_passes_cwd_only_to_checks_that_want_it` justifies at length
+    was asserted by nothing — a docstring claiming coverage the tests did not
+    provide.
+
+    `bash repro.sh` is the shape an agent actually types after `cd`-ing into its
+    scratch dir, and resolving it against the HOOK process's cwd instead would
+    silently look at the wrong file — or no file — and allow the kill.
+    """
+    (tmp_path / "repro.sh").write_text(_CRASH1_BODY)
+    assert gc.evaluate("bash repro.sh", "claude-code", str(tmp_path)), (
+        "a relative script path was not resolved against the command's cwd")
+    # Negative half: the SAME relative name under a different cwd must not be
+    # invented out of nothing, or the check is reading files it was not pointed at.
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    assert gc.evaluate("bash repro.sh", "claude-code", str(other)) is None
+
+
+def test_a_script_that_does_not_exist_yet_is_ALLOWED(tmp_path):
+    """Fail OPEN on an unreadable target. The hook must never turn 'I could not
+    look' into a denial of a command that may be perfectly fine."""
+    assert gc.evaluate(f"bash {tmp_path}/never-written.sh", "claude-code",
+                       str(tmp_path)) is None
+
+
+def test_an_unexpanded_variable_path_is_ALLOWED(tmp_path):
+    """`bash $SCRIPT` names something this process cannot resolve; guessing
+    would read an unrelated file and deny on ITS contents."""
+    assert gc.evaluate('bash "$SCRIPT"', "claude-code", str(tmp_path)) is None
+
+
+def test_a_self_EXECUTING_script_terminates(tmp_path):
+    """A cycle must not spin a hook that runs on every Bash call.
+
+    ⚠ This test was written against `. <self>` first, and that made it VACUOUS
+    the moment the sourced arm was dropped: `.` stopped being a script operand,
+    so nothing recursed and the cycle guard was never reached. It uses `bash
+    <self>` — which IS an operand — so the `seen` set is genuinely exercised.
+    """
+    p = tmp_path / "loop.sh"
+    p.write_text('#!/usr/bin/env bash\nbash ' + str(p) + '\n')
+    assert gc.evaluate(f"bash {p}", "claude-code", str(tmp_path)) is None
+
+
+def test_a_cycle_still_finds_a_kill_on_the_OTHER_side_of_it(tmp_path):
+    """The termination guard must not swallow the finding: a pair of scripts that
+    call each other, one of which kills, still denies. Without this, "it
+    terminated" and "it looked" are indistinguishable."""
+    a = tmp_path / "a.sh"
+    b = tmp_path / "b.sh"
+    a.write_text('#!/usr/bin/env bash\nbash ' + str(b) + '\n')
+    b.write_text('#!/usr/bin/env bash\nbash ' + str(a) + '\ntmux kill-server\n')
+    assert gc.evaluate(f"bash {a}", "claude-code", str(tmp_path))
+
+
+def test_an_oversized_file_is_not_read(script, tmp_path):
+    """The cap keeps a pathological read off the hot path. Stated as a KNOWN
+    GAP, not a safety property: a kill past the cap is not seen."""
+    big = _CRASH1_BODY + ("# padding\n" * 40000)
+    assert len(big.encode()) > gc._SCRIPT_READ_MAX_BYTES
+    path = script(big, "big.sh")
+    assert gc.evaluate(f"bash {path}", "claude-code", str(tmp_path)) is None
+
+
+def test_bash_dash_c_is_still_handled_by_the_nested_text_arm(tmp_path):
+    """`-c` carries TEXT, not a file — the pre-existing arm owns it, and this
+    test exists so a future edit to `_script_operand` cannot silently hand that
+    case to a file read that would find nothing."""
+    assert gc.evaluate('bash -c "tmux kill-server"', "claude-code", str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FALSE-POSITIVE LEDGER, derived and non-vacuous.
+#
+# This is the measurement that chose the arm's scope. It CANNOT pass by walking
+# nothing: the population is asserted non-empty first, and a known-bad script is
+# injected into the same sweep as a positive control, so a sweep wired to a
+# wrong path fails instead of reporting a reassuring zero.
+# --------------------------------------------------------------------------- #
+def test_no_real_script_in_this_repo_is_denied_by_the_script_arm(tmp_path):
+    root = Path(__file__).resolve().parents[3]
+    dirs = [root / "scripts", root / "githooks", root / "scripts/collector",
+            root / "scripts/dl-router", root / "scripts/opencode"]
+    files = [p for d in dirs if d.is_dir() for p in sorted(d.iterdir())
+             if p.is_file() and p.suffix not in (".md", ".json", ".lock")]
+
+    assert len(files) > 80, (
+        f"the sweep found only {len(files)} scripts — a zero-denial result from "
+        "a population this small is a fact about the walk, not about the guard")
+
+    denied = [str(p) for p in files
+              if gc.check_executed_script_file(f"bash {p}", str(root))]
+    assert denied == [], (
+        "the script arm denies real scripts in this repo: " + ", ".join(denied)
+        + ". A guard that fires on routine work is worse than no guard.")
+
+    # POSITIVE CONTROL, in the same sweep and the same call shape: if this does
+    # not deny, the loop above proved nothing.
+    bad = tmp_path / "control.sh"
+    bad.write_text(_CRASH1_BODY)
+    assert gc.check_executed_script_file(f"bash {bad}", str(root)), (
+        "the positive control was ALLOWED — this sweep is wired to nothing and "
+        "its zero above is meaningless")


### PR DESCRIPTION
## What this closes

The wide-kill guard from #1415 was deployed and **correct**, and it did not stop the
same accident happening **twice more on 2026-09-11** — 52 and 53 live Claude
conversations. It gates Bash-tool **TEXT**; both times the command was in a file:

```
Write -> /tmp/.../repro.sh   containing  TMUX_TMPDIR=... ; tmux kill-server
Bash  -> bash /tmp/.../repro.sh
```

Control pair, run **before** writing anything: the inline spelling **denies**, the
identical bytes inside a file **allowed at rc 0**.

## Attribution — not "it happened around then"

| | crash 1 | crash 2 |
|---|---|---|
| script written | 00:05:42.8 | 02:36:32.8 |
| executed | 00:05:46.3 | 02:36:42.9 |
| **server dies** | **00:05:47** | **02:36:44** |
| unrelated sessions interrupted at that instant | **4** | **3** |

Those sessions were doing unrelated work in other repos. A per-command denial cannot
interrupt four unrelated sessions; a dying shared server can.

🔴 **The handoff had the times wrong** (00:08 / 02:23 — the second by 13 minutes),
which is why repeated searches concluded "nothing logged" and why this was recorded
as UNATTRIBUTED.

Also ruled out properly: `oom-kill:` is **0 across every boot** against a **working**
positive control (a contained 50 MB cgroup OOM does log on this host — the prior
"positive control of 54" does not reproduce); `segfault` fires 6× elsewhere; both
windows hold **zero** kernel entries.

## Why only the tmux check runs over file contents

The obvious design — run the whole policy over the file — was **measured and
rejected**:

| scope | population | denied |
|---|---|---|
| whole policy over file bodies | 103 top-level `scripts/` | **2** — `ship.sh`, `drift-check.sh` |
| this arm (tmux check only) | ~~135 scripts, 5 dirs~~ | ~~**0**~~ |
| ⚠ **that row was measured NON-RECURSIVELY and is RETRACTED** | 819 files, recursive | **5**, all Python — see round 1 below |
| this arm, after the round-1 interpreter fix | 819 files, recursive, both invocation shapes | **0** |

Both denials are false positives from prose. Denying `bash scripts/ship.sh` is exactly
the permanently-red gate `_IRREVERSIBLE_CHECKS` argues against. Widening this arm needs
the same two numbers.

## Two gaps, stated rather than papered over

- **`source x.sh` / `. x.sh` is NOT read** — even though sourcing runs in the *current*
  shell and so deserves it more. A different invariant outranks it here:
  `test_the_hot_path_reads_no_files_and_execs_no_git` pins that this hook must not open
  a file just because a command names one, and `. wt.env; ls` is the commonest shape on
  that path. Pinned by its own test so it cannot close silently.
- **a bare `x.sh` through `$PATH`** — resolving it means guessing a PATH this process
  does not share with the command; a wrong guess denies on an unrelated file.

## The repo's own invariants caught two things review did not

Both fixed, not worked around:

1. **The hot-path `open()` ledger.** My first version read every sourced file on every
   Bash call. That is why `source` is out of scope.
2. **A mutation survivor.** `p = path` — ignoring `cwd` entirely — **SURVIVED a green
   suite**, because every test wrote an absolute path. That is a docstring claiming
   coverage the tests did not provide. `bash repro.sh` after a `cd` is the shape agents
   actually type; now pinned in both directions.

## Verification

- **3145 passed, 1 failed** in `scripts/claude-hooks/tests/` on the tree with
  `origin/main` MERGED IN (round 3). The one failure is INHERITED —
  `test_clawgate_writeback_guard.py::test_the_skill_names_the_same_DEPLOYED_path_the_hook_prints`
  fails on `origin/main` alone, measured in a clean detached worktree of it.
- ~~The **2 failures are INHERITED**~~ — byte-identical on `origin/main` (the kill-mention
  ledger over two `claudedocs` handoffs). This branch adds **zero** new offenders; the
  added/removed sets match `main` exactly. #1543 / #1549 fix that.
- ~~**Mutation sweep 8/8 KILLED**~~ — 🔴 **RETRACTED.** A 13-mutant re-run found **SIX
  survivors**. Replaced by a 24-mutant sweep, **24/24 KILLED**, `CONTROL-GREEN`, a
  known-fatal positive control KILLED, under `PYTHONDONTWRITEBYTECODE=1` with
  `__pycache__` cleared between mutants and the tree restored byte-identically
  (`cmp`). Matrix in the round-1 comment.
- 11-case control matrix: every invocation shape denies; `kill-pane`, a caller-made
  `-L my-probe-$$` server, a missing file, an unexpanded variable, `ship.sh` and
  `drift-check.sh` all still allow.

## 🔴 Blast radius, said out loud

This adds the **sixteenth** check to a policy that runs on **every Bash call in every
Claude Code session on both hosts**, and the **second** check that reads the world.
Both facts are pinned by name in `test_guard_core.py` so neither can grow unremarked.
It is a behaviour change to the operator's primary tool and is vetoable on that basis.

⚠ **Overlaps `test_guard_core.py` with #1543 / #1549.** Disjoint files are not safety
and neither is a clean merge, so the merged tree wants a run before this lands —
whichever of us is second.


---

## 🔴 ROUND 1 — an adversarial audit found two 🔴, and three claims in this body were false

The audit read `09f07aa7`. Everything below was **re-measured**, not argued.

### F1 🔴 the arm added 0.2–1 s to EVERY Bash call, on commands this repo mandates

In-process `evaluate()` medians (21 runs each), workbench, same tree:

| command | `origin/main` | `09f07aa7` | fixed |
|---|---|---|---|
| `scripts/claim-work.sh --list` | 0.21 ms | **1195 ms** | **1.02 ms** |
| `scripts/drift-check.sh` | 0.18 ms | **820 ms** | **1.59 ms** |
| `bash scripts/gate.sh --tier both` | 0.36 ms | 50.0 ms | 0.71 ms |
| `./scripts/claude-hooks/guard_core.py` | 0.53 ms | 844 ms **(DENY)** | 0.70 ms (allow) |
| `ls -la` | 0.11 ms | 0.14 ms | 0.16 ms |

`claim-work.sh` is **mandated by the resume skill** and this hook fires on every
Bash call in every session on both hosts.

The cost was never the read (88 KiB ≈ 0.5 ms). It was `commands()` — 187 ms on
that body, paid **twice** (once by the check, once to find nested invocations) —
and then again for every path-like token in the script's **prose** that happened
to name a real file. Traced: one `scripts/claim-work.sh --list` read
`claude/RULES.md`, `claude/RULES-ARCHIVE.md` (106 KiB), `/etc/machine-id`,
`~/.gitconfig`, `scripts/task-spec-drafter/drafter.sh` and 20 more.

Three gates fix it, and they are different gates:

1. **A sentinel pre-gate implied by the matcher.** `_is_wide_kill_word` requires
   `tok.startswith(_TMUX_KILL_MANY_PREFIX)`, so every spelling this check can
   deny carries `kill-s`. `_SCRIPT_TEXT_CHECKS` is now a tuple of
   **(check, sentinel) PAIRS** — structural, because a pre-gate keyed to one
   check's sentinel becomes silently wrong the moment a second check joins.
   Pinned two-way by name; the implication is *proved* at the matcher, not
   asserted. Coverage loss: **zero**, and quote-split spellings
   (`tmux 'kill-'server`, `tmux kill\-server`) still deny because the body is
   also tested with quoting stripped. One residual — a line-continuation splice
   — is declared and pinned.
   ⚠ `str.translate` for that strip cost **20 ms** on a 216 KiB body; three
   `str.replace` passes cost 0.6 ms. The pre-gate must not become the cost it
   exists to avoid.
2. **A descent cap** (`_SCRIPT_DESCEND_MAX_BYTES = 8 KiB`). The body is still
   **checked** at any size up to the read cap; a nested `bash <other>` inside a
   body over 8 KiB is **not followed**. That one IS a coverage trade and is
   stated as one, with both arms pinned. The parser costs ~5 ms at 8 KiB, 34 ms
   at 16 KiB, 211 ms at 88 KiB.
3. **The interpreter rule** from F7 below, which also stops binaries being
   parsed.

A structural regression pin counts `commands()` calls rather than wall clock: a
big benign body must cost exactly ONE parse, with a positive control proving the
counter can move.

### F2 🔴 a comment claimed a test prevented F1. It did not.

`test_the_hot_path_reads_no_files_and_execs_no_git` and
`test_the_hot_path_gate_is_the_same_walk_it_guards` assert only
`not [o for o in opened if str(env) in o]` — that *the sourced env file* was not
opened. Neither pins a total. **Measured: both pass with this PR applied while
`evaluate('…/scripts/ship.sh --no-laptop')` opens `ship.sh`.** The block citing
them as the reason `source` is excluded was false, and it is now corrected in
place rather than quietly reworded.

The `source` exclusion is **kept**, on a reason that survives re-measurement and
is about the POPULATION, not about an existing invariant: `. wt.env; ls` is the
commonest shape on this hook's hot path and an env file is not a program. It is
now pinned by a test that actually constrains it —
`test_the_script_arm_opens_only_the_files_it_will_execute` asserts the exact SET
of paths opened for a realistic mix (`. env; ls` → **nothing**), with a positive
control so no assertion can pass by observing nothing.

### F3 🟡 real bypasses, all measured ALLOW with a file containing a kill

**Fixed** (each verified ALLOW before, DENY after): `busybox sh x.sh`,
`busybox ash x.sh`, `bash -O extglob x.sh`, `bash +O extglob x.sh`,
`bash +o histexpand x.sh`, `bash 2>/dev/null x.sh`, `bash >/tmp/o.log x.sh`,
`bash 2> /tmp/e.log x.sh`, and — newly caught rather than merely declared —
`bash < x.sh` and `bash -s < x.sh`, where the shell reads its PROGRAM from the
redirect.

**Declared and pinned as gaps** (a ledger, not a passing grade):
`cat x.sh | bash`, `tmux run-shell`, `tmux source-file`, `make -f`, `python3`,
`watch bash`, `xargs`, `find -exec`, `nix develop … -c bash`, `bash -c repro.sh`.

🔴 The deny message said *"Do not go looking for a spelling that slips past this
check"* while `cat x.sh | bash` works. That sentence is **deleted**; it now says
gaps exist, are listed in the source, and using one is the same accident.

### F4 🟡 the `seen` set swallowed a real kill, order-dependently

`seen` was global to the walk while `depth` is per-branch. Measured on
`A→B→C→X→K`: `bash A.sh; bash X.sh` → **ALLOW**, `bash X.sh; bash A.sh` →
**DENY**. Same files, verdict decided by order. Keyed on `(realpath, depth)`
now; both orders pinned.

### F6 🟡 "8/8 KILLED" was wrong — 6 of 13 mutants survived

The claim in the original body is **retracted**. Each survivor was a guard some
docstring here claimed to cover, and each now has a test that kills it:
the path-separator test, the `-c` early return, the value-flag skip, the
`*?$\``-rejection (whose old test was vacuous — `_read_script('$SCRIPT')` finds
no file either way), and `if not os.path.isfile(p)` — the **anti-hang guard**
for FIFOs, which was neither commented nor tested, and whose failure mode is
"every Bash call in every session blocks forever", not "this command is denied".
The replacement sweep and its matrix are in the round-1 comment.

### F7 🟡 the false-positive sweep walked the wrong population

It called `d.iterdir()` — **non-recursive** — over five directories, missing 671
files under `scripts/` alone. Recursively, the arm as written denied **FIVE**
real files: `scripts/claude-hooks/guard_core.py` (mode 0755, so
`./scripts/claude-hooks/guard_core.py` is a real invocation),
`scripts/opencode/lib/oc_permissions.py`, `scripts/tests/test_opencode_engine.py`,
`scripts/tests/test_opencode_config.py`, and a `__pycache__/*.pyc`. Every one is
**Python**.

Fixed by the principled rule: **the INVOCATION decides the interpreter.**
`bash x` parses as shell whatever the file says (anything else would be a
bypass); `./x` honours the shebang, and a file with no shebang is shell only if
it is executable at all. A NUL sniff keeps binaries out of the parser.

The sweep is now `rglob`, excludes `__pycache__`, sweeps **both** invocation
shapes, and has a floor of 600 (the old floor of 80 was satisfied by the walk
that missed 671 files). Honest figure, 2026-09-12: **819 files, 0 denied**
direct-execution; **86 shell programs, 0 denied** under `bash <file>`.

### F8 🟡 the escape hatch's advice was inverted

`_QUOTING_ESCAPE_HATCH` tells the caller to write the text to a FILE — backwards
when what is denied is RUNNING a file. This arm now appends its own tail saying
so, and pointing at the real remedy (`-L my-probe-$$`, or move the prose out of
the executable file). Ordering asserted, so the correction cannot precede the
advice it corrects.

### F10 🟢 nits

"one hop" → `_SCRIPT_RECURSION_LIMIT = 3` gives **three**; measured, hops 1–3
deny and hop 4 allows, and the boundary is now pinned on both sides.
`bash -- -weird.sh` was ALLOW (`--` did `continue` without forcing the next
token to be the operand) and is now DENY.

### Scope table, corrected

| scope | population | denied |
|---|---|---|
| whole policy over file bodies | 103 top-level `scripts/` | **2** — `ship.sh`, `drift-check.sh` |
| this arm, as first written | 135 files, 5 dirs, **non-recursive** | 0 — **wrong population** |
| this arm, as first written | **819 files, recursive** | **5**, all Python |
| this arm, after F7 | **819 files, recursive**, both invocation shapes | **0** |



---

## 🔴 ROUND 2 — the round-1 `seen` fix introduced two 🔴 of its own

A delta audit cleared the sentinel pre-gate (92,274 constructed spellings, 0
coverage losses) and the interpreter rule (19 shebang attacks), and then found
that the three-line edit which fixed the round-1 order bug had created:

1. **A NEW order-dependent ALLOW on the exact shape this PR exists to block.**
   The visited key omitted `direct` and was written BEFORE the read, so a path
   whose read returned `None` poisoned the set. With the incident body in a
   mode-0644 no-shebang file — what the Write tool produces —
   `./repro.sh || bash repro.sh` (the ordinary "not executable, fall back"
   idiom) **ALLOWED**, while `bash repro.sh || ./repro.sh` denied.
2. **An uncaught `ValueError: lstat: embedded null character in path` escaping
   `evaluate()`**, reachable from 19 tracked `icon-*.png` files with no crafted
   input. Failed CLOSED, so a confusing false deny rather than a bypass.

Both fixed; both pinned in both orders. Also in round 2: fan-out is now bounded
(two-level 30×30 fan-out **16,381 ms → 183 ms**) by a budget that **never gates
the check**; bundled short flags (`bash -eo pipefail x.sh` and four more) closed;
the line-continuation gap re-attributed to the tokeniser with its wrong remedy
deleted; the 8 KiB cap's stated cost corrected ~4×; the deny's remedy no longer
names a `#` comment as a cause that can fire.

🔴 **Two of the audit's own prescriptions did not survive re-measurement** and
are recorded as negatives: `direct` in the visited key is NOT an independent
second half (its mutant SURVIVED — it is defence in depth, labelled as such with
the invariant pinned), and two of my own mutants first SURVIVED because I had
constructed them badly, not because the tests were weak.

Full matrices in the round-2 comment.



---

## 🔴 ROUND 3 — the fan-out budget was itself an order-dependent ALLOW

A delta audit confirmed both round-2 🔴 as fixed and **wider than claimed** (an
exhaustive pairwise sweep found 0 order-dependent pairs out of 660, against 64
before), confirmed the merge lost nothing, and then found that the *budget* added
in round 2 had re-opened order-dependence in a new coordinate:

    bash b0.sh; …; bash b7.sh; bash last.sh   ALLOW  🔴   (kill two hops down)
    bash last.sh; bash b0.sh; …; bash b7.sh   DENY        same files, reversed

— while `guard_core.py` headed that paragraph *"THE BUDGET DELIBERATELY NEVER
GATES THE CHECK"* and the test was named `..._NEVER_gates_the_CHECK`. **Third
round running in which the fix for the previous round's order-dependence
re-opened it elsewhere, and the second in which the sentence written to justify
it denied the behaviour.**

**The walk is now breadth-first and spends its budget in a canonical order**
(smallest body first, then resolved path), so the verdict is a function of the
file SET, not of the order the command names them in. Measured over 40 orderings
of the audit's own fixture: **8 ALLOW / 32 DENY → 0 ALLOW / 40 DENY**. The
residual — a kill below a level whose budget ran out is still missed,
deterministically — is declared in the same paragraph rather than described as an
absence.

🔴 **The direction the audit offered was built and measured, and it does not
hold**: charging only sentinel-bearing bodies is not a bound at all (30×30
fan-out **187 ms → 17,855 ms**, worse than *no* budget), because almost nothing
bears the sentinel.

Also round 3: the value-flag cluster rule was **factually wrong** and its comment
certified it (`bash -eoO pipefail extglob x.sh` consumes two words and still runs
the script — verified against GNU bash 5.3.15); the round-2 `&`-redirect
"retraction" was itself false in two ways and is corrected in both; two docstrings
claimed coverage the suite does not have; and the fan-out timings were two runs
presented as one fact.

⚠ **Four guards now have SURVIVING mutants**, all subsumed by the level
ordering — `depth` and `direct` in the visited key, the last-level `break`, and
`break`-vs-`continue`. They are kept, labelled, and reported as survivors rather
than dressed up as covered; one test pins the ordering that makes them redundant.

Full matrices in the round-3 comment.
