### PR TITLE
chore(audit-pr): close the round-0 trial — it STAYS, and a TRIAL RECORD replaces the retirement condition

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -49,11 +49,12 @@ that is empty by construction and a finding-free pass over it reads as a clean r
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-⚠ **Consider `--round 0` FIRST — the requirements & deletion pass (its own section below).** It
-asks whether the change should EXIST, which no item on the checklist asks; it is the only round
-that can conclude *close this PR, do not audit it*. It is ON TRIAL, so it is a judgement call, not
-a step — but it has to be reachable from here or the trial closes by attrition rather than by
-evidence. Whichever you run, record `ran: R · changed the outcome: C` on the PR.
+🔴 **RUN `--round 0` FIRST — the requirements & deletion pass (its own section below).** It asks
+whether the change should EXIST, which no item on the checklist asks; it is the only round that can
+conclude *close this PR, do not audit it*. **No longer on trial: the trial CLOSED at `ran: 6 ·
+changed the outcome: 3`** (evidence in the section itself). 🔴 **Run it at PR-CREATE time, not when
+you get round to auditing** — that is the one finding the trial produced, and the
+`audit-pr-nudge.py` PostToolUse hook now routes it there for you.
 
 **Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. What each hid, and `GOPRIVATE`: reference file.
 
@@ -85,8 +86,8 @@ one scratchpad path and the branch namespace, so two audit rounds that both pick
 
 ## ROUND 0 — QUESTION THE REQUIREMENT, THEN DELETE (runs BEFORE the checklist)
 
-⚠ **ON TRIAL, NOT A STANDING RULE — read the retirement condition at the end of this section
-before you run it.**
+✅ **A STANDING RULE — the trial is CLOSED. Read the TRIAL RECORD at the end of this section for
+what it cost and what it found; you do not have to re-litigate whether to run it.**
 
 Every axis below asks whether the change is CORRECT. None asks whether it should EXIST, and an
 audit scoped to a diff will never raise it on its own: that is how a 145 KB webhook listener
@@ -150,18 +151,30 @@ add-back heuristic needs a measurement nothing here performs — and the sentenc
 which is the shape this skill tells you to delete rather than reverse. Recorded so nobody derives
 it again.
 
-🔴 **RETIREMENT CONDITION — this section is on trial.** Run it on the next 3–5 PRs and record, on
-each PR, its verdict and whether that verdict CHANGED what happened. **If it ran and changed
-nothing, DELETE this section** — do not automate it further, and do not keep it because it reads
-well.
+✅ **TRIAL RECORD — CLOSED 2026-09-12 at `ran: 6 · changed the outcome: 3`. The section STAYS. Do
+not re-open the question; read what it found instead.** The retirement condition that stood here
+said *"if it ran and changed nothing, DELETE this section"*. It ran and it changed things, so the
+condition is spent and is recorded rather than left standing — a trial nobody can close is how a
+judgement call becomes permanent by attrition.
 
-🔴 **REPORT THE PAIR — `ran: R · changed the outcome: C` — never `C` alone.** A bare zero cannot
-distinguish "it ran five times and was useless" from "nobody ever typed `--round 0`", and those
-have opposite conclusions: the first retires the section, the second says the trial never started.
-`--round` still DEFAULTS to 1, so the second is the likelier reading of a silent zero. `R = 0` is
-not evidence about this section at all — it is evidence about its routing, and the fix is to run it,
-not to delete it. Closed by that pair reaching a decision, recorded on the PR that removes this
-section or on the one that promotes it out of trial.
+Decomposition, because the PAIR is the record and `C` alone is meaningless: trials 1–2 → 2/2 ·
+trials 3–5 → **3/0** · a peer session's round 0 on `#1518` → 1/1 (it closed that PR unmerged).
+
+🔴 **THE FINDING WAS THE ROUTING, NOT THE SECTION — and every zero above says so.** All three of
+trials 3–5 produced a verdict and none could act, because each was dispatched after the decision
+was already taken: `#1523` merged **27 min BEFORE** its audit was dispatched, `#1510` merged **+6
+min after**, `#1518` was closed **5 min before** the report returned. Audit runtimes were
+459/920/776 s, so no speedup reaches any of them. **Round 0's question is only actionable while the
+merge decision is open**, so the fix was a trigger, not an edit to this section:
+`scripts/claude-hooks/audit-pr-nudge.py` now routes round 0 as step 1 of the nudge it fires on
+`gh pr create` (pinned by `scripts/claude-hooks/tests/test_audit_pr_nudge.py`). Full evidence:
+`claudedocs/handoff-audit-pr-ladder.md`.
+
+⚠ **Keep reporting `ran: R · changed the outcome: C` on each PR** — not to decide this section's
+fate, which is settled, but because it is the only record of whether the TRIGGER is working. A bare
+`C` cannot distinguish "it ran and was useless" from "nobody invoked it", and those have opposite
+conclusions; `--round` still defaults to 1, so a silent zero is more likely a routing failure than a
+verdict about the pass.
 
 <!-- 🔴 LOAD-BEARING HEADING, NOT NAVIGATION. `_read_round_zero` in
      scripts/audit-dispatch.py captures the ROUND 0 section up to the next

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -170,6 +170,14 @@ merge decision is open**, so the fix was a trigger, not an edit to this section:
 `gh pr create` (pinned by `scripts/claude-hooks/tests/test_audit_pr_nudge.py`). Full evidence:
 `claudedocs/handoff-audit-pr-ladder.md`.
 
+⚠ **CORROBORATED FROM OUTSIDE THE TRIAL, which is why the pair is not re-opened to count it.** A
+different session hit the same thing after this record closed: `#1568` merged **6 min** after it
+opened (`04:11:19Z` → `04:17:24Z`, re-derived here, not taken from its PR body), so its round-0
+audit landed **after** the merge and every candidate it found became a follow-up. That is a
+FOURTH independent instance of the post-decision dispatch, and it is evidence about the ROUTING,
+not a seventh trial — **do not fold it into `R`.** It is here because the thing most likely to
+happen next is someone re-deriving this finding from fresh trials instead of reading it.
+
 ⚠ **Keep reporting `ran: R · changed the outcome: C` on each PR** — not to decide this section's
 fate, which is settled, but because it is the only record of whether the TRIGGER is working. A bare
 `C` cannot distinguish "it ran and was useless" from "nobody invoked it", and those have opposite

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -8268,10 +8268,43 @@ def test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships():
             "the middle of the section, the brief now carries only its head "
             f"while the skill still reads complete:\n{section[:600]}"
         )
-    assert "RETIREMENT CONDITION" in section, (
-        "the retirement condition is not in the text the script inlines. It "
-        "is the only thing standing between a trial and a permanent rule, and "
-        "an auditor who never sees it cannot apply it."
+    # 🔴 THE TRIAL IS CLOSED, SO WHAT THE AUDITOR MUST SEE HAS CHANGED. This
+    # used to assert "RETIREMENT CONDITION" was inlined, on the grounds that it
+    # "is the only thing standing between a trial and a permanent rule". That
+    # trial closed 2026-09-12 at `ran: 6 · changed the outcome: 3` and the
+    # condition was replaced by the TRIAL RECORD. Asserting the old string now
+    # would pin a sentence the skill deliberately retired; asserting nothing
+    # would let the section drift back to claiming it is on trial, which is the
+    # state that makes a standing rule re-litigable on every invocation.
+    # 🔴 ASSERT THE RECORD'S SUBSTANCE, NOT ITS NAME — measured, because the
+    # first draft of this guard asserted `"TRIAL RECORD" in section` and a
+    # mutation sweep SURVIVED it: renaming the record's own heading left the
+    # phrase in the banner ABOVE it ("read the TRIAL RECORD at the end of this
+    # section"), so a POINTER to the record satisfied a check meant to prove the
+    # record was there. Same shape as test_audit_pr_nudge.py's first routing
+    # guard. The pair is the thing that cannot be faked by a cross-reference.
+    assert "ran: 6" in section and "changed the outcome: 3" in section, (
+        "the section does not inline the trial's PAIR (`ran: 6 · changed the "
+        "outcome: 3`). That pair IS the record: `C` alone cannot distinguish "
+        "'it ran and was useless' from 'nobody invoked it', and those have "
+        "opposite conclusions. A heading naming a record it does not carry, or "
+        "a pointer to one elsewhere, is not the record."
+    )
+    assert "ROUTING" in section, (
+        "the section inlines the pair but not the FINDING it produced — that "
+        "the dispatch ROUTING was the defect, not the pass. Without it the next "
+        "session reads three zeros and re-derives the retirement question from "
+        "more ordinary trials, which is exactly what the record exists to stop."
+    )
+    assert "RETIREMENT CONDITION" not in section, (
+        "the section still inlines a RETIREMENT CONDITION. The trial is closed; "
+        "a condition left standing invites a future session to retire a rule "
+        "that has already earned its place — and it cannot be satisfied twice."
+    )
+    assert "ON TRIAL, NOT A STANDING RULE" not in section, (
+        "the section still announces itself as ON TRIAL. It is a standing rule "
+        "now; telling an auditor otherwise makes them weigh whether to run it "
+        "instead of running it."
     )
     # 🔴 THE HALF THAT WAS MISSING, AND THE ONLY ONE THAT CAN FAIL FOR THE
     # CAUSE THAT MATTERS. Every assertion above is a PRESENCE check, and the


### PR DESCRIPTION
Closes the last step of rank 1 in `claudedocs/handoff-audit-pr-ladder.md`. Follows `#1565` (the trigger), which is merged and deployed to both hosts.

## The trial closed at `ran: 6 · changed the outcome: 3`

The retirement condition said *"if it ran and changed nothing, DELETE this section"*. It ran, and it changed things **three times — every time it arrived before the decision**. So the condition is spent and is **recorded rather than left standing**: a trial nobody closes is how a judgement call becomes permanent by attrition, and a condition left standing invites a future session to retire a rule that has already earned its place.

Decomposition: trials 1–2 → 2/2 · trials 3–5 → **3/0** · a peer's round 0 on `#1518` → 1/1.

🔴 **The finding was the ROUTING, and the record says so.** All three of trials 3–5 produced a verdict and none could act: `#1523` merged **27 min before** dispatch, `#1510` **+6 min after**, `#1518` was closed **5 min before** the report returned — against runtimes of 459/920/776 s. Without that sentence in the record, the next session reads three zeros and re-derives the retirement question from three more ordinary trials.

Three edits, all inside the section the dispatcher inlines: the `⚠ ON TRIAL` banner → `✅ A STANDING RULE`; the top-of-skill *"Consider `--round 0`"* → *"RUN `--round 0` FIRST"*, naming the trigger; the condition → the record.

## The pin had to move, and my first version was walkable

`test_audit_dispatch.py` asserted `"RETIREMENT CONDITION" in section` — now the wrong thing to pin. Replaced with four assertions, each mutation-controlled and each failing with its **own** message:

| mutant | result |
|---|---|
| M1 — the pair removed from the section | pair guard fires |
| M2 — a RETIREMENT CONDITION re-introduced | absence guard fires |
| M3 — the pair dropped from the heading | pair guard fires |
| M4 — the ROUTING finding reworded away | finding guard fires |

🔴 **M1's first version SURVIVED.** I asserted `"TRIAL RECORD" in section`, and renaming the record's own heading left that phrase in the banner *above* it (*"read the TRIAL RECORD at the end of this section"*) — so a **pointer** to the record satisfied a check meant to prove the record existed. A guard on a name, walkable by a cross-reference. Replaced with assertions on the record's **substance** (the pair, and the finding), which a cross-reference cannot fake. **Second time in two commits I wrote a spelled guard and the sweep caught it** — worth saying out loud rather than burying.

⚠ One M1 retry reported `MUTATION DID NOT APPLY — result meaningless` because my pattern missed the file's line wrapping. That scored **nothing** rather than a false SURVIVED — the battery's own assert doing its job. Re-run with a pattern taken from the file, it killed correctly. Skill restored byte-identical (`cmp -s` → IDENTICAL) from a `cp -a` copy, never `git checkout --`.

## Verification

`test_audit_dispatch.py` → **135 passed**. `test_audit_ladder_stop_rule.py` (it pins whole paragraphs of this skill) → **16 passed**. The emitted round-0 brief still carries its heading and the record, with `RETIREMENT CONDITION` → 0 and `## THE CHECKLIST` → 0 (the axes stay withheld). No gate tier run and none claimed.

⚠ **Merged ≠ deployed** — this skill is a `home.file` target, so `~/.claude/skills/audit-pr/SKILL.md` keeps the old text until `ship.sh`.