### PR TITLE
fix(audit-pr): the commit count and the line count came from different populations — and the TAIL is missed audit surface, not development

### DIFF
--- a/claudedocs/audit-ladder-review-2026-09-04.md
+++ b/claudedocs/audit-ladder-review-2026-09-04.md
@@ -489,14 +489,46 @@ Both directions, and they do not cancel.
   Four of the five measured repos have **zero** interior gaps. The likely mechanism is a devrc
   *authoring* habit rather than a property of the ladder: titling one comment "rounds N and
   N+1" and posting a single block for both, which is exactly #1233's shape.
-  ⚠ **TAIL churn is large everywhere (10,052 lines externally) and is NOT a finding yet.** It
-  conflates post-final-block fixes with development that continued after the ladder ended;
-  nothing in the ranges separates them, and classifying it needs the commits read. Do not
-  quote it as unaudited ladder work.
+  🔴 **TAIL churn IS MOSTLY MISSED AUDIT SURFACE — classified 2026-09-11, and the earlier
+  "probably ordinary development" reading was WRONG.** This bullet previously said the tail
+  conflates post-final-block fixes with development that continued after the ladder ended and
+  must not be quoted as unaudited work. The conflation is real; the *proportion* is not what
+  was guessed. Read every commit in the five largest devrc tails (#1046, #1000, #1209, #1121,
+  #998 — **3,349 of devrc's 3,727 tail lines, 17 commits**) plus the largest external one
+  (homelab-talos #707, 1,276 lines):
+
+  | what the commit is | commits |
+  |---|---|
+  | fixes / audit responses (one says *"audit round 5"* in its subject) | 9 |
+  | **merge-conflict RESOLUTIONS** | 4 |
+  | docs, handoff and a CI re-trigger | 3 |
+  | **ordinary development (a feature)** | **1** |
+
+  **One of seventeen is a feature.** homelab #707's single tail commit is *"withdraw the
+  doc-orphan guard, keep the seven orphan fixes"* — an audit response too.
+  🔴 **AND BY LINES THE BIGGEST SINGLE ITEM IS A SEMANTIC-CONFLICT RESOLUTION INSIDE A
+  `merge main`: 1,039 of #1046's 1,105 lines.** Its own commit message documents renumbering a
+  collided exit constant and rewriting 515/487 lines of one test file. That is exactly the
+  hazard `claude/RULES.md` names — *a clean git merge is not a clean merge; a semantic conflict
+  survives it* — landing in a region no audit round's range covered. `--remerge-diff` is what
+  makes it visible at all (shape B of the reference file's range table, working as designed).
+  ⚠ **SCOPE: this is the top of the distribution, not all of it** — 6 of 79 tail adjacencies,
+  ~34% of the 13,779 tail lines. The remaining 73 are unclassified, and a long tail of small
+  gaps may well be more development-heavy than these.
   ⚠ **Two repos are UNMEASURABLE, each for its own reason, and neither is a pass.** naida-ai
   ran 214 PRs and posted **no ledger at all**, so there is nothing to measure coverage
   against — "no ladders ran here" and "ladders ran without blocks" are the same observation
   from this instrument, and so is "they were fine". auditloop has no PR history in scope.
+  🔴 **A COMMIT COUNT IN THE 2026-09-11 TABLE ABOVE WAS WRONG IN THE FLATTERING DIRECTION, and
+  the same defect is in the SHIPPED BRIEF.** `measure_ledger` takes its commit count from
+  `rev-list --count <frm>..<to>` and its line count from the numstat **`--not <base>`** — two
+  different populations — and `audit-dispatch.py` printed the first as *"over N commit(s)"*
+  directly beside the second's command. MEASURED on #1046's tail: **55 commits reported, 2
+  contributing churn.** The other 53 were an upstream bring-in the churn correctly excludes.
+  Corrected figures: #1046 55→**2**, #1000 32→**7**, #1209 12→**3**, #1064 125→0-churn,
+  #1274 10→0-churn, #1110 7→0-churn. **Every LINE count in this review is unaffected** — the
+  churn command always had the exclusion. `RangeChurn` now carries both counts under separate
+  names and the brief prints both with the excluded number stated.
   ⚠ **Three caveats on the counts.** (a) Every carrier count is a **FLOOR** — `gh` does not
   return REVIEW comments, so a block posted as a review is invisible, the same blind spot
   `audit-dispatch.py` warns about. (b) Two repos **hit the 400-PR scan limit**, so their

--- a/claudedocs/handoff-ladder-range-coverage.md
+++ b/claudedocs/handoff-ladder-range-coverage.md
@@ -16,35 +16,28 @@ then outside it. Came in as ranks 10 and 8 of `handoff-audit-pr-ladder.md`; that
 since renumbered and dropped both, so this is the durable home.
 
 ## State now
-- **Branch:** `feat/ladder-carrier-enumerator` at `405c4b45`, pushed, **no PR yet**.
-  Worktree `/home/zach/workspace/devrc-ladder-find`, clean, branched off `058c90c2`.
-- ✅ **Rank 10 DONE and MERGED — `#1519` → squash `766c1295`**, verified by CONTENT on
-  `origin/main` (`scripts/ladder-range-coverage.py`, `scripts/tests/mutants-ladder-range-coverage.sh`,
-  and `measure_range_churn` all present), never by ancestry.
-  - `scripts/ladder-range-coverage.py` classifies every adjacency in a ladder's chain of
-    block ranges — TIGHT / GAP / OVERLAP / UNRELATED, plus the tail — and reports the
-    uncovered churn for the window `[first block's from, head]`.
-  - `measure_range_churn` was EXTRACTED from `audit-dispatch.py::measure_ledger` and is
-    shared, so the report cannot drift from the command the skill tells an auditor to run.
-  - Open item **5** of `claudedocs/audit-ladder-review-2026-09-04.md` is marked CLOSED in
-    that doc, with its residual stated.
-- ✅ **devrc measured (the review's own 20 ladders):** INTERIOR **655** lines in 2 ladders,
-  TAIL **3,727** in 11. Commands and per-ladder rows in the PR body of `#1519`.
-- ✅ **Rank 8 DONE — all six named repos churn-measured or UNMEASURABLE with a reason**, its
-  closing condition met. Results written into the `CANNOT-SEE` section of
-  `claudedocs/audit-ladder-review-2026-09-04.md` (uncommitted at time of writing; see ranked
-  item 1). **129 carriers outside devrc against 70 inside**; INTERIOR **88** total across 126
-  measured external ladders, TAIL 10,052. The per-repo table is in that doc, not repeated here.
-  ⚠ The raw per-repo reports were scratchpad files and are gone — re-run the commands in the
-  investigation block below rather than hunting for them.
-- **Deploy/verify status:** `766c1295` is merged and **NOT deployed** — no `ship.sh` run this
-  session. It adds a script and a test; nothing a consumer runs changed, and
-  `ladder-range-coverage.py` is invoked by path, not from `~/.claude`. `405c4b45` is pushed
-  only: not merged, not deployed.
-- ⚠ **No `clawgate-task:` field recorded.** `clawgate_handoff.sh resolve` exited **5**
-  (nothing resolved). An unknown session id answers 200 with an empty array, so that cannot
-  distinguish "this session touched no task" from "the id is wrong" — it is NOT a clean bill
-  of health, and no task was created to fill the blank.
+- **Branch / PR:** `#1552` OPEN (`fix/churn-commit-population`, worktree
+  `/home/zach/workspace/devrc-tailclass`) — the commit-population fix plus the tail
+  classification. Previous two both MERGED: `#1519` → `766c1295`, `#1528` → `b42ac7c3`.
+- ✅ **Ranked item 1 DONE** — `feat/ladder-carrier-enumerator` landed as `#1528`; the rank-8
+  table is committed, no longer working-tree-only.
+- **CARRIED FORWARD (the previous `State now` would have dropped it):** open items **5** (the
+  range-coverage hole) and the devrc-only half of the CANNOT-SEE bullet in
+  `claudedocs/audit-ladder-review-2026-09-04.md` are marked CLOSED in that doc, each with its
+  residual stated. That doc — not this one — is the durable home for the measurement results.
+- ✅ **Ranked item 2 DONE (pending #1552's merge)** — the tail is classified, and the answer
+  REVERSES this doc's own leading hypothesis. See the investigation below.
+- 🔴 **A defect found in the SHIPPED brief, fixed in `#1552`:** `measure_ledger` paired a
+  commit count from `<frm>..<to>` with a line count from the same range `--not <base>`, and
+  `audit-dispatch.py` printed the former as *"over N commit(s)"* beside the latter's command.
+  Measured: #1046's tail reported **55** commits when **2** contributed churn. Line counts are
+  unaffected; only the commit counts were wrong, and always in the flattering direction.
+- **Deploy/verify status:** nothing in `#1519`/`#1528`/`#1552` needs a `home-manager switch`
+  except `#1519`'s one managed path (`claude/skills/audit-pr/reference/round-ladder-evidence.md`),
+  which is **deployed and byte-verified on BOTH hosts** — `md5 cfaf3169` identical across
+  `origin/main`, workbench and laptop. `#1552` touches `scripts/` and `claudedocs/` only.
+- ⚠ Still no `clawgate-task:` field — `clawgate_handoff.sh resolve` exits **5** (nothing
+  resolved), which cannot distinguish "touched no task" from "wrong id". Not a clean bill.
 
 ## Open investigations — live diagnosis state
 
@@ -106,26 +99,46 @@ since renumbered and dropped both, so this is the durable home.
   cannot execute a kill — or whether the scan should be scoped to executable paths. That is
   the fix; adding each new doc to the ledger is the treadmill.
 
+### RESOLVED — the TAIL is missed audit surface, not development. This doc's own hypothesis was WRONG.
+- **Symptom + exact repro:** the tail was 13,779 lines across 79 adjacencies and
+  uninterpretable. Classified by reading every commit in the range, with the exclusion the
+  measurement applies:
+  ```bash
+  git -C <repo> log --format='  parents=%p :: %s' <frm>..<to> --not <base>
+  ```
+  🔴 **Omitting `--not <base>` there is the trap I nearly published from** — without it the
+  listing shows `main`'s own squash commits and #1046's tail reads as 55 unrelated PRs.
+- **Observed (with values):** five largest devrc tails (#1046, #1000, #1209, #1121, #998 —
+  3,349 of devrc's 3,727 tail lines, **17 commits**) plus homelab-talos #707 (1,276 lines, 1
+  commit): **9** fixes/audit responses (one names *"audit round 5"* in its subject), **4**
+  merge-conflict resolutions, **3** docs/handoff/CI-retrigger, **1** feature.
+- **Ruled out:** *"most of the tail is ordinary post-ladder development"* — this doc's leading
+  hypothesis, **falsified**. One of seventeen commits is a feature. via: measurement
+- **Ruled out:** *"`--remerge-diff` inflates a main-merge's churn"* — suspected when one merge
+  contributed 1,039 of #1046's 1,105 lines. It does not: that merge's own message documents a
+  renumbered exit constant and 515/487 rewritten lines in one test file. Real hand resolution,
+  shape B of the reference table working as designed. via: measurement
+- **Leading hypothesis (the part still open):** the unclassified 73 adjacencies — a long tail
+  of small gaps — may be more development-heavy than the top 6. The top of a distribution is
+  not the distribution.
+- **Next probe:** classify a RANDOM sample of 10 of the remaining 73, not the next-largest
+  ones, so the sample is not length-biased the way this one is by construction.
+
 ## Next steps (ranked)
-1. **Land `feat/ladder-carrier-enumerator`** — `405c4b45` plus the uncommitted rank-8 table in
-   `claudedocs/audit-ladder-review-2026-09-04.md`, in worktree
-   `/home/zach/workspace/devrc-ladder-find`. **An unmerged pushed branch is invisible to
-   `ship.sh` and to the next `/resume`, and the rank-8 numbers exist ONLY in that working
-   tree** — `claude/RULES.md` calls that unsaved work one routine `checkout` from deletion.
-   Claim `audit-pr-ladder-8` is HELD by this session; release it when this lands.
-   forcing: regression — the measurement is uncommitted and its scratch reports are already gone
-2. **Classify the three largest TAIL gaps by reading their commits** — post-final-block fixes
-   vs ordinary development. Until this is done, the 3,727-line devrc tail and the
-   7,314-line homelab-talos one must NOT be quoted as unaudited ladder work, and the
-   range-coverage defect's real size is unknown (it may be as small as 88 lines externally).
+1. **Merge `#1552`** and release claim `ladder-range-coverage-2`. It carries the commit-count
+   fix for the shipped brief, so every `audit-dispatch.py` ledger keeps mis-stating its commit
+   population until this lands.
+   forcing: regression — the brief prints a commit count from the wrong population on every round
+2. **Classify a RANDOM 10 of the 73 unclassified tail adjacencies.** The 6 already done were
+   picked by size, so they are length-biased by construction and cannot speak for the rest.
    forcing: none
-3. **Fix or rescope `_KILL_MENTION_LEDGER`** so a new handoff doc cannot red the gate. See the
-   investigation below for the two candidate fixes.
-   forcing: gate — `tekton/devrc-pytests` is red on `main` itself today, for every PR
-4. **Rank 9 — mine the stop-rationale prose across every carrier.** Now cheap: `--find-carriers
-   --list-only` produces the population that used to be hand-built (199 carriers across the
-   seven repos). Survives durably as open item **4** of
-   `claudedocs/audit-ladder-review-2026-09-04.md`.
+3. **Fix or rescope `_KILL_MENTION_LEDGER`** so a new handoff doc cannot red the gate.
+   `tekton/devrc-pytests` is red on `main` itself; reproduced on a clean `origin/main`
+   worktree at `50e8a71a`.
+   forcing: gate — red on `main` today, for every PR
+4. **Rank 9 — mine the stop-rationale prose across every carrier.** `--find-carriers
+   --list-only` now produces the population (199 across seven repos) that used to be
+   hand-built. Durable home: open item **4** of `claudedocs/audit-ladder-review-2026-09-04.md`.
    forcing: none
 
 ## Gotchas / decisions / dead-ends
@@ -178,6 +191,38 @@ since renumbered and dropped both, so this is the durable home.
 - ⚠ **`--find-carriers` fetches `refs/pull/<n>/head` into the target checkout**, which for the
   client repos means writing objects into shared clones. Additive only — it moves no ref and
   touches no working tree — but it is a write, and two of those repos are client-owned.
+
+- 🔴 **A COUNT AND A MEASUREMENT BESIDE IT CAN COME FROM DIFFERENT POPULATIONS, AND THE SHIPPED
+  LEDGER DID IT FOR ITS WHOLE LIFE.** `rev-list --count A..B` without `--not <base>`, printed
+  beside a numstat that has it. #1046: **55 reported, 2 real**. The tell is structural and
+  cheap to check — **two git invocations, one flag apart, whose outputs get printed in one
+  sentence.** Ask of any "N commits produced M lines": were N and M selected the same way?
+- 🔴 **THE WRONG NUMBER WAS THE ONE THAT MADE THE FINDING LOOK BORING.** 55-commits-1105-lines
+  reads as drift; 2-commits-one-of-them-a-conflict-resolution is a finding. A measurement
+  error that flatters the null is the one nobody chases.
+- 🔴 **I NEARLY CLASSIFIED FROM THE WRONG COMMIT SET.** My first `git log` of #1046's tail
+  omitted `--not origin/main` and showed 12+ of `main`'s own squash commits — which looked
+  exactly like "the PR kept developing", i.e. it CONFIRMED the hypothesis I held. The
+  confirming evidence was an artifact of dropping one flag. **List the population the
+  measurement measures, not the range it names.**
+- 🔴 **A TEST KEYED ON AN ABSOLUTE CALL ORDINAL BREAKS SILENTLY AND MISLEADINGLY.**
+  `test_a_failed_cumulative_measurement_does_not_print_a_false_cause` failed the SECOND
+  `rev-list` to target the cumulative measurement; adding one helper call re-pointed that at
+  the PER-ROUND one, so the test failed for a reason unrelated to its subject and the failure
+  message pointed at the wrong thing. Re-keyed to count only calls WITHOUT `--not` — one per
+  `measure_ledger`. **When two callers share a helper, key on an argument, not a count.**
+- **The assert-it-applied driver earned its place twice in one session.** Two mutants'
+  target strings were moved by my own edits; the battery printed `MUTATION DID NOT APPLY —
+  result meaningless` instead of a clean pass for mutants that never executed.
+- ⚠ **My own fixture expectation was wrong and the code was right.** The first version of the
+  new guard asserted the churn population was 1; it is 2, because a clean merge commit is not
+  reachable from the base either and so belongs to the population while contributing zero
+  lines. Corrected in the test, with the reason recorded there — that is the same shape as
+  #1046, where the merge contributed 1,039 lines rather than none.
+- ⚠ **CORRECTION to this doc's own earlier claim:** it said the rank-8 scratchpad reports
+  "are gone — re-run the driver rather than hunting for them". They were still there. That
+  was a prediction written as an observation; the reports survived and were what the
+  classification read.
 
 ## How to verify
 ```bash

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -922,8 +922,13 @@ def real_runner(cmd, cwd=None):
 
 LedgerReport = namedtuple(
     "LedgerReport",
-    "files added deleted commits reason cumulative cumulative_reason",
+    "files added deleted commits churn_commits reason cumulative cumulative_reason",
 )
+# 🔴 `churn_commits` is the count the LINE COUNT came from — `<anchor>..<tip>`
+# with the same `--not <base>` the numstat uses. `commits` omits that exclusion.
+# The brief must name which it is printing: "over N commit(s)" beside a
+# `--not <base>` command read as the churn population and was not it. See
+# `RangeChurn`.
 # 🔴 `head_check` is the FOURTH read rule, beside rc 0 / silent stderr /
 # non-empty range. See `verify_head_is_the_pr`.
 HeadCheck = namedtuple("HeadCheck", "ok reason local_sha pr_sha")
@@ -1257,7 +1262,17 @@ def anchor_is_head(anchor, head_check):
 # The ledger — the skill's own command, with the skill's own read rules
 # --------------------------------------------------------------------------- #
 
-RangeChurn = namedtuple("RangeChurn", "files added deleted commits reason")
+RangeChurn = namedtuple(
+    "RangeChurn", "files added deleted commits churn_commits reason"
+)
+# 🔴 TWO COUNTS, AND THE DIFFERENCE IS THE POINT. `commits` is `<frm>..<to>`;
+# `churn_commits` is the same range `--not <base>` — the population the numstat
+# below actually measures. They diverge hugely in the shape this repo produces
+# constantly: MEASURED on devrc #1046's tail, `commits`=55 and `churn_commits`=2,
+# because 53 of those commits are an upstream bring-in the churn correctly
+# excludes. Quoting `commits` beside the line count pairs a number from one
+# population with a number from another, and reads as "55 commits produced 1,105
+# lines" when two did.
 
 
 def measure_range_churn(runner, repo_dir, frm, to, base):
@@ -1286,7 +1301,7 @@ def measure_range_churn(runner, repo_dir, frm, to, base):
     `reason` and NO number — a failed command is not a zero.
     """
     def fail(reason):
-        return RangeChurn(None, None, None, None, reason)
+        return RangeChurn(None, None, None, None, None, reason)
 
     rc, out, err = runner(
         ["git", "-C", repo_dir, "rev-list", "--count", f"{frm}..{to}"]
@@ -1304,7 +1319,25 @@ def measure_range_churn(runner, repo_dir, frm, to, base):
         # No commits ⇒ no churn, and no numstat call (which is also what this
         # function's extraction preserved: `measure_ledger` never reached the
         # numstat on an empty range either). The CALLER decides what it means.
-        return RangeChurn({}, 0, 0, 0, None)
+        return RangeChurn({}, 0, 0, 0, 0, None)
+
+    # The SECOND count — the population the numstat below measures. Same range,
+    # same `--not <base>`. See the `RangeChurn` note: a caller that prints
+    # `commits` beside the line count is quoting two different populations.
+    rc, out2, err2 = runner([
+        "git", "-C", repo_dir, "rev-list", "--count", f"{frm}..{to}",
+        "--not", base,
+    ])
+    if rc != 0:
+        return fail(f"`git rev-list {frm}..{to} --not {base}` exited {rc}: "
+                    f"{(err2 or out2).strip() or 'no output'}")
+    if err2.strip():
+        return fail(f"`git rev-list … --not {base}` wrote to stderr: {err2.strip()}")
+    try:
+        churn_commits = int(out2.strip())
+    except ValueError:
+        return fail(f"`git rev-list --count … --not {base}` printed "
+                    f"{out2.strip()!r}, not a number")
 
     rc, out, err = runner([
         "git", "-C", repo_dir, "log", "--numstat", "--format=",
@@ -1331,7 +1364,7 @@ def measure_range_churn(runner, repo_dir, frm, to, base):
         files[path] = (cur[0] + na, cur[1] + nd)
         added += na
         deleted += nd
-    return RangeChurn(files, added, deleted, commits, None)
+    return RangeChurn(files, added, deleted, commits, churn_commits, None)
 
 
 def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
@@ -1362,7 +1395,7 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
     not a zero, and neither is a measurement of the wrong tree.
     """
     def fail(reason):
-        return LedgerReport(None, None, None, None, reason, None, None)
+        return LedgerReport(None, None, None, None, None, reason, None, None)
 
     if head_check is not None and not head_check.ok:
         return fail(
@@ -1413,7 +1446,8 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
         )
 
     return LedgerReport(
-        churn.files, churn.added, churn.deleted, churn.commits, None, None, None
+        churn.files, churn.added, churn.deleted, churn.commits,
+        churn.churn_commits, None, None, None
     )
 
 
@@ -3329,7 +3363,10 @@ def render_ledger(facts):
     measured_tip = hc.local_sha if (hc is not None and hc.ok) else "HEAD"
     lines += [
         f"`git log --numstat --format= --remerge-diff {facts.prev_sha}.."
-        f"{measured_tip} --not {facts.base_ref}` over {led.commits} commit(s):",
+        f"{measured_tip} --not {facts.base_ref}` over "
+        f"{led.churn_commits} commit(s) "
+        f"({led.commits} in the range, {led.commits - led.churn_commits} of them "
+        f"excluded as already in {facts.base_ref}):",
         "",
         "```",
         f"{'added':>7} {'deleted':>8}  path",

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -248,7 +248,14 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
         label, churn, reason = _classify(ad, runner, repo_dir, frm, to, base)
         added = churn.added if churn else None
         deleted = churn.deleted if churn else None
-        commits = churn.commits if churn else None
+        # 🔴 `churn_commits`, NEVER `commits` — the count must come from the same
+        # population as the lines beside it. MEASURED on devrc #1046's tail: this
+        # report printed `55 commit(s), 1105 line(s)` when the churn population
+        # was TWO commits (a 66-line fix and a 1,039-line semantic-conflict
+        # resolution). 53 were an upstream bring-in that `--not <base>` excludes
+        # from the churn and that the raw count included. The wrong number is the
+        # flattering one: it makes a real finding look like routine drift.
+        commits = churn.churn_commits if churn else None
         if label == GAP:
             uncovered_a += added or 0
             uncovered_d += deleted or 0

--- a/scripts/tests/mutants-ladder-range-coverage.sh
+++ b/scripts/tests/mutants-ladder-range-coverage.sh
@@ -92,7 +92,7 @@ ROWS=0
 # below, counts the module, and fails with the replacement value. Two instances
 # of a too-low floor silently widening have already been recorded in
 # `mutants-audit-ladder.sh`; this is pinned from the first commit instead.
-MIN_TESTS=19
+MIN_TESTS=20
 failing() {
   local out n f total
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
@@ -215,6 +215,19 @@ run "the zero-line-gap caveat goes back to a literal" \
     '                   f"{zero_line_gaps} gap(s) in THIS run look like that.")' \
     '                   "Three of the 20 ladders look like that.")'
 
+# 🔴 The regression that made a real finding read as routine drift: pairing a raw
+# range count with a `--not <base>` line count. devrc #1046's tail printed
+# `55 commit(s), 1105 line(s)` when the churn population was TWO.
+run "the commit count reverts to the RAW range population" \
+    test_the_commit_count_beside_the_lines_is_the_CHURN_population "$LRC" \
+    '        commits = churn.churn_commits if churn else None' \
+    '        commits = churn.commits if churn else None'
+
+run "the churn-population count is never computed" \
+    test_the_commit_count_beside_the_lines_is_the_CHURN_population "$DISP" \
+    '        churn_commits = int(out2.strip())' \
+    '        churn_commits = int(out.strip())'
+
 echo
 echo "== the labels that must NOT become a sized GAP =="
 run "an OVERLAP is reported as a GAP instead" \
@@ -267,7 +280,7 @@ echo "== the shared core, and the rule that must differ per caller =="
 # directions have their own row, because one mutant cannot show both.
 run "the shared core starts refusing an empty range" \
     test_measure_range_churn_does_NOT_refuse_an_empty_range "$DISP" \
-    '        return RangeChurn({}, 0, 0, 0, None)' \
+    '        return RangeChurn({}, 0, 0, 0, 0, None)' \
     '        return fail("the range is EMPTY")'
 
 run "measure_ledger stops refusing an empty range" \
@@ -280,10 +293,12 @@ run "measure_ledger stops refusing an empty range" \
 run "the churn numbers are dropped on the way back out" \
     test_measure_ledger_still_measures_a_real_range "$DISP" \
     '    return LedgerReport(
-        churn.files, churn.added, churn.deleted, churn.commits, None, None, None
+        churn.files, churn.added, churn.deleted, churn.commits,
+        churn.churn_commits, None, None, None
     )' \
     '    return LedgerReport(
-        churn.files, 0, 0, churn.commits, None, None, None
+        churn.files, 0, 0, churn.commits,
+        churn.churn_commits, None, None, None
     )'
 
 run "a failed git call becomes a zero instead of a reason" \

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -7635,15 +7635,24 @@ def test_a_failed_cumulative_measurement_does_not_print_a_false_cause():
     Two mechanisms, one observable — the exact rule this module cites everywhere
     else to justify its own COULD-NOT-MEASURE design.
 
-    Driven by failing the SECOND `rev-list` only: the per-round measurement
+    Driven by failing the SECOND `measure_ledger` only: the per-round measurement
     succeeds (so a ledger is rendered) and the cumulative one, from the anchor,
-    does not.
+    does not. Both use the SAME range here (`aaaa1111..HEAD`), so they cannot be
+    told apart by their arguments — only by which call they are.
+
+    🔴 KEYED ON THE PLAIN `rev-list`, NOT AN ABSOLUTE ORDINAL. This said
+    `calls["n"] > 1` and broke the moment `measure_range_churn` grew a second
+    `rev-list` (the `--not <base>` churn-population count): call 2 became the
+    PER-ROUND measurement's, so the per-round failed, no ledger rendered, and the
+    test failed for a reason that had nothing to do with what it guards. Counting
+    only the calls WITHOUT `--not` means one per `measure_ledger`, so this
+    survives either measurement gaining or losing helper calls.
     """
     calls = {"n": 0}
     base = make_runner(comments=[CLAIMS_BLOCK_R2])
 
     def runner(cmd, cwd=None):
-        if cmd[:2] == ["git", "-C"] and cmd[3] == "rev-list":
+        if cmd[:2] == ["git", "-C"] and cmd[3] == "rev-list" and "--not" not in cmd:
             calls["n"] += 1
             if calls["n"] > 1:
                 return 128, "", "fatal: bad revision 'aaaa1111..HEAD'"

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -429,6 +429,58 @@ def test_a_ledger_starting_at_round_2_says_round_1_is_out_of_window(lrc, ad,
 # The shared core — the extraction must not have changed `measure_ledger`
 # --------------------------------------------------------------------------- #
 
+def test_the_commit_count_beside_the_lines_is_the_CHURN_population(lrc, ad,
+                                                                   base_repo):
+    """🔴 Regression, and the wrong number was the FLATTERING one.
+
+    MEASURED on devrc #1046's tail: this report printed `55 commit(s), 1105
+    line(s)` when the churn population was TWO commits — a 66-line fix and a
+    1,039-line semantic-conflict resolution. The other 53 were an upstream
+    bring-in that `--not <base>` excludes from the churn and that the raw
+    `rev-list --count` included. Pairing them makes a real finding ("two commits
+    nobody audited, one of them a conflict resolution") read as routine drift
+    across 55 commits.
+
+    The fixture reproduces that shape: a gap whose commits are MOSTLY already in
+    the base. **FOUR** upstream commits, not one, so the two counts differ by a
+    margin no off-by-one can explain — 6 in the range, 2 contributing churn.
+
+    ⚠ The churn population is 2, not 1, and that is CORRECT: the merge commit is
+    not reachable from `main` either, so it belongs to the population while
+    contributing zero lines. My first version of this test asserted 1 and the
+    code was right — the same shape as #1046, where that merge contributed 1,039
+    lines of conflict resolution rather than none.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 10, "round 1 fix")
+    # Four commits that land on `main` — excluded from churn by `--not main`.
+    _git(repo, "checkout", "--quiet", "main")
+    for i in range(4):
+        _commit(repo, f"up{i}.py", 8, f"upstream {i}")
+    _git(repo, "checkout", "--quiet", "feat")
+    _git(repo, "merge", "--quiet", "--no-edit", "main")
+    # …and ONE that does not.
+    head = _commit(repo, "mine.py", 5, "the only churn-contributing commit")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 11, head, "main",
+                           [_block(1, base, r1_to)])
+
+    tail = L.adjacencies[-1]
+    assert tail.label == lrc.GAP
+    assert (tail.added, tail.deleted) == (5, 0), "only `mine.py` is churn"
+    assert tail.commits == 2, (
+        f"the reported count is {tail.commits}; it must be the churn population "
+        "(2 — the merge plus `mine.py`), not the raw range"
+    )
+
+    raw = ad.measure_range_churn(ad.real_runner, str(repo), r1_to, head, "main")
+    assert raw.commits == 6 and raw.churn_commits == 2, (
+        "the fixture must make the two populations differ by more than one, or "
+        f"this guard cannot see the bug (commits={raw.commits}, "
+        f"churn_commits={raw.churn_commits})"
+    )
+
+
 def test_measure_range_churn_does_NOT_refuse_an_empty_range(ad, base_repo):
     """The inverted read rule, asserted directly.
 


### PR DESCRIPTION
Ranked item 2 of `claudedocs/handoff-ladder-range-coverage.md`. Claim: `ladder-range-coverage-2`.

Classifying the largest tail gaps answered the open question **and** exposed a defect in the instrument doing the classifying — and in the brief every auditor reads.

## The defect

`measure_ledger` takes its commit count from `rev-list --count <frm>..<to>` and its line count from the numstat **`--not <base>`**. Two populations. `audit-dispatch.py` printed the first as *"over N commit(s)"* directly beside the second's command; `ladder-range-coverage.py` inherited it.

**MEASURED on devrc #1046's tail: 55 commits reported, TWO contributing churn.** The other 53 were an upstream bring-in the churn correctly excludes.

🔴 **The wrong number was the flattering one.** *"55 commits produced 1,105 lines"* reads as routine drift. *"Two commits nobody audited, one of them a semantic-conflict resolution"* is a finding. Corrected: #1046 **55→2**, #1000 **32→7**, #1209 **12→3**.

✅ **Every LINE count ever produced is unaffected** — the churn command always carried the exclusion. `RangeChurn` and `LedgerReport` now carry both counts under separate names, and the brief prints the churn population with the excluded number stated beside it.

## The classification — my own hypothesis was wrong

The handoff's leading hypothesis was *"most of the tail is ordinary post-ladder development, not missed audit surface"*. **It is not.** Every commit in the five largest devrc tails (**3,349 of devrc's 3,727 tail lines, 17 commits**) plus the largest external one:

| what the commit is | commits |
|---|---|
| fixes / audit responses — one says *"audit round 5"* in its own subject | 9 |
| **merge-conflict RESOLUTIONS** | 4 |
| docs, handoff, a CI re-trigger | 3 |
| **ordinary development** | **1** |

**One of seventeen is a feature.** homelab-talos #707's single tail commit is *"withdraw the doc-orphan guard, keep the seven orphan fixes"* — an audit response too.

🔴 **And by lines the single biggest item is a semantic-conflict resolution inside a `merge main`: 1,039 of #1046's 1,105.** Its own message documents renumbering a collided exit constant and rewriting 515/487 lines of one test file. That is the hazard `claude/RULES.md` states in terms — *a clean git merge is not a clean merge; a semantic conflict survives it* — landing in a region no audit round's range covered. `--remerge-diff` is why it is visible at all: shape B of the reference table, working as designed.

⚠ **Scope, stated in the doc too:** 6 of 79 tail adjacencies, **~34% of the 13,779 tail lines**. The other 73 are unclassified and a long tail of small gaps may well be more development-heavy. This is the top of the distribution, not all of it.

## Collateral, both worth reading

**An existing pin broke for a reason unrelated to what it guards.** `test_a_failed_cumulative_measurement_does_not_print_a_false_cause` keyed on *"fail the SECOND `rev-list`"*; my extra call silently re-pointed that at the **per-round** measurement, so the per-round failed, no ledger rendered, and the test failed misleadingly. Re-keyed to count only calls **without** `--not` — one per `measure_ledger` — which survives either measurement gaining or losing helper calls. An absolute ordinal over a helper's call sequence is brittle by construction.

**The battery caught two of its own mutants going stale.** My edits moved their target strings, and the assert-it-applied driver reported `MUTATION DID NOT APPLY — result meaningless` rather than a clean pass for mutants that never executed. Both re-pointed.

## Verification

- `test_ladder_range_coverage.py` + `test_audit_dispatch.py` — **156 passed**.
- `scripts/tests/mutants-ladder-range-coverage.sh` — **22 rows, all as expected**, including two new rows for this regression (revert the count to the raw population; never compute the churn population) and both `SURVIVES` controls.
- The new guard's fixture uses **four** upstream commits, not one, so the two populations differ by a margin no off-by-one explains (6 in range, 2 in churn).
- ⚠ My first version of that guard asserted `churn_commits == 1` and **the code was right**: a clean merge commit is not reachable from the base either, so it belongs to the population while contributing zero lines — the same shape as #1046, where that merge contributed 1,039.
- Floor pin fired a **third** time (20→21) and named its replacement.
- Content, hostname and shebang gates: **128 passed**, re-run after staging.

⚠ No full tier was run; CI evaluates that. `tekton/devrc-pytests` remains red on `main` itself for the unrelated `_KILL_MENTION_LEDGER` reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)