### PR TITLE
fix(scoped-tests): un-red main — an UNBOUNDED runner spawn, routed through the harness rather than excused by a ledger row

### DIFF
--- a/scripts/tests/test_scoped_tests_shared_surface.py
+++ b/scripts/tests/test_scoped_tests_shared_surface.py
@@ -26,7 +26,6 @@ would satisfy every positive case here and be catastrophically wrong. So
 direction, and without it this module would be green for a broken guard.
 """
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -42,6 +41,11 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 # forbidden by `test_runtime_shebangs.py`, because `env` is absent from the nix
 # build sandbox -- so such a stub cannot run in the tier the merge is gated on.
 from testlib.mockbin import write_exec  # noqa: E402
+
+# 🔴 The ONE bound for runner traffic. Importing the harness rather than
+# spawning `bash` here is what keeps this file out of `_OWN_BOUND_LEDGER` —
+# see `_run_scoped` below for why a ledger row would have been the wrong fix.
+from testlib import scoped_harness  # noqa: E402
 
 # Every glob the script declares, as a concrete path a diff could contain.
 # 🔴 Pinned as a LEDGER, two-way: `test_every_declared_trigger_is_exercised`
@@ -76,12 +80,25 @@ def _declared_globs() -> list[str]:
 
 
 def _run_scoped(repo: Path) -> subprocess.CompletedProcess:
-    env = {**os.environ}
     # `--base HEAD` so the comparison is against the fixture's own commit and
     # the result cannot depend on how far the real origin/main has moved.
-    return subprocess.run(
-        ["bash", str(SCOPED), "--base", "HEAD", "--dry-run", str(repo)],
-        capture_output=True, text=True, env=env, cwd=str(repo),
+    #
+    # 🔴 ROUTED THROUGH `scoped_harness.run`, NOT SPAWNED DIRECTLY, and that is
+    # the whole reason this function exists in this shape. The direct
+    # `subprocess.run([...])` it replaced carried NO `timeout=` at all, so
+    # `_spell_bound` scored it `ABSENT` and `test_every_site_writing_its_OWN_
+    # runner_bound_is_in_the_ledger` went red the moment this file landed —
+    # `main` was red on it for hours. The harness supplies `RUNNER_TIMEOUT_S`,
+    # which is the ONE bound for this predicate.
+    #
+    # ⚠ The alternative the guard offers — a `_OWN_BOUND_LEDGER` row — would be
+    # wrong here. A row is for a site that genuinely needs its own bound (or is
+    # the documented non-runner false positive); this is real runner traffic
+    # with no bound, i.e. a suite that can hang forever. A row would have
+    # recorded the hazard instead of removing it.
+    return scoped_harness.run(
+        [str(SCOPED), "--base", "HEAD", "--dry-run", str(repo)],
+        cwd=repo,
     )
 
 


### PR DESCRIPTION
🔴 **`main` is RED at `4e970998`** on `test_runner_bound_ledger.py::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`:

```
scripts/tests/test_scoped_tests_shared_surface.py  [ABSENT] x1
```

`_run_scoped` spawned `bash scripts/scoped-tests.sh` through a direct `subprocess.run([...])` carrying **no `timeout=` at all**, so `_spell_bound` scored it `ABSENT`. The file arrived with `#1532` and reddened the guard on landing.

## Routed, not excused — the guard's two remedies are not equivalent

The failure message offers either *"add a row WITH ITS REASON"* or *"route the call through `testlib.scoped_harness.run()`"*. A `_OWN_BOUND_LEDGER` row is for a site that genuinely needs its **own** bound, or for the single documented non-runner false positive (`test_run_tests_floors.py`, which `sed`s a function out of `run-tests.sh` and runs no suite).

This is neither. It is **real runner traffic with no bound** — a suite that can hang forever. A ledger row would have **recorded** the hazard; the harness **removes** it by supplying `RUNNER_TIMEOUT_S`, which is the one bound for this predicate.

The harness already supplies `capture_output` / `text` / `cwd` identically, and it spawns `["bash", *args]` — the exact shape being replaced — so behaviour is unchanged.

## Verification

| | before | after |
|---|---|---|
| `test_runner_bound_ledger.py` | **1 failed**, 4 passed | **5 passed** |
| `test_scoped_tests_shared_surface.py` | 13 passed | **13 passed** |

🔴 **Positive control** — reverting `_run_scoped` to the unbounded direct spawn puts the guard back to `[ABSENT] x1`, and restoring turns it green again. So this **fixes rather than silences**.

Also drops the now-unused `import os`: the removed `env = {**os.environ}` was a no-op, and the harness inherits the environment when passed none.

## Context

⚠ This is the **second independent red on `main`** found in this session. The first — the kill-mention treadmill, where six docs reddened `main` in two hours and every fix was itself a doc — was closed structurally by `#1561` (not by me; my own attempt became an offender and I closed it as obsolete).

**Both are the same shape: a two-way ledger pin broken by a file that landed without its row.** That is worth noticing as a class, not just as two incidents — these pins are load-bearing and correct, but nothing stops a new file landing red, and `main` carried both for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQx16RMr8YQYBfsXaBEsSm