### PR TITLE
docs(gate-flake): #1568 asserted a count it got wrong and a window that cannot be falsified — plus the retirements it owed

### DIFF
--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -2097,11 +2097,17 @@ covers; pin it with `--config`, do not `cd`.
   those AFTER it** — the same design class in a second ledger, and the live one). Table and
   residuals in `handoff-gate-flake-store-api.md` rank 1.
   The pre-verification wording, kept for the provenance it names:
-- 🔴 **RANK 22 CLOSED-PENDING-VERIFICATION, 2026-09-11.** `#1458` squash **`ce9b55c3`** merged and
-  content-verified; recorded by `#1462` (`60033d1e`) and corrected by `#1525` (`018e483b`). The
-  second flake it uncovered is filed as **`handoff-gate-flake-store-api.md` rank 7** (`#1477`,
-  `50e8a71a`), which also corrects that doc's rank 1. **The verifier is the flake RATE against
-  heads that CARRY `ce9b55c3` — `git merge-base --is-ancestor`, never a date comparison.**
+- ~~**RANK 22 CLOSED-PENDING-VERIFICATION, 2026-09-11.**~~ **SUPERSEDED 2026-09-12 — the
+  verification it asks for HAS BEEN RUN; see the bullet directly above.** Retained only for the
+  provenance shas it uniquely names: `#1458` squash **`ce9b55c3`** merged and content-verified;
+  recorded by `#1462` (`60033d1e`) and corrected by `#1525` (`018e483b`). The second flake it
+  uncovered is filed as **`handoff-gate-flake-store-api.md` rank 7** (`#1477`, `50e8a71a`), which
+  also corrects that doc's rank 1. 🔴 **Its closing sentence — an INSTRUCTION to go run the
+  flake-rate read — is DELETED rather than preserved**, per
+  `claude/skills/handoff/reference/supersede.md`: keeping a corrected *reading* is the point,
+  keeping a corrected *instruction* arms a landmine for whoever greps `rank 22` in a 2,200-line doc
+  and lands on this hit instead of the bullet above. The predicate it stated was correct and
+  survives above — ancestry, never a date.
 - 🔴 **`cairn recall --repo <cairn>` is `scope-absent`; the scope is `devrc`.** The OSS repo has no
   store scope. `cairn search --scope devrc '<term>'` is what surfaced `ci-repro/` and the
   `#1211`/`#1219`/`#1239` history that made rank 22's whole diagnosis possible.

--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -2094,10 +2094,11 @@ covers; pin it with `--config`, do not `cd`.
   worth carrying forward: the gate's remaining red is not a flake.** Deterministic ledger
   censuses over tracked text account for **27 of 99** post-fix verdicts (22 the kill-mention
   ledger, all of them before `#1561` exempted `claudedocs/`; **5 the runner-bound ledger, 4 of
-  those AFTER it** — the same design class in a second ledger, which is the THIRD instance in two
-  days). ⚠ **Both instances are now fixed** (`#1561` `c0bbd6d9`, `#1567` `6f1867b1`); this bullet
-  called the second "the live one" and that was true for about an hour. **The CLASS is what
-  survives: nothing stops a fourth census reddening `main` for everyone.** Table and residuals in
+  those AFTER it** — the same design class in a second ledger, the SECOND instance enumerated). ⚠ **Both instances are now fixed** (`#1561` `c0bbd6d9`, `#1567` `6f1867b1`); this bullet
+  called the second "the live one" and that was true for about an hour. ⚠ **It also called this the
+  THIRD instance while saying "both instances are now fixed" two lines later; only TWO are
+  enumerated anywhere** (rank 1 of the gate-flake doc). **The CLASS is what survives: nothing stops
+  the NEXT census reddening `main` for everyone.** Table and residuals in
   `handoff-gate-flake-store-api.md` rank 1.
   The pre-verification wording, kept for the provenance it names:
 - ~~**RANK 22 CLOSED-PENDING-VERIFICATION, 2026-09-11.**~~ **SUPERSEDED 2026-09-12 — the

--- a/claudedocs/handoff-cairn-oss-multi-instance.md
+++ b/claudedocs/handoff-cairn-oss-multi-instance.md
@@ -2094,8 +2094,11 @@ covers; pin it with `--config`, do not `cd`.
   worth carrying forward: the gate's remaining red is not a flake.** Deterministic ledger
   censuses over tracked text account for **27 of 99** post-fix verdicts (22 the kill-mention
   ledger, all of them before `#1561` exempted `claudedocs/`; **5 the runner-bound ledger, 4 of
-  those AFTER it** — the same design class in a second ledger, and the live one). Table and
-  residuals in `handoff-gate-flake-store-api.md` rank 1.
+  those AFTER it** — the same design class in a second ledger, which is the THIRD instance in two
+  days). ⚠ **Both instances are now fixed** (`#1561` `c0bbd6d9`, `#1567` `6f1867b1`); this bullet
+  called the second "the live one" and that was true for about an hour. **The CLASS is what
+  survives: nothing stops a fourth census reddening `main` for everyone.** Table and residuals in
+  `handoff-gate-flake-store-api.md` rank 1.
   The pre-verification wording, kept for the provenance it names:
 - ~~**RANK 22 CLOSED-PENDING-VERIFICATION, 2026-09-11.**~~ **SUPERSEDED 2026-09-12 — the
   verification it asks for HAS BEEN RUN; see the bullet directly above.** Retained only for the

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -8,11 +8,11 @@ cairn recall --repo ~/workspace/devrc
 reader into the pinned package, so the old spelling now fails with a file-not-found. **It is not
 just this doc: see rank 9 for the population, which is the single place those counts live.** Only
 this doc's invocation is fixed here; fixing one site and implying the rest is the partial-sweep
-failure. ⚠ **This block previously restated the counts and got two of them wrong in the direction
-rank 9 exists to prevent** — `63`/`71` are the BARE-PATH figures, not the *prescribing* ones
-(`61`/`65`), and it listed `5` source files while rank 9, in the same commit, said `6` and named the
-Dockerfile the list had dropped. **Two copies of a count are how one of them becomes wrong; rank 9
-owns them.**
+failure. ⚠ **This block deliberately carries NO counts.** It previously restated them and got two wrong in
+the direction rank 9 exists to prevent — quoting the bare-path figures for *prescribing*, and listing
+five source files where rank 9, in the same commit, said six and named the Dockerfile the list had
+dropped. **A second copy of a count is how one of them becomes wrong, and the fix is to have one
+copy, not two agreeing ones: rank 9 owns these.**
 Terse pointers this doc does not carry, curated by past sessions and outliving it.
 🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
 reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
@@ -30,10 +30,17 @@ number, and the number relocates the problem.** The store-api fsync flake is nam
 `tekton/devrc-pytests` verdicts on heads that CARRY `ce9b55c3` against **12 of 298** that do not
 (P(0) ≈ 0.017), measured by **ancestry**. 🔴 **And what the same read found instead: the gate's
 remaining red is dominated by DETERMINISTIC ledger censuses over tracked text — 27 of 99 post-fix
-verdicts, ~7× this flake at its worst — of which 22 were closed at the source by `#1561` and
-5 are the runner-bound ledger, on which `main` IS RED RIGHT NOW — already owned by `#1567`.**
-That is the new rank 8. Full
-table, controls and residuals in rank 1; claim `gate-flake-store-api-1` was held for the read.
+verdicts, ~7× this flake at its worst — of which 22 were the kill-mention ledger, closed at the
+source by `#1561` (`c0bbd6d9`), and 5 the runner-bound ledger, closed by `#1567` (`6f1867b1`).**
+Both reddened `main` itself; both are fixed, confirmed at `origin/main` `337114e0` (**5 passed** on
+`test_runner_bound_ledger.py`, **1 passed** on the kill guard). 🔴 **The CLASS is not fixed: at least
+two instances in two days, and nothing prevents the next.** That is rank 8 — closed as an instance,
+retained for the class. ⚠ **The 27 / 22 / 5 figures are a READ-TIME population that cannot be
+re-derived** (rank 1 says why); do not treat a later disagreement as a refutation.
+⚠ **This paragraph said `main` IS RED RIGHT NOW for about an hour after `#1567` merged**, while rank
+8 five hundred lines below already said CLOSED — and `State now` is the block a resuming session
+reads first. **Four other sites were swept for that phrasing and this one, the most-read, was
+missed.** Full table, controls and residuals in rank 1; claim `gate-flake-store-api-1` released.
 
 🔴 **THE AUDIT LADDER IS CLOSED — by decision, not by a clean round.** `#1219` and its
 successor `#1239` are both MERGED. The ladder ran **8 rounds on `#1219` + 2 on `#1239`**;
@@ -113,16 +120,24 @@ heads carrying `ce9b55c3` against 12 of 298 that do not, P(0) ≈ 0.017 — and 
 snippet below. It is retained for ONE reason and it is not "use it": its **predicate is a LIMIT, not
 a baseline** — `--limit 40` newest-first with no ancestry test at all, which is the date-shaped
 sampling rank 1 says gives a wrong denominator. The closing reading used ancestry over 400 heads.
-🔴 **AND ITS CLASSIFIER IS BROKEN FOR THE ONE TEST THIS DOC IS ABOUT — an earlier revision of this
-very paragraph praised it, which would have sent someone to re-use it.** The snippet greps status
-DESCRIPTIONS for `subsystem_store_api\|TestTheActor\|TestAHungRoundTrip\|TestTheBackstop`, but a
-description carries `Class.test_name` and **never a filename**, so `subsystem_store_api` cannot fire
-at all. Measured over the 101 failure verdicts rank 1 collected: the 12 store-api rows — rank 1's
-entire pre-window count — are matched **0** times. ⚠ **It is not wired to nothing, and the
-distinction matters:** a positive control over the same 101 rows matches **4** (`TestTheActor…` ×3,
-`TestAHungRoundTrip…` ×1), so the grep works and the *token list* is simply missing
-`TestARefusedWrite…`. **Re-run as written it would return 0 in BOTH arms — a vacuous zero read as
-"the fix worked".** via: measurement
+🔴 **AND ITS CLASSIFIER CANNOT SEE THE ONE TEST THIS DOC IS ABOUT — an earlier revision of this very
+paragraph praised it, which would have sent someone to re-use it.** The snippet greps status
+DESCRIPTIONS for `subsystem_store_api\|TestTheActor\|TestAHungRoundTrip\|TestTheBackstop`. A
+description **never carries a filename**, so `subsystem_store_api` cannot fire at all; and it carries
+a `Class.test_name` only sometimes — over the 101 failure verdicts rank 1 collected, **27 of the 100
+named rows are `Class.test_name` and 73 are a bare `test_…` name**, so a class-keyed token misses a
+test reported bare even when its class is listed.
+🔴 **TWO DIFFERENT POPULATIONS, AND AN EARLIER REVISION OF THIS PARAGRAPH CONFLATED THEM AND
+CONTRADICTED ITSELF.** The **12** rows naming the fsync flake (`TestARefusedWrite…`) — rank 1's entire
+pre-window count — match **0**. The **21** rows naming *any* class that lives in
+`test_subsystem_store_api.py` match **4** (`TestTheActor…` ×3, `TestAHungRoundTrip…` ×1). Calling the
+first set "the store-api rows" while quoting the second as a positive control asserted 0 and 4 about
+the same thing.
+⚠ So the grep is **not** wired to nothing, and **"it returns 0 in both arms" was wrong** — on the
+pre-window it returns **4** and on the post-window **0**, which is worse than a flat zero: it reads
+as a rate that fell to nil while being blind to the only test in question. ⚠ **Adding
+`TestARefusedWrite…` to the token list does not fix it** — that is the fix-direction trap, because
+73 of 100 rows name no class at all. via: measurement
 ⚠ **What is still UNMEASURED is the block's own hypothesis at its second point:** it predicted the
 rate "drops to ~0 where a tmpfs is available, and is **unchanged where the fallback fires**". The
 reading confirms the first half and says nothing about the second — **nothing has measured whether
@@ -148,7 +163,7 @@ zero is a real absence rather than a pattern that never matches anything.
 🔴 **(c) The manifest read is itself unpinned and HAS ALREADY MOVED** — the same defect as the
 verdict census above. Verified exactly at `homelab-talos` **`b2f42ef5`** (2,482 lines, `pytests` 59,
 `emptyDir` 3, all three in comments). `origin/trunk` has since taken `3c53d618` — *"/nix becomes a
-per-run emptyDir"* — and now reads **2,584 lines, `pytests` 62, `emptyDir` 12**, i.e. it added real
+per-run emptyDir"* — and AT `3c53d618` reads **2,584 lines, `emptyDir` 12**, i.e. it added real
 emptyDirs where the control had found only comments. **Re-read both manifests at a named sha; do not
 quote these numbers.**
 ⚠ **And two halves, only the first a reading of this cluster:** "nothing overrides it" is measured;
@@ -382,7 +397,7 @@ Not a bug — a measurement that would mislead if run as written.
    ✅ **That one was neither a flake nor a stale-base echo — `main` ITSELF WAS RED ON IT, and it is
    now FIXED: `#1567` merged `6f1867b1` at 2026-09-12T05:07:06Z.** Red measured at three successive
    tips (`4e970998` **1 failed, 1655 passed**; `8114a124` and `61f41adf` **1 failed, 4 passed**
-   each, that file alone), then **5 passed** at `origin/main` after the merge. It is **rank 8**,
+   each, that file alone), then **5 passed** at `origin/main` `337114e0` after the merge. It is **rank 8**,
    closed. via: measurement
 
    ⚠ **THE GATE'S OWN OBSERVABILITY IS WORSE THAN ITS RED RATE: `error` is 29 of 99 post-window
@@ -497,12 +512,18 @@ Not a bug — a measurement that would mislead if run as written.
    `#1239` (`65f7325b`) both merged and content-verified; ladder ended by decision after 10
    rounds. Five residuals are disclosed in-source and listed under Gotchas. Nothing to do.
    forcing: none — done; retained so the rank numbering stays stable.
-6. **Fix the espanso `:acq`/`:rna` collision — `main` IS RED** — devrc, `nix/home.nix`. Full
-   diagnosis in the Open-investigations block above. Not this effort's change and deliberately
-   not fixed here; it is one snippet's `search_terms`. **Whoever fixes it should run the
-   keylog tests, which are the deterministic check.**
-   forcing: regression — `main` is red on `tekton/devrc-main-pytests` and a real
-   Ctrl+Space search path is broken.
+6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE and `main` is NOT red on it.**
+   Measured at `origin/main` `337114e0` by the criterion this item itself names as the deterministic
+   check: the keylog suite → **104 passed** at `origin/main` `337114e0`. The underlying terms are now disjoint in `nix/home.nix`
+   (`:acq` = ask/clarify/clarifying/questions; `:rna` = recommend/recom/next/actions/rank/leverage).
+   Not fixed by this effort — it was someone else's one-line `search_terms` change; recorded because
+   the item asserted a live red.
+   ⚠ **It carried `forcing: regression — `main` is red` while the test was green, and `forcing:` is
+   the machine-readable field a `claim-work` session sorts on** — so the stale value was not cosmetic,
+   it advertised a gate-forcing regression with nothing to fix behind it. A bash comment 300 lines
+   away telling the reader to re-verify does not undo that. **Retire the `forcing:` in the same edit
+   as the red.**
+   forcing: none — fixed; the diagnosis above is retained as the worked example.
 
 7. **A FIXED 120 s SUBPROCESS BOUND IN A FILE WHOSE WALL TIME IS NOT STABLE —
    `scripts/tests/test_run_tests_targets.py`.** Its tests spawn a nested `run-tests.sh`,
@@ -567,7 +588,7 @@ Not a bug — a measurement that would mislead if run as written.
    mechanical way: `scripts/tests/test_runner_bound_ledger.py` → **5 passed** at `origin/main` after
    the merge, against **1 failed, 4 passed** before it. 🔴 **Kept at full length because the CLASS is
    what matters — it is the class rank 1's measurement found has replaced the flake this doc was
-   written to chase, and it is the third census in this family in two days.**
+   written to chase. At least TWO instances in two days, both enumerated in rank 1 (kill-mention 22, runner-bound 5); no third is enumerated anywhere, so do not write one.**
    Measured 2026-09-12 by running the file directly at `origin/main` `4e970998` in a clean worktree:
    `…::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`
    → **1 failed, 1655 passed in 251.49s**, and re-measured after each of the two times `main` moved
@@ -584,7 +605,7 @@ Not a bug — a measurement that would mislead if run as written.
      `#1524`@03:16:50Z, `#1556`/`#1559`/`#1522`@03:40–03:46Z — plus `#1494`@03:14:37Z.
      via: measurement
    - ✅ **FIXED BY `#1567`** (`fix/scoped-surface-runner-bound`, opened 2026-09-12T03:58:34Z, head
-     `57030bfd`, **merged `6f1867b1` at 05:07:06Z** — 56 minutes later), which had the same diagnosis
+     `57030bfd`, **merged `6f1867b1` at 05:07:06Z** — 1 h 08 m later), which had the same diagnosis
      and took the right arm. 🔴 **The pre-create sweep is what caught this** — the red was measured and filed here
      at the same hour `#1567` was opened, and the lock could not have seen it, because nothing
      was claimed. This is the class `design-claim-by-push.md` lists as NOT covered.
@@ -596,15 +617,15 @@ Not a bug — a measurement that would mislead if run as written.
      to `[ABSENT] x1`. Provenance it also names: the file arrived with `#1532` and reddened the
      guard on landing.
    ✅ **Closing condition MET 2026-09-12:** `#1567` merged (`6f1867b1`) **and**
-   `test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` green on `origin/main` — run, not
-   assumed: **5 passed**. ⚠ **The window from filing to closed was 1 h 10 m, and this item spent
+   `test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` green on `origin/main` `337114e0`
+   — run, not assumed: **5 passed**. ⚠ **The window from filing to closed was 1 h 08 m, and this item spent
    most of it asserting `main` is red "RIGHT NOW" in four places.** That is the same defect class as
    the tip-sha line in `State now`: a present-tense claim about a mutable state, with nothing to
    expire it. **Write the measurement and its timestamp; let the closing condition carry the
    present tense.**
    forcing: none — fixed. It reddened the gate on 5 PR heads and `main` itself; retained because the
    CLASS (a census over tracked text reddening `main` for everyone) is `claude/RULES.md`'s
-   "a permanently-red gate is worse than no gate" and recurred three times in two days.
+   "a permanently-red gate is worse than no gate" and recurred at least twice in two days.
 
 9. ⚠ **`#1508` DELETED `scripts/lib/subsystem_recall.py` AND 61 HANDOFF DOCS STILL PRESCRIBE
    RUNNING IT.** Measured 2026-09-12 at `origin/main` `8114a124`, by `git grep` against the ref
@@ -652,7 +673,14 @@ Not a bug — a measurement that would mislead if run as written.
    git grep -c 'python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py' origin/main \
      -- 'claudedocs/*' ':(exclude)claudedocs/handoff-gate-flake-store-api.md'
    ```
-   sums to **0**. 🔴 **THE EXCLUDE IS LOAD-BEARING AND AN EARLIER VERSION OF THIS CONDITION WAS
+   sums to **0**. ⚠ **READ THAT AS "60 of the 61 docs", NOT "no doc prescribes the dead path".** The
+   exclude buys satisfiability at the cost of coverage, and the excluded file is the very one whose
+   "Run this first" block was the motivating instance — so this condition can read 0 while THIS doc
+   prescribes it. Mechanically confirmed in both directions on a throwaway copy: adding the dead
+   invocation to any OTHER `claudedocs/` file moves it 64 → 65; adding it to this file leaves 64.
+   A narrower exclusion (key on the fenced block rather than the path) would close that; the two
+   surviving occurrences here genuinely must be printed.
+   🔴 **THE EXCLUDE IS LOAD-BEARING AND AN EARLIER VERSION OF THIS CONDITION WAS
    UNSATISFIABLE WITHOUT IT — while asserting, in the same breath, that it was not.** That version
    read *"keyed to the invocation, not the bare path — docs that merely discuss the dead path
    (including this item) must not make the condition unsatisfiable"*, which was false: this item
@@ -835,7 +863,8 @@ git -C $DEVRC show origin/main:scripts/testlib/store_siting.py \
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
   $DEVRC/scripts/tests/test_store_siting_ledger.py -q -p no:cacheprovider
 
-# rank 6's keylog red — NO LONGER RED. Measured 2026-09-12 at origin/main: 104 passed.
+# rank 6's keylog red — NO LONGER RED. Measured 2026-09-12 at origin/main 337114e0: 104 passed.
+#   The sha is the point: an unpinned origin/main reading is the defect rank 1 names.
 #   ⚠ This line read `# 1 failed, 100 passed` with "expected until rank 6 is fixed"; rank 6 itself
 #   still says `main` IS RED on it. Re-verify rank 6 before acting on it — this is the fourth
 #   present-tense red claim in these docs found stale in one session.
@@ -844,10 +873,10 @@ nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
 gh api repos/innovation-upstream/devrc/commits/$(git -C $DEVRC rev-parse origin/main)/status \
   --jq '.statuses[]|"\(.context) \(.state): \(.description[0:100])"'
 #   ⚠ This can show NO completed verdict at all, and that is the NORMAL case, measured at n=100 in
-#   handoff-gate-speed-and-ci-signal.md — its bullet "Only ~21-22 of 100 main commits get an
+#   handoff-gate-speed-and-ci-signal.md — its bullet "Only ~21–22 of 100 `main` commits get an
 #   authoritative verdict". A gate producing no verdict is not a green one: read the state, never
 #   just the absence of a `failure`, and prefer PR heads to main for any rate (that doc's bullet
-#   "main is a useless population for this question"). Quoted by opening words, not line number —
+#   "`main` is a useless population for this question"). Quoted by opening words, not line number —
 #   both targets moved when this PR edited that file.
 
 # rank 8 — CLOSED by #1567 (6f1867b1). This is its closing condition, so expect 5 PASSED.

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -1,9 +1,18 @@
 # Handoff: gate-flake-store-api — 2026-09-01
 
-## Run this first — the index, one read-only command
+## Run this first — the index, one command
 ```bash
-python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo ~/workspace/devrc
+cairn recall --repo ~/workspace/devrc
 ```
+⚠ **This block used to prescribe `python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py`, and
+`#1508` DELETED that file** — the cairn consolidation moved the reader into the pinned package, so
+the old spelling now fails with a file-not-found. 🔴 **It is not just this doc: `63` files under
+`claudedocs/` still prescribe that path (`71` occurrences), plus `5` source comments
+(`scripts/lib/handoff_search.py`, `scripts/tests/test_subsystem_recall.py`,
+`test_repo_path_guard.py`, `test_store_root_ledger.py`, `scripts/present/measure.py` — all PROSE,
+no code path).** Only this doc's occurrence is fixed here; the sweep is filed as rank 9, because
+fixing one site and implying the rest is the partial-sweep failure. Counts measured 2026-09-12 at
+`origin/main` `8114a124`.
 Terse pointers this doc does not carry, curated by past sessions and outliving it.
 🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
 reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
@@ -32,7 +41,15 @@ every round but the last produced findings, and the last was ended deliberately 
 findings had converged on prose accuracy inside a test guard while the effort's actual
 verifier (rank 1) had still never been run.
 
-- devrc `main` @ `65f7325b`. Claim `gate-flake-store-api-5` **RELEASED**.
+- 🔴 **There is deliberately NO "devrc `main` @ \<sha\>" line here any more.** It read `65f7325b` —
+  the `#1239` squash — until 2026-09-12, by which point this doc's own later text had moved past it
+  twice. The replacement was written as `8114a124` and **was stale before it was pushed**: `main`
+  took `#1564` in the interval, which is the second time in one session. **A bare tip sha in a
+  State-now section is a claim that expires on the next merge, and nothing in this repo updates
+  it.** Every sha here is instead pinned to the commit it is ABOUT — `ce9b55c3`, `c0bbd6d9`, and
+  `8114a124`/`4e970998` as named measurement POINTS, never as "the tip". Claims:
+  `gate-flake-store-api-5` **RELEASED**; `gate-flake-store-api-1` released 2026-09-12 once the
+  measurement landed.
 - `#1219` → squash `b4fde334`. `#1234` (doc) → `3d0695c7`. `#1239` → squash **`65f7325b`**.
 - Content-verified on `origin/main`: the gap guard
   `test_a_store_root_bound_in_a_pytest_FIXTURE_is_NOT_counted` is present; the three dead
@@ -89,7 +106,40 @@ Found by accident while doing the tmpfs work. Documented on `main` in
   (`TestAHungRoundTripSAYSWhichSideBlocked`), so they must be re-run, and the fix
   must be shown RED at a `devrc-fsync`-style path before and GREEN after.
 
-### Whether the tmpfs siting actually reduces the flake rate — UNMEASURED
+### CLOSED 2026-09-12 — whether the tmpfs siting reduces the flake rate: MEASURED, and it did
+🔴 **This block's heading read "UNMEASURED" and its "Next probe, verbatim" below told the next
+session to run a probe that HAS NOW BEEN RUN.** Read rank 1 for the reading — 0 of 99 verdicts on
+heads carrying `ce9b55c3` against 12 of 298 that do not, P(0) ≈ 0.017 — and do **not** re-run the
+snippet below. It is retained for two reasons and neither is "use it": its `grep -c` classifier
+names the right test families, and its **predicate is a LIMIT, not a baseline** — `--limit 40`
+newest-first with no ancestry test at all, which is the date-shaped sampling rank 1 says gives a
+wrong denominator. The closing reading used ancestry over 400 heads instead.
+⚠ **What is still UNMEASURED is the block's own hypothesis at its second point:** it predicted the
+rate "drops to ~0 where a tmpfs is available, and is **unchanged where the fallback fires**". The
+reading confirms the first half and says nothing about the second — **nothing has measured whether
+the GATE container has a usable tmpfs**, so a 0 is consistent with both "sited" and "the mechanism
+stopped firing for some other reason". That is rank 1's `[0, 22]` bound's sibling: recorded, not
+closed.
+✅ **The residual is much NARROWER than "it might change nothing in CI", and the narrowing is
+MEASURED on the manifest, not argued from defaults.** `store_siting.py:67` makes the only candidate
+`/dev/shm` and `:221` sets `_MIN_FREE_BYTES = 4 MiB`. The gate pipeline
+(`homelab-talos` `origin/trunk:clusters/homelab/apps/tekton-pipelines/triggers/devrc-ci-pipeline.yaml`,
+2,482 lines) contains **0 occurrences of `shm` and 0 of `medium:`** — positive controls on the same
+read: `pytests` 59, `emptyDir` 3, all three in comments — so **nothing overrides `/dev/shm` for the
+`pytests` step** and it gets the container runtime's default. ⚠ **Two halves, and only the first is
+a reading of this cluster:** "nothing in the manifest overrides it" is measured; "therefore 64 MiB"
+is the *containerd/Docker* default that `store_siting.py`'s own docstring cites, and **no node on
+this cluster was read for it** — a runtime or node setting can change it. Against a 4 MiB floor the
+check passes by 16× if that default holds, so the fallback needs `/dev/shm` **absent, read-only, or
+already ~94% consumed** — and the last of those is the concurrent-writer case the docstring already
+says cannot be closed from in-process. **What stays owed is one reading of a real gate container**;
+`kubectl` cannot take it after the fact (gate pods are ephemeral, pipelineruns pruned hourly), so
+the other surface is a `store:` path in any FUTURE store-api failure log — `devrc-store-*` = sited,
+`pytest-of-*` = fell back.
+
+The original block, unchanged below.
+
+#### Whether the tmpfs siting actually reduces the flake rate — as written before the measurement
 - **Symptom + exact repro:** none yet; this is an open measurement, not a bug.
 - **Observed (with values):** disk vs tmpfs, replaying `_replace_bytes`'s sequence
   (mkstemp → write → fsync file → `os.replace` → fsync dir), MAX reported because
@@ -268,7 +318,7 @@ Not a bug — a measurement that would mislead if run as written.
    🔴 **EVERY PER-TEST COUNT HERE IS A LOWER BOUND, AND THAT IS ALREADY MEASURED IN-REPO —
    do not upgrade the 0 into "it did not fail".** A GitHub status description is capped at 140
    characters; **100 of the 101 failure descriptions in this population are 138 characters, i.e.
-   truncated**, and `scripts/main-status-watch.py:236-239` records the measurement that matters: a
+   truncated**, and `scripts/main-status-watch.py:232-239` records the measurement that matters: a
    row described `failed=7` while naming ONE test, a row named none, and the row that named
    *this* flake was cut mid-word at `…_CAN_see_the_dif`. A description can prove "at least one
    test failed and here is its name"; it can never prove "these are all of them".
@@ -298,24 +348,53 @@ Not a bug — a measurement that would mislead if run as written.
    `scripts/tests/test_runner_bound_ledger.py`, and **4 of those POSTDATE `c0bbd6d9`**
    (03:16:50Z–03:46:19Z): the same design class, in a second ledger `#1561` does not cover.
    🔴 **That one is neither a flake nor a stale-base echo — `main` ITSELF IS RED ON IT**, run
-   directly at `origin/main` `4e970998` in a clean worktree: **1 failed, 1655 passed in 251s**,
+   directly at `origin/main` in a clean worktree at THREE successive tips — `4e970998` (**1 failed,
+   1655 passed**), `8114a124` and `61f41adf` (**1 failed, 4 passed** each, that file alone) —
    the only diff being two `claudedocs/` files these scanners do not read. It is **rank 8**.
    via: measurement
 
-   ⚠ **AND THE GATE'S OWN OBSERVABILITY IS WORSE THAN ITS RED RATE — noticed here, not
-   diagnosed.** `error` is **29 of 99** post-window verdicts (29%) against 41 of 298 (14%)
-   pre, and `main`'s last **8** commits carry **no completed `tekton/devrc-main-pytests`
-   verdict at all**: six `superseded by a newer run or a closed pull request`, two
-   `NO GATE POD: … the gate never started`, newest pending. A gate producing no verdict is not
-   a green one, and a rate computed over verdicts cannot see the runs that never reported.
+   ⚠ **THE GATE'S OWN OBSERVABILITY IS WORSE THAN ITS RED RATE: `error` is 29 of 99 post-window
+   verdicts (29%) against 41 of 298 (14%) pre. A gate producing no verdict is not a green one, and
+   a rate computed over verdicts cannot see the runs that never reported.**
+   🔴 **THIS IS NOT A NEW OBSERVATION AND THIS DOC SHOULD NOT RE-MEASURE IT — it is
+   `handoff-gate-speed-and-ci-signal.md`'s, at a larger sample and with the decomposition:**
+   *"Only ~21–22 of 100 `main` commits get an authoritative verdict (59.5% superseded, 15%
+   KILLED, 5% NO GATE POD)"* (`:54`), and split on this very fix, *"Of 43 post-fix pytests
+   verdicts on `main`, **40 were artefacts** … leaving **3** authoritative successes. Use PR
+   heads."* (`:363`). **Read those, not a count taken here.** The four artefact strings
+   (`NO CAPACITY` / `NO GATE POD` / `KILLED` / `BROKEN GATE`) are a SHIPPED mechanism, not
+   undiagnosed noise — `handoff-cairn-task-linkage.md:37`; they make the loss legible rather
+   than recovering it.
+   ⚠ **A paragraph here previously reported `main`'s "last 8 commits" with its own breakdown, and
+   it was wrong twice over — the count (`six superseded`; it was FOUR, plus one `KILLED` and one
+   pending, re-derived over the named range `457a5dc7~1..8114a124`) and the FRAME. "The last N
+   commits" is a moving window: `main` took two commits between writing it and checking it, so
+   the sentence was unfalsifiable by construction. Name a sha range or do not quote a window.**
 
    **What this does NOT close:** nothing here was measured on the OSS copy
    (`ZacxDev/cairn`'s identical 18-open-coded / 5-sited split), and the `[0, 22]` bound above is
    the residual this instrument cannot narrow — the pipelineruns that could have are pruned.
-   Kept at rank 1 only until someone re-words it as the census item it has become.
+   ⚠ **And the item's own placement is now wrong, stated plainly rather than left as a mood:** a
+   store-api fsync flake measured at 0 is no longer this doc's Goal, and ranks 8 and 9 are not
+   either — they are "what is CI's signal worth", which `handoff-gate-speed-and-ci-signal.md`
+   owns and already tracks (`:28-33` the census family, `:115-130` the 140-byte cap). **Moving
+   them is a doc-surgery task with a real closing condition** — the three items live in ONE doc
+   with `forcing:` lines intact and nothing cross-referencing them twice — and it is not done
+   here. Rank numbering stays stable regardless; claims are keyed to it.
 
-   — superseded text, kept because its caveat is still true of any FUTURE baseline: the old
-   baseline (5 store-api failures among 14 open PRs, 2026-09-01) is **not comparable**; it was
+   🔴 **THE PRESCRIPTIVE HALF OF THIS ITEM NOW LIVES IN `## How to verify`, NOT HERE.** The
+   runnable form — anchor, ancestry predicate, the three positive-control PRs — is one block, at
+   the bottom of this doc. What follows below is kept as PROVENANCE (why the anchor is
+   `ce9b55c3` and not `65f7325b`, and why a date filter is wrong), not as instructions: the
+   measurement has been taken, so read it as the record of a decision rather than a recipe.
+   Duplicating a recipe is what `claude/RULES.md` calls one rule in two places.
+
+   — superseded text. ⚠ **Its stated justification did NOT survive re-reading and is corrected
+   here:** this was kept as "a caveat still true of any FUTURE baseline", but it is a warning about
+   one specific PAST baseline, and rank 1's reading now supplies its own pre-window baseline
+   (12/298), so the 2026-09-01 figure is no longer anything's comparison point. The NUMBER is kept
+   because `supersede.md` says values age well; the claim about its scope is withdrawn. The old
+   baseline (5 store-api failures among 14 open PRs, 2026-09-01) was **not comparable** — it was
    measured against a partially-sited suite.
    🔴 **THE ANCHOR MOVED AGAIN — `65f7325b` IS NO LONGER THE LAST INTERVENTION.** `#1458`
    (squash **`ce9b55c3`**, 2026-09-10) found that `#1211`/`#1219`/`#1239` sited **5** store
@@ -338,9 +417,15 @@ Not a bug — a measurement that would mislead if run as written.
    rate that counts reds without classifying them will read rank 7's flake as this one failing
    to close. **Classify by the failing TEST before counting.** ⚠ Do **not** read that as "and
    the causes are unrelated" — rank 7 records why that is unestablished.
-   forcing: gate — a check has been failing PRs whose diff cannot reach it. ⚠ **Advisory, not
-   required: measured 2026-09-10 and re-measured 2026-09-11 — `main` has no required status
-   checks, no rulesets, `enforce_admins: false`.** See this doc's Gotchas for the qualifiers
+   forcing: **none — done.** ⚠ **This read `forcing: gate — a check has been failing PRs whose diff
+   cannot reach it` until 2026-09-12, and rank 1's OWN payload disproves it for this flake: 0 of 99.
+   A forcing function that survives the measurement retiring it keeps the item at position 1 of a
+   ranked list and is exactly how a finished item attracts a session.** The forcing claim did not
+   vanish, it MOVED — it is now rank 8's (`main` red on the runner-bound census) and rank 9's, both
+   below. Retained, unrenumbered, so live `claim-work` refs keep resolving — see rank 5's precedent.
+   ⚠ **And the advisory qualifier still applies to every gate item here, so it is kept:** measured
+   2026-09-10 and re-measured 2026-09-11 — `main` has no required status
+   checks, no rulesets, `enforce_admins: false`. See this doc's Gotchas for the qualifiers
    (the state is deliberate and is not yours to restore). 🔴 **`claude/skills/tekton/SKILL.md`
    says the OPPOSITE** — "requires both", "`enforce_admins: true`" — and is STALE; an earlier
    draft of this line cited it as corroboration. Re-read the setting live; cite no doc for it.
@@ -432,7 +517,10 @@ Not a bug — a measurement that would mislead if run as written.
    1's measurement found has replaced the flake it was written to chase.** Measured 2026-09-12
    by running the file directly at `origin/main` `4e970998` in a clean worktree:
    `scripts/tests/test_runner_bound_ledger.py::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`
-   → **1 failed, 1655 passed in 251.49s**, on the `new` arm:
+   → **1 failed, 1655 passed in 251.49s**, and re-measured after each of the two times `main` moved
+   under this work — `8114a124` (**1 failed, 4 passed in 19.56s**) and `61f41adf` (**1 failed, 4
+   passed in 17.57s**), that file alone — so the red is a property of the tree across THREE points,
+   not of one run. On the `new` arm:
    `{('scripts/tests/test_scoped_tests_shared_surface.py', 'ABSENT'): 1}`. That file spawns a
    runner with **no bound of its own** and has no `_OWN_BOUND_LEDGER` row, so the two-way seam
    ledger fires exactly as designed. **Not a flake, not a stale-base echo** — the control is that
@@ -459,6 +547,50 @@ Not a bug — a measurement that would mislead if run as written.
    mechanically checkable by running that one file. Checked by whoever next reads this doc.
    forcing: regression — `main` is red, and `claude/RULES.md`'s "a permanently-red gate is worse
    than no gate" applies to the third census in this family in two days.
+
+9. ⚠ **`#1508` DELETED `scripts/lib/subsystem_recall.py` AND 61 HANDOFF DOCS STILL PRESCRIBE
+   RUNNING IT.** Measured 2026-09-12 at `origin/main` `8114a124`, by `git grep` against the ref
+   rather than a working tree: the **command** spelling
+   `python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py` appears **65** times in **61** files
+   under `claudedocs/` — each a "Run this first" block that now fails file-not-found. (The bare
+   PATH appears 71 times in 63 files; the extra 6 are prose about the path, not invocations, which
+   is why the closing condition below is keyed to the command form.) The replacement is
+   `cairn recall --repo <path>`. Positive control on the same read: `cairn recall` already appears
+   54 times in `claudedocs/`, so the corrected spelling is in use and the grep can see it.
+   via: measurement
+   - ✅ **No code path is broken — all 6 source-file references are comments or docstrings**:
+     `scripts/lib/handoff_search.py`, `scripts/present/measure.py`,
+     `scripts/tests/test_subsystem_recall.py`, `scripts/tests/test_repo_path_guard.py`,
+     `scripts/tests/test_store_root_ledger.py`, and `scripts/subsystem-store-api/Dockerfile` —
+     whose `:36` is **already correct** (*"there is nothing at `scripts/lib/subsystem_recall.py` to
+     COPY"*) and whose `COPY` at `:61` takes a vendored `.cairn-lib/` copy. ⚠ **An earlier count
+     here said 5 and missed the Dockerfile**, because the sweep was an extension-filtered `find`
+     rather than a `git grep` over the ref. Enumerate from the ref.
+   - 🔴 **THIS IS NOT NEW — the index has carried it as an `OPEN:` bullet since 2026-09-01, and
+     that bullet names this exact remedy.** `cairn recall --ref subsystem-store-api --scope devrc`,
+     the `2026-09-01: OPEN:` bullet *"THE CUTOVER LEFT TWO STORES AND `/resume` READS THE DEAD
+     ONE"*, whose third listed fix is *"rewrite the prescribed command in the
+     `resume`/`subsystem-index` skills and both handoff docs to `cairn recall`"*. **Read that
+     bullet before working this** — it also records the frozen-mirror half, which this item does
+     not, and it is the older object. What this rank adds is only the POPULATION (65 invocations /
+     61 files, re-counted at `8114a124`) and the fact that `#1508` has since made the command fail
+     outright rather than merely read a stale store. ⚠ **Found by `cairn recall` at resume time,
+     not by searching** — the recall surface answered a question this doc had not asked.
+   - **Found while editing one of those docs, not by looking for it.** Only
+     `handoff-gate-flake-store-api.md`'s own invocation is fixed (in the PR that filed this); the
+     other 64 are untouched, deliberately — a one-site fix that reads as a sweep is the failure
+     `claude/RULES.md` names under "one rule, one place".
+   - ⚠ **Same CLASS as `handoff-cairn-oss-multi-instance.md` rank 23 (stale spellings the
+     consolidation left behind), DIFFERENT population** — rank 23 is `subsystem_touch.py
+     --validate` under `claude/skills/`; this is `subsystem_recall.py` under `claudedocs/`. Do not
+     close either by the other's grep.
+   - 🔴 **A doc's "Run this first" line is the one command a resuming session runs before anything
+     else**, so this fails at the moment it is least expected and reads as a broken environment.
+   **Closing condition:** `git grep -c 'python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py'
+   origin/main -- 'claudedocs/*'` sums to **0**. Keyed to the invocation, not the bare path —
+   docs that merely *discuss* the dead path (including this item) must not make the condition
+   unsatisfiable. Mechanical; checked by running that grep.
+   forcing: none — nothing is broken at runtime; it wastes a session's first command.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **A CHANGE THAT COULD SILENTLY DO NOTHING NEEDS A TEST THAT FAILS WHEN IT DOES
@@ -637,9 +769,10 @@ nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
   $DEVRC/scripts/collector/keylog/tests -q -p no:cacheprovider    # 1 failed, 100 passed
 gh api repos/innovation-upstream/devrc/commits/$(git -C $DEVRC rev-parse origin/main)/status \
   --jq '.statuses[]|"\(.context) \(.state): \(.description[0:100])"'
-#   ⚠ This can show NO completed verdict at all: on 2026-09-12 main's last 8 commits carried
-#   six `superseded by a newer run…` and two `NO GATE POD`. A gate producing no verdict is
-#   not a green one — read the state, never just the absence of a `failure`.
+#   ⚠ This can show NO completed verdict at all, and that is the NORMAL case, measured at n=100
+#   in handoff-gate-speed-and-ci-signal.md:54 (~21-22 of 100 main commits get an authoritative
+#   verdict). A gate producing no verdict is not a green one — read the state, never just the
+#   absence of a `failure`, and prefer PR heads to main for any rate (that doc's :363).
 
 # rank 8 — main's CURRENT own red, and the reproduction is one file (expect 1 failed)
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -286,13 +286,27 @@ Not a bug — a measurement that would mislead if run as written.
 - **Next probe:** re-run the date comparison above; when most heads postdate `b4fde334`, run the
   probe from the doc's earlier block and **record the new baseline date beside the count**.
 
-### 🔴 `main` IS RED, and it is NOT this effort's doing — espanso `:acq` shadows `:rna`
-- **Symptom + exact repro:** `scripts/collector/keylog/tests/test_espanso_detect.py:929`,
-  `test_live_existing_resolutions_not_made_ambiguous`, fails on **plain `origin/main`**:
+### CLOSED 2026-09-12 — espanso `:acq` shadowed `:rna`; the terms are disjoint and nothing is red
+🔴 **THIS BLOCK READ "`main` IS RED" IN THE PRESENT TENSE, WITH A "Next probe, verbatim" TELLING THE
+NEXT SESSION TO GO FIX IT — 220 lines above the rank 6 that the SAME COMMIT marked CLOSED.** It is
+the second time in this one PR that a rank was retired and its Open-investigations block left
+live (round 2 caught the first, on rank 8). **When you close a rank, grep the doc for its subject;
+the ranked list is not the only place it is asserted.** Status: see rank 6 — evidence is a direct
+read of `nix/home.nix`, NOT the suite cited below.
+⚠ **TWO THINGS IN THIS BLOCK ARE NOW WRONG AND ARE KEPT ONLY AS THE WORKED EXAMPLE.**
+(a) The repro's stated expectation `# 1 failed, 100 passed` is **104 passed** today.
+(b) 🔴 **The test it names does not exist** — `test_live_existing_resolutions_not_made_ambiguous`
+was deleted by `#1265` (`68d10b19`, *"drop the 10 live-config guards"*), and `:929` is now an
+unrelated docstring line. **The suite named here is structurally blind to `nix/home.nix`: deleting
+that file outright still gives 104 passed.** So this repro could never have re-confirmed the
+collision, and the eliminations below are about the RULE, not the live config.
+- **Symptom + the repro AS IT WAS WRITTEN (do not run it — see above):**
+  `scripts/collector/keylog/tests/test_espanso_detect.py:929`,
+  `test_live_existing_resolutions_not_made_ambiguous`, was said to fail on plain `origin/main`:
   ```bash
   git -C $DEVRC worktree add --detach /tmp/ctl origin/main
   nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
-    /tmp/ctl/scripts/collector/keylog/tests -q -p no:cacheprovider   # 1 failed, 100 passed
+    /tmp/ctl/scripts/collector/keylog/tests -q -p no:cacheprovider   # CLAIMED 1 failed, 100 passed
   ```
 - **Observed (with values):** `AssertionError: search terms regressed (term -> (expected,
   actual, matching snippets)): {'recom': (':rna', None, [':acq', ':rna']), 'recommend':
@@ -311,11 +325,12 @@ Not a bug — a measurement that would mislead if run as written.
   and the control on plain `main` fails identically. via: measurement
 - **Ruled out:** *"a load flake"* — it fails in 0.22s, deterministically, with a value-bearing
   assertion naming the colliding snippets. via: measurement
-- **Leading hypothesis:** `:acq`'s `search_terms` need narrowing so they stop matching
-  `recom`/`recommend`, OR `:rna`'s need a disambiguating term. The fix is in `nix/home.nix`,
-  and it belongs to whoever added `:acq`.
-- **Next probe, verbatim:** `git -C $DEVRC show a720d30d -- nix/home.nix` to read the added
-  snippet, then decide which side's `search_terms` move.
+- **Leading hypothesis — CONFIRMED AND ACTED ON BY SOMEONE ELSE:** `:acq`'s `search_terms` needed
+  narrowing so they stop matching `recom`/`recommend`. That is what shipped; `:acq` is now
+  `ask clarify clarifying questions` and no longer contains either term.
+- **Next probe: NONE.** ⚠ The probe here was *"`git -C $DEVRC show a720d30d -- nix/home.nix`, then
+  decide which side's `search_terms` move"* — that decision has been made and merged. **Read
+  `nix/home.nix:419`/`:431` if you want to confirm it; do not re-open the question.**
 
 ## Next steps (ranked)
 🔴 Numbering is STABLE — `claim-work --slug-for <this doc> <rank>` derives from it.
@@ -512,17 +527,31 @@ Not a bug — a measurement that would mislead if run as written.
    `#1239` (`65f7325b`) both merged and content-verified; ladder ended by decision after 10
    rounds. Five residuals are disclosed in-source and listed under Gotchas. Nothing to do.
    forcing: none — done; retained so the rank numbering stays stable.
-6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE and `main` is NOT red on it.**
-   Measured at `origin/main` `337114e0` by the criterion this item itself names as the deterministic
-   check: the keylog suite → **104 passed** at `origin/main` `337114e0`. The underlying terms are now disjoint in `nix/home.nix`
-   (`:acq` = ask/clarify/clarifying/questions; `:rna` = recommend/recom/next/actions/rank/leverage).
-   Not fixed by this effort — it was someone else's one-line `search_terms` change; recorded because
-   the item asserted a live red.
-   ⚠ **It carried `forcing: regression — `main` is red` while the test was green, and `forcing:` is
-   the machine-readable field a `claim-work` session sorts on** — so the stale value was not cosmetic,
-   it advertised a gate-forcing regression with nothing to fix behind it. A bash comment 300 lines
-   away telling the reader to re-verify does not undo that. **Retire the `forcing:` in the same edit
-   as the red.**
+6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE.** Evidence is a DIRECT READ
+   of the live config at `origin/main` `337114e0`: `nix/home.nix:419` `:acq` =
+   `ask clarify clarifying questions`, `:431` `:rna` = `recommend recom next actions rank leverage`
+   — **disjoint**. Not fixed by this effort; it was someone else's one-line `search_terms` change,
+   recorded because the item asserted a live red.
+   🔴 **AN EARLIER REVISION OF THIS CLOSURE NAMED THE KEYLOG SUITE AS "THE DETERMINISTIC CHECK", AND
+   THAT SUITE CANNOT SEE `nix/home.nix` AT ALL — a vacuous green used as a closing condition, which
+   is the exact failure this doc exists to catch.** Controls, run on a `cp -a` copy with its `.git`
+   removed first: re-introducing the collision in full → **104 passed**; **deleting `nix/home.nix`
+   outright → 104 passed**. The suite tests the RULE against hand-copied fixtures, not the live file.
+   ⚠ **And it is blind BY DECISION, which is the part worth carrying:** `#1265` (`68d10b19`) *"drop
+   the 10 live-config guards — they re-break on every snippet edit"*. So there is **no automated
+   check on this interface**, and the next `search_terms` collision lands with the suite green.
+   **Read the config; do not run the suite and believe it.**
+   ✅ **THE OTHER CLOSING CONDITIONS IN THIS DOC WERE SWEPT FOR THE SAME DEFECT — one instance, not a
+   pattern.** Rank 7's already does it right and says so (*"Verify with the detector's own positive
+   control, not an absence … a rename, skip or deselect satisfies it with nothing fixed"*); rank 8's
+   was run rather than assumed; rank 9's was mechanically exercised in both directions. **Rank 6 was
+   the only one resting on an instrument that cannot observe its subject.** Swept because a defect
+   found at one site is a hypothesis about the others — not because a second was expected.
+   ⚠ **It also carried `forcing: regression — `main` is red` after the red was gone, and `forcing:`
+   is the machine-readable field a `claim-work` session sorts on** — so the stale value was not
+   cosmetic, it advertised a gate-forcing regression with nothing behind it. **Retire the `forcing:`
+   in the same edit as the red**, and do not delegate the correction to a comment elsewhere in the
+   file: one was left 300 lines below and went on contradicting this item for a further round.
    forcing: none — fixed; the diagnosis above is retained as the worked example.
 
 7. **A FIXED 120 s SUBPROCESS BOUND IN A FILE WHOSE WALL TIME IS NOT STABLE —
@@ -585,8 +614,8 @@ Not a bug — a measurement that would mislead if run as written.
 
 8. ✅ **CLOSED 2026-09-12 — `main` WAS RED, DETERMINISTICALLY, ON THE RUNNER-BOUND LEDGER, AND
    `#1567` FIXED IT (`6f1867b1`, merged 05:07:06Z).** Closing condition met and checked the
-   mechanical way: `scripts/tests/test_runner_bound_ledger.py` → **5 passed** at `origin/main` after
-   the merge, against **1 failed, 4 passed** before it. 🔴 **Kept at full length because the CLASS is
+   mechanical way: `scripts/tests/test_runner_bound_ledger.py` → **5 passed** at `origin/main`
+   `337114e0`, against **1 failed, 4 passed** at `61f41adf` before the merge. 🔴 **Kept at full length because the CLASS is
    what matters — it is the class rank 1's measurement found has replaced the flake this doc was
    written to chase. At least TWO instances in two days, both enumerated in rank 1 (kill-mention 22, runner-bound 5); no third is enumerated anywhere, so do not write one.**
    Measured 2026-09-12 by running the file directly at `origin/main` `4e970998` in a clean worktree:
@@ -618,7 +647,7 @@ Not a bug — a measurement that would mislead if run as written.
      guard on landing.
    ✅ **Closing condition MET 2026-09-12:** `#1567` merged (`6f1867b1`) **and**
    `test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` green on `origin/main` `337114e0`
-   — run, not assumed: **5 passed**. ⚠ **The window from filing to closed was 1 h 08 m, and this item spent
+   — run, not assumed: **5 passed**. ⚠ **The window from filing to closed was 57 m (rank 8 filed in `029e801c`, authored 04:10:02Z; `#1567` merged 05:07:06Z), and this item spent
    most of it asserting `main` is red "RIGHT NOW" in four places.** That is the same defect class as
    the tip-sha line in `State now`: a present-tense claim about a mutable state, with nothing to
    expire it. **Write the measurement and its timestamp; let the closing condition carry the
@@ -865,9 +894,10 @@ nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
 
 # rank 6's keylog red — NO LONGER RED. Measured 2026-09-12 at origin/main 337114e0: 104 passed.
 #   The sha is the point: an unpinned origin/main reading is the defect rank 1 names.
-#   ⚠ This line read `# 1 failed, 100 passed` with "expected until rank 6 is fixed"; rank 6 itself
-#   still says `main` IS RED on it. Re-verify rank 6 before acting on it — this is the fourth
-#   present-tense red claim in these docs found stale in one session.
+#   ⚠ This line read `# 1 failed, 100 passed` with "expected until rank 6 is fixed". Rank 6 is now
+#   CLOSED and so is its Open-investigations block — both were left asserting a live red for a
+#   round after the red was gone. 🔴 And this suite CANNOT see nix/home.nix: deleting that file
+#   outright still gives 104 passed, so do not read a green here as evidence about espanso.
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
   $DEVRC/scripts/collector/keylog/tests -q -p no:cacheprovider    # expect 104 passed
 gh api repos/innovation-upstream/devrc/commits/$(git -C $DEVRC rev-parse origin/main)/status \
@@ -881,7 +911,7 @@ gh api repos/innovation-upstream/devrc/commits/$(git -C $DEVRC rev-parse origin/
 
 # rank 8 — CLOSED by #1567 (6f1867b1). This is its closing condition, so expect 5 PASSED.
 #   A `1 failed` here means the census has regressed, NOT that the recipe is stale.
-#   ⚠ This line said `expect 1 failed` for the 70 minutes rank 8 was open, which would have read
+#   ⚠ This line said `expect 1 failed` for the 57 minutes rank 8 was open, which would have read
 #   as a broken recipe the moment it was fixed. A verify-block expectation must track the
 #   closing condition, not the state at the time of writing.
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -288,16 +288,26 @@ Not a bug — a measurement that would mislead if run as written.
 
 ### CLOSED 2026-09-12 — espanso `:acq` shadowed `:rna`; the terms are disjoint and nothing is red
 🔴 **THIS BLOCK READ "`main` IS RED" IN THE PRESENT TENSE, WITH A "Next probe, verbatim" TELLING THE
-NEXT SESSION TO GO FIX IT — 220 lines above the rank 6 that the SAME COMMIT marked CLOSED.** It is
-the second time in this one PR that a rank was retired and its Open-investigations block left
-live (round 2 caught the first, on rank 8). **When you close a rank, grep the doc for its subject;
-the ranked list is not the only place it is asserted.** Status: see rank 6 — evidence is a direct
-read of `nix/home.nix`, NOT the suite cited below.
-⚠ **TWO THINGS IN THIS BLOCK ARE NOW WRONG AND ARE KEPT ONLY AS THE WORKED EXAMPLE.**
+NEXT SESSION TO GO FIX IT — 226 lines above the rank 6 that the SAME COMMIT marked CLOSED.** It is
+the second time in this one PR that a rank was retired and a live claim about it left standing
+elsewhere in the doc (round 2 caught the first, in `State now`). **When you close a rank, grep the
+doc for its subject; the ranked list is not the only place it is asserted.** Status and the correct
+evidence: **rank 6** — the discriminating field is `:acq`'s **`label`**, not its `search_terms`, and
+not the suite cited below.
+⚠ **FOUR THINGS IN THIS BLOCK ARE WRONG; IT IS KEPT ONLY AS THE WORKED EXAMPLE. An earlier revision
+said "TWO" and enumerated two — a closed count that was short, which is the defect this doc keeps
+finding.**
 (a) The repro's stated expectation `# 1 failed, 100 passed` is **104 passed** today.
 (b) 🔴 **The test it names does not exist** — `test_live_existing_resolutions_not_made_ambiguous`
-was deleted by `#1265` (`68d10b19`, *"drop the 10 live-config guards"*), and `:929` is now an
-unrelated docstring line. **The suite named here is structurally blind to `nix/home.nix`: deleting
+was deleted by `#1265` (`68d10b19`, *"drop the 10 live-config guards"*), and nothing sits at `:929`
+that relates to it.
+(c) 🔴 **"both `recom` and `recommend` now resolve to NOTHING" is NOT REACHABLE on today's code.**
+Driving the real `EspansoDetector._attribute` against configs rebuilt from the actual `nix/home.nix`
+lines: green tree → `recom` resolves to `:rna`; **the RED-shaped config also resolves to `:rna`**,
+because `_attribute`'s declared-interface precedence now decides it. Only a genuine *declared*
+`search_terms` collision still yields `None`.
+(d) 🔴 **"This is a REAL user-facing regression" therefore describes no state the current code can
+produce.** The label-shadowing class is closed in code, not merely in the config. **The suite named here is structurally blind to `nix/home.nix`: deleting
 that file outright still gives 104 passed.** So this repro could never have re-confirmed the
 collision, and the eliminations below are about the RULE, not the live config.
 - **Symptom + the repro AS IT WAS WRITTEN (do not run it — see above):**
@@ -312,9 +322,12 @@ collision, and the eliminations below are about the RULE, not the live config.
   actual, matching snippets)): {'recom': (':rna', None, [':acq', ':rna']), 'recommend':
   (':rna', None, [':acq', ':rna'])}`. A new `:acq` snippet's search terms collide with
   `:rna`, so both `recom` and `recommend` now resolve to **nothing** instead of `:rna`.
+  ⚠ **NOT REACHABLE on today's code — see (c) in the header.** Measured against the real
+  `_attribute`: the red-shaped config resolves `recom` to `:rna` anyway.
   Introduced by `a720d30d` (`espanso`) touching `nix/home.nix` — a bare commit straight to
   `main`, no PR.
-- 🔴 **This is a REAL user-facing regression, not a test being fussy.** The espanso audit
+- ~~🔴 **This is a REAL user-facing regression, not a test being fussy.**~~ **WITHDRAWN — see (d).**
+  The espanso audit
   established Zach fires ~100% via Ctrl+Space SEARCH, so `search_terms` ARE the interface:
   typing "recommend" used to reach `:rna` and now reaches an ambiguous set.
 - **Confirmed three independent ways:** the merged-tree `gate.sh` run; a control run on
@@ -325,12 +338,18 @@ collision, and the eliminations below are about the RULE, not the live config.
   and the control on plain `main` fails identically. via: measurement
 - **Ruled out:** *"a load flake"* — it fails in 0.22s, deterministically, with a value-bearing
   assertion naming the colliding snippets. via: measurement
-- **Leading hypothesis — CONFIRMED AND ACTED ON BY SOMEONE ELSE:** `:acq`'s `search_terms` needed
-  narrowing so they stop matching `recom`/`recommend`. That is what shipped; `:acq` is now
-  `ask clarify clarifying questions` and no longer contains either term.
+- 🔴 **Leading hypothesis — REFUTED IN BOTH ARMS; the fix was a third option outside the fork.** It
+  read: narrow `:acq`'s `search_terms`, OR give `:rna`'s a disambiguator. **Neither happened.**
+  `:acq`'s `search_terms` are `["ask" "clarify" "clarifying" "questions"]` on `a720d30d`,
+  `a451abc0^`, `a451abc0` and `337114e0` — byte-identical across the red trees AND the green one, and
+  they never contained `recom`/`recommend`. What shipped (`a451abc0`) moved the offending phrase out
+  of `:acq`'s **`label`** and into its `replace`, which `_token_matches` does not read.
+  ⚠ **An earlier revision of this line said CONFIRMED.** The conclusion came true; the hypothesis was
+  wrong. **Do not mark a hypothesis confirmed from its outcome.** via: measurement
 - **Next probe: NONE.** ⚠ The probe here was *"`git -C $DEVRC show a720d30d -- nix/home.nix`, then
-  decide which side's `search_terms` move"* — that decision has been made and merged. **Read
-  `nix/home.nix:419`/`:431` if you want to confirm it; do not re-open the question.**
+  decide which side's `search_terms` move"* — and it would have answered nothing, because the
+  `search_terms` are the same on both sides. 🔴 **If you confirm anything, read `:acq`'s `label`**
+  (`nix/home.nix:419`) — that is the field that moved. Do not re-open the question.
 
 ## Next steps (ranked)
 🔴 Numbering is STABLE — `claim-work --slug-for <this doc> <rank>` derives from it.
@@ -527,26 +546,48 @@ collision, and the eliminations below are about the RULE, not the live config.
    `#1239` (`65f7325b`) both merged and content-verified; ladder ended by decision after 10
    rounds. Five residuals are disclosed in-source and listed under Gotchas. Nothing to do.
    forcing: none — done; retained so the rank numbering stays stable.
-6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE.** Evidence is a DIRECT READ
-   of the live config at `origin/main` `337114e0`: `nix/home.nix:419` `:acq` =
-   `ask clarify clarifying questions`, `:431` `:rna` = `recommend recom next actions rank leverage`
-   — **disjoint**. Not fixed by this effort; it was someone else's one-line `search_terms` change,
-   recorded because the item asserted a live red.
-   🔴 **AN EARLIER REVISION OF THIS CLOSURE NAMED THE KEYLOG SUITE AS "THE DETERMINISTIC CHECK", AND
-   THAT SUITE CANNOT SEE `nix/home.nix` AT ALL — a vacuous green used as a closing condition, which
-   is the exact failure this doc exists to catch.** Controls, run on a `cp -a` copy with its `.git`
-   removed first: re-introducing the collision in full → **104 passed**; **deleting `nix/home.nix`
-   outright → 104 passed**. The suite tests the RULE against hand-copied fixtures, not the live file.
-   ⚠ **And it is blind BY DECISION, which is the part worth carrying:** `#1265` (`68d10b19`) *"drop
-   the 10 live-config guards — they re-break on every snippet edit"*. So there is **no automated
-   check on this interface**, and the next `search_terms` collision lands with the suite green.
-   **Read the config; do not run the suite and believe it.**
-   ✅ **THE OTHER CLOSING CONDITIONS IN THIS DOC WERE SWEPT FOR THE SAME DEFECT — one instance, not a
-   pattern.** Rank 7's already does it right and says so (*"Verify with the detector's own positive
-   control, not an absence … a rename, skip or deselect satisfies it with nothing fixed"*); rank 8's
-   was run rather than assumed; rank 9's was mechanically exercised in both directions. **Rank 6 was
-   the only one resting on an instrument that cannot observe its subject.** Swept because a defect
-   found at one site is a hypothesis about the others — not because a second was expected.
+6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE, and the FIELD THAT FIXED IT
+   IS NOT THE ONE TWO EARLIER REVISIONS OF THIS ITEM NAMED.** `a451abc0` swapped `:acq`'s `replace`
+   and `label`: the string *"ask clarifying questions and recommend improvements and anything useful
+   to include"* moved OUT of `label` and INTO `replace`. `_token_matches`
+   (`scripts/collector/keylog/espanso_detect.py:440-452`) reads trigger + **label** + `search_terms`
+   and **never `replace`**, so that one swap removed `recommend`/`recom` from the matcher's view.
+   `a720d30d` is what put the phrase in the label in the first place. The repo already said so, at
+   `test_espanso_detect.py:728-732` and `espanso_detect.py:350-357`.
+   ✅ **And the class is ALSO closed in CODE, independently of the config:** `_attribute`'s
+   declared-interface precedence means a snippet declaring a term in `search_terms` outbids one that
+   merely SPELLS it in a label — `espanso_detect.py:349-353`, guarded by four tests
+   (`test_declared_owner_resolves_a_term_both_snippets_spell`,
+   `test_declared_owner_does_not_reach_the_picker`, `…_cannot_invent_a_resolution`,
+   `…_never_repoints_a_unique_match`).
+   🔴 **THIS ITEM'S CLOSING EVIDENCE WAS VACUOUS TWICE, IN DIFFERENT WAYS, AND THE SECOND WAS THE FIX
+   FOR THE FIRST.** (a) It named the keylog suite as *"the deterministic check"* — that suite cannot
+   see `nix/home.nix` at all: on a `cp -a` copy with its `.git` removed, re-introducing the collision
+   gives **104 passed** and **deleting `nix/home.nix` outright** gives **104 passed**. (b) The fix for
+   (a) replaced it with *"a DIRECT READ of `:acq`/`:rna`'s `search_terms` — disjoint"*, and **those
+   two lists are byte-identical on the red trees (`a720d30d`, `a451abc0^`) and the green one
+   (`337114e0`)**: `:acq` is `["ask" "clarify" "clarifying" "questions"]` throughout and never
+   contained either term. **So the prescribed read returns "disjoint — closed" on the tree this doc
+   calls RED.** A check that cannot distinguish the two states is vacuous whether it is a test or a
+   human reading a field. **Read the `label`, not the `search_terms`.** via: measurement
+   ⚠ **An earlier revision also labelled the old hypothesis CONFIRMED.** It offered two arms — narrow
+   `:acq`'s terms, or add a disambiguator to `:rna`'s — and **neither happened**; the fix was a third
+   option outside the fork. Do not mark a hypothesis confirmed because its conclusion came true.
+   ⚠ **The suite is blind to the live config BY DECISION:** `#1265` (`68d10b19`) *"drop the 10
+   live-config guards — they re-break on every snippet edit"* (the title says 10; the commit deletes
+   9 `def test_` functions — the commit's own count, quoted as written). 🔴 **So state the residual at
+   its real scope, which is narrower than "this interface is unguarded":** the label-shadowing route
+   is closed in code and tested (above); what nothing covers is a genuine **declared** `search_terms`
+   collision between two snippets, which resolves to `None` and leaves the suite at **104 passed**.
+   That is the one case to read the config for.
+   ✅ **THE OTHER CLOSING CONDITIONS IN THIS DOC WERE SWEPT FOR THE SAME DEFECT.** Rank 7's already
+   does it right and says so (*"Verify with the detector's own positive control, not an absence … a
+   rename, skip or deselect satisfies it with nothing fixed"*); rank 8's was run rather than assumed;
+   rank 9's was mechanically exercised in both directions; ranks 1–5 carry no live condition.
+   ⚠ **That sweep's own blind spot, recorded: it exempted THIS item's replacement evidence**, which
+   was the defect's new home — so "rank 6 was the only one" was true of the text the sweep read and
+   false of the text the same commit wrote. **When you fix a vacuous check, put the replacement
+   through the sweep too.**
    ⚠ **It also carried `forcing: regression — `main` is red` after the red was gone, and `forcing:`
    is the machine-readable field a `claim-work` session sorts on** — so the stale value was not
    cosmetic, it advertised a gate-forcing regression with nothing behind it. **Retire the `forcing:`

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -286,70 +286,34 @@ Not a bug — a measurement that would mislead if run as written.
 - **Next probe:** re-run the date comparison above; when most heads postdate `b4fde334`, run the
   probe from the doc's earlier block and **record the new baseline date beside the count**.
 
-### CLOSED 2026-09-12 — espanso `:acq` shadowed `:rna`; the terms are disjoint and nothing is red
-🔴 **THIS BLOCK READ "`main` IS RED" IN THE PRESENT TENSE, WITH A "Next probe, verbatim" TELLING THE
-NEXT SESSION TO GO FIX IT — 226 lines above the rank 6 that the SAME COMMIT marked CLOSED.** It is
-the second time in this one PR that a rank was retired and a live claim about it left standing
-elsewhere in the doc (round 2 caught the first, in `State now`). **When you close a rank, grep the
-doc for its subject; the ranked list is not the only place it is asserted.** Status and the correct
-evidence: **rank 6** — the discriminating field is `:acq`'s **`label`**, not its `search_terms`, and
-not the suite cited below.
-⚠ **FOUR THINGS IN THIS BLOCK ARE WRONG; IT IS KEPT ONLY AS THE WORKED EXAMPLE. An earlier revision
-said "TWO" and enumerated two — a closed count that was short, which is the defect this doc keeps
-finding.**
-(a) The repro's stated expectation `# 1 failed, 100 passed` is **104 passed** today.
-(b) 🔴 **The test it names does not exist** — `test_live_existing_resolutions_not_made_ambiguous`
-was deleted by `#1265` (`68d10b19`, *"drop the 10 live-config guards"*), and nothing sits at `:929`
-that relates to it.
-(c) 🔴 **"both `recom` and `recommend` now resolve to NOTHING" is NOT REACHABLE on today's code.**
-Driving the real `EspansoDetector._attribute` against configs rebuilt from the actual `nix/home.nix`
-lines: green tree → `recom` resolves to `:rna`; **the RED-shaped config also resolves to `:rna`**,
-because `_attribute`'s declared-interface precedence now decides it. Only a genuine *declared*
-`search_terms` collision still yields `None`.
-(d) 🔴 **"This is a REAL user-facing regression" therefore describes no state the current code can
-produce.** The label-shadowing class is closed in code, not merely in the config. **The suite named here is structurally blind to `nix/home.nix`: deleting
-that file outright still gives 104 passed.** So this repro could never have re-confirmed the
-collision, and the eliminations below are about the RULE, not the live config.
-- **Symptom + the repro AS IT WAS WRITTEN (do not run it — see above):**
-  `scripts/collector/keylog/tests/test_espanso_detect.py:929`,
-  `test_live_existing_resolutions_not_made_ambiguous`, was said to fail on plain `origin/main`:
-  ```bash
-  git -C $DEVRC worktree add --detach /tmp/ctl origin/main
-  nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
-    /tmp/ctl/scripts/collector/keylog/tests -q -p no:cacheprovider   # CLAIMED 1 failed, 100 passed
-  ```
-- **Observed (with values):** `AssertionError: search terms regressed (term -> (expected,
-  actual, matching snippets)): {'recom': (':rna', None, [':acq', ':rna']), 'recommend':
-  (':rna', None, [':acq', ':rna'])}`. A new `:acq` snippet's search terms collide with
-  `:rna`, so both `recom` and `recommend` now resolve to **nothing** instead of `:rna`.
-  ⚠ **NOT REACHABLE on today's code — see (c) in the header.** Measured against the real
-  `_attribute`: the red-shaped config resolves `recom` to `:rna` anyway.
-  Introduced by `a720d30d` (`espanso`) touching `nix/home.nix` — a bare commit straight to
-  `main`, no PR.
-- ~~🔴 **This is a REAL user-facing regression, not a test being fussy.**~~ **WITHDRAWN — see (d).**
-  The espanso audit
-  established Zach fires ~100% via Ctrl+Space SEARCH, so `search_terms` ARE the interface:
-  typing "recommend" used to reach `:rna` and now reaches an ambiguous set.
-- **Confirmed three independent ways:** the merged-tree `gate.sh` run; a control run on
-  plain `origin/main`; and Tekton's own `tekton/devrc-main-pytests` on `5a82aaa9` —
-  `failure: FAILING: test_live_existing_resolutions_not_made_ambiguous`.
-- **Ruled out:** *"`#1239` caused it"* — `#1239` touches only `scripts/testlib/store_siting.py`
-  and `scripts/tests/test_store_siting_ledger.py`, which cannot reach espanso resolution;
-  and the control on plain `main` fails identically. via: measurement
-- **Ruled out:** *"a load flake"* — it fails in 0.22s, deterministically, with a value-bearing
-  assertion naming the colliding snippets. via: measurement
-- 🔴 **Leading hypothesis — REFUTED IN BOTH ARMS; the fix was a third option outside the fork.** It
-  read: narrow `:acq`'s `search_terms`, OR give `:rna`'s a disambiguator. **Neither happened.**
-  `:acq`'s `search_terms` are `["ask" "clarify" "clarifying" "questions"]` on `a720d30d`,
-  `a451abc0^`, `a451abc0` and `337114e0` — byte-identical across the red trees AND the green one, and
-  they never contained `recom`/`recommend`. What shipped (`a451abc0`) moved the offending phrase out
-  of `:acq`'s **`label`** and into its `replace`, which `_token_matches` does not read.
-  ⚠ **An earlier revision of this line said CONFIRMED.** The conclusion came true; the hypothesis was
-  wrong. **Do not mark a hypothesis confirmed from its outcome.** via: measurement
-- **Next probe: NONE.** ⚠ The probe here was *"`git -C $DEVRC show a720d30d -- nix/home.nix`, then
-  decide which side's `search_terms` move"* — and it would have answered nothing, because the
-  `search_terms` are the same on both sides. 🔴 **If you confirm anything, read `:acq`'s `label`**
-  (`nix/home.nix:419`) — that is the field that moved. Do not re-open the question.
+### CLOSED 2026-09-03 — espanso `:acq` shadowed `:rna`; fixed in CODE, not in the config
+🔴 **THIS BLOCK WAS 65 LINES OF COMMIT-BY-COMMIT ATTRIBUTION AND IT WAS WRONG FOUR TIMES IN FOUR
+AUDIT ROUNDS — so it is CUT rather than corrected a fifth time.** Each round's replacement was
+written with more care than the last and was still wrong: a test suite that cannot read the file
+(round 3), a `search_terms` read that is byte-identical on the red and green trees (round 4), then
+the wrong fix commit AND four guard tests that stay green when the mechanism is deleted (round 5).
+**The error rate did not fall. That is the signature of a claim nobody can satisfy, not of
+insufficient diligence** — a handoff doc has no way to stay correct about a five-commit, two-mechanism
+history as the code moves, and no test here can check it (the doc gates cannot see even a bogus path
+in this file).
+✅ **What is true, and mechanically checkable:** the collision is gone — `recom` resolves to `:rna` on
+`origin/main`. It was fixed in the DETECTOR, not the config: **`#1247` (`b9b2493d`, 2026-09-02T17:16,
+*"declare :rna the owner of recom/recommend — unbreaks main, red since `a720d30d`"*, touching only
+`espanso_detect.py` + its tests), generalised by `#1252` (`de677683`, *"a snippet's declared
+`search_terms` outbid another's LABEL"*).** `a720d30d` caused it; `a451abc0` landed 23 h after it was
+already fixed and is what `#1265`'s body says reddened `main` next.
+🔴 **THE RECORD LIVES IN THE CODE, WHICH IS WHERE IT STAYS CORRECT** — `espanso_detect.py:344-372`
+(the precedence rule and why), `test_espanso_detect.py:727-757` (the operator's ruling and the owner
+table), and its FIX 7 block. **Read those, not a doc's copy of them.** The durable lesson is one
+sentence and is in the index under `devrc/espanso-audit`: *a matcher reads the LABEL, so a cosmetic
+reword can shadow another snippet's declared search route — and the field that looks discriminating
+(`search_terms`) is identical on the red and green trees, so reading it cannot tell them apart.*
+⚠ **The one residual, measured and narrower than "this interface is unguarded":** precedence is inert
+when NO candidate declares the term, so a label-only collision still resolves to `None`, and the
+keylog suite cannot see it (deleting `nix/home.nix` outright still gives 104 passed — `#1265`
+dropped the live-config guards deliberately). Two routes, not one.
+✅ **What survives from the method, because it is about the method and not about espanso:** *a check
+that cannot distinguish the two states is vacuous whether it is a test or a human reading a field.*
 
 ## Next steps (ranked)
 🔴 Numbering is STABLE — `claim-work --slug-for <this doc> <rank>` derives from it.
@@ -546,55 +510,14 @@ collision, and the eliminations below are about the RULE, not the live config.
    `#1239` (`65f7325b`) both merged and content-verified; ladder ended by decision after 10
    rounds. Five residuals are disclosed in-source and listed under Gotchas. Nothing to do.
    forcing: none — done; retained so the rank numbering stays stable.
-6. ✅ **CLOSED 2026-09-12 — the espanso `:acq`/`:rna` collision is GONE, and the FIELD THAT FIXED IT
-   IS NOT THE ONE TWO EARLIER REVISIONS OF THIS ITEM NAMED.** `a451abc0` swapped `:acq`'s `replace`
-   and `label`: the string *"ask clarifying questions and recommend improvements and anything useful
-   to include"* moved OUT of `label` and INTO `replace`. `_token_matches`
-   (`scripts/collector/keylog/espanso_detect.py:440-452`) reads trigger + **label** + `search_terms`
-   and **never `replace`**, so that one swap removed `recommend`/`recom` from the matcher's view.
-   `a720d30d` is what put the phrase in the label in the first place. The repo already said so, at
-   `test_espanso_detect.py:728-732` and `espanso_detect.py:350-357`.
-   ✅ **And the class is ALSO closed in CODE, independently of the config:** `_attribute`'s
-   declared-interface precedence means a snippet declaring a term in `search_terms` outbids one that
-   merely SPELLS it in a label — `espanso_detect.py:349-353`, guarded by four tests
-   (`test_declared_owner_resolves_a_term_both_snippets_spell`,
-   `test_declared_owner_does_not_reach_the_picker`, `…_cannot_invent_a_resolution`,
-   `…_never_repoints_a_unique_match`).
-   🔴 **THIS ITEM'S CLOSING EVIDENCE WAS VACUOUS TWICE, IN DIFFERENT WAYS, AND THE SECOND WAS THE FIX
-   FOR THE FIRST.** (a) It named the keylog suite as *"the deterministic check"* — that suite cannot
-   see `nix/home.nix` at all: on a `cp -a` copy with its `.git` removed, re-introducing the collision
-   gives **104 passed** and **deleting `nix/home.nix` outright** gives **104 passed**. (b) The fix for
-   (a) replaced it with *"a DIRECT READ of `:acq`/`:rna`'s `search_terms` — disjoint"*, and **those
-   two lists are byte-identical on the red trees (`a720d30d`, `a451abc0^`) and the green one
-   (`337114e0`)**: `:acq` is `["ask" "clarify" "clarifying" "questions"]` throughout and never
-   contained either term. **So the prescribed read returns "disjoint — closed" on the tree this doc
-   calls RED.** A check that cannot distinguish the two states is vacuous whether it is a test or a
-   human reading a field. **Read the `label`, not the `search_terms`.** via: measurement
-   ⚠ **An earlier revision also labelled the old hypothesis CONFIRMED.** It offered two arms — narrow
-   `:acq`'s terms, or add a disambiguator to `:rna`'s — and **neither happened**; the fix was a third
-   option outside the fork. Do not mark a hypothesis confirmed because its conclusion came true.
-   ⚠ **The suite is blind to the live config BY DECISION:** `#1265` (`68d10b19`) *"drop the 10
-   live-config guards — they re-break on every snippet edit"* (the title says 10; the commit deletes
-   9 `def test_` functions — the commit's own count, quoted as written). 🔴 **So state the residual at
-   its real scope, which is narrower than "this interface is unguarded":** the label-shadowing route
-   is closed in code and tested (above); what nothing covers is a genuine **declared** `search_terms`
-   collision between two snippets, which resolves to `None` and leaves the suite at **104 passed**.
-   That is the one case to read the config for.
-   ✅ **THE OTHER CLOSING CONDITIONS IN THIS DOC WERE SWEPT FOR THE SAME DEFECT.** Rank 7's already
-   does it right and says so (*"Verify with the detector's own positive control, not an absence … a
-   rename, skip or deselect satisfies it with nothing fixed"*); rank 8's was run rather than assumed;
-   rank 9's was mechanically exercised in both directions; ranks 1–5 carry no live condition.
-   ⚠ **That sweep's own blind spot, recorded: it exempted THIS item's replacement evidence**, which
-   was the defect's new home — so "rank 6 was the only one" was true of the text the sweep read and
-   false of the text the same commit wrote. **When you fix a vacuous check, put the replacement
-   through the sweep too.**
-   ⚠ **It also carried `forcing: regression — `main` is red` after the red was gone, and `forcing:`
-   is the machine-readable field a `claim-work` session sorts on** — so the stale value was not
-   cosmetic, it advertised a gate-forcing regression with nothing behind it. **Retire the `forcing:`
-   in the same edit as the red**, and do not delegate the correction to a comment elsewhere in the
-   file: one was left 300 lines below and went on contradicting this item for a further round.
-   forcing: none — fixed; the diagnosis above is retained as the worked example.
-
+6. ✅ **CLOSED — the espanso `:acq`/`:rna` collision is gone: `recom` resolves to `:rna` on
+   `origin/main`.** Fixed in the DETECTOR by `#1247` (`b9b2493d`) and generalised by `#1252`
+   (`de677683`) — **not** by a config edit, and not by this effort. Recorded only because this item
+   asserted a live red and carried `forcing: regression` after the red was gone.
+   ⚠ **The causal archaeology that used to sit here is CUT** — it was wrong in four successive audit
+   rounds, each time in a new way. See the superseded Open-investigations block above for why cutting
+   beat correcting, and read `espanso_detect.py:344-372` for the mechanism.
+   forcing: none — fixed.
 7. **A FIXED 120 s SUBPROCESS BOUND IN A FILE WHOSE WALL TIME IS NOT STABLE —
    `scripts/tests/test_run_tests_targets.py`.** Its tests spawn a nested `run-tests.sh`,
    SIGKILLed at the bound (`TimeoutExpired`, rc `-9`). **Six bound sites** — `_run` `:107`,

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -287,8 +287,8 @@ Not a bug — a measurement that would mislead if run as written.
   probe from the doc's earlier block and **record the new baseline date beside the count**.
 
 ### CLOSED 2026-09-03 — espanso `:acq` shadowed `:rna`; fixed in CODE, not in the config
-🔴 **THIS BLOCK WAS 65 LINES OF COMMIT-BY-COMMIT ATTRIBUTION AND IT WAS WRONG FOUR TIMES IN FOUR
-AUDIT ROUNDS — so it is CUT rather than corrected a fifth time.** Each round's replacement was
+🔴 **THIS BLOCK WAS 65 LINES OF COMMIT-BY-COMMIT ATTRIBUTION AND THREE SUCCESSIVE AUDIT ROUNDS EACH
+FOUND IT WRONG — so it is CUT rather than corrected a fourth time.** Each round's replacement was
 written with more care than the last and was still wrong: a test suite that cannot read the file
 (round 3), a `search_terms` read that is byte-identical on the red and green trees (round 4), then
 the wrong fix commit AND four guard tests that stay green when the mechanism is deleted (round 5).
@@ -297,11 +297,14 @@ insufficient diligence** — a handoff doc has no way to stay correct about a fi
 history as the code moves, and no test here can check it (the doc gates cannot see even a bogus path
 in this file).
 ✅ **What is true, and mechanically checkable:** the collision is gone — `recom` resolves to `:rna` on
-`origin/main`. It was fixed in the DETECTOR, not the config: **`#1247` (`b9b2493d`, 2026-09-02T17:16,
+`origin/main`. ⚠ **It is closed TWICE OVER, independently — say it that way, not "the code not the
+config".** The DETECTOR fix landed **23 h first**: **`#1247` (`b9b2493d`, 2026-09-02T22:16Z,
 *"declare :rna the owner of recom/recommend — unbreaks main, red since `a720d30d`"*, touching only
 `espanso_detect.py` + its tests), generalised by `#1252` (`de677683`, *"a snippet's declared
 `search_terms` outbid another's LABEL"*).** `a720d30d` caused it; `a451abc0` landed 23 h after it was
-already fixed and is what `#1265`'s body says reddened `main` next.
+already fixed and is what `#1265`'s body says reddened `main` next. **Measured both arms:** pre-fix
+detector + RED config → `None`; pre-fix detector + TODAY's config → `:rna`; today's detector + RED
+config → `:rna`. Either side alone closes it.
 🔴 **THE RECORD LIVES IN THE CODE, WHICH IS WHERE IT STAYS CORRECT** — `espanso_detect.py:344-372`
 (the precedence rule and why), `test_espanso_detect.py:727-757` (the operator's ruling and the owner
 table), and its FIX 7 block. **Read those, not a doc's copy of them.** The durable lesson is one
@@ -512,7 +515,9 @@ that cannot distinguish the two states is vacuous whether it is a test or a huma
    forcing: none — done; retained so the rank numbering stays stable.
 6. ✅ **CLOSED — the espanso `:acq`/`:rna` collision is gone: `recom` resolves to `:rna` on
    `origin/main`.** Fixed in the DETECTOR by `#1247` (`b9b2493d`) and generalised by `#1252`
-   (`de677683`) — **not** by a config edit, and not by this effort. Recorded only because this item
+   (`de677683`) 23 h before the config edit, which is independently sufficient on its own — so the
+   closure is over-determined and "the code, not the config" would be a claim about ORDER, not about
+   sufficiency. Not fixed by this effort. Recorded only because this item
    asserted a live red and carried `forcing: regression` after the red was gone.
    ⚠ **The causal archaeology that used to sit here is CUT** — it was wrong in four successive audit
    rounds, each time in a new way. See the superseded Open-investigations block above for why cutting

--- a/claudedocs/handoff-gate-flake-store-api.md
+++ b/claudedocs/handoff-gate-flake-store-api.md
@@ -4,15 +4,15 @@
 ```bash
 cairn recall --repo ~/workspace/devrc
 ```
-⚠ **This block used to prescribe `python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py`, and
-`#1508` DELETED that file** — the cairn consolidation moved the reader into the pinned package, so
-the old spelling now fails with a file-not-found. 🔴 **It is not just this doc: `63` files under
-`claudedocs/` still prescribe that path (`71` occurrences), plus `5` source comments
-(`scripts/lib/handoff_search.py`, `scripts/tests/test_subsystem_recall.py`,
-`test_repo_path_guard.py`, `test_store_root_ledger.py`, `scripts/present/measure.py` — all PROSE,
-no code path).** Only this doc's occurrence is fixed here; the sweep is filed as rank 9, because
-fixing one site and implying the rest is the partial-sweep failure. Counts measured 2026-09-12 at
-`origin/main` `8114a124`.
+⚠ **This block used to prescribe the deleted `scripts/lib/subsystem_recall.py`** — `#1508` moved the
+reader into the pinned package, so the old spelling now fails with a file-not-found. **It is not
+just this doc: see rank 9 for the population, which is the single place those counts live.** Only
+this doc's invocation is fixed here; fixing one site and implying the rest is the partial-sweep
+failure. ⚠ **This block previously restated the counts and got two of them wrong in the direction
+rank 9 exists to prevent** — `63`/`71` are the BARE-PATH figures, not the *prescribing* ones
+(`61`/`65`), and it listed `5` source files while rank 9, in the same commit, said `6` and named the
+Dockerfile the list had dropped. **Two copies of a count are how one of them becomes wrong; rank 9
+owns them.**
 Terse pointers this doc does not carry, curated by past sessions and outliving it.
 🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
 reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
@@ -110,26 +110,50 @@ Found by accident while doing the tmpfs work. Documented on `main` in
 🔴 **This block's heading read "UNMEASURED" and its "Next probe, verbatim" below told the next
 session to run a probe that HAS NOW BEEN RUN.** Read rank 1 for the reading — 0 of 99 verdicts on
 heads carrying `ce9b55c3` against 12 of 298 that do not, P(0) ≈ 0.017 — and do **not** re-run the
-snippet below. It is retained for two reasons and neither is "use it": its `grep -c` classifier
-names the right test families, and its **predicate is a LIMIT, not a baseline** — `--limit 40`
-newest-first with no ancestry test at all, which is the date-shaped sampling rank 1 says gives a
-wrong denominator. The closing reading used ancestry over 400 heads instead.
+snippet below. It is retained for ONE reason and it is not "use it": its **predicate is a LIMIT, not
+a baseline** — `--limit 40` newest-first with no ancestry test at all, which is the date-shaped
+sampling rank 1 says gives a wrong denominator. The closing reading used ancestry over 400 heads.
+🔴 **AND ITS CLASSIFIER IS BROKEN FOR THE ONE TEST THIS DOC IS ABOUT — an earlier revision of this
+very paragraph praised it, which would have sent someone to re-use it.** The snippet greps status
+DESCRIPTIONS for `subsystem_store_api\|TestTheActor\|TestAHungRoundTrip\|TestTheBackstop`, but a
+description carries `Class.test_name` and **never a filename**, so `subsystem_store_api` cannot fire
+at all. Measured over the 101 failure verdicts rank 1 collected: the 12 store-api rows — rank 1's
+entire pre-window count — are matched **0** times. ⚠ **It is not wired to nothing, and the
+distinction matters:** a positive control over the same 101 rows matches **4** (`TestTheActor…` ×3,
+`TestAHungRoundTrip…` ×1), so the grep works and the *token list* is simply missing
+`TestARefusedWrite…`. **Re-run as written it would return 0 in BOTH arms — a vacuous zero read as
+"the fix worked".** via: measurement
 ⚠ **What is still UNMEASURED is the block's own hypothesis at its second point:** it predicted the
 rate "drops to ~0 where a tmpfs is available, and is **unchanged where the fallback fires**". The
 reading confirms the first half and says nothing about the second — **nothing has measured whether
 the GATE container has a usable tmpfs**, so a 0 is consistent with both "sited" and "the mechanism
 stopped firing for some other reason". That is rank 1's `[0, 22]` bound's sibling: recorded, not
 closed.
-✅ **The residual is much NARROWER than "it might change nothing in CI", and the narrowing is
-MEASURED on the manifest, not argued from defaults.** `store_siting.py:67` makes the only candidate
-`/dev/shm` and `:221` sets `_MIN_FREE_BYTES = 4 MiB`. The gate pipeline
-(`homelab-talos` `origin/trunk:clusters/homelab/apps/tekton-pipelines/triggers/devrc-ci-pipeline.yaml`,
-2,482 lines) contains **0 occurrences of `shm` and 0 of `medium:`** — positive controls on the same
-read: `pytests` 59, `emptyDir` 3, all three in comments — so **nothing overrides `/dev/shm` for the
-`pytests` step** and it gets the container runtime's default. ⚠ **Two halves, and only the first is
-a reading of this cluster:** "nothing in the manifest overrides it" is measured; "therefore 64 MiB"
-is the *containerd/Docker* default that `store_siting.py`'s own docstring cites, and **no node on
-this cluster was read for it** — a runtime or node setting can change it. Against a 4 MiB floor the
+✅ **The residual is NARROWER than "it might change nothing in CI" — but read the three corrections
+below before quoting the narrowing, because the first version of this paragraph overstated what it
+had read.** `store_siting.py:221` sets `_MIN_FREE_BYTES = 4 MiB`.
+🔴 **(a) `/dev/shm` is the DEFAULT candidate, not the only one.** `:270` is
+`for candidate in (os.environ.get(_CANDIDATE_ENV), _DEFAULT_CANDIDATE)` and `_CANDIDATE_ENV` at
+`:66` is **`DEVRC_TEST_TMPFS`**, consulted FIRST. An earlier revision here said `:67` "makes the only
+candidate `/dev/shm`" — wrong, and it made the grep below look exhaustive when it could not match
+the env override at all.
+🔴 **(b) The read must cover TWO manifests, and the first version named one.** Besides
+`devrc-ci-pipeline.yaml`, the `pytests` pod spec also lives in
+`devrc-ci-triggertemplate.yaml` (it carries its own `podTemplate:`). Both were re-read: **0
+occurrences of `shm`, 0 of `medium:`, and 0 of `DEVRC_TEST_TMPFS` across both** — so the conclusion
+*"nothing overrides `/dev/shm` for the `pytests` step"* **holds**, but on the wider read, not the
+first one. ⚠ **The strong control was available and unused:** sibling pipelines DO set
+`medium: Memory` (`clawgate-ci-pipeline.yaml`, `auditloop-ci-pipeline.yaml` and three others), so the
+zero is a real absence rather than a pattern that never matches anything.
+🔴 **(c) The manifest read is itself unpinned and HAS ALREADY MOVED** — the same defect as the
+verdict census above. Verified exactly at `homelab-talos` **`b2f42ef5`** (2,482 lines, `pytests` 59,
+`emptyDir` 3, all three in comments). `origin/trunk` has since taken `3c53d618` — *"/nix becomes a
+per-run emptyDir"* — and now reads **2,584 lines, `pytests` 62, `emptyDir` 12**, i.e. it added real
+emptyDirs where the control had found only comments. **Re-read both manifests at a named sha; do not
+quote these numbers.**
+⚠ **And two halves, only the first a reading of this cluster:** "nothing overrides it" is measured;
+"therefore 64 MiB" is the *containerd/Docker* default that `store_siting.py`'s own docstring cites,
+and **no node on this cluster was read for it** — a runtime or node setting can change it. Against a 4 MiB floor the
 check passes by 16× if that default holds, so the fallback needs `/dev/shm` **absent, read-only, or
 already ~94% consumed** — and the last of those is the concurrent-writer case the docstring already
 says cannot be closed from in-process. **What stays owed is one reading of a real gate container**;
@@ -347,40 +371,65 @@ Not a bug — a measurement that would mislead if run as written.
    closed at the source, so that 22 does not forecast. **5** are
    `scripts/tests/test_runner_bound_ledger.py`, and **4 of those POSTDATE `c0bbd6d9`**
    (03:16:50Z–03:46:19Z): the same design class, in a second ledger `#1561` does not cover.
-   🔴 **That one is neither a flake nor a stale-base echo — `main` ITSELF IS RED ON IT**, run
-   directly at `origin/main` in a clean worktree at THREE successive tips — `4e970998` (**1 failed,
-   1655 passed**), `8114a124` and `61f41adf` (**1 failed, 4 passed** each, that file alone) —
-   the only diff being two `claudedocs/` files these scanners do not read. It is **rank 8**.
-   via: measurement
+   🔴 **EVERY NUMBER IN THIS WHOLE ITEM IS READ-TIME-ONLY AND CANNOT BE RE-DERIVED LATER — say so
+   wherever you quote it.** GitHub keeps **one** status per context per commit and a superseding run
+   overwrites it, so the rows this reading counted are progressively destroyed as PRs re-run. A
+   re-read hours later already disagreed: 20 kill-ledger reds rather than 22, and 9 runner-bound with
+   8 after the fix rather than 5 with 4 — **same direction, strengthening, different values**, with
+   the original rows gone. So `27 of 99` is a reading taken 2026-09-12 ~04:00Z over 400 PR heads and
+   is **not** a quantity a later session can check. **That is an argument for citing this paragraph
+   rather than re-measuring, and for never treating a disagreement with it as a refutation.**
+   ✅ **That one was neither a flake nor a stale-base echo — `main` ITSELF WAS RED ON IT, and it is
+   now FIXED: `#1567` merged `6f1867b1` at 2026-09-12T05:07:06Z.** Red measured at three successive
+   tips (`4e970998` **1 failed, 1655 passed**; `8114a124` and `61f41adf` **1 failed, 4 passed**
+   each, that file alone), then **5 passed** at `origin/main` after the merge. It is **rank 8**,
+   closed. via: measurement
 
    ⚠ **THE GATE'S OWN OBSERVABILITY IS WORSE THAN ITS RED RATE: `error` is 29 of 99 post-window
    verdicts (29%) against 41 of 298 (14%) pre. A gate producing no verdict is not a green one, and
    a rate computed over verdicts cannot see the runs that never reported.**
    🔴 **THIS IS NOT A NEW OBSERVATION AND THIS DOC SHOULD NOT RE-MEASURE IT — it is
-   `handoff-gate-speed-and-ci-signal.md`'s, at a larger sample and with the decomposition:**
-   *"Only ~21–22 of 100 `main` commits get an authoritative verdict (59.5% superseded, 15%
-   KILLED, 5% NO GATE POD)"* (`:54`), and split on this very fix, *"Of 43 post-fix pytests
-   verdicts on `main`, **40 were artefacts** … leaving **3** authoritative successes. Use PR
-   heads."* (`:363`). **Read those, not a count taken here.** The four artefact strings
-   (`NO CAPACITY` / `NO GATE POD` / `KILLED` / `BROKEN GATE`) are a SHIPPED mechanism, not
-   undiagnosed noise — `handoff-cairn-task-linkage.md:37`; they make the loss legible rather
-   than recovering it.
-   ⚠ **A paragraph here previously reported `main`'s "last 8 commits" with its own breakdown, and
-   it was wrong twice over — the count (`six superseded`; it was FOUR, plus one `KILLED` and one
-   pending, re-derived over the named range `457a5dc7~1..8114a124`) and the FRAME. "The last N
-   commits" is a moving window: `main` took two commits between writing it and checking it, so
-   the sentence was unfalsifiable by construction. Name a sha range or do not quote a window.**
+   `handoff-gate-speed-and-ci-signal.md`'s, at a larger sample and with the decomposition** — its
+   bullet beginning *"Only ~21–22 of 100 `main` commits get an authoritative verdict"* (59.5%
+   superseded, 15% KILLED, 5% NO GATE POD), and, split on this very fix, the one beginning
+   *"`main` is a useless population for this question and that is structural"* (of 43 post-fix
+   verdicts, **40 artefacts**, **3** authoritative — *"Use PR heads."*). **Read those, not a count
+   taken here.** The four artefact strings (`NO CAPACITY` / `NO GATE POD` / `KILLED` /
+   `BROKEN GATE`) are a SHIPPED mechanism, not undiagnosed noise — see
+   `handoff-cairn-task-linkage.md`'s bullet *"Four mechanisms now post four strings"*; they make the
+   loss legible rather than recovering it.
+   🔴 **Those are quoted by their OPENING WORDS, not by line number, and that is deliberate** — an
+   earlier revision of this paragraph cited `:363`, having just "corrected" it from `:365`, and then
+   **invalidated its own citation by inserting 25 lines above the target in the same commit**. A
+   line number in a sibling doc that the same PR edits is an expiring claim. Quote the sentence.
+
+   🔴 **THE CENSUS THAT REPLACED A WRONG COUNT WAS ALSO WRONG, AND THE SECOND MISS IS THE
+   INSTRUCTIVE ONE.** The original said `main`'s "last 8 commits" held *six* `superseded`, two
+   `NO GATE POD`, newest pending. Its first correction said **four**, one `KILLED`, one pending.
+   **Re-read 2026-09-12T05:2xZ over the same named range `457a5dc7~1..8114a124`: FIVE superseded,
+   two `NO GATE POD`, one `KILLED`, and ZERO pending.** The headline — *no completed verdict across
+   those 8* — held every time; the breakdown was wrong twice.
+   ⚠ **Naming a sha range fixed the wrong axis.** A range pins the COMMITS; it does not pin their
+   VERDICTS, and the verdict is the mutable thing: `8114a124` read `pending` when the first
+   correction was written and had flipped to `superseded` by 04:32:10Z — **24 minutes before that
+   commit was even authored**. GitHub overwrites a status per context, so the earlier rows are
+   *gone* and no later reader can reproduce either number. 🔴 **So a verdict census needs a READ
+   TIME as well as a range, and it is never re-derivable afterwards — which is the argument for not
+   writing one here at all.** Kept only as the worked example of the class.
 
    **What this does NOT close:** nothing here was measured on the OSS copy
    (`ZacxDev/cairn`'s identical 18-open-coded / 5-sited split), and the `[0, 22]` bound above is
    the residual this instrument cannot narrow — the pipelineruns that could have are pruned.
    ⚠ **And the item's own placement is now wrong, stated plainly rather than left as a mood:** a
-   store-api fsync flake measured at 0 is no longer this doc's Goal, and ranks 8 and 9 are not
-   either — they are "what is CI's signal worth", which `handoff-gate-speed-and-ci-signal.md`
-   owns and already tracks (`:28-33` the census family, `:115-130` the 140-byte cap). **Moving
-   them is a doc-surgery task with a real closing condition** — the three items live in ONE doc
-   with `forcing:` lines intact and nothing cross-referencing them twice — and it is not done
-   here. Rank numbering stays stable regardless; claims are keyed to it.
+   store-api fsync flake measured at 0 is no longer this doc's Goal, and rank 9 is not either — it
+   is "what is CI's signal worth", which `handoff-gate-speed-and-ci-signal.md` owns and already
+   tracks (its Open-investigation on the census family, and its own 140-byte-cap finding).
+   🔴 **This is NOT a work item and is deliberately not dressed as one.** An earlier revision called
+   moving them *"a doc-surgery task with a real closing condition"* — it named no doc, no owner and
+   no mechanical check, and *"nothing cross-referencing them twice"* is not decidable, so by
+   `claude/RULES.md`'s own test it was an object nobody could close. **It is an observation for
+   whoever next restructures these two docs.** Rank numbering stays stable regardless; claims are
+   keyed to it.
 
    🔴 **THE PRESCRIPTIVE HALF OF THIS ITEM NOW LIVES IN `## How to verify`, NOT HERE.** The
    runnable form — anchor, ancestry predicate, the three positive-control PRs — is one block, at
@@ -513,13 +562,17 @@ Not a bug — a measurement that would mislead if run as written.
    forcing: gate — it reddened `#1454`, `#1458` and `#1462`, all merged with
    `tekton/devrc-pytests` RED because of it.
 
-8. 🔴 **`main` IS RED, DETERMINISTICALLY, ON THE RUNNER-BOUND LEDGER — and it is the class rank
-   1's measurement found has replaced the flake it was written to chase.** Measured 2026-09-12
-   by running the file directly at `origin/main` `4e970998` in a clean worktree:
-   `scripts/tests/test_runner_bound_ledger.py::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`
+8. ✅ **CLOSED 2026-09-12 — `main` WAS RED, DETERMINISTICALLY, ON THE RUNNER-BOUND LEDGER, AND
+   `#1567` FIXED IT (`6f1867b1`, merged 05:07:06Z).** Closing condition met and checked the
+   mechanical way: `scripts/tests/test_runner_bound_ledger.py` → **5 passed** at `origin/main` after
+   the merge, against **1 failed, 4 passed** before it. 🔴 **Kept at full length because the CLASS is
+   what matters — it is the class rank 1's measurement found has replaced the flake this doc was
+   written to chase, and it is the third census in this family in two days.**
+   Measured 2026-09-12 by running the file directly at `origin/main` `4e970998` in a clean worktree:
+   `…::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`
    → **1 failed, 1655 passed in 251.49s**, and re-measured after each of the two times `main` moved
    under this work — `8114a124` (**1 failed, 4 passed in 19.56s**) and `61f41adf` (**1 failed, 4
-   passed in 17.57s**), that file alone — so the red is a property of the tree across THREE points,
+   passed in 17.57s**), that file alone — so the red was a property of the tree across THREE points,
    not of one run. On the `new` arm:
    `{('scripts/tests/test_scoped_tests_shared_surface.py', 'ABSENT'): 1}`. That file spawns a
    runner with **no bound of its own** and has no `_OWN_BOUND_LEDGER` row, so the two-way seam
@@ -530,9 +583,9 @@ Not a bug — a measurement that would mislead if run as written.
      carrying `ce9b55c3`, **4 of them after `c0bbd6d9`** (`#1561`) closed the *sibling* census —
      `#1524`@03:16:50Z, `#1556`/`#1559`/`#1522`@03:40–03:46Z — plus `#1494`@03:14:37Z.
      via: measurement
-   - ✅ **ALREADY OWNED — `#1567` (`fix/scoped-surface-runner-bound`, opened 2026-09-12T03:58:34Z,
-     head `57030bfd`) has the same diagnosis and takes the right arm. Do not start a second
-     fix.** 🔴 **The pre-create sweep is what caught this** — the red was measured and filed here
+   - ✅ **FIXED BY `#1567`** (`fix/scoped-surface-runner-bound`, opened 2026-09-12T03:58:34Z, head
+     `57030bfd`, **merged `6f1867b1` at 05:07:06Z** — 56 minutes later), which had the same diagnosis
+     and took the right arm. 🔴 **The pre-create sweep is what caught this** — the red was measured and filed here
      at the same hour `#1567` was opened, and the lock could not have seen it, because nothing
      was claimed. This is the class `design-claim-by-push.md` lists as NOT covered.
    - **The fork in the fix, and `#1567` resolves it the right way.** The assertion offers two
@@ -542,11 +595,16 @@ Not a bug — a measurement that would mislead if run as written.
      positive-controls the fix by reverting to the unbounded spawn and watching the guard return
      to `[ABSENT] x1`. Provenance it also names: the file arrived with `#1532` and reddened the
      guard on landing.
-   **Closing condition:** `#1567` merged, AND
-   `test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` green on `origin/main` —
-   mechanically checkable by running that one file. Checked by whoever next reads this doc.
-   forcing: regression — `main` is red, and `claude/RULES.md`'s "a permanently-red gate is worse
-   than no gate" applies to the third census in this family in two days.
+   ✅ **Closing condition MET 2026-09-12:** `#1567` merged (`6f1867b1`) **and**
+   `test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` green on `origin/main` — run, not
+   assumed: **5 passed**. ⚠ **The window from filing to closed was 1 h 10 m, and this item spent
+   most of it asserting `main` is red "RIGHT NOW" in four places.** That is the same defect class as
+   the tip-sha line in `State now`: a present-tense claim about a mutable state, with nothing to
+   expire it. **Write the measurement and its timestamp; let the closing condition carry the
+   present tense.**
+   forcing: none — fixed. It reddened the gate on 5 PR heads and `main` itself; retained because the
+   CLASS (a census over tracked text reddening `main` for everyone) is `claude/RULES.md`'s
+   "a permanently-red gate is worse than no gate" and recurred three times in two days.
 
 9. ⚠ **`#1508` DELETED `scripts/lib/subsystem_recall.py` AND 61 HANDOFF DOCS STILL PRESCRIBE
    RUNNING IT.** Measured 2026-09-12 at `origin/main` `8114a124`, by `git grep` against the ref
@@ -554,7 +612,10 @@ Not a bug — a measurement that would mislead if run as written.
    `python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py` appears **65** times in **61** files
    under `claudedocs/` — each a "Run this first" block that now fails file-not-found. (The bare
    PATH appears 71 times in 63 files; the extra 6 are prose about the path, not invocations, which
-   is why the closing condition below is keyed to the command form.) The replacement is
+   is why the closing condition below is keyed to the command form.) **After the PR that filed this
+   item, the condition's own grep counts 64 across 60 files** — this doc's invocation fixed, its
+   remaining prose mentions excluded by path. Quote whichever you mean; they are not the same number.
+   The replacement is
    `cairn recall --repo <path>`. Positive control on the same read: `cairn recall` already appears
    54 times in `claudedocs/`, so the corrected spelling is in use and the grep can see it.
    via: measurement
@@ -586,10 +647,20 @@ Not a bug — a measurement that would mislead if run as written.
      close either by the other's grep.
    - 🔴 **A doc's "Run this first" line is the one command a resuming session runs before anything
      else**, so this fails at the moment it is least expected and reads as a broken environment.
-   **Closing condition:** `git grep -c 'python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py'
-   origin/main -- 'claudedocs/*'` sums to **0**. Keyed to the invocation, not the bare path —
-   docs that merely *discuss* the dead path (including this item) must not make the condition
-   unsatisfiable. Mechanical; checked by running that grep.
+   **Closing condition:**
+   ```
+   git grep -c 'python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py' origin/main \
+     -- 'claudedocs/*' ':(exclude)claudedocs/handoff-gate-flake-store-api.md'
+   ```
+   sums to **0**. 🔴 **THE EXCLUDE IS LOAD-BEARING AND AN EARLIER VERSION OF THIS CONDITION WAS
+   UNSATISFIABLE WITHOUT IT — while asserting, in the same breath, that it was not.** That version
+   read *"keyed to the invocation, not the bare path — docs that merely discuss the dead path
+   (including this item) must not make the condition unsatisfiable"*, which was false: this item
+   discusses the dead path **using the full invocation spelling**, three times. Measured at that
+   revision: the grep returned **67** across 61 files, of which **3** were this file's own prose.
+   **A condition keyed on a literal string that the item MUST print can never reach zero** — the
+   invocation-vs-path rewrite moved the defect between spellings instead of removing it. Mechanical;
+   checked by running that grep, and re-check the exclude still names this file if it is renamed.
    forcing: none — nothing is broken at runtime; it wastes a session's first command.
 
 ## Gotchas / decisions / dead-ends
@@ -764,17 +835,26 @@ git -C $DEVRC show origin/main:scripts/testlib/store_siting.py \
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
   $DEVRC/scripts/tests/test_store_siting_ledger.py -q -p no:cacheprovider
 
-# 🔴 main's OWN red — expected until rank 6 is fixed; it is NOT this effort's
+# rank 6's keylog red — NO LONGER RED. Measured 2026-09-12 at origin/main: 104 passed.
+#   ⚠ This line read `# 1 failed, 100 passed` with "expected until rank 6 is fixed"; rank 6 itself
+#   still says `main` IS RED on it. Re-verify rank 6 before acting on it — this is the fourth
+#   present-tense red claim in these docs found stale in one session.
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
-  $DEVRC/scripts/collector/keylog/tests -q -p no:cacheprovider    # 1 failed, 100 passed
+  $DEVRC/scripts/collector/keylog/tests -q -p no:cacheprovider    # expect 104 passed
 gh api repos/innovation-upstream/devrc/commits/$(git -C $DEVRC rev-parse origin/main)/status \
   --jq '.statuses[]|"\(.context) \(.state): \(.description[0:100])"'
-#   ⚠ This can show NO completed verdict at all, and that is the NORMAL case, measured at n=100
-#   in handoff-gate-speed-and-ci-signal.md:54 (~21-22 of 100 main commits get an authoritative
-#   verdict). A gate producing no verdict is not a green one — read the state, never just the
-#   absence of a `failure`, and prefer PR heads to main for any rate (that doc's :363).
+#   ⚠ This can show NO completed verdict at all, and that is the NORMAL case, measured at n=100 in
+#   handoff-gate-speed-and-ci-signal.md — its bullet "Only ~21-22 of 100 main commits get an
+#   authoritative verdict". A gate producing no verdict is not a green one: read the state, never
+#   just the absence of a `failure`, and prefer PR heads to main for any rate (that doc's bullet
+#   "main is a useless population for this question"). Quoted by opening words, not line number —
+#   both targets moved when this PR edited that file.
 
-# rank 8 — main's CURRENT own red, and the reproduction is one file (expect 1 failed)
+# rank 8 — CLOSED by #1567 (6f1867b1). This is its closing condition, so expect 5 PASSED.
+#   A `1 failed` here means the census has regressed, NOT that the recipe is stale.
+#   ⚠ This line said `expect 1 failed` for the 70 minutes rank 8 was open, which would have read
+#   as a broken recipe the moment it was fixed. A verify-block expectation must track the
+#   closing condition, not the state at the time of writing.
 nix develop $DEVRC -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest \
   $DEVRC/scripts/tests/test_runner_bound_ledger.py -q -p no:cacheprovider
 

--- a/claudedocs/handoff-gate-speed-and-ci-signal.md
+++ b/claudedocs/handoff-gate-speed-and-ci-signal.md
@@ -110,7 +110,15 @@ the END. **Ranks 1–3 and 9 are CLOSED tombstones**; renumbering re-points ever
    forcing: none
 2. **CLOSED — `#1469`'s audit ladder, `#1502`, shipped and consumer-verified.**
    forcing: none
-3. **CLOSED — the store-api flake was already fixed by `#1458`; `#1512` records it.**
+3. **CLOSED — the store-api flake was already fixed by `#1458`. ⚠ `#1512` is NO LONGER the
+   measurement of record**: it split on `ce9b55c3`'s TIMESTAMP and its zero was underpowered
+   (4/125 → 0/45, P(0) ≈ 0.23). Superseded 2026-09-12 by an ANCESTRY split over 400 PR heads —
+   **0 of 99** verdicts on heads carrying the sha against **12 of 298** that do not, P(0) ≈
+   **0.017** — recorded in `devrc#1568` (`8114a124`), full table at
+   `handoff-gate-flake-store-api.md` rank 1. ⚠ **`#1512`'s table is not WRONG**: re-splitting the
+   same 397 verdicts by date reclassified 5 and **0 of 101 failures**, so its predicate was the
+   wrong test and changed nothing at this sample. Cite the newer read; keep `#1512` for its
+   "it was never the worst flake" finding, which stands.
    forcing: none
 4. **`#1524` — OPEN, and it OWES A DELTA RE-AUDIT before merge.** Round 1's fix round produced six
    fixes, and the ladder rule is explicit: a round that produced findings needing fixes is followed
@@ -122,8 +130,17 @@ the END. **Ranks 1–3 and 9 are CLOSED tombstones**; renumbering re-points ever
    cache hit — the cost is entirely rebuild-on-change.
    forcing: none
 6. **The flake screen in `main-status-watch.py` is probably inert** — decide on/after **2026-10-11**.
-   🔴 Decide it TOGETHER with rank 4: `main-status-watch.py:232-286` already implements the same
+   🔴 Decide it TOGETHER with rank 4: `main-status-watch.py`'s flake screen already implements the same
    completeness-proving screen in **15 lines**, and `#1524` rebuilds that gate at ~885. Same question.
+   🔴 **NEW EVIDENCE FOR THAT DECISION, 2026-09-12 — and it cuts toward DELETE.** The screen exists
+   to skip re-runs on KNOWN FLAKES, and the store-api flake it was written around is now at **0 of
+   99** verdicts on heads carrying `ce9b55c3` (`handoff-gate-flake-store-api.md` rank 1). The same
+   read independently re-derived this file's own truncation finding from scratch — **100 of 101
+   failure descriptions truncated at 138 characters** — which is what makes the screen unsatisfiable
+   (the measurement sits beside `_FAILING_RE` in that file). So the screen now guards a flake that has
+   stopped occurring, using a completeness proof a 138-byte field cannot supply. ⚠ **Not a decision —
+   the 2026-10-11 date and "decide them together" both stand**; this is the datum to decide ON, and it
+   did not exist when the date was set.
    forcing: none
 7. **Pin the `repo-full-name` invariant in `homelab-infra`'s supersede tests.** `test_supersede_
    wiring.py` has **zero** occurrences of the string pass 2's correctness rests on. Fix: extend
@@ -134,8 +151,18 @@ the END. **Ranks 1–3 and 9 are CLOSED tombstones**; renumbering re-points ever
    7 days of normal merging is NOT a clean bill — it is the instrument failing to see its bucket.
    forcing: user — the operator chose merge-in-dry-run-arm-later.
 9. **CLOSED by `#1561`** — the kill scanners no longer read `claudedocs/`, which ends the treadmill
-   rather than paying another round of it.
-   forcing: none
+   rather than paying another round of it. **Rate evidence that the close is real and not merely
+   merged:** the kill-mention ledger accounts for **22** `tekton/devrc-pytests` reds across PR heads
+   and **every one predates `c0bbd6d9`** — read 2026-09-12 ~04:00Z in `devrc#1568`; see rank 1 of
+   `handoff-gate-flake-store-api.md` for why that population is read-time-only and cannot be
+   re-derived.
+   🔴 **Both instances of the CLASS are now fixed and the class itself is not.** The same design — a
+   census over tracked text reddening `main` for everyone — fired next from
+   `scripts/tests/test_runner_bound_ledger.py` (**5** reds, **4** after `c0bbd6d9`), closed by
+   `#1567` `6f1867b1`. **At least two instances in two days, both measured here, and nothing prevents
+   the next one.** Tracked as `handoff-gate-flake-store-api.md` rank 8, closed as an instance and
+   retained for the class.
+   forcing: none — both instances shipped; the class is unaddressed and owned by nobody.
 10. **ROUTE `scripts/stale-base-triage.py`, OR DECIDE NOT TO SHIP IT.** Nothing invokes it — no timer,
    hook, CI step, skill or nix entry. ~885 payload lines + ~1,350 test lines that run only if someone
    remembers the path. Round 0 raised it, round 1 restated it, no fix round addresses it because it is

--- a/claudedocs/handoff-gate-speed-and-ci-signal.md
+++ b/claudedocs/handoff-gate-speed-and-ci-signal.md
@@ -159,7 +159,7 @@ the END. **Ranks 1–3 and 9 are CLOSED tombstones**; renumbering re-points ever
    🔴 **Both instances of the CLASS are now fixed and the class itself is not.** The same design — a
    census over tracked text reddening `main` for everyone — fired next from
    `scripts/tests/test_runner_bound_ledger.py` (**5** reds, **4** after `c0bbd6d9`), closed by
-   `#1567` `6f1867b1`. **At least two instances in two days, both measured here, and nothing prevents
+   `#1567` `6f1867b1` (**5 passed** at `origin/main` `337114e0`). **At least two instances in two days, both measured here, and nothing prevents
    the next one.** Tracked as `handoff-gate-flake-store-api.md` rank 8, closed as an instance and
    retained for the class.
    forcing: none — both instances shipped; the class is unaddressed and owned by nobody.

--- a/claudedocs/handoff-gate-speed-and-ci-signal.md
+++ b/claudedocs/handoff-gate-speed-and-ci-signal.md
@@ -136,9 +136,12 @@ the END. **Ranks 1–3 and 9 are CLOSED tombstones**; renumbering re-points ever
    to skip re-runs on KNOWN FLAKES, and the store-api flake it was written around is now at **0 of
    99** verdicts on heads carrying `ce9b55c3` (`handoff-gate-flake-store-api.md` rank 1). The same
    read independently re-derived this file's own truncation finding from scratch — **100 of 101
-   failure descriptions truncated at 138 characters** — which is what makes the screen unsatisfiable
+   failure descriptions truncated at 138 of the 140-character cap** — which is what makes the screen unsatisfiable
    (the measurement sits beside `_FAILING_RE` in that file). So the screen now guards a flake that has
-   stopped occurring, using a completeness proof a 138-byte field cannot supply. ⚠ **Not a decision —
+   stopped occurring, using a completeness proof a 140-byte field cannot supply. ⚠ **Both figures are
+   a READ-TIME population that cannot be re-derived** (GitHub keeps one status per context and
+   supersedes overwrite it) — see `handoff-gate-flake-store-api.md` rank 1; a later disagreement is
+   not a refutation. ⚠ **Not a decision —
    the 2026-10-11 date and "decide them together" both stand**; this is the datum to decide ON, and it
    did not exist when the date was set.
    forcing: none


### PR DESCRIPTION
Follow-up to **#1568**, which merged **6 minutes** after it opened — so its round-0 audit landed **10 minutes after the merge**, and every candidate it found is a follow-up rather than a change to that PR. Round 0 re-verified #1568's self-reported numbers and **every checkable one verified exactly**: `sited_root` on 106 lines, the surviving `tmp_path / "store"` at `:449`, the class at `:14543`, `ce9b55c3`/`c0bbd6d9` both real, rank 8's subject real, the claim genuinely held. This PR fixes the one that did not, and pays the retirements.

## The claim that was wrong

> *"`main`'s last **8** commits carry no completed `tekton/devrc-main-pytests` verdict: **six** `superseded…`, two `NO GATE POD`, newest pending."*

Re-derived over the **named range** `457a5dc7~1..8114a124`: **four** superseded, two `NO GATE POD`, one **`KILLED`**, one pending. The headline — zero completed verdicts — held; the breakdown did not.

🔴 **The frame was worse than the count.** "The last N commits" is a moving window, and `main` took two commits between writing the sentence and checking it. It was unfalsifiable by construction. **Name a sha range or do not quote a window.**

## …and it was a worse duplicate of a sibling doc

That paragraph re-measured at n=8, badly, something `handoff-gate-speed-and-ci-signal.md` already owns at **n=100** with the decomposition (`:54`), and split on this very fix (`:363`: *"of 43 post-fix verdicts on `main`, **40 were artefacts** … leaving **3**. Use PR heads."*). `KILLED` is not an undiagnosed mode either — the four artefact strings are a **shipped mechanism** (`handoff-cairn-task-linkage.md:37`). Replaced with a pointer to both.

## Retirements the measurement owed

| site | was | now |
|---|---|---|
| gate-speed rank 3 | rested on `#1512`'s timestamp split (P≈0.23) | names the ancestry read (P≈0.017), while stating `#1512` was *underpowered, not corrupted* |
| gate-speed rank 9 | `forcing: gate`, two options open | **CLOSED** by `#1561`, with rate evidence; successor named (`test_runner_bound_ledger.py`, live) |
| gate-speed rank 6 | "probably inert — decide on/after 2026-10-11" | gets the datum to decide **on**, without pre-empting the date |
| cairn-oss rank-22 bullet | retained an **instruction** to go run the finished work | struck per `supersede.md`; instruction deleted, unique provenance shas kept |
| gate-flake rank 1 | `forcing: gate` | `forcing: none` — its own payload (0 of 99) disproves it; the forcing claim *moved* to ranks 8/9 |
| the retained "superseded text" | justified as "a caveat still true of any FUTURE baseline" | justification **withdrawn** — it is a warning about one past baseline; the number is kept |
| `State now` | `main @ 65f7325b`, two merges stale | **no tip sha at all** — see below |
| open investigation | *"tmpfs siting … UNMEASURED"*, still prescribing the probe | CLOSED, with its residual stated: the hypothesis's *second* half is still unmeasured |

🔴 **The tip-sha line is the self-demonstrating one.** I replaced `65f7325b` with `8114a124` — and it was stale **before it was pushed**, because `main` took `#1564` in the interval. So the line is gone rather than corrected; every sha in the doc is now pinned to the commit it is *about*, never to "the tip".

## One residual narrowed — measured, not argued

Whether the gate container has a usable tmpfs was "the first thing to check". `store_siting.py:221` sets `_MIN_FREE_BYTES = 4 MiB`, `:67` makes `/dev/shm` the only candidate, and the gate pipeline (2,482 lines) has **0** occurrences of `shm` and **0** of `medium:` — positive controls on the same read: `pytests` 59, `emptyDir` 3. So nothing overrides `/dev/shm` for the `pytests` step. ⚠ Stated in two halves because only one is a reading of *this* cluster: "nothing overrides it" is measured; "therefore 64 MiB" is the runtime default, and **no node was read**.

## New rank 9 — and it is not new

`#1508` deleted `scripts/lib/subsystem_recall.py`; **61** `claudedocs/` files still prescribe running it (**65** invocations). The bare path appears 71 times in 63 files, which is why the closing condition is keyed to the **invocation** — otherwise the item makes its own condition unsatisfiable. Six source references, all comments, none broken; the Dockerfile's is already correct. ⚠ An earlier count said **5** and missed the Dockerfile, because the sweep was an extension-filtered `find` rather than a `git grep` over the ref.

🔴 **The index has carried this as an `OPEN:` bullet since 2026-09-01 naming this exact remedy**, and `cairn recall` surfaced it at resume time. Rank 9 points there instead of presenting it as new.

## Outside this diff

The index entry `devrc/subsystem-store-api` still stated the verifier as **OPEN** against the 2026-09-01 baseline — and the index is read **before** the doc, so the next session met the opposite of the truth first. Corrected by `cairn append` (revision `68a1bc6fb145b460`). Round 0 called this its highest-value single finding.

## Round-0 trial ledger — transcribed verbatim, as its owner requires

**`ran: 6 · changed the outcome: 3`**

This dispatch makes `R=7` and **cannot move `C`**: it was a post-merge ordinary trial, which `handoff-audit-pr-ladder.md:31` already diagnosed as the cause of every zero, and `:116` says not to run more of. The remaining work is the **trigger** (**#1565**), not more trials. Recorded here rather than quietly skipped.

## Verification

Three `claudedocs/` files, prose only. `test_handoff_audit.py` + `test_handoff_doc.py` + `test_handoff_index.py` + `test_doc_path_rot.py`: **802 passed**. ⚠ Those gates parse headings but **do not validate path citations** — proven in #1568 by inserting a bogus path and watching them stay green — so citations here were checked by hand, which is how the `:236-239` → `:232-239` and `:365` → `:363` corrections were found.

Rank 8's red re-measured at **three** successive `main` tips (`4e970998`, `8114a124`, `61f41adf`) because the base moved twice under this work. `#1567` still `OPEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rg3dNxWP65JYxjRujF23a