### PR TITLE
chore(cairn): move the pin to 562a6ea — ships the client-side bullet-cap refusal

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1788926377,
-        "narHash": "sha256-voZR/UA9CaqNgQEk1W6Sg1eOttA01n7k6+RdCleFlWs=",
+        "lastModified": 1789187709,
+        "narHash": "sha256-CH8S7TQf9Kmpk0eBMDwZhbolGtvBWMvOyp30TinvyX4=",
         "owner": "ZacxDev",
         "repo": "cairn",
-        "rev": "c84c14292e9977d2675f9d0645b10c6d7453086d",
+        "rev": "562a6ea2970cabf2e5ef658c0ebe9817693b81e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
One input, three lines: `c84c142` → `562a6ea2970cabf2e5ef658c0ebe9817693b81e2`. `ZacxDev/cairn#12`, clawgate task #558.

The **server half** of that PR is already live — `subsystem-store-api:0.8.1`, pinned in `homelab-infra` at `160fdb2d3`, verified against the live store (`2001 → 1 over`, `3210 → 1210 over`, target entry bullet count 12 before and 12 after). This is the **client half**, which is the part that makes the limit learnable without exceeding it: `cairn append` refuses locally before the network and names the overage, and `append --help` carries the number.

Both halves import ONE constant from `entry_shape`, so they cannot disagree about the value.

## Why this bump exists

Without it the two halves are in different states in a way that *looks like success*. Measured before this change: `cairn append` with a 2,037-char text printed `the store REFUSED the write … — 37 over`. That is the NEW SERVER's message, so it reads as the feature working — while the whole point of the client half is that the store should never have been contacted. A correct-looking error was the evidence that the client half was missing.

## Verified on the built artifact BEFORE committing

Paired, against a dead store port so the network attempt is observable:

| control | result |
|---|---|
| 2037 chars | `refusing to send … 37 over. Nothing was written, and the store was not contacted.` |
| 2000 chars (at cap) | passes the local check and **attempts the network** (store unreachable) — proving the guard is not refusing everything |

Artifact content: `refusing to send` ×1 in the client, `BULLET_TEXT_MAX` ×1 in `libexec/cairn/lib/entry_shape.py`. Store path is `cairn-562a6ea`, so the version label tracks the rev as `flake.nix`'s own comment intends.

**Gate:** `scripts/tests/test_cairn_flake_pin.py` 15 passed. Lock diff touches only the `cairn` node (3 lines).

## Not verified

`home-manager switch` has not been run yet — merged ≠ deployed, and nothing nix-managed moves without it.