### PR TITLE
fix(guard): un-red main — my own merged handoff became the ledger's offender, and eliding it was not enough

### DIFF
--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -782,8 +782,17 @@ Tekton legs sat on top of two deploy-blockers.
   `nix develop <wt> --command python3 -m pytest <wt>/scripts/claude-hooks/tests/test_guard_core.py -q`
   → **`2 failed, 1534 passed`**.
 - **Observed (with values):** census — `added: ['claudedocs/handoff-tmux-webapp.md'], removed: []`;
-  scanner — `offenders: [('claudedocs/handoff-tmux-webapp.md', 'tmux kill-session')]`. The mention
-  is real, at `handoff-tmux-webapp.md:3409`, and is on `origin/main` too.
+  scanner — `offenders: [('claudedocs/handoff-tmux-webapp.md', '<the wide-kill verb>')]`. The
+  mention is real, at `handoff-tmux-webapp.md:3409`, and is on `origin/main` too.
+  🔴 **THE VERB IS ELIDED HERE ON PURPOSE — AND ELISION ALONE WAS NOT ENOUGH, WHICH IS THE
+  LESSON.** An earlier revision of this bullet quoted it literally and made THIS doc an offender,
+  red on `origin/main` (`f3e27aa3`: `added: ['claudedocs/handoff-cairn-oss-multi-instance.md']`).
+  Eliding it dropped the count from 2 failures to 1 — and the doc **still** matched, at `:43` and
+  `:2020`, both written by OTHER sessions documenting this same breakage. **A census over prose
+  that mentions a command turns every write-up of the census into a new entry**, and with several
+  sessions writing about it at once, no single author can elide their way out. So this doc IS
+  ledgered (both allowlists), and the elision stays as the cheap half: don't add the sixth,
+  seventh and eighth mention while the row already covers you.
 - **Ruled out: that the rows it deleted were wrong.** Its commit says they "recorded a mention
   that does not exist"; `grep -n` finds it at `:3409` at that same head. via: measurement
 - **Ruled out: that `f346ba28` was already green.** It was **1 failed** — only its own new doc

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2524,6 +2524,11 @@ def test_tmux_kill_prefix_matches_both_wide_kills_and_neither_narrow_one():
 # classify it. Paths only — line numbers are what rotted last time.
 _KILL_MENTION_LEDGER = {
     "claudedocs/handoff-tmux-restore-chain.md": "prose: the incident write-up",
+    # Several sessions documenting THIS ledger's own breakage, in one doc. Its
+    # author elided their mention and it still matched at :43 and :2020, both
+    # written by others — which is the self-amplifying shape worth knowing:
+    # a census over prose turns every write-up of the census into an entry.
+    "claudedocs/handoff-cairn-oss-multi-instance.md": "prose: write-ups OF this ledger firing, by several sessions",
     "claudedocs/handoff-tmux-scratchpad-bar-statusline.md": "prose: a gotcha warning AGAINST it — \"Never `kill-server`; that destroys every session\"",
     "scripts/claude-hooks/bash-guard.py": "prose: the guard's own ban list",
     "scripts/claude-hooks/guard_core.py": "prose: this check, its docstring and its message",
@@ -2689,6 +2694,7 @@ def test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny():
     shell_text = re.compile(r"tmux(?:\s+-{1,2}[^\s'\"]+)*\s+kill-s[a-z-]*")
     quoting_is_the_point = {
         "claudedocs/handoff-tmux-restore-chain.md",
+        "claudedocs/handoff-cairn-oss-multi-instance.md",  # see the ledger entry
         "scripts/claude-hooks/bash-guard.py",
         "scripts/claude-hooks/guard_core.py",
         "scripts/claude-hooks/tests/test_guard_core.py",


### PR DESCRIPTION
`origin/main` (`f3e27aa3`) is red on both kill guards with exactly one offender — **`claudedocs/handoff-cairn-oss-multi-instance.md`, which I introduced.** `#1548`'s handoff text quoted the wide-kill verb literally while documenting `#1522`'s breakage. That is precisely the self-amplifying shape `#1522`'s own title names: *a census over prose turns every write-up of the census into a new entry.*

## The fix, in the order I measured it

| tree | result |
|---|---|
| `origin/main` `f3e27aa3` | **2 failed**, 1534 passed |
| + elide **my** quoted verb | **1 failed**, 1535 passed |
| + ledger it in **both** allowlists | **1536 passed, 0 failed** |

## The part worth recording

**Eliding was necessary and not sufficient.** Once my line stopped matching, the doc still matched at `:43` and `:2020` — both written by *other* sessions documenting this same breakage. With several sessions writing about it concurrently, no single author can elide their way out, so the doc is ledgered.

The elision stays as the cheap half, with a note in the doc saying why: don't add the seventh and eighth mention when the row already covers you.

**Both allowlists, deliberately.** `_KILL_MENTION_LEDGER` and `quoting_is_the_point` are separate sets, and a fix that populates one leaves the suite red. That asymmetry has now caught three separate attempts today — `#1522`'s, an earlier one of mine, and this one.

## Verification

File-level, `__pycache__` cleared between runs, `PYTHONDONTWRITEBYTECODE=1`. The scanner carries its own positive control (`seen_in_allowlisted > 0`, asserting the pattern matched *something* in the files written to contain such text), so the green is not vacuous.

Independent of `#1522`, `#1549` and `#1551` — none of them classifies this doc (checked at each head before opening this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4p3xnvfqhRRjAUGKLK96v
