### PR TITLE
feat(audit-pr): classify gap commits by the round they DECLARE — 40 UNLEDGERED rounds, split interior/tail

### DIFF
--- a/claudedocs/audit-ladder-review-2026-09-04.md
+++ b/claudedocs/audit-ladder-review-2026-09-04.md
@@ -557,34 +557,70 @@ Both directions, and they do not cancel.
   ✅ **SAMPLING SUPERSEDED BY A CENSUS, 2026-09-11 — `--find-carriers` now classifies every gap
   commit in every repo that carries ladders.** The sample's own by-product is the instrument:
   a commit whose subject names the audit round it belongs to, sitting in a range no round
-  covered, is self-declared missed audit surface. **186 gap commits:**
+  covered, is an UNLEDGERED ROUND (see below — not unaudited churn). **186 gap commits:**
 
-  | repo | gap commits | ROUND-REF | MERGE | unclassified | gaps with a ROUND-REF |
-  |---|---|---|---|---|---|
-  | devrc | 69 | **11** | 23 | 35 | 9 |
-  | homelab-talos | 79 | **16** | 17 | 46 | 16 |
-  | civit-datapacket-talos | 25 | **7** | 2 | 16 | 7 |
-  | civitai-gpu-fleet | 10 | **5** | 0 | 5 | 5 |
-  | vetr-app | 1 | **1** | 0 | 0 | 1 |
-  | vetr-api | 2 | 0 | 0 | 2 | 0 |
-  | **TOTAL** | **186** | **40** | 42 | 104 | **38** |
+  Split INTERIOR / TAIL as `round-ref · merge · unclassified`, because only the interior half is
+  unambiguous — see the 🔴 under the table:
 
-  **40 commits across 38 gaps say in their own subject which audit round they belong to, while
-  sitting in a range no round's ledger covers.** That is the finding this whole arc was after,
-  and it needs no judgement: the commits assert it themselves.
-  🔴 **ZERO false positives on the real corpus, verified by reading all 11 devrc hits** — every
-  one is a genuine round commit, including one whose reference is a trailing parenthetical
-  (`… (round-2 audit)`). And the control that matters: **`eb947328` is among them** — the exact
-  commit this review identified BY HAND as #1233's uncovered round 3. The classifier found it
-  independently.
-  🔴 **THE CENSUS IS A FLOOR, NEVER A RATE, AND THE OUTPUT SAYS SO.** It sees only a round
-  reference a commit chose to write down; a round's fix with an ordinary subject lands in
-  `unclassified`, indistinguishable from a feature. Measured against the 32 hand-classified
-  commits: **8 self-declared where the hand pass found 20 fixes.** So the 104 `unclassified`
-  are **not** development — they are unread, and the tool refuses to guess. An earlier draft
-  had five heuristic buckets keyed on commit types and correction verbs; it was deleted,
-  because `claude/RULES.md` is explicit that a guard spelled over WORDS is walkable by
-  rewording, and a classifier is no different.
+  | repo | gap commits | INTERIOR | TAIL | gaps w/ round-ref |
+  |---|---|---|---|---|
+  | devrc | 69 | **1** · 0 · 1 | 10 · 23 · 34 | 9 |
+  | homelab-talos | 79 | **3** · 0 · 2 | 13 · 17 · 44 | 16 |
+  | civit-datapacket-talos | 25 | 0 · 0 · 0 | 7 · 2 · 16 | 7 |
+  | civitai-gpu-fleet | 10 | 0 · 0 · 0 | 5 · 0 · 5 | 5 |
+  | vetr-app | 1 | 0 · 0 · 0 | 1 · 0 · 0 | 1 |
+  | vetr-api | 2 | 0 · 0 · 0 | 0 · 0 · 2 | 0 |
+  | **TOTAL** | **186** | **4** · 0 · 7 | **36** · 42 · 101 | **38** |
+
+  🔴 **FOUR, NOT FORTY — and an earlier revision of this section headlined the 40.** Forty
+  commits name their round; only **4 are INTERIOR**, the class where the reading is unambiguous.
+  The other **36 are TAIL**, which conflates a fix posted after the final block with work that
+  simply continued after the ladder ended — nothing in the ranges separates them. Summing the
+  two is the error the line-count banner above forbids in capitals, committed inside the census
+  that was meant to honour it. **Quote the 4.**
+
+  🔴 **WHAT THOSE 40 ARE IS AN *UNLEDGERED ROUND*, NOT UNAUDITED CHURN — and this paragraph
+  asserted the opposite until round 0 of `#1576` caught it.** A subject reading `audit round 5 —
+  <what was fixed>` is EVIDENCE THAT ROUND 5 RAN; the commit IS that round's fix. What the gap
+  proves is that the round posted no two-sha `audited=` block, so its delta chains into nobody's
+  range and nothing re-audited it. That is a **ledgering** defect. Reading "an audit happened
+  here" as "no audit covered this" applies judgement in the direction the text contradicts.
+  🔴 **THE CASE THAT SETTLES IT IS THE ONE THIS SECTION CALLED ITS CONTROL.** `eb947328` is
+  #1233's round 3 — and the CANNOT-SEE bullet above says in terms that #1233's round-4 comment
+  is **titled "rounds 3 and 4"**. Round 3 *was* audited, inside round 4's comment; what was
+  missing was its block. The mechanism hypothesis two paragraphs up says the same thing. So it
+  is a real find and a real defect, and it is **not** evidence the code went unread — and it is
+  not an independent control either: `_ROUND_REF_POSITIVES` already pins the identical
+  `round-3 audit` form, so the regex matched a shape its own ledger carries. It confirms one
+  case; it validates nothing about the inference.
+  **The residual hazard, stated narrowly because it is the true one:** round N's fix has no
+  successor block, so the gate-reset rule was not honoured and no round ever diffed that delta.
+  ✅ **ZERO false positives for what it does claim, verified by reading all 11 devrc hits** —
+  every one genuinely names a round, including a trailing parenthetical (`… (round-2 audit)`).
+  **Base-rate control:** the pattern matches **4 of 624** devrc `main` squash subjects (0.6%)
+  against 11 of 69 devrc gap commits (16%) — **~26× enriched** in the gap population, so it is not
+  firing on everything.
+  🔴 **READ THE SPLIT, NOT THE 40.** Measured on devrc: **10 of 11 ROUND-REF commits are TAIL
+  and exactly ONE is interior**, so the combined headline is ~91% the ambiguous class — and the
+  line counts three paragraphs up carry a 🔴 banner forbidding exactly this sum. The census now
+  prints interior and tail separately for the same reason.
+  🔴 **IT IS A FLOOR, NEVER A RATE, AND THE OUTPUT SAYS SO.** It sees only a round reference a
+  commit chose to write down. Measured against the 32 hand-classified commits: **8 self-declared
+  where the hand pass found 20 fixes**, so it is ~40% sensitive. The 104 `unclassified` are
+  **not** development — they are unread, and the tool refuses to guess. An earlier draft had
+  five heuristic buckets keyed on commit types and correction verbs; deleted, because
+  `claude/RULES.md` is explicit that a guard spelled over WORDS is walkable by rewording and a
+  classifier is no different.
+  🔴 **AND IT DOES NOT SUPERSEDE THE HAND SAMPLING — 63 of 79 adjacencies REMAIN UNREAD BY A
+  HUMAN.** An earlier wording said the census "supersedes sampling" and deleted the `63 of 79`
+  caveat in the same edit; that is a different and weaker claim wearing the stronger one's
+  words. The census classifies a **proxy** at ~40% sensitivity over a different unit (commits,
+  not adjacencies). Both are needed and neither is complete.
+  ⚠ **OVERLAP and UNRELATED have never fired** — 0 occurrences across every recorded run plus a
+  64-carrier devrc re-run. Kept deliberately: `_is_ancestor` returns `None` on an unresolvable
+  sha, and deleting that path makes such a sha read as a GAP *with a size*. A never-fired
+  refusal is cheaper than the number it stops anyone inventing — but it is untested by adoption,
+  and this line is the record of that.
   ⚠ **Two repos are UNMEASURABLE, each for its own reason, and neither is a pass.** naida-ai
   ran 214 PRs and posted **no ledger at all**, so there is nothing to measure coverage
   against — "no ladders ran here" and "ladders ran without blocks" are the same observation
@@ -667,3 +703,16 @@ Both directions, and they do not cancel.
    #1108, #1219 here) still has its round-1 churn unmeasured. The script says so per ladder
    rather than inventing a number, because what "round 1" means for a ledger that begins at 2
    is a judgement about that PR, not arithmetic.
+6. **Decide what happens to the 40 UNLEDGERED ROUNDS the census names** — its own output says
+   *"Read them; the subjects are printed above"*, and nothing owns doing that. Two acceptable
+   closures, and a third that is not:
+   - ✅ *Closes when* a session reads the **interior** ones — **1 of the 40 on devrc**, so this
+     is small — and records per PR whether the round's delta was ever re-audited under another
+     round's block. The TAIL ones are the ambiguous class and are deliberately NOT in scope.
+   - ✅ Or *closes when* the operator writes on this item that the 40 will not be read, which is
+     a legitimate answer and cheaper than a census nobody acts on.
+   - 🔴 It does **not** close by the census being re-run with a bigger number. Producing the
+     list again is not reading it.
+   ⚠ Filed because round 0 of `#1576` found the list had been produced with no owner:
+   `claude/RULES.md` requires a closing condition and a named checker, and a measurement whose
+   product is 40 named commits that nobody reads is a cost, not a capability.

--- a/claudedocs/audit-ladder-review-2026-09-04.md
+++ b/claudedocs/audit-ladder-review-2026-09-04.md
@@ -552,8 +552,39 @@ Both directions, and they do not cancel.
   per-repo: two of these three repos use `trunk`, not `main`. An ad-hoc script that guessed
   `origin/main` failed loudly on four of the ten; the measurement itself takes each PR's own
   `baseRefName` from `gh` and was never wrong about it.
-  ⚠ Still 63 of 79 unclassified, and the two samples agree, which is weak evidence that a third
-  would too — they do not agree about a *rate* because neither was sized to estimate one.
+  ⚠ The two samples agree, which is weak evidence that a third would too — they do not agree
+  about a *rate* because neither was sized to estimate one.
+  ✅ **SAMPLING SUPERSEDED BY A CENSUS, 2026-09-11 — `--find-carriers` now classifies every gap
+  commit in every repo that carries ladders.** The sample's own by-product is the instrument:
+  a commit whose subject names the audit round it belongs to, sitting in a range no round
+  covered, is self-declared missed audit surface. **186 gap commits:**
+
+  | repo | gap commits | ROUND-REF | MERGE | unclassified | gaps with a ROUND-REF |
+  |---|---|---|---|---|---|
+  | devrc | 69 | **11** | 23 | 35 | 9 |
+  | homelab-talos | 79 | **16** | 17 | 46 | 16 |
+  | civit-datapacket-talos | 25 | **7** | 2 | 16 | 7 |
+  | civitai-gpu-fleet | 10 | **5** | 0 | 5 | 5 |
+  | vetr-app | 1 | **1** | 0 | 0 | 1 |
+  | vetr-api | 2 | 0 | 0 | 2 | 0 |
+  | **TOTAL** | **186** | **40** | 42 | 104 | **38** |
+
+  **40 commits across 38 gaps say in their own subject which audit round they belong to, while
+  sitting in a range no round's ledger covers.** That is the finding this whole arc was after,
+  and it needs no judgement: the commits assert it themselves.
+  🔴 **ZERO false positives on the real corpus, verified by reading all 11 devrc hits** — every
+  one is a genuine round commit, including one whose reference is a trailing parenthetical
+  (`… (round-2 audit)`). And the control that matters: **`eb947328` is among them** — the exact
+  commit this review identified BY HAND as #1233's uncovered round 3. The classifier found it
+  independently.
+  🔴 **THE CENSUS IS A FLOOR, NEVER A RATE, AND THE OUTPUT SAYS SO.** It sees only a round
+  reference a commit chose to write down; a round's fix with an ordinary subject lands in
+  `unclassified`, indistinguishable from a feature. Measured against the 32 hand-classified
+  commits: **8 self-declared where the hand pass found 20 fixes.** So the 104 `unclassified`
+  are **not** development — they are unread, and the tool refuses to guess. An earlier draft
+  had five heuristic buckets keyed on commit types and correction verbs; it was deleted,
+  because `claude/RULES.md` is explicit that a guard spelled over WORDS is walkable by
+  rewording, and a classifier is no different.
   ⚠ **Two repos are UNMEASURABLE, each for its own reason, and neither is a pass.** naida-ai
   ran 214 PRs and posted **no ledger at all**, so there is nothing to measure coverage
   against — "no ladders ran here" and "ladders ran without blocks" are the same observation

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -77,6 +77,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from collections import namedtuple
@@ -131,7 +132,8 @@ def real_runner(cmd, cwd=None):
 TIGHT, GAP, OVERLAP, UNRELATED = "TIGHT", "GAP", "OVERLAP", "UNRELATED"
 
 Adjacency = namedtuple(
-    "Adjacency", "label frm to from_round to_round added deleted commits reason"
+    "Adjacency",
+    "label frm to from_round to_round added deleted commits reason gap_commits"
 )
 Ladder = namedtuple(
     "Ladder",
@@ -160,6 +162,77 @@ def _is_ancestor(runner, repo_dir, a, b):
     # UNMEASURABLE; collapsing it to False there would label the adjacency a GAP
     # and hand it a size.
     return None
+
+
+# --------------------------------------------------------------------------- #
+# Gap-commit classification — TWO certain buckets, and an honest "ask a human"
+# --------------------------------------------------------------------------- #
+# 🔴 THE SIGNAL IS SELF-DECLARED, WHICH IS WHY THIS IS NOT A HEURISTIC SOUP.
+# Measured over 32 hand-classified tail commits (2026-09-11, devrc +
+# homelab-talos + civit-datapacket-talos): EIGHT of them name the audit round
+# they belong to, in their own subject line — `audit round 5`, `audit r3`,
+# `round-2 audit`, `round-3 audit`, `audit round 9`. A commit that says it is a
+# round's fix IS missed audit surface when it sits in a gap; no judgement is
+# needed and none is applied.
+#
+# 🔴 EVERYTHING ELSE IS REPORTED UNCLASSIFIED ON PURPOSE. An earlier draft of
+# this had five buckets keyed on conventional-commit types and correction verbs
+# (`fix(`, `correct`, `retract`, …). That is a guess dressed as a measurement:
+# `claude/RULES.md` is explicit that a guard spelled over WORDS is walkable by
+# rewording, and the same applies to a classifier. So the census reports what it
+# KNOWS — self-declared round references, and merges, which are structural — and
+# hands the rest over by name. A smaller true answer beats a larger guessed one.
+_ROUND_REF_RE = re.compile(
+    r"""(?ix)
+    \b(?:
+        audit \s* (?: \s | - ) \s* r (?:ound)? \s* \.? \s* \d+   # audit round 3 · audit r3
+      | r (?:ound)? \s* - \s* \d+ \s+ audit                      # round-2 audit
+      | round \s+ \d+ \s+ (?:delta \s+ )? (?:re-)? audit         # round 4 delta re-audit
+    )\b
+    """
+)
+
+GapCommit = namedtuple("GapCommit", "sha parents subject round_ref is_merge")
+
+
+def classify_gap_commits(runner, repo_dir, frm, to, base):
+    """-> ([GapCommit], reason) for the commits that CONTRIBUTE the gap's churn.
+
+    🔴 `--not <base>` IS LOAD-BEARING HERE AND OMITTING IT INVERTS THE ANSWER.
+    Measured 2026-09-11: listing devrc #1046's tail without it showed 55 of
+    `main`'s OWN squash commits, which reads exactly like "the PR kept
+    developing" — i.e. it CONFIRMS the hypothesis that the tail is ordinary
+    development, using commits that are not in the churn at all. The confirming
+    evidence was an artifact of a dropped flag. This function exists partly so
+    that flag cannot be dropped by hand again.
+
+    ⚠ `base` must be the PR's OWN base. Two of the three repos measured use
+    `trunk`; a hand-written `origin/main` failed loudly on 4 of 10 samples, which
+    is the lucky failure — a WRONG-but-resolvable base would have changed the
+    numbers silently.
+    """
+    rc, out, err = runner([
+        "git", "-C", repo_dir, "log", "--format=%H%x00%p%x00%s",
+        f"{frm}..{to}", "--not", base,
+    ])
+    if rc != 0:
+        return [], (f"`git log {frm}..{to} --not {base}` exited {rc}: "
+                    f"{(err or out).strip() or 'no output'}")
+    if err.strip():
+        return [], f"`git log` wrote to stderr: {err.strip()}"
+
+    commits = []
+    for line in out.splitlines():
+        parts = line.split("\0")
+        if len(parts) < 3:
+            continue
+        sha, parents, subject = parts[0], parts[1].split(), parts[2]
+        commits.append(GapCommit(
+            sha=sha, parents=parents, subject=subject,
+            round_ref=bool(_ROUND_REF_RE.search(subject)),
+            is_merge=len(parents) >= 2,
+        ))
+    return commits, None
 
 
 def _classify(ad, runner, repo_dir, frm, to, base):
@@ -276,8 +349,20 @@ def measure_ladder(ad, runner, repo_dir, pr, head, base, comment_texts):
             else:
                 interior_a += added or 0
                 interior_d += deleted or 0
+        # Only a GAP has commits worth classifying — a TIGHT adjacency has none,
+        # and OVERLAP/UNRELATED have no measurable population at all.
+        gap_commits = []
+        if label == GAP:
+            gap_commits, why = classify_gap_commits(
+                runner, repo_dir, frm, to, base)
+            if why:
+                # Reported, never swallowed: an unclassifiable gap must not read
+                # as a gap with zero round references.
+                gap_commits = [GapCommit("", [], f"COULD NOT LIST: {why}",
+                                         False, False)]
         adjacencies.append(
-            Adjacency(label, frm, to, r_from, r_to, added, deleted, commits, reason)
+            Adjacency(label, frm, to, r_from, r_to, added, deleted, commits,
+                      reason, gap_commits)
         )
 
     return Ladder(
@@ -460,6 +545,18 @@ def render(ladders, notes):
                            f"{a.commits} commit(s), "
                            f"{(a.added or 0) + (a.deleted or 0)} line(s) "
                            f"(+{a.added}/-{a.deleted}) in NO block's range")
+                for c in a.gap_commits:
+                    if not c.sha:
+                        out.append(f"       ⚠ {c.subject}")
+                    elif c.round_ref:
+                        out.append(f"       🔴 ROUND-REF  {c.sha[:8]} "
+                                   f"{c.subject[:74]}")
+                    elif c.is_merge:
+                        out.append(f"       MERGE      {c.sha[:8]} "
+                                   f"{c.subject[:74]}")
+                    else:
+                        out.append(f"       unclassified {c.sha[:8]} "
+                                   f"{c.subject[:72]}")
             else:
                 out.append(f"  {a.label}  {where}: {a.reason}")
         out.append(f"  UNCOVERED: {L.uncovered_added + L.uncovered_deleted} line(s)"
@@ -512,6 +609,45 @@ def render(ladders, notes):
         for a in L.adjacencies
         if a.label == GAP and a.commits and not (a.added or 0) + (a.deleted or 0)
     )
+    # 🔴 The census. Counts only what is SELF-DECLARED or STRUCTURAL; everything
+    # else is handed over by name rather than guessed at.
+    gc = [c for L in ladders if L.reason is None
+          for a in L.adjacencies if a.label == GAP
+          for c in a.gap_commits if c.sha]
+    if gc:
+        ref = sum(1 for c in gc if c.round_ref)
+        mrg = sum(1 for c in gc if c.is_merge and not c.round_ref)
+        rest = len(gc) - ref - mrg
+        gaps_with_ref = sum(
+            1 for L in ladders if L.reason is None
+            for a in L.adjacencies
+            if a.label == GAP and any(c.round_ref for c in a.gap_commits))
+        out.append("")
+        out.append(f"GAP-COMMIT CENSUS over {len(gc)} commit(s) in the gaps above:")
+        out.append(f"  🔴 ROUND-REF     {ref} — the commit's own subject names the "
+                   "audit round it belongs to.")
+        out.append("                      A round's fix sitting in a gap IS "
+                   "missed audit surface, self-declared;")
+        out.append("                      no judgement was applied and none is "
+                   "needed.")
+        out.append(f"  MERGE          {mrg} — structural (>=2 parents). Read its "
+                   "remerge-diff: a SEMANTIC")
+        out.append("                      conflict resolution hides here, and is "
+                   "real hand-written work.")
+        out.append(f"  unclassified   {rest} — 🔴 NOT 'ordinary development'. This "
+                   "tool declines to guess.")
+        out.append("                      Read them; the subjects are printed "
+                   "above.")
+        out.append(f"  → {gaps_with_ref} of the gaps carry at least one ROUND-REF "
+                   "commit.")
+        out.append("⚠ THE CENSUS IS A FLOOR ON MISSED AUDIT SURFACE, NEVER A RATE. "
+                   "It can only see a round")
+        out.append("  reference a commit chose to write down — a round's fix with "
+                   "an ordinary subject is")
+        out.append("  indistinguishable here from a feature, and lands in "
+                   "`unclassified`. Measured over 32")
+        out.append("  hand-classified commits: 8 self-declared, and the hand pass "
+                   "found 20 fixes in total.")
     if zero_line_gaps:
         out.append("⚠ A COMMIT COUNT IS NOT A CHURN COUNT. A GAP of many commits "
                    "and 0 lines is `--not")

--- a/scripts/ladder-range-coverage.py
+++ b/scripts/ladder-range-coverage.py
@@ -171,9 +171,29 @@ def _is_ancestor(runner, repo_dir, a, b):
 # Measured over 32 hand-classified tail commits (2026-09-11, devrc +
 # homelab-talos + civit-datapacket-talos): EIGHT of them name the audit round
 # they belong to, in their own subject line — `audit round 5`, `audit r3`,
-# `round-2 audit`, `round-3 audit`, `audit round 9`. A commit that says it is a
-# round's fix IS missed audit surface when it sits in a gap; no judgement is
-# needed and none is applied.
+# `round-2 audit`, `round-3 audit`, `audit round 9`.
+#
+# 🔴 WHAT IT MEASURES IS AN **UNLEDGERED ROUND**, NOT UNAUDITED CHURN — and the
+# first version of this file asserted the opposite, which is backwards. A commit
+# subject reading `audit round 5 — <what was fixed>` is EVIDENCE THAT ROUND 5
+# RAN; it is that round's own fix. What the gap proves is that the round posted
+# no two-sha `audited=<from>..<to>` block, so its churn chains into nobody's
+# range. That is a LEDGERING defect, and reading "an audit happened here" as
+# "no audit covered this" applies judgement in the direction the text
+# contradicts.
+#
+# 🔴 THE CASE THAT SETTLES IT IS THE ONE THIS FILE FIRST CALLED ITS CONTROL.
+# `eb947328` is devrc #1233's round 3 — and
+# `claudedocs/audit-ladder-review-2026-09-04.md` says in terms that #1233's
+# round-4 comment is TITLED "rounds 3 and 4". Round 3 was audited, inside round
+# 4's comment; what was missing was its block. The review's own mechanism
+# hypothesis says the same thing — "a devrc authoring habit: titling one comment
+# 'rounds N and N+1' and posting a single block for both".
+#
+# So the residual hazard is narrower, true, and still machine-checkable:
+# **round N's fix has no successor block, so the gate-reset rule was not
+# honoured and nothing re-audited that delta.** State that; do not state that
+# the code was never looked at.
 #
 # 🔴 EVERYTHING ELSE IS REPORTED UNCLASSIFIED ON PURPOSE. An earlier draft of
 # this had five buckets keyed on conventional-commit types and correction verbs
@@ -611,25 +631,53 @@ def render(ladders, notes):
     )
     # 🔴 The census. Counts only what is SELF-DECLARED or STRUCTURAL; everything
     # else is handed over by name rather than guessed at.
-    gc = [c for L in ladders if L.reason is None
-          for a in L.adjacencies if a.label == GAP
-          for c in a.gap_commits if c.sha]
+    # 🔴 SPLIT BY INTERIOR/TAIL, because this file forbids summing them thirty
+    # lines up and the first census did it anyway. Measured on devrc: 10 of 11
+    # ROUND-REF commits are TAIL and exactly ONE is interior, so a single
+    # headline is ~91% the ambiguous class — the number that would get quoted.
+    def _bucket(tail_only):
+        return [c for L in ladders if L.reason is None
+                for a in L.adjacencies if a.label == GAP
+                and ((a.to_round is None) == tail_only)
+                for c in a.gap_commits if c.sha]
+
+    gc_int, gc_tail = _bucket(False), _bucket(True)
+    gc = gc_int + gc_tail
     if gc:
-        ref = sum(1 for c in gc if c.round_ref)
-        mrg = sum(1 for c in gc if c.is_merge and not c.round_ref)
-        rest = len(gc) - ref - mrg
+        def _counts(rows):
+            r = sum(1 for c in rows if c.round_ref)
+            m = sum(1 for c in rows if c.is_merge and not c.round_ref)
+            return r, m, len(rows) - r - m
+
+        ref, mrg, rest = _counts(gc)
+        i_ref, i_mrg, i_rest = _counts(gc_int)
+        t_ref, t_mrg, t_rest = _counts(gc_tail)
         gaps_with_ref = sum(
             1 for L in ladders if L.reason is None
             for a in L.adjacencies
             if a.label == GAP and any(c.round_ref for c in a.gap_commits))
         out.append("")
         out.append(f"GAP-COMMIT CENSUS over {len(gc)} commit(s) in the gaps above:")
+        out.append(f"  🔴 INTERIOR  round-ref {i_ref} · merge {i_mrg} · "
+                   f"unclassified {i_rest}   (of {len(gc_int)} commit(s))")
+        out.append(f"     TAIL      round-ref {t_ref} · merge {t_mrg} · "
+                   f"unclassified {t_rest}   (of {len(gc_tail)} commit(s))")
+        out.append("  🔴 READ THE SPLIT, NOT THE TOTAL — the same rule the line "
+                   "counts carry. An INTERIOR")
+        out.append("     round-ref is unambiguous; a TAIL one may be a fix posted "
+                   "after the final block")
+        out.append("     OR work that continued after the ladder ended, and "
+                   "nothing here separates them.")
         out.append(f"  🔴 ROUND-REF     {ref} — the commit's own subject names the "
                    "audit round it belongs to.")
-        out.append("                      A round's fix sitting in a gap IS "
-                   "missed audit surface, self-declared;")
-        out.append("                      no judgement was applied and none is "
-                   "needed.")
+        out.append("                      That is an UNLEDGERED ROUND: the round "
+                   "RAN (this is its own fix)")
+        out.append("                      and posted no two-sha `audited=` block, "
+                   "so its delta chains into")
+        out.append("                      nobody's range and nothing re-audited "
+                   "it. 🔴 NOT evidence the code")
+        out.append("                      was never looked at — the subject says "
+                   "the opposite.")
         out.append(f"  MERGE          {mrg} — structural (>=2 parents). Read its "
                    "remerge-diff: a SEMANTIC")
         out.append("                      conflict resolution hides here, and is "
@@ -640,7 +688,7 @@ def render(ladders, notes):
                    "above.")
         out.append(f"  → {gaps_with_ref} of the gaps carry at least one ROUND-REF "
                    "commit.")
-        out.append("⚠ THE CENSUS IS A FLOOR ON MISSED AUDIT SURFACE, NEVER A RATE. "
+        out.append("⚠ THE CENSUS IS A FLOOR ON UNLEDGERED ROUNDS, NEVER A RATE. "
                    "It can only see a round")
         out.append("  reference a commit chose to write down — a round's fix with "
                    "an ordinary subject is")

--- a/scripts/tests/mutants-ladder-range-coverage.sh
+++ b/scripts/tests/mutants-ladder-range-coverage.sh
@@ -242,11 +242,6 @@ run "the gap listing stops excluding the base" \
 
 # 🔴 THE MUTANT MUST REMOVE THE REASON, NOT REWORD IT. My first version swapped
 # the message for a different string that still contained "exited", so the guard
-# could not see it and the row SURVIVED — a mutant that proves nothing, caught
-# only because the row was expected to die. Mutate the narrowest thing that can
-# actually be wrong: the reason itself going None, which is the hazard.
-# 🔴 THE MUTANT MUST REMOVE THE REASON, NOT REWORD IT. My first version swapped
-# the message for a different string that still contained "exited", so the guard
 # could not see it and the row SURVIVED — a mutant proving nothing, caught only
 # because the row was expected to die. And the second version tried to replace a
 # two-line f-string, whose embedded quotes broke the DRIVER's own shell parsing.

--- a/scripts/tests/mutants-ladder-range-coverage.sh
+++ b/scripts/tests/mutants-ladder-range-coverage.sh
@@ -81,18 +81,17 @@ ROWS=0
 # 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
 # FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
 # mutant SURVIVED. The floor catches COLLAPSE, not growth; `run-tests.sh`'s own
-# formula is `m - min(50, max(1, m/20))`, which at m=20 is 19.
-# 🔴 IT FIRED TWICE BEFORE THIS FILE WAS EVEN MERGED, which is the whole argument:
-# the module grew 18 → 19 (pin said 17, failed with `should be 18, not 17`), then
-# 19 → 20 one commit later (pin said 18, failed with `should be 19, not 18`).
-# Neither growth was a refactor — each was a single test added while fixing
-# something — and a hand-maintained floor would have silently tolerated both.
+# formula is `m - min(50, max(1, m/20))`, which at m=25 is 24.
+# 🔴 IT HAS NOW FIRED FOUR TIMES, EVERY ONE ON ORDINARY GROWTH: 18→19 (pin said
+# 17), 19→20, 20→21, 21→25. Not one was a refactor — each was tests added while
+# fixing something — and a hand-maintained floor would have silently tolerated
+# every one of them, widening from one test of slack to five.
 # 🔴 DO NOT maintain this by memory — `test_ladder_range_coverage.py::
 # test_the_batterys_floor_is_re_derived_from_this_modules_size` reads the literal
 # below, counts the module, and fails with the replacement value. Two instances
 # of a too-low floor silently widening have already been recorded in
 # `mutants-audit-ladder.sh`; this is pinned from the first commit instead.
-MIN_TESTS=20
+MIN_TESTS=24
 failing() {
   local out n f total
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
@@ -227,6 +226,44 @@ run "the churn-population count is never computed" \
     test_the_commit_count_beside_the_lines_is_the_CHURN_population "$DISP" \
     '        churn_commits = int(out2.strip())' \
     '        churn_commits = int(out.strip())'
+
+# 🔴 The census asserts exactly ONE number (self-declared round references) and
+# declines the rest. Both halves are mutable into a lie: a dead pattern reports a
+# reassuring zero, and a greedy one turns every fix into self-declared surface.
+run "the round-reference pattern matches NOTHING" \
+    test_the_round_reference_pattern_is_pinned_BOTH_ways "$LRC" \
+    '_ROUND_REF_RE = re.compile(' \
+    '_ROUND_REF_RE = re.compile("(?!x)x") or re.compile('
+
+run "the gap listing stops excluding the base" \
+    test_the_gap_commit_listing_EXCLUDES_the_base "$LRC" \
+    '        f"{frm}..{to}", "--not", base,' \
+    '        f"{frm}..{to}",'
+
+# 🔴 THE MUTANT MUST REMOVE THE REASON, NOT REWORD IT. My first version swapped
+# the message for a different string that still contained "exited", so the guard
+# could not see it and the row SURVIVED — a mutant that proves nothing, caught
+# only because the row was expected to die. Mutate the narrowest thing that can
+# actually be wrong: the reason itself going None, which is the hazard.
+# 🔴 THE MUTANT MUST REMOVE THE REASON, NOT REWORD IT. My first version swapped
+# the message for a different string that still contained "exited", so the guard
+# could not see it and the row SURVIVED — a mutant proving nothing, caught only
+# because the row was expected to die. And the second version tried to replace a
+# two-line f-string, whose embedded quotes broke the DRIVER's own shell parsing.
+# Mutate the narrowest thing that can actually be wrong and needs no quoting:
+# the rc check itself, so a failed git call falls through to an empty listing
+# with NO reason — which is the hazard.
+run "a listing failure is swallowed as zero round-refs" \
+    test_a_gap_whose_commits_cannot_be_LISTED_says_so "$LRC" \
+    '    if rc != 0:
+        return [], (f"`git log' \
+    '    if False:
+        return [], (f"`git log'
+
+run "the census calls its remainder development" \
+    test_the_census_does_NOT_call_the_remainder_development "$LRC" \
+    "unclassified   {rest} — 🔴 NOT 'ordinary development'. This " \
+    "unclassified   {rest} — ordinary development. This "
 
 echo
 echo "== the labels that must NOT become a sized GAP =="

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -481,6 +481,131 @@ def test_the_commit_count_beside_the_lines_is_the_CHURN_population(lrc, ad,
     )
 
 
+# --------------------------------------------------------------------------- #
+# The gap-commit census — self-declared round references
+# --------------------------------------------------------------------------- #
+
+# 🔴 A TWO-WAY LEDGER OF REAL SUBJECTS, not invented ones. Every positive is a
+# commit subject that actually appeared in a measured tail gap (devrc,
+# homelab-talos, civit-datapacket-talos, 2026-09-11) plus `audit-dispatch.py`'s
+# own dispatch wording. Every negative is a real subject from the SAME gaps that
+# must NOT match — including two that a looser pattern would catch
+# (`re-trigger`, `widen the … guard`) and one that names a rule number.
+_ROUND_REF_POSITIVES = [
+    "fix(telemetry,find-session): audit round 5 — the retraction never reached the code",
+    "fix(audit r3): parse the packet length by index(), not regex — and END the ladder",
+    "fix(comic-flex): audit round 3 — retract a second wrong reason",
+    "ci(vetr): close the round-2 audit — F1's shape repeated ONE LAYER DOWN",
+    "docs(external-ip-source-drift): round-3 audit — three numbers this ladder staled",
+    "fix(autoremix): audit round 9 — pin the word 'unconditionally'",
+    "docs(alerts): audit round 5 drive-by — rule 1's selector needs ONE conjunct",
+    "Delta re-audit round 4 of PR 900",
+]
+_ROUND_REF_NEGATIVES = [
+    "fix(handoff_doc): rule (i) SHADOWED the stale-base refusal in every realistic repo",
+    "merge: main into fix/handoff-doc-absent-base-refusal",
+    "feat(find-session): search the OTHER hosts' Claude corpora",
+    "docs(clawgate): two seam-guard comments claimed more than the code does",
+    "chore(ci): re-trigger — devrc-pytests returned a false red under load",
+    "test(gate): widen the conditional-pin guard to its docstring — all, not any",
+]
+
+
+def test_the_round_reference_pattern_is_pinned_BOTH_ways(lrc):
+    """🔴 The instrument validation, and both halves are mandatory.
+
+    A pattern that matches nothing makes the census report a reassuring ZERO
+    round references — indistinguishable from a corpus with none. A pattern that
+    matches too much turns every `fix(...)` into self-declared audit surface and
+    inflates the one number this tool is willing to assert.
+
+    Measured: 8 of 8 positives, 0 of 6 false positives. These are the subjects
+    the hand classification read, so agreement here is agreement with a human
+    pass over the same commits.
+    """
+    missed = [s for s in _ROUND_REF_POSITIVES if not lrc._ROUND_REF_RE.search(s)]
+    assert not missed, f"the pattern cannot see a real round reference: {missed}"
+    false_pos = [s for s in _ROUND_REF_NEGATIVES if lrc._ROUND_REF_RE.search(s)]
+    assert not false_pos, f"the pattern over-matches: {false_pos}"
+
+
+def test_the_gap_commit_listing_EXCLUDES_the_base(lrc, ad, base_repo):
+    """🔴 Omitting `--not <base>` inverts the conclusion, so it is asserted.
+
+    MEASURED: listing devrc #1046's tail without it showed 55 of `main`'s own
+    squash commits, which reads exactly like "the PR kept developing" — the
+    hypothesis under test, confirmed by commits that contribute no churn at all.
+    Here the fixture puts THREE base commits in the range and one branch commit;
+    the listing must return the branch commit (plus the merge), never the three.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 6, "round 1 fix")
+    _git(repo, "checkout", "--quiet", "main")
+    for i in range(3):
+        _commit(repo, f"up{i}.py", 4, f"upstream {i} — MUST NOT be listed")
+    _git(repo, "checkout", "--quiet", "feat")
+    _git(repo, "merge", "--quiet", "--no-edit", "main")
+    head = _commit(repo, "mine.py", 3, "fix(thing): audit round 7 — the real one")
+
+    commits, why = lrc.classify_gap_commits(
+        lrc.real_runner, str(repo), r1_to, head, "main")
+
+    assert why is None, why
+    subjects = [c.subject for c in commits]
+    assert not [s for s in subjects if "MUST NOT be listed" in s], subjects
+    assert any(c.round_ref for c in commits), subjects
+    assert any(c.is_merge for c in commits), "the merge belongs to the population"
+    assert base and ad
+
+
+def test_a_gap_whose_commits_cannot_be_LISTED_says_so(lrc, ad, base_repo):
+    """🔴 A listing failure must not read as "a gap with zero round references".
+
+    Same rule as the churn refusal: an empty result and a broken command are the
+    same observable, so the broken one has to name itself.
+    """
+    repo, _base = base_repo
+    commits, why = lrc.classify_gap_commits(
+        lrc.real_runner, str(repo), "no-such-ref", "HEAD", "main")
+    assert commits == []
+    assert why and "exited" in why
+
+    # …and the reason must survive into the rendered report.
+    fake = lrc.Adjacency(
+        lrc.GAP, "a" * 40, "b" * 40, 1, None, 5, 0, 1, None,
+        [lrc.GapCommit("", [], "COULD NOT LIST: boom", False, False)])
+    L = lrc.Ladder(1, "b" * 40, "main", 1, 1, 1, [fake], 10, 5, 0,
+                   (0, 0), (5, 0), None, [], [])
+    rendered = lrc.render([L], [])
+    assert "COULD NOT LIST: boom" in rendered
+    assert ad
+
+
+def test_the_census_does_NOT_call_the_remainder_development(lrc, ad, base_repo):
+    """🔴 The honesty clause, asserted rather than trusted.
+
+    The whole point of reporting only self-declared and structural buckets is
+    that the leftover is UNKNOWN. A census that labelled it "development" would
+    be the guess-dressed-as-measurement this tool was written to replace — and it
+    would invert the finding, since the hand pass found 20 fixes among 32 while
+    only 8 declared a round.
+    """
+    repo, base = base_repo
+    r1_to = _commit(repo, "a.py", 6, "round 1 fix")
+    head = _commit(repo, "b.py", 4, "fix(thing): something with no round named")
+
+    L = lrc.measure_ladder(ad, lrc.real_runner, str(repo), 12, head, "main",
+                           [_block(1, base, r1_to)])
+    rendered = lrc.render([L], [])
+
+    assert "GAP-COMMIT CENSUS" in rendered
+    assert "unclassified   1" in rendered
+    assert "NOT 'ordinary development'" in rendered
+    assert "FLOOR ON MISSED AUDIT SURFACE, NEVER A RATE" in rendered
+    # the un-declared commit must NOT be counted as a round reference
+    assert "ROUND-REF     0" in rendered
+
+
 def test_measure_range_churn_does_NOT_refuse_an_empty_range(ad, base_repo):
     """The inverted read rule, asserted directly.
 

--- a/scripts/tests/test_ladder_range_coverage.py
+++ b/scripts/tests/test_ladder_range_coverage.py
@@ -601,9 +601,19 @@ def test_the_census_does_NOT_call_the_remainder_development(lrc, ad, base_repo):
     assert "GAP-COMMIT CENSUS" in rendered
     assert "unclassified   1" in rendered
     assert "NOT 'ordinary development'" in rendered
-    assert "FLOOR ON MISSED AUDIT SURFACE, NEVER A RATE" in rendered
+    assert "FLOOR ON UNLEDGERED ROUNDS, NEVER A RATE" in rendered
     # the un-declared commit must NOT be counted as a round reference
     assert "ROUND-REF     0" in rendered
+    # 🔴 ROUND-REF must be described as an UNLEDGERED ROUND, never as evidence
+    # the code was unaudited. Round 0 of #1576 found the original wording
+    # asserted the opposite of what the commit subject says.
+    assert "UNLEDGERED ROUND" in rendered
+    assert "NOT evidence the code" in rendered
+    # 🔴 and the census must SPLIT interior from tail — this file forbids summing
+    # them for lines, and the first census summed them for commits anyway.
+    assert "🔴 INTERIOR  round-ref" in rendered
+    assert "TAIL      round-ref" in rendered
+    assert "READ THE SPLIT, NOT THE TOTAL" in rendered
 
 
 def test_measure_range_churn_does_NOT_refuse_an_empty_range(ad, base_repo):


### PR DESCRIPTION
Follow-on filed by #1564. Claim: `ladder-tail-round-classifier`.

⚠ **This body was rewritten after rounds 0 and 1.** An earlier version headlined **40** and claimed this "supersedes sampling with a census" — both retracted by the diff's own later commits. The correction history is in the two audit comments below; this text is the current claim.

## The signal

#1564 found, as a by-product, that tail fixes often **name the audit round they belong to in their own commit subject**. That is machine-checkable, so the classifier lists the commits contributing each GAP's churn and buckets them.

## What it asserts — and the number to quote is 4, not 40

| repo | gap commits | INTERIOR (r·m·u) | TAIL (r·m·u) |
|---|---|---|---|
| devrc | 69 | **1** · 0 · 1 | 10 · 23 · 34 |
| homelab-talos | 79 | **3** · 0 · 2 | 13 · 17 · 44 |
| civit-datapacket-talos | 25 | 0 · 0 · 0 | 7 · 2 · 16 |
| civitai-gpu-fleet | 10 | 0 · 0 · 0 | 5 · 0 · 5 |
| vetr-app | 1 | 0 · 0 · 0 | 1 · 0 · 0 |
| vetr-api | 2 | 0 · 0 · 0 | 0 · 0 · 2 |
| **TOTAL** | **186** | **4** · 0 · 3 | **36** · 42 · 101 |

🔴 **40 commits name a round; only 4 are INTERIOR**, the class where the reading is unambiguous. The other 36 are TAIL, which conflates a fix posted after the final block with work that simply continued after the ladder ended. Summing them is what the file's own line-count banner forbids in capitals. **Quote the 4.**

## Three limits, all in the output rather than only here

🔴 **What it measures is an UNLEDGERED ROUND, not unaudited churn.** A subject reading `audit round 5 — …` is evidence the round **RAN**; the gap proves it posted no two-sha `audited=` block. That is a *ledgering* defect. Round 0 caught the code asserting the opposite.

🔴 **"Names a round" is not "is that round's fix."** A `docs(handoff)` commit **narrating** a round matches too. Measured on devrc `main`: **2 of 4 matched subjects are narration** — half the population on that corpus. Deliberately not patterned around (excluding `docs(` is a guess over words, and wrong both ways — for a prose-payload ladder every fix is a `docs(` commit). Each row prints the matched **span** so a reader can judge.

🔴 **It is a floor, ~40% sensitive, never a rate.** Against the 32 hand-classified commits it sees 8 where the hand pass found 20 fixes. The 104 `unclassified` are **not** development — they are unread, and the tool refuses to guess. An earlier draft had five heuristic buckets keyed on commit types and correction verbs; deleted, because a guard spelled over *words* is walkable by rewording.

⚠ **It does not supersede the hand sampling** — 63 of 79 adjacencies remain unread by a human. The census classifies a proxy over a different unit (commits, not adjacencies). Both are needed; neither is complete.

## Evidence for what it does claim

- **Zero false positives** on the real corpus, verified by reading all 11 devrc hits — including one whose reference is a trailing `(round-2 audit)`.
- **Base-rate control:** matches **4 of 1,377** devrc `main` squash subjects (0.29%) vs 16% of gap commits — **~55× enriched**. Command in the doc.
- `eb947328` (#1233's round 3) is among the hits. ⚠ **It is NOT an independent control** — `_ROUND_REF_POSITIVES` already pins the identical `round-3 audit` form, so the regex matched a shape its own ledger carries. It confirms one case and validates nothing about the inference. An earlier version of this body claimed otherwise.

## Verification

- 27 tests; battery **30 rows, all as expected**, both `SURVIVES` controls green.
- `--not <base>` is asserted by a test, not remembered — omitting it makes a tail read as the base branch's own squash commits, which *confirms* the hypothesis under test using commits that contribute no churn.
- A listing failure is reported, never swallowed as "zero round-refs".
- ⚠ No full tier run. `tekton/devrc-pytests` is red for an inherited `main`-side reason (`test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger`, naming a file this PR does not touch).

## Audit record

`ran: 2 · changed the outcome: 2`. Round 0 questioned two requirements (both right); round 1 returned 5 🟡 / 2 🟢 / **no 🔴**, including a **demonstrated vacuous guard half** (`re.compile(r"\d")` survived the suite) and a census TOTAL row that did not sum. Both audit comments are below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)