### PR TITLE
feat(audit-pr-nudge): route ROUND 0 at PR-create time — the trial measured the ROUTING, not the section, as the defect

### DIFF
--- a/scripts/claude-hooks/audit-pr-nudge.py
+++ b/scripts/claude-hooks/audit-pr-nudge.py
@@ -1,13 +1,29 @@
 #!/usr/bin/env python3
 """PostToolUse nudge: when a PR is created via `gh pr create`, inject context so
-Claude proactively OFFERS the adversarial pre-merge audit (`/audit-pr <n>`) instead
-of waiting for the user to hand-type "dispatch a subagent to audit this PR …".
+Claude proactively OFFERS the pre-merge audit — ROUND 0 FIRST, then the nine
+correctness axes — instead of waiting for the user to hand-type "dispatch a
+subagent to audit this PR …".
 
 Why this exists: a transcript audit found that exact request typed by hand ≥14x
 across 6 sessions while the matching `/audit-pr` skill sat unused — recall at the
 right moment was the gap, not the command. This fires at the moment a PR is born,
 which is when the audit is most actionable. Deterministic (matches the literal
 `gh pr create` command), non-blocking (it only adds context — never denies).
+
+🔴 WHY THE MESSAGE NAMES ROUND 0, AND NAMES IT FIRST. Round 0 is the
+requirements-and-deletion pass: the only round that can conclude *close this PR,
+do not audit it*. Its question — should this change EXIST — is actionable only
+while the merge decision is open, so a round 0 that arrives after the merge is
+not a slow audit, it is a wasted one. MEASURED over the round-0 trial
+(`claudedocs/handoff-audit-pr-ladder.md`, rank 1): `ran: 6 · changed the
+outcome: 3`, and every zero was a post-decision dispatch — `#1523` merged 27 min
+BEFORE its audit was dispatched, `#1510` merged 6 min after, `#1518` closed 5 min
+before the report returned. Audit runtimes were 459/920/776 s, so no speedup
+reaches any of them: the section worked whenever it arrived in time and the
+ROUTING was the defect. THIS HOOK is the only thing in the system that fires when
+a PR is born, so the fix belongs here and nowhere else — one rule, one place.
+The message is pinned by `tests/test_audit_pr_nudge.py`, which was watched RED at
+`db7bf3ff`; before that commit nothing read this text at all.
 
 Coverage note: this catches PRs CREATED in-session. Auditing a pre-existing PR
 (e.g. reviewing someone else's) is still a manual `/audit-pr <n>` — by design,
@@ -50,10 +66,16 @@ def main():
 
     nudge = (
         f"A PR was just created: {target}. Before moving on (and before merging), "
-        f"proactively OFFER to run `/audit-pr {arg}` — the adversarial pre-merge "
-        f"audit (bugs, regressions, race conditions, security, backward-compat, "
-        f"second-order effects). Don't silently skip it; if now isn't the right "
-        f"moment, say so. This is the reflexive substitute for hand-typing an audit request."
+        f"proactively OFFER the pre-merge audit — in this order, because the order "
+        f"is the mechanism:\n"
+        f"1. 🔴 ROUND 0 FIRST — `/audit-pr {arg}`, worked as its ROUND 0 section "
+        f"(requirements & deletion). It is the only round that can conclude *close "
+        f"this PR, do not audit it*, and that question is actionable ONLY while the "
+        f"merge decision is open. MEASURED: dispatched later instead of now, the "
+        f"report landed AFTER the decision in 3 of 4 trials.\n"
+        f"2. Then the nine correctness axes — `/audit-pr {arg}`.\n"
+        f"Round 0 REPLACES nothing: it reports and cannot end a ladder. Don't "
+        f"silently skip either; if now isn't the right moment, say so."
     )
     print(json.dumps({
         "hookSpecificOutput": {

--- a/scripts/claude-hooks/tests/test_audit_pr_nudge.py
+++ b/scripts/claude-hooks/tests/test_audit_pr_nudge.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Tests for audit-pr-nudge.py — the PostToolUse nudge fired when a PR is created.
+
+🔴 WHY THIS FILE EXISTS, AND WHY IT EXISTS NOW. The hook shipped with NO
+behavioural test: measured 2026-09-12 at db7bf3ff, `git grep -l audit-pr-nudge`
+returned 9 files, of which the only two tests covered its FILENAME
+(test_on_disk_artifact_names.py) and its REGISTRATION in settings.json
+(test_register_nudge_hook.py). Nothing read the text it injects — so the message
+was unpinned by construction, which is the same shape
+`claudedocs/handoff-audit-pr-ladder.md` records for counts quoted in prose that
+no assertion reads.
+
+WHAT THE MESSAGE HAS TO DO, and why it is a correctness property rather than
+wording. A round-0 audit (the requirements-and-deletion pass) is the only round
+that can conclude *close this PR, do not audit it*, and its question — should
+this change EXIST — is actionable ONLY before the merge decision is taken.
+MEASURED over the round-0 trial (same handoff, rank 1): dispatched at audit time
+rather than at PR-create time, the report landed after the decision in 3 of 4
+trials — `#1523` merged 27 min BEFORE its audit was even dispatched, `#1510`
+merged 6 min after, `#1518` was closed 5 min before the report returned. The
+section worked whenever it arrived in time; the ROUTING was the defect. This
+hook is the only thing in the system that fires at the moment a PR is born, so
+the routing fix belongs here and nowhere else — one rule, one place.
+
+Hence test 3: the nudge must NAME round 0. That is the regression guard, and it
+was watched RED at db7bf3ff, where the message named only `/audit-pr <n>` (which
+defaults to round 1).
+
+⚠ The other tests here are INVARIANT GUARDS, not regression coverage — no shipped
+bug violated them. They are labelled as such below so nobody counts them as
+evidence of a fixed defect. They exist because test 3 alone could pass while the
+hook had stopped firing at all, and a guard nobody can see fail is worthless.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parents[1] / "audit-pr-nudge.py"
+
+CREATE_CMD = "gh pr create --base main --head feat/x --title t --body b"
+PR_URL = "https://github.com/innovation-upstream/devrc/pull/1542"
+
+
+def run(payload):
+    """Feed the hook a PostToolUse payload; return (rc, parsed-or-None, raw)."""
+    p = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    out = p.stdout.strip()
+    parsed = None
+    if out:
+        try:
+            parsed = json.loads(out)
+        except json.JSONDecodeError:
+            parsed = None
+    return p.returncode, parsed, out
+
+
+def context(payload):
+    """The injected text, or '' when the hook stayed silent."""
+    _, parsed, _ = run(payload)
+    if not parsed:
+        return ""
+    return parsed.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def fired(cmd=CREATE_CMD, response=None):
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": cmd},
+        "tool_response": response if response is not None else {"stdout": PR_URL},
+    }
+
+
+# --- 1. INVARIANT GUARD: it fires on a real creation, and names the PR --------
+def test_it_fires_on_a_real_pr_creation_and_names_the_number():
+    text = context(fired())
+    assert text, "the hook stayed silent on a real `gh pr create` that printed a PR URL"
+    assert "1542" in text, f"the nudge does not name the PR number: {text!r}"
+    assert PR_URL in text, "the nudge does not carry the PR URL"
+
+
+# --- 2. NEGATIVE CONTROL: can it stay silent? --------------------------------
+# 🔴 This is the control that makes every other assertion here meaningful. A hook
+# wired to print unconditionally would pass test 1 and test 3 while being useless.
+def test_no_pr_url_in_the_output_means_silence():
+    # The phrase is present in the COMMAND (a commit message can contain it — the
+    # hook's own docstring records a real misfire of exactly this shape), but no
+    # PR was created, so there is no URL and the hook must say nothing.
+    assert context(fired(response={"stdout": "nothing was created here"})) == ""
+
+
+def test_a_non_create_gh_command_is_ignored_even_with_a_pr_url_present():
+    # `gh pr view` prints a PR URL too. The command gate must reject it.
+    assert context(fired(cmd="gh pr view 1542 --json url", response={"stdout": PR_URL})) == ""
+
+
+def test_a_pushs_create_a_pr_hint_does_not_fire():
+    # GitHub's post-push hint is /pull/new/<branch> — no digits, must not match.
+    hint = "remote: https://github.com/innovation-upstream/devrc/pull/new/feat/x"
+    assert context(fired(response={"stdout": hint})) == ""
+
+
+def test_a_non_bash_tool_is_ignored():
+    assert context({"tool_name": "Read", "tool_input": {}, "tool_response": {}}) == ""
+
+
+# --- 3. THE REGRESSION GUARD: round 0 must be ROUTED here --------------------
+# 🔴 WATCHED RED at db7bf3ff, where the nudge named only `/audit-pr <n>`.
+# Failure this prevents: a PR is created, the nudge recalls only the correctness
+# audit, round 0 is never offered at the one moment its verdict can change the
+# outcome, and it gets dispatched later — after the merge decision — which is the
+# measured failure in 3 of 4 trials.
+def _first_instruction(text):
+    """The numbered step the reader is told to do FIRST, or '' if there is none.
+
+    🔴 STRUCTURAL ON PURPOSE. An earlier version of this guard asserted only
+    `"round 0" in text.lower()` and a mutation sweep SURVIVED it: stripping
+    `ROUND 0 FIRST` out of step 1 left the tail caveat "Round 0 REPLACES
+    nothing…" in place, so the phrase was still present while the routing was
+    gone. A guard on a WORD is walkable by putting that word somewhere harmless;
+    this one pins WHERE it has to appear.
+    """
+    for line in text.split("\n"):
+        if line.lstrip().startswith("1."):
+            return line
+    return ""
+
+
+def test_the_nudge_routes_round_0_IN_ITS_FIRST_INSTRUCTION():
+    text = context(fired())
+    step1 = _first_instruction(text)
+    assert step1, f"the nudge has no numbered first step to route anything: {text!r}"
+    assert "round 0" in step1.lower(), (
+        "the nudge's FIRST instruction does not name round 0. This hook is the "
+        "only thing that fires when a PR is born, and round 0's question (should "
+        "this change EXIST) is only actionable before the merge decision — so a "
+        "mention further down does not route it. Mutation-controlled: asserting "
+        f"mere presence of the phrase SURVIVED a mutant. Step 1 was: {step1!r}"
+    )
+
+
+def test_the_nudge_says_round_0_comes_FIRST_not_merely_that_it_exists():
+    # A mention is not routing. The reader has to learn the ORDER, because
+    # spending the correctness axes on a change that should not exist is the
+    # ordering failure round 0 exists to prevent.
+    text = context(fired())
+    low = text.lower()
+    assert "first" in low, f"the nudge mentions round 0 but not that it comes first: {text!r}"
+    # And round 0 must be named BEFORE the generic audit offer, in reading order.
+    i_r0 = low.find("round 0")
+    i_audit = low.find("/audit-pr")
+    assert i_r0 != -1 and i_audit != -1
+    assert i_r0 < i_audit or low.find("--round 0") < low.rfind("/audit-pr"), (
+        "round 0 is mentioned after the plain audit offer, so a reader skimming "
+        f"the first sentence still reaches for the correctness pass: {text!r}"
+    )
+
+
+def test_it_still_offers_the_full_correctness_audit():
+    # Round 0 REPLACES nothing: it reports and cannot end a ladder. Dropping the
+    # correctness offer while adding round 0 would be "wider on one axis,
+    # narrower on another" — the shape the audit skill tells you to hunt for.
+    text = context(fired())
+    assert "/audit-pr" in text, f"the nudge no longer offers the audit at all: {text!r}"
+    assert "1542" in text
+
+
+# --- 4. INVARIANT GUARD: the hook never blocks -------------------------------
+def test_it_exits_zero_on_every_input_including_garbage():
+    # It is a nudge: it adds context and must never deny a tool call.
+    for payload in (fired(), fired(response={"stdout": ""}), {"tool_name": "Bash"}):
+        rc, _, _ = run(payload)
+        assert rc == 0, f"the nudge exited {rc} — it must never block a tool call"
+    p = subprocess.run(
+        [sys.executable, str(HOOK)], input="not json at all",
+        capture_output=True, text=True,
+    )
+    assert p.returncode == 0, "malformed stdin must not make the hook exit non-zero"
+
+
+def test_tool_response_as_a_raw_string_is_handled():
+    # The harness passes a dict or a bare string; both must work.
+    assert "1542" in context(fired(response=f"created {PR_URL}"))

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -929,6 +929,16 @@ HERMETIC_TARGETS=(
   # suppression predicate is gated here rather than left to the ungated hand-rolled
   # scripts beside it.
   scripts/claude-hooks/tests/test_next_step_nudge.py
+  # Same reason again — a FILE, because the directory's neighbours are hand-rolled.
+  # audit-pr-nudge is the PostToolUse nudge that fires when a PR is created, and what
+  # it is gated FOR is its MESSAGE: it is the only thing in the system firing at the
+  # moment a PR is born, which is the only moment a round-0 verdict ("should this
+  # change exist") can still change the outcome. Measured over the round-0 trial,
+  # dispatching later landed the report after the decision in 3 of 4 trials — so the
+  # ORDER the message prescribes is a correctness property, not wording. It shipped
+  # with no behavioural test at all: its only two were its FILENAME and its
+  # REGISTRATION, so the text was unpinned by construction.
+  scripts/claude-hooks/tests/test_audit_pr_nudge.py
   # Same reason again — a FILE, not the directory. This one gates the DELIVERY seam
   # rather than a hook's own logic: that register-nudge-hook.py is deployed, that a
   # switch actually RUNS it, and that the run leaves the right end state in a
@@ -2350,6 +2360,12 @@ TARGET_FLOORS=(
   # put through the gate's OWN function rather than arithmetic:
   #   _suggested_floor 130 = 130 - min(50, max(1, 130/20 = 6)) = 130 - 6 = 124.
   "scripts/claude-hooks/tests/test_next_step_nudge.py|124"
+  # 2026-09-12, audit-pr-nudge's MESSAGE arrives as a NEW target: 10 collected
+  # (2 regression guards watched RED at db7bf3ff + 8 invariant guards, labelled as
+  # such in the file so nobody counts them as evidence of a fixed defect).
+  # Gate's own count through the gate's own rule:
+  #   _suggested_floor 10 = 10 - min(50, max(1, 10/20 = 0 -> 1)) = 10 - 1 = 9.
+  "scripts/claude-hooks/tests/test_audit_pr_nudge.py|9"
   # 2026-08-13, the registrar's DELIVERY seam arrives as a NEW target: 17 collected.
   # Gate's own count through the gate's own rule:
   #   _suggested_floor 17 = 17 - min(50, max(1, 17/20 = 0 -> 1)) = 17 - 1 = 16.


### PR DESCRIPTION
Closes the open half of rank 1 in `claudedocs/handoff-audit-pr-ladder.md`.

## What the trial actually concluded

`ran: 6 · changed the outcome: 3` — the section **works**. But **every zero was a post-decision dispatch**:

| trial | PR | when the audit could act |
|---|---|---|
| 3 | `#1523` | merged **27 min before** dispatch |
| 4 | `#1518` | closed **5 min before** the report returned |
| 5 | `#1510` | merged **+6 min** after dispatch, inside the audit |

Runtimes were 459/920/776 s, so no speedup reaches any of them. Round 0's question — *should this change EXIST* — is actionable only while the merge decision is open.

## 🔴 The trigger already existed and just didn't mention round 0

This hook fires on `gh pr create`, i.e. exactly when a PR is born, and its message named only `/audit-pr <n>` — which defaults to round 1. So the fix is **one rule in one place**, not the new poller the handoff listed as option (b): step 1 now routes ROUND 0 FIRST with the reason, step 2 keeps the nine correctness axes, and the message says round 0 **replaces nothing** so nobody reads it as a substitute.

Cost, stated because it is paid on every PR creation: **460 → 728 chars**. A first draft was 1,015; I cut the parenthetical restating what the skill body already carries.

## The hook had no behavioural test

Measured at `db7bf3ff`: 9 files reference `audit-pr-nudge`, and the only two tests covered its **filename** and its **registration**. Nothing read the text it injects, so the message was unpinned by construction.

New `tests/test_audit_pr_nudge.py`, 10 tests:

- **Matrix: red at `db7bf3ff` (2 failed / 8 passed) → green at HEAD (10 passed).** The 8 that passed at base are labelled **invariant guards** in the docstring, not regression coverage.
- **Negative controls**, because a hook wired to print unconditionally would pass the routing assertions while being useless: no PR URL → silence (the hook's own docstring records a real misfire where a *commit message* contained the phrase); `gh pr view` with a URL present → silence; the post-push `/pull/new/<branch>` hint → silence; non-Bash tool → silence.

### 🔴 My first version of the guard survived its own mutation

Asserting only `"round 0" in text.lower()` was **walkable**: stripping `ROUND 0 FIRST` out of step 1 left the tail caveat *"Round 0 REPLACES nothing…"* in place, so the phrase was still present while the routing was gone. A guard on a **word**, not on the **state**. Replaced with a structural one that parses the numbered first step and asserts round 0 is named *there*.

- Re-run: that mutant now kills **both** guards (it killed 1 before).
- A second, **isolated** mutant — keep round 0 in step 1, remove only `FIRST` — kills **only** the ordering guard, which is what proves the two are independent rather than redundant.
- Hook restored from a `cp -a` copy, never `git checkout --`, which would have reverted the uncommitted fix along with the mutant.

## Verification

`scripts/claude-hooks/tests/` → **3044 passed** on the merged tree. ⚠ `scoped-tests.sh` deliberately skips the hook families, so no scoped run covers this; I ran the family by path. **No gate tier was run and none is claimed.**

⚠ **Merged ≠ deployed.** This is a `home.file` target, so the live hook keeps emitting the old message until `home-manager switch` / `scripts/ship.sh`. Observed first-hand: the deployed copy fired its pre-change text at me *while I was making this change*.