### PR TITLE
fix(guard-core): main is RED again — a doc quoting this scanner's own output tripped it, one hour after the last fix

### DIFF
--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2551,6 +2551,13 @@ _KILL_MENTION_LEDGER = {
     "claudedocs/handoff-mention-system-repos.md":
         "prose: a META-mention — it only quotes that the doc above 'landed "
         "carrying `tmux kill-server` text', i.e. it is about this ledger",
+    # THIRD-ORDER, and the clearest statement of why this guard keeps
+    # re-redding `main`: this doc quotes THIS SCANNER'S OWN OUTPUT (its
+    # `offenders=` list) inside a write-up ABOUT this very failure. Writing
+    # the incident down reproduced it, within an hour of the last fix.
+    "claudedocs/handoff-cairn-oss-multi-instance.md":
+        "prose: quotes this scanner's own offenders= output in a write-up "
+        "ABOUT this guard",
 }
 
 # A tmux argv list that carries NO `-L` and is nevertheless fine, because it is
@@ -2701,6 +2708,7 @@ def test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny():
         # how `main` stayed red on TWO tests for one root cause.
         "claudedocs/handoff-tmux-webapp.md",
         "claudedocs/handoff-mention-system-repos.md",
+        "claudedocs/handoff-cairn-oss-multi-instance.md",
     }
     seen_in_allowlisted, offenders = 0, []
     for rel in _tracked_files():


### PR DESCRIPTION
fix(guard-core): main is RED again, one hour later, from a doc quoting THIS SCANNER'S OWN OUTPUT

Same two tests, third offending file, and this one is self-referential:
`claudedocs/handoff-cairn-oss-multi-instance.md:785` quotes the scanner's own
`offenders: [...]` list inside a write-up ABOUT this guard. Documenting the
incident reproduced it.

MEASURED on a clean detached worktree of `origin/main` (9e5c348c), after #1543
had already merged: 2 failed, 1582 passed —

  test_every_kill_server_call_site_in_the_repo_is_classified
  test_no_tracked_shell_text_writes_a_kill_this_guard_would_deny

added: ['claudedocs/handoff-cairn-oss-multi-instance.md']

Both ledgers updated again, because they remain SEPARATE: a file classified in
`_KILL_MENTION_LEDGER` is still an offender to `quoting_is_the_point`.

1536 passed.

🔴 THE PATTERN IS NOW MEASURED, NOT SUSPECTED, AND IT IS A DESIGN PROBLEM
RATHER THAN A RUN OF BAD LUCK. Three files in roughly one hour, from three
different sessions, every one of them PROSE in a handoff doc, and each new fix
is itself a doc that can trip the next one. The guard's value is real — it
watches for a command that has destroyed live conversations twice — but its
current shape means every session that WRITES ABOUT it reds `main` for
everybody, and the fix is always "add another line to two hand-maintained
lists".

Worth an operator decision rather than a fourth entry; recorded here rather
than acted on, because narrowing a destructive-command guard is not a call to
make unilaterally. Options, cheapest first: exempt `claudedocs/**` from the
prose scanners (docs execute nothing, and all three offenders were docs);
merge the two ledgers so one entry covers both; or require an inline opt-out
marker in the prose itself instead of a central list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VaeYxVr4aESJ7dWhgBRUtS
