### PR TITLE
feat(mention-open): open a clicked GitHub mention in octo.nvim, behind a browser fallback

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,9 +82,36 @@
       system = "x86_64-linux";
       # Explicit allowUnfree so unfree pkgs (elixir-ls, playwright browsers)
       # build without relying on an ambient NIXPKGS_ALLOW_UNFREE / --impure.
+      # ---------------------------------------------------------------------
+      # 🔴 THE OVERLAY EXISTS SO ONE PACKAGE IS SPELLED `pkgs.nvim-octo`, AND
+      # THAT SPELLING IS LOAD-BEARING RATHER THAN COSMETIC.
+      #
+      # `nvim-octo` is consumed in two places: `nix/pkgs/tools/default.nix`
+      # (so the operator has it on PATH) and — the one that matters — the hint
+      # wrapper's `lib.makeBinPath` in `nix/programs/alacritty/default.nix`.
+      # That list is pinned against `mention-open.py`'s own syntax tree by
+      # `test_mention_open.py::test_the_alacritty_wrapper_PATH_covers_every_
+      # executable_the_handler_spawns`, which reads the block TEXTUALLY and
+      # matches `pkgs\.[A-Za-z0-9_-]+`. A local `let`-bound derivation is not
+      # spelled that way, so it would be INVISIBLE to the reader: the wrapper
+      # would look like it pins nothing for `nvim-octo`, and the seam that test
+      # exists to hold — "everything the handler spawns is on the wrapper's
+      # PATH" — would quietly stop covering the review TUI.
+      #
+      # So the package is put into the package set instead of being threaded as
+      # an argument. `callPackage` is not used: the derivation takes `pkgs`
+      # whole (it reaches `pkgs.vimPlugins`, `pkgs.neovim` and
+      # `pkgs.writeShellApplication`), so it is called with `final` directly —
+      # which also means a later overlay can still override it.
+      # ---------------------------------------------------------------------
+      nvimOctoOverlay = final: _prev: {
+        nvim-octo = import ./nix/pkgs/tools/nvim-octo { pkgs = final; };
+      };
+
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
+        overlays = [ nvimOctoOverlay ];
       };
       # Same allowUnfree treatment for the frozen 1.57 nixpkgs — the browser
       # bundle is unfree there too, and an --impure fallback would make the

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -58,6 +58,19 @@ with pkgs; [
   # discriminating check is in the assertion message of
   # test_engine_is_the_version_every_measurement_is_keyed_to.
   opencode
+
+  # nvim-octo — neovim + octo.nvim as a single-purpose GitHub review TUI, the
+  # surface a clicked `repo#N` mention opens in. Supplied by the overlay in
+  # `flake.nix` (see the comment there for why it must be spelled `pkgs.X`),
+  # built from `nix/pkgs/tools/nvim-octo/`.
+  #
+  # ⚠ THIS ENTRY IS FOR THE OPERATOR'S OWN PATH AND IS NOT WHAT THE CLICK USES.
+  # The hint handler is spawned by alacritty with the display manager's
+  # environment and resolves the binary through the wrapper's pinned
+  # `lib.makeBinPath` in `nix/programs/alacritty/default.nix` — which also
+  # survives the ~1s window where a `home-manager switch` blanks
+  # `~/.nix-profile`. Both entries are real; neither substitutes for the other.
+  nvim-octo
 ]
 ++ (import ./tmux-fuzzyclaw.nix { inherit pkgs workspace; })
 # clawgatectl — machine client for the clawgate JSON API. Built from the

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -58,19 +58,6 @@ with pkgs; [
   # discriminating check is in the assertion message of
   # test_engine_is_the_version_every_measurement_is_keyed_to.
   opencode
-
-  # nvim-octo — neovim + octo.nvim as a single-purpose GitHub review TUI, the
-  # surface a clicked `repo#N` mention opens in. Supplied by the overlay in
-  # `flake.nix` (see the comment there for why it must be spelled `pkgs.X`),
-  # built from `nix/pkgs/tools/nvim-octo/`.
-  #
-  # ⚠ THIS ENTRY IS FOR THE OPERATOR'S OWN PATH AND IS NOT WHAT THE CLICK USES.
-  # The hint handler is spawned by alacritty with the display manager's
-  # environment and resolves the binary through the wrapper's pinned
-  # `lib.makeBinPath` in `nix/programs/alacritty/default.nix` — which also
-  # survives the ~1s window where a `home-manager switch` blanks
-  # `~/.nix-profile`. Both entries are real; neither substitutes for the other.
-  nvim-octo
 ]
 ++ (import ./tmux-fuzzyclaw.nix { inherit pkgs workspace; })
 # clawgatectl — machine client for the clawgate JSON API. Built from the

--- a/nix/pkgs/tools/nvim-octo/default.nix
+++ b/nix/pkgs/tools/nvim-octo/default.nix
@@ -30,6 +30,18 @@
 #   gruvbox-nvim       — the colorscheme `octo-init.lua` sets, matching the
 #                        alacritty palette in nix/programs/alacritty.
 #
+# ⚠ IT IS NOT IN `home.packages`, AND THAT IS DELIBERATE. `nix/pkgs/tools/
+# default.nix` carried an entry for a while; it bought only a hand-typed
+# invocation nobody asked for, while adding a `home.packages` entry (a known
+# collision surface with an imperative `nix profile install` on this host) and a
+# second wrapped-neovim closure on the operator's PATH. The CLICK does not use
+# it: the hint handler resolves `nvim-octo` through the wrapper's pinned
+# `lib.makeBinPath` in `nix/programs/alacritty/default.nix`, which is the entry
+# the AST ledger pins and the one that survives the ~1s window where a
+# `home-manager switch` blanks `~/.nix-profile`. The overlay in `flake.nix`
+# already forces this derivation to build, so nothing is un-gated by its
+# absence.
+#
 # 🔴 `gh` IS A HARD REQUIREMENT, NOT A NICETY. octo's `setup()` checks
 # `vim.fn.executable(config.values.gh_cmd)` and REFUSES to initialise without
 # it — the `Octo` user command is created by `commands.setup()`, which runs
@@ -68,11 +80,14 @@ in
 pkgs.writeShellApplication {
   name = "nvim-octo";
 
-  # `git` is here because octo reads the remote host/name for buffers opened
-  # WITHOUT an explicit repo. `mention-open.py` always passes one, so this is
-  # belt-and-braces for a hand-typed invocation rather than a path the click
-  # depends on — stated plainly rather than justified as essential.
-  runtimeInputs = [ nvimWithOcto pkgs.gh pkgs.git ];
+  # ⚠ `pkgs.git` IS DELIBERATELY ABSENT, AND IT WAS HERE. octo reads a remote's
+  # host/name only for a buffer opened WITHOUT an explicit repo — and this
+  # wrapper REFUSES such an invocation: `nvim-octo.sh` requires both arguments
+  # and exits 64 without them. So git could only ever have served a call shape
+  # that cannot happen, which is dead weight in the closure plus a comment
+  # justifying a code path that does not exist. If a future `nvim-octo` grows a
+  # one-argument or zero-argument form, add it back WITH that form.
+  runtimeInputs = [ nvimWithOcto pkgs.gh ];
 
   text = builtins.readFile ./nvim-octo.sh;
 

--- a/nix/pkgs/tools/nvim-octo/default.nix
+++ b/nix/pkgs/tools/nvim-octo/default.nix
@@ -1,0 +1,84 @@
+# nvim-octo — neovim + octo.nvim, wrapped as a single-purpose review TUI.
+#
+# WHAT IT IS FOR: a clicked GitHub `repo#N` mention in the terminal opens a full
+# review-and-merge surface instead of a browser tab. `scripts/mention-open.py`
+# spawns `alacritty … -e nvim-octo <owner/repo> <number>`; this package is that
+# `nvim-octo`.
+#
+# 🔴 A DEDICATED WRAPPER, NOT octo ADDED TO THE OPERATOR'S DAILY NEOVIM. Two
+# reasons, and the second is the load-bearing one:
+#   * the review surface stays hermetic — its plugin set, its colours and its
+#     keymaps cannot be changed by an edit to an editor config, and it cannot
+#     be broken by one either;
+#   * the merge-safety config in ./octo-init.lua strips upstream's four merge
+#     KEYMAPS and its `<CR>` merge MENU. Doing that inside the daily editor
+#     would impose this repo's risk posture on every other use of neovim, which
+#     is not what was asked for and is not reversible per-buffer.
+#
+# 🔴 vimPlugins.octo-nvim DECLARES NO RUNTIME DEPENDENCIES. It is a bare
+# `buildVimPlugin`, so nothing pulls in the modules its Lua actually
+# `require`s. Every entry in `start` below is therefore mandatory rather than
+# decorative:
+#   plenary-nvim       — octo's async/job primitives; `require("plenary.job")`.
+#   fzf-lua            — the picker `octo-init.lua` selects. NOT a preference:
+#                        the telescope provider is the only one that wires
+#                        `picker_config.mappings.merge_pr` to a merge action,
+#                        and that table survives `mappings_disable_default`.
+#                        See the picker note in octo-init.lua.
+#   nvim-web-devicons  — fzf-lua and octo's file panel both resolve icons
+#                        through it; without it the panel renders unlabelled.
+#   gruvbox-nvim       — the colorscheme `octo-init.lua` sets, matching the
+#                        alacritty palette in nix/programs/alacritty.
+#
+# 🔴 `gh` IS A HARD REQUIREMENT, NOT A NICETY. octo's `setup()` checks
+# `vim.fn.executable(config.values.gh_cmd)` and REFUSES to initialise without
+# it — the `Octo` user command is created by `commands.setup()`, which runs
+# after that check, so a missing `gh` yields an editor where the ex-command in
+# the wrapper below does not exist. It is pinned by store path through
+# `runtimeInputs` rather than inherited, because the whole call chain starts in
+# an alacritty hint spawned with the DISPLAY MANAGER's environment.
+{ pkgs, lib ? pkgs.lib }:
+
+let
+  octoInit = ./octo-init.lua;
+
+  # 🔴 THE INIT IS REFERENCED BY STORE PATH, WHICH IS WHAT MAKES THE CONFIG AND
+  # THE BINARY ONE ARTEFACT. An edit to octo-init.lua changes this derivation's
+  # inputs, so a host running an old wrapper is running the old config too —
+  # there is no state where the keymaps on screen disagree with the file in the
+  # repo except "you have not switched yet", which is the honest one.
+  nvimWithOcto = pkgs.neovim.override {
+    configure = {
+      customRC = ''
+        luafile ${octoInit}
+      '';
+      packages.octo = {
+        start = with pkgs.vimPlugins; [
+          octo-nvim
+          plenary-nvim
+          fzf-lua
+          nvim-web-devicons
+          gruvbox-nvim
+        ];
+        opt = [ ];
+      };
+    };
+  };
+in
+pkgs.writeShellApplication {
+  name = "nvim-octo";
+
+  # `git` is here because octo reads the remote host/name for buffers opened
+  # WITHOUT an explicit repo. `mention-open.py` always passes one, so this is
+  # belt-and-braces for a hand-typed invocation rather than a path the click
+  # depends on — stated plainly rather than justified as essential.
+  runtimeInputs = [ nvimWithOcto pkgs.gh pkgs.git ];
+
+  text = builtins.readFile ./nvim-octo.sh;
+
+  meta = with lib; {
+    description = "neovim + octo.nvim as a single-purpose GitHub review TUI";
+    mainProgram = "nvim-octo";
+    platforms = platforms.linux;
+  };
+}

--- a/nix/pkgs/tools/nvim-octo/nvim-octo.sh
+++ b/nix/pkgs/tools/nvim-octo/nvim-octo.sh
@@ -1,0 +1,68 @@
+# nvim-octo <owner/repo> <number>
+#
+# The body of the `writeShellApplication` in ./default.nix. It carries NO
+# shebang and NO `set` line on purpose: `writeShellApplication` prepends both
+# (`set -o errexit -o nounset -o pipefail`) and runs shellcheck over the
+# assembled result, so spelling them here would duplicate them.
+#
+# 🔴 IT IS A SEPARATE FILE, NOT AN INLINE NIX STRING, SO A TEST CAN RUN IT.
+# `scripts/tests/test_nvim_octo.py` executes this exact text under
+# `bash -euo pipefail` with a STUB `nvim` on PATH — which is the only way to
+# watch the validation below reject a bad argument, and the only way to see
+# what ex-command a good one produces. A string interpolated into default.nix
+# would be reachable only by building the derivation and running the real
+# editor, which this repo must never do from a test.
+#
+# 🔴 WHY THE EX-COMMAND IS ASSEMBLED HERE AND NOT IN THE PYTHON HANDLER.
+# `mention-open.py` spawns `alacritty … -e nvim-octo <repo> <num>` — two plain
+# argv entries, no quoting anywhere. Building `-c "Octo 42 owner/repo"` in
+# Python would put a shell-quoting hazard in the click path AND would make the
+# spawn's argv depend on data, which the AST ledger in test_mention_open.py
+# reads as `<computed>`. The composition belongs on this side of the boundary.
+
+if [ "$#" -ne 2 ]; then
+  printf 'usage: nvim-octo <owner/repo> <number>\n' >&2
+  exit 64
+fi
+
+repo="$1"
+num="$2"
+
+# `owner/repo` — exactly one slash, no traversal, and only the characters
+# GitHub actually allows in an owner or a repository name.
+#
+# ⚠ A `case` GLOB, NOT A REGEX, and the negative arm is FIRST so it wins. The
+# first pattern rejects any forbidden character, a second slash, a leading or
+# trailing slash, and any `..` segment; only then does the positive arm require
+# that a slash is present at all. Order matters: `*/*` alone would accept
+# `../../etc/passwd`.
+case "$repo" in
+  *[!A-Za-z0-9._/-]* | */*/* | /* | */ | *..*)
+    printf 'nvim-octo: not an owner/repo: %s\n' "$repo" >&2
+    exit 65
+    ;;
+  */*) : ;;
+  *)
+    printf 'nvim-octo: not an owner/repo: %s\n' "$repo" >&2
+    exit 65
+    ;;
+esac
+
+# Digits only, and at least one. `""` rather than the shell's usual empty-string
+# spelling because this text is read verbatim into a Nix `''…''` string, where
+# two single quotes are the escape sequence.
+case "$num" in
+  "" | *[!0-9]*)
+    printf 'nvim-octo: not a reference number: %s\n' "$num" >&2
+    exit 66
+    ;;
+esac
+
+# 🔴 THE NUMBER IS THE FIRST ARGUMENT TO `Octo`, AND THE ORDER IS THE CONTRACT.
+# octo's `M.octo(object, action, ...)` does `tonumber(object)` and, when that
+# succeeds, treats `action` as the repository — `:Octo 42 owner/repo`. Passing
+# a URL instead would take a different branch that reads the KIND out of the
+# path, and `mention-open.py` cannot know the kind: it builds `/pull/{id}` for
+# every mention and lets github.com redirect. The number lets octo's own
+# `issueOrPullRequest` query answer that question against the server.
+exec nvim -c "Octo $num $repo"

--- a/nix/pkgs/tools/nvim-octo/octo-init.lua
+++ b/nix/pkgs/tools/nvim-octo/octo-init.lua
@@ -47,7 +47,34 @@
 -- merge action. So the picker choice below is a SAFETY setting, not a taste
 -- one, and the test asserts it for that reason.
 
-require("octo").setup({
+-- --------------------------------------------------------------------------
+-- EDITOR OPTIONS FIRST — and the ORDER IS LOAD-BEARING, not tidiness.
+-- --------------------------------------------------------------------------
+-- 🔴 `require("octo").setup()` CAN THROW, AND IT THROWS FOR A REASON THIS
+-- WRAPPER CAN PLAUSIBLY HIT. MEASURED against octo 2026-08-28 with `gh` absent
+-- from PATH: octo's own guard is `if not vim.fn.executable(cfg.gh_cmd) then`,
+-- and `vim.fn.executable()` returns the NUMBER 0 — which is TRUTHY in Lua. So
+-- `not 0` is false, the guard never fires, and execution falls through to
+-- `gh.setup()`, where plenary's `Job:new` raises "command must be executable".
+-- Upstream bug; not ours to fix from here, but ours to survive.
+--
+-- With the setup call last, that traceback aborted the rest of this file: no
+-- colorscheme, no options — a window that looks broken in a second, unrelated
+-- way on top of the real failure. Everything that does not depend on octo is
+-- therefore done BEFORE the call, and the call itself is wrapped.
+vim.o.termguicolors = true
+vim.o.background = "dark"
+vim.o.laststatus = 2
+vim.o.number = true
+vim.o.signcolumn = "yes"
+
+-- Gruvbox, to match every other terminal this operator looks at (the alacritty
+-- palette in `nix/programs/alacritty/default.nix` is the same theme).
+-- `pcall` because a colorscheme failure must not be able to cost the review.
+pcall(vim.cmd.colorscheme, "gruvbox")
+
+local ok, err = pcall(function()
+  require("octo").setup({
   -- See the picker note above: this is load-bearing, not preference.
   picker = "fzf-lua",
 
@@ -242,16 +269,26 @@ require("octo").setup({
       prev_comment = { lhs = "[c", desc = "go to previous comment" },
     },
   },
-})
+  })
+end)
 
--- Gruvbox, to match every other terminal this operator looks at (the alacritty
--- palette in `nix/programs/alacritty/default.nix` is the same theme).
-vim.o.termguicolors = true
-vim.o.background = "dark"
-pcall(vim.cmd.colorscheme, "gruvbox")
-
--- Quitting the LAST window closes the float terminal, which is the whole
--- lifecycle of a review window opened from a click.
-vim.o.laststatus = 2
-vim.o.number = true
-vim.o.signcolumn = "yes"
+-- 🔴 A FAILURE IS ANNOUNCED, NEVER SWALLOWED. The `pcall` exists to stop a
+-- setup error tearing the rest of this file in half, not to hide one — and the
+-- consequence of an error here is specific and otherwise baffling: `commands
+-- .setup()` never runs, so the `Octo` user command is never created, and the
+-- `-c "Octo <N> <owner/repo>"` the wrapper appends fails with `E492: Not an
+-- editor command: Octo` in a window that otherwise looks fine.
+--
+-- The message names the cause that can actually reach this arm. `gh` is pinned
+-- onto this wrapper's PATH by store path through `runtimeInputs`, so a missing
+-- `gh` means the deployed wrapper is not the one this repo builds.
+if not ok then
+  vim.notify(
+    "nvim-octo: octo.nvim failed to initialise, so `:Octo` does not exist.\n"
+      .. "The commonest cause is `gh` missing from this wrapper's PATH, which "
+      .. "nix pins — so a stale deploy rather than a config error. Run "
+      .. "`home-manager switch --flake ~/workspace/devrc --impure`.\n"
+      .. tostring(err),
+    vim.log.levels.ERROR
+  )
+end

--- a/nix/pkgs/tools/nvim-octo/octo-init.lua
+++ b/nix/pkgs/tools/nvim-octo/octo-init.lua
@@ -1,0 +1,257 @@
+-- octo.nvim configuration for `nvim-octo` — the review TUI a clicked GitHub
+-- mention opens in. Sourced by the generated init.vim (`luafile`), so it runs
+-- BEFORE the `-c "Octo <N> <owner/repo>"` the wrapper appends.
+--
+-- 🔴 THIS FILE IS PARSED BY A TEST. `scripts/tests/test_nvim_octo.py` reads the
+-- `mappings.pull_request` table structurally and asserts that NO merge key is
+-- declared in it, plus `default_merge_method`, `default_delete_branch` and
+-- `picker`. Reword the comments freely; do not move those settings into a
+-- computed expression, because a value the reader cannot see is a value nobody
+-- is checking.
+
+-- --------------------------------------------------------------------------
+-- MERGE SAFETY — why this config re-declares ~45 mappings by hand
+-- --------------------------------------------------------------------------
+-- 🔴 octo.nvim HAS NO MERGE CONFIRMATION. `commands.lua`'s `pr merge` calls
+-- `gh.pr.merge(opts)` with no prompt of any kind, and upstream binds it to FOUR
+-- keystrokes in a PR buffer: `<localleader>pm`, `<localleader>psm`,
+-- `<localleader>prm` and `<localleader>pk` (merge the whole stack). A mistyped
+-- localleader sequence in a buffer opened by CLICKING A LINK would merge a pull
+-- request. That is the hazard this file exists to close.
+--
+-- `mappings_disable_default = true` clears every default mapping table before
+-- the user tables below are merged in (octo `config.lua`'s `M.setup`), so what
+-- is declared here is the COMPLETE set of octo keymaps. Merging is then
+-- reachable only by TYPING `:Octo pr merge`, which is a deliberate act.
+--
+-- 🔴 `pr_options` IS DELIBERATELY NOT RE-DECLARED, AND THAT IS NOT AN
+-- OVERSIGHT. Upstream binds it to `<CR>` — a single keystroke — and its menu
+-- (octo `mappings.lua`) offers "Merge PR", "Squash and Merge PR" and "Delete
+-- Branch" alongside the read-only entries. Re-declaring it would have put merge
+-- back one `<CR>` away while every merge KEYMAP was gone, which is the shape of
+-- a guard that reads as coverage and provides none. Everything useful that menu
+-- offered has its own direct mapping below (`list_commits`, `list_changed_
+-- files`, `show_pr_diff`, `toggle_checks`, `review_start`, `approve_pr`) or is
+-- one typed `:Octo pr …` away.
+--
+-- ⚠ `issue_options` IS re-declared: its menu carries no merge and no branch
+-- deletion. The asymmetry is the point.
+--
+-- 🔴 THE PICKER'S `<C-r>` MERGE IS A SECOND, SEPARATE PATH, AND
+-- `mappings_disable_default` DOES NOT TOUCH IT. `picker_config.mappings` lives
+-- outside the `mappings` table that flag clears, so upstream's
+-- `merge_pr = { lhs = "<C-r>" }` survives it. What closes it is `picker =
+-- "fzf-lua"`: MEASURED against octo 2026-08-28, the whole
+-- `lua/octo/pickers/fzf-lua/` tree contains no occurrence of "merge" at all —
+-- only the telescope provider wires `picker_config.mappings.merge_pr.lhs` to a
+-- merge action. So the picker choice below is a SAFETY setting, not a taste
+-- one, and the test asserts it for that reason.
+
+require("octo").setup({
+  -- See the picker note above: this is load-bearing, not preference.
+  picker = "fzf-lua",
+
+  -- 🔴 SQUASH, because upstream's default is "merge" (a merge commit) and this
+  -- operator's repositories squash. Left at the default, the first merge made
+  -- from this TUI would produce the wrong commit shape on a repo whose last
+  -- five merges were all squashes.
+  default_merge_method = "squash",
+
+  -- 🔴 FALSE — which is also upstream's default, and it is kept EXPLICIT
+  -- because it is load-bearing here rather than incidental. These repos set
+  -- `delete_branch_on_merge`, and deleting a STACKED PARENT's branch makes
+  -- GitHub auto-close the child PR and then REFUSE to reopen it: the branch is
+  -- restorable, the PR object is not, and the child's review thread is lost.
+  default_delete_branch = false,
+
+  -- Reviewing needs no local checkout: octo only offers to check one out when
+  -- this is true (`reviews/init.lua`). A review opened from a clicked link must
+  -- never touch a working tree — other sessions share these checkouts.
+  use_local_fs = false,
+
+  mappings_disable_default = true,
+
+  mappings = {
+    -- Copied from octo 2026-08-28's own defaults, MINUS the seven merge
+    -- entries (merge_pr, squash_and_merge_pr, rebase_and_merge_pr,
+    -- merge_pr_stack, merge_pr_queue, squash_and_merge_queue,
+    -- rebase_and_merge_queue) and minus pr_options. Same left-hand sides, so
+    -- upstream documentation still describes this buffer.
+    pull_request = {
+      checkout_pr = { lhs = "<localleader>po", desc = "checkout PR" },
+      list_commits = { lhs = "<localleader>pc", desc = "list PR commits" },
+      list_changed_files = { lhs = "<localleader>pf", desc = "list PR changed files" },
+      show_pr_diff = { lhs = "<localleader>pd", desc = "show PR diff" },
+      add_reviewer = { lhs = "<localleader>va", desc = "add reviewer" },
+      remove_reviewer = { lhs = "<localleader>vd", desc = "remove reviewer request" },
+      close_issue = { lhs = "<localleader>ic", desc = "close PR" },
+      reopen_issue = { lhs = "<localleader>io", desc = "reopen PR" },
+      list_issues = { lhs = "<localleader>il", desc = "list open issues on same repo" },
+      reload = { lhs = "<C-r>", desc = "reload PR" },
+      approve_pr = { lhs = "<leader>qa", desc = "approve PR" },
+      open_in_browser = { lhs = "<C-b>", desc = "open PR in browser" },
+      copy_url = { lhs = "<C-y>", desc = "copy url to system clipboard" },
+      copy_sha = { lhs = "<C-e>", desc = "copy commit SHA to system clipboard" },
+      goto_file = { lhs = "gf", desc = "go to file" },
+      stack_up = { lhs = "]s", desc = "open the next PR up the stack" },
+      stack_down = { lhs = "[s", desc = "open the next PR down the stack" },
+      goto_check = { lhs = "<localleader>gc", desc = "open the CI check under the cursor" },
+      toggle_checks = { lhs = "<localleader>tc", desc = "fold or unfold the CI checks list" },
+      add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
+      remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
+      create_label = { lhs = "<localleader>lc", desc = "create label" },
+      add_label = { lhs = "<localleader>la", desc = "add label" },
+      remove_label = { lhs = "<localleader>ld", desc = "remove label" },
+      goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
+      add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
+      delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
+      comment_edits = { lhs = "<localleader>ce", desc = "show comment edit history" },
+      reference_in_new_issue = { lhs = "<localleader>ri", desc = "reference comment in new issue" },
+      next_comment = { lhs = "]c", desc = "go to next comment" },
+      prev_comment = { lhs = "[c", desc = "go to previous comment" },
+      react_hooray = { lhs = "<localleader>rp", desc = "add/remove hooray reaction" },
+      react_heart = { lhs = "<localleader>rh", desc = "add/remove heart reaction" },
+      react_eyes = { lhs = "<localleader>re", desc = "add/remove eyes reaction" },
+      react_thumbs_up = { lhs = "<localleader>r+", desc = "add/remove thumbs-up reaction" },
+      react_thumbs_down = { lhs = "<localleader>r-", desc = "add/remove thumbs-down reaction" },
+      react_rocket = { lhs = "<localleader>rr", desc = "add/remove rocket reaction" },
+      react_laugh = { lhs = "<localleader>rl", desc = "add/remove laugh reaction" },
+      react_confused = { lhs = "<localleader>rc", desc = "add/remove confused reaction" },
+      review_start = { lhs = "<localleader>vs", desc = "start a review for the current PR" },
+      review_resume = { lhs = "<localleader>vr", desc = "resume a pending review for the current PR" },
+      resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+      unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
+    },
+
+    issue = {
+      issue_options = { lhs = "<CR>", desc = "show issue options" },
+      close_issue = { lhs = "<localleader>ic", desc = "close issue" },
+      reopen_issue = { lhs = "<localleader>io", desc = "reopen issue" },
+      list_issues = { lhs = "<localleader>il", desc = "list open issues on same repo" },
+      reload = { lhs = "<C-r>", desc = "reload issue" },
+      open_in_browser = { lhs = "<C-b>", desc = "open issue in browser" },
+      copy_url = { lhs = "<C-y>", desc = "copy url to system clipboard" },
+      add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
+      remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
+      create_label = { lhs = "<localleader>lc", desc = "create label" },
+      add_label = { lhs = "<localleader>la", desc = "add label" },
+      remove_label = { lhs = "<localleader>ld", desc = "remove label" },
+      goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
+      add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
+      delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
+      comment_edits = { lhs = "<localleader>ce", desc = "show comment edit history" },
+      reference_in_new_issue = { lhs = "<localleader>ri", desc = "reference comment in new issue" },
+      next_comment = { lhs = "]c", desc = "go to next comment" },
+      prev_comment = { lhs = "[c", desc = "go to previous comment" },
+    },
+
+    review_thread = {
+      goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
+      add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
+      add_suggestion = { lhs = "<localleader>sa", desc = "add suggestion" },
+      delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
+      comment_edits = { lhs = "<localleader>ce", desc = "show comment edit history" },
+      next_comment = { lhs = "]c", desc = "go to next comment" },
+      prev_comment = { lhs = "[c", desc = "go to previous comment" },
+      select_next_entry = { lhs = "]q", desc = "move to next changed file" },
+      select_prev_entry = { lhs = "[q", desc = "move to previous changed file" },
+      select_first_entry = { lhs = "[Q", desc = "move to first changed file" },
+      select_last_entry = { lhs = "]Q", desc = "move to last changed file" },
+      select_next_unviewed_entry = { lhs = "]u", desc = "move to next unviewed file" },
+      select_prev_unviewed_entry = { lhs = "[u", desc = "move to previous unviewed file" },
+      close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
+      resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+      unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
+    },
+
+    -- The review VERDICT window. `<C-r>` is "request changes" here, in a
+    -- buffer that exists only while a review is being submitted — it is not
+    -- the PR buffer's `<C-r>`, which reloads.
+    submit_win = {
+      approve_review = { lhs = "<C-a>", desc = "approve review", mode = { "n" } },
+      comment_review = { lhs = "<C-m>", desc = "comment review", mode = { "n" } },
+      request_changes = { lhs = "<C-r>", desc = "request changes review", mode = { "n" } },
+      close_review_tab = { lhs = "<C-c>", desc = "close review tab", mode = { "n" } },
+    },
+
+    review_diff = {
+      submit_review = { lhs = "<localleader>vs", desc = "submit review" },
+      discard_review = { lhs = "<localleader>vd", desc = "discard review" },
+      add_review_comment = { lhs = "<localleader>ca", desc = "add a new review comment", mode = { "n", "x" } },
+      add_review_suggestion = { lhs = "<localleader>sa", desc = "add a new review suggestion", mode = { "n", "x" } },
+      focus_files = { lhs = "<localleader>e", desc = "move focus to changed file panel" },
+      toggle_files = { lhs = "<localleader>b", desc = "hide/show changed files panel" },
+      next_thread = { lhs = "]t", desc = "move to next thread" },
+      prev_thread = { lhs = "[t", desc = "move to previous thread" },
+      select_next_entry = { lhs = "]q", desc = "move to next changed file" },
+      select_prev_entry = { lhs = "[q", desc = "move to previous changed file" },
+      select_first_entry = { lhs = "[Q", desc = "move to first changed file" },
+      select_last_entry = { lhs = "]Q", desc = "move to last changed file" },
+      select_next_unviewed_entry = { lhs = "]u", desc = "move to next unviewed file" },
+      select_prev_unviewed_entry = { lhs = "[u", desc = "move to previous unviewed file" },
+      close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
+      toggle_viewed = { lhs = "<localleader><space>", desc = "toggle viewer viewed state" },
+      goto_file = { lhs = "gf", desc = "go to file" },
+      copy_sha = { lhs = "<C-e>", desc = "copy commit SHA to system clipboard" },
+      review_commits = { lhs = "<localleader>C", desc = "review PR commits" },
+    },
+
+    file_panel = {
+      submit_review = { lhs = "<localleader>vs", desc = "submit review" },
+      discard_review = { lhs = "<localleader>vd", desc = "discard review" },
+      next_entry = { lhs = "j", desc = "move to next changed file" },
+      prev_entry = { lhs = "k", desc = "move to previous changed file" },
+      select_entry = { lhs = "<cr>", desc = "show selected changed file diffs" },
+      refresh_files = { lhs = "R", desc = "refresh changed files panel" },
+      focus_files = { lhs = "<localleader>e", desc = "move focus to changed file panel" },
+      toggle_files = { lhs = "<localleader>b", desc = "hide/show changed files panel" },
+      select_next_entry = { lhs = "]q", desc = "move to next changed file" },
+      select_prev_entry = { lhs = "[q", desc = "move to previous changed file" },
+      select_first_entry = { lhs = "[Q", desc = "move to first changed file" },
+      select_last_entry = { lhs = "]Q", desc = "move to last changed file" },
+      select_next_unviewed_entry = { lhs = "]u", desc = "move to next unviewed file" },
+      select_prev_unviewed_entry = { lhs = "[u", desc = "move to previous unviewed file" },
+      close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
+      toggle_viewed = { lhs = "<localleader><space>", desc = "toggle viewer viewed state" },
+      review_commits = { lhs = "<localleader>C", desc = "review PR commits" },
+    },
+
+    -- `repo_options` is dropped for the same reason `pr_options` is: its `<CR>`
+    -- menu mutates (Star / Unstar / Change Subscription / Create Issue). Not a
+    -- merge hazard, but not something a click should be one keypress from
+    -- either, and the entries are all one typed `:Octo repo …` away.
+    repo = {
+      open_in_browser = { lhs = "<C-b>", desc = "open repo in browser" },
+    },
+
+    release = {
+      open_in_browser = { lhs = "<C-b>", desc = "open release in browser" },
+    },
+
+    discussion = {
+      open_in_browser = { lhs = "<C-b>", desc = "open discussion in browser" },
+      copy_url = { lhs = "<C-y>", desc = "copy url to system clipboard" },
+      add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
+      delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
+      comment_edits = { lhs = "<localleader>ce", desc = "show comment edit history" },
+      next_comment = { lhs = "]c", desc = "go to next comment" },
+      prev_comment = { lhs = "[c", desc = "go to previous comment" },
+    },
+  },
+})
+
+-- Gruvbox, to match every other terminal this operator looks at (the alacritty
+-- palette in `nix/programs/alacritty/default.nix` is the same theme).
+vim.o.termguicolors = true
+vim.o.background = "dark"
+pcall(vim.cmd.colorscheme, "gruvbox")
+
+-- Quitting the LAST window closes the float terminal, which is the whole
+-- lifecycle of a review window opened from a click.
+vim.o.laststatus = 2
+vim.o.number = true
+vim.o.signcolumn = "yes"

--- a/nix/programs/alacritty/default.nix
+++ b/nix/programs/alacritty/default.nix
@@ -34,6 +34,21 @@ let
   # a hope, and it fails in BOTH directions, so a package nobody spawns is a
   # finding too.
   #
+  # ⚠ `pkgs.nvim-octo` IS THE SECOND ENTRY THE argv[0] READER CANNOT SEE, and
+  # it needs a THIRD reader rather than the `-c` one above. The review TUI is
+  # spawned as `alacritty … -e nvim-octo <repo> <num>`: argv[0] is the terminal
+  # and the `-e` payload is one level down, exactly like `fzf` — but `fzf`
+  # sits after a `-c` inside a shell script, and this sits after a `-e` as a
+  # bare command. `_exec_payload_commands` in `test_mention_open.py` reads the
+  # first word after a literal `-e` out of the handler's SYNTAX TREE (resolving
+  # a module constant, which is how `mention-open.py` spells it as
+  # `REVIEW_EXE`), so this entry is pinned to a call site and not to a comment.
+  # Without it the click opens a terminal that flashes and vanishes —
+  # alacritty exits 0 whether its `-e` command exits 0 or 127 — which is the
+  # silent dead end `open_tui`'s `shutil.which` pre-flight exists to convert
+  # into a browser fallback plus one toast. Both halves are real; the pre-flight
+  # is what makes a MISSING entry survivable, not what makes it acceptable.
+  #
   # ⚠ `pkgs.gh` USED TO BE HERE and is REMOVED. Its comment justified it as
   # "PASS 3's only tool" — PASS 3 was the GitHub-wide namesake search, which is
   # deleted (see `mention-open.py`'s docstring for the 4.3s it cost), and the
@@ -46,7 +61,7 @@ let
       # relying on the inherited PATH is not enough: a click landing in that
       # window would find none of these by bare name.
       pkgs.python312 pkgs.git pkgs.tmux pkgs.xdg-utils pkgs.libnotify
-      pkgs.alacritty pkgs.fzf
+      pkgs.alacritty pkgs.fzf pkgs.nvim-octo
     ]}:$PATH
     exec ${pkgs.python312}/bin/python3 \
       ${config.home.homeDirectory}/workspace/devrc/scripts/mention-open.py "$@"

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -16,7 +16,7 @@ authority, and a match the scanner rejects opens nothing.
 
 RESOLUTION
 ----------
-  1 openable candidate   -> xdg-open it, UNLESS the repository was guessed from
+  1 openable candidate   -> open it, UNLESS the repository was guessed from
                             the tmux pane — see `repo_source` in `main()`.
   2+ (a bare `#N`)       -> the picker, one row per platform, showing the URL.
   any of the above whose repository was GUESSED
@@ -29,8 +29,26 @@ RESOLUTION
                             literal here, so every row a picker could offer
                             would 404. See `colour_literal_offer`.
 
+WHERE IT OPENS
+--------------
+Resolution says WHICH reference; `open_target` says on WHICH SURFACE. A GitHub
+issue or pull request can open in `nvim-octo` — neovim with octo.nvim, a full
+review-and-merge TUI packaged at `nix/pkgs/tools/nvim-octo/` — instead of a
+browser tab. Everything else (a clawgate task, a ClickUp id, any GitHub URL
+that is not `/issues/N` or `/pull/N`) is always `xdg-open`.
+
+The TUI is taken only when this host HAS it, and the browser stays reachable
+from three directions: `--browser` on the command line, `browser` in the marker
+file at `~/.config/mention-open/target`, and `open_tui`'s own pre-flight, which
+falls back and says so. Read `open_target`'s docstring for the rung order.
+
 🔴 THE CLICK PATH MAKES NO NETWORK CALL. This is a hard property, not a target,
 and it is pinned by `test_the_resolution_path_spawns_ONLY_these_local_commands`.
+⚠ THE TUI IS NOT PART OF THAT CLAIM AND MUST NOT BE READ INTO IT. octo.nvim
+resolves a reference with a GraphQL call — that is the entire reason the NUMBER
+is passed rather than a `/pull/` URL — but it happens inside a detached child
+process, after this handler has exited. What is pinned is that THIS module
+spawns nothing that talks to a network.
 
 🔴 THE CANDIDATE UNIVERSE IS THE REPOS THE OPERATOR CONTRIBUTES TO — NEVER ALL
 OF GITHUB, AND A GITHUB-WIDE NAMESAKE SEARCH USED TO LIVE HERE. `gh api
@@ -212,6 +230,39 @@ PICKS_PATH = Path(
     os.environ.get("MENTION_OPEN_PICKS")
     or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
     / "mention-open" / "picks.jsonl")
+
+# Where the operator PINS which surface a GitHub mention opens in. Same
+# directory as its four siblings above, and read the same way: a file, not an
+# environment variable.
+#
+# 🔴 AN ENV VAR STRUCTURALLY CANNOT WORK HERE, AND THAT IS THE WHOLE REASON THIS
+# IS A FILE. Alacritty spawns the hint handler with ITS OWN environment, which
+# came from the DISPLAY MANAGER at login — the same fact the wrapper's pinned
+# `PATH` in `nix/programs/alacritty/default.nix` exists for. A variable exported
+# in a shell, an `.envrc`, or even `~/.zshenv` is therefore invisible to every
+# click: the operator would set it, see nothing change, and have no way to tell
+# a broken feature from an unread variable. `~/.server-mode` is the precedent in
+# this repo for exactly that shape.
+#
+# ⚠ THE ENV DOOR BELOW REDIRECTS THE *PATH*, NEVER THE VALUE, and it exists for
+# the reason its four siblings' doors do: a `monkeypatch.setattr` on a module
+# constant is invisible to a child process that re-imports this file, and nine
+# tests were once measured reading the operator's real host state because of it.
+# It is not a second way to choose the target — pointing it at a file is still
+# the only way to say "tui".
+MENTION_TARGET_PATH = Path(
+    os.environ.get("MENTION_OPEN_TARGET")
+    or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    / "mention-open" / "target")
+
+# The two surfaces a resolved mention can be opened on.
+#
+# `TARGET_BROWSER` is `xdg-open`, which is what every click did before the
+# review TUI existed and what every click still does for a clawgate task, a
+# ClickUp id, or a GitHub reference this host cannot open in `nvim-octo`.
+TARGET_TUI = "tui"
+TARGET_BROWSER = "browser"
+TARGET_VALUES = (TARGET_TUI, TARGET_BROWSER)
 
 # 🔴 A TIMER NOW CONVERGES THE MAPPING, AND THIS PARAGRAPH USED TO SAY THE
 # OPPOSITE — do not re-derive the old reasoning from a stale copy of it. It read
@@ -979,6 +1030,45 @@ def repo_of_github_url(url: str) -> str:
     return full if _OWNER_REPO_RE.match(full) else ""
 
 
+# `owner/repo` AND the reference NUMBER, from a github.com issue-or-pull URL.
+#
+# 🔴 STRICTER THAN `repo_of_github_url` ON PURPOSE, AND THE EXTRA STRICTNESS IS
+# THE POINT. That function answers "which repository should the pick log
+# record", so a two-segment path is enough for it. This one answers "what may I
+# hand to `Octo <N> <owner/repo>`", and handing that a number the URL does not
+# carry — or a path that is a release, a commit or a repo root — is a wrong
+# buffer rather than a missing log line. So the kind segment and the digits are
+# both REQUIRED, and the pattern is anchored at both ends.
+#
+# ⚠ BOTH `issues` AND `pull` ARE ACCEPTED, AND THE HANDLER CANNOT TELL THEM
+# APART ANYWAY. `mention-open.py` builds `/pull/{id}` for EVERY GitHub mention
+# (see `openable`), and github.com redirects `/pull/<issue-number>` to
+# `/issues/<n>` server-side — so the URL's kind segment is a guess this module
+# has never been able to make. That is exactly why `open_tui` passes the NUMBER
+# to octo rather than the URL: `Octo <N> <repo>` fires one `issueOrPullRequest`
+# GraphQL query and dispatches on the `__typename` the SERVER returns. Accepting
+# `issues` here costs nothing and keeps a hand-typed URL working.
+_GITHUB_REF_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/(?:issues|pull)/(?P<num>[0-9]+)/?$")
+
+
+def github_ref(url: str) -> tuple[str, str]:
+    """`("owner/repo", "N")` for a github.com issue/pull URL, else `("", "")`.
+
+    Returns a PAIR rather than raising, so every caller's failure branch is the
+    same shape as the "this is a clawgate task" branch — there is no exceptional
+    case here, only a URL this surface cannot open.
+    """
+    m = _GITHUB_REF_RE.match(url or "")
+    if not m:
+        return "", ""
+    full = f"{m.group('owner')}/{m.group('repo')}"
+    if not _OWNER_REPO_RE.match(full):
+        return "", ""
+    return full, m.group("num")
+
+
 def row_to_url(row: str, candidates: list[dict]) -> str:
     """Map a picker row back to its URL. Matches on the URL suffix rather than
     the row index, so a picker that decorates or reorders rows cannot open the
@@ -1226,7 +1316,13 @@ def notify(summary: str, body: str = "") -> None:
         pass
 
 
-def open_url(url: str) -> int:
+def open_browser(url: str) -> int:
+    """`xdg-open`, which is what EVERY click did before the review TUI existed.
+
+    Renamed from `open_url`, which is now the dispatcher above it. The body is
+    unchanged: this is the fallback every other arm returns to, so it must keep
+    working for a URL no other surface can open at all.
+    """
     try:
         subprocess.Popen(["xdg-open", url],
                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -1234,6 +1330,170 @@ def open_url(url: str) -> int:
         notify("could not open the link", f"{type(exc).__name__}: {exc}")
         return 1
     return 0
+
+
+# The float terminal the review TUI runs in, and its geometry.
+#
+# `--class float,mention-review` puts it under `for_window [class="float"]
+# floating enable` in `nix/i3/config.nix` — the same rule the fzf picker's
+# terminal uses — while the instance half names THIS window specifically, so an
+# i3 rule can size or place a review without catching the picker.
+#
+# Bigger than `PICKER_*` because the two windows hold different things: the
+# picker is a list, a review is a diff beside a file panel.
+REVIEW_CLASS = "float,mention-review"
+REVIEW_COLUMNS = 200
+REVIEW_LINES = 50
+
+# The wrapper that runs neovim with octo.nvim configured. Packaged as
+# `nix/pkgs/tools/nvim-octo/` and pinned onto the hint wrapper's PATH by
+# `nix/programs/alacritty/default.nix`.
+#
+# 🔴 A MODULE CONSTANT AND NOT A LITERAL IN TWO PLACES. It is both the name
+# `tui_available()` looks up and the `-e` payload below; two spellings of one
+# name is how a rename leaves a pre-flight checking a binary nobody spawns.
+# `test_mention_open.py` resolves this constant out of the SYNTAX TREE for the
+# same reason `PICKER_SH` is resolved — see `_exec_payload_commands`.
+REVIEW_EXE = "nvim-octo"
+
+
+def tui_available() -> bool:
+    """Is the review TUI on THIS handler's PATH?
+
+    🔴 THE ONE PLACE THAT QUESTION IS ASKED. `open_target` asks it to decide
+    whether the TUI is the DEFAULT, and `open_tui` asks it again immediately
+    before the spawn — deliberately twice, because they are different questions
+    about different moments and a `which` result from the decision is a
+    hypothesis about the spawn, not a fact. Consolidating the PREDICATE is what
+    stops the two rungs disagreeing about what "available" means.
+    """
+    import shutil  # noqa: PLC0415 — see run_picker's import comment
+    return shutil.which(REVIEW_EXE) is not None
+
+
+def read_target_marker(path: Path | None = None) -> str:
+    """The operator's pinned target, or `""` when they have not pinned one.
+
+    Anything that is not exactly one of `TARGET_VALUES` — an empty file, a typo,
+    a stray newline-only write, a directory — reads as UNPINNED rather than as
+    an error. A marker file that cannot be understood must not be able to wedge
+    a click: the default rung below is always reachable.
+
+    The path is read at CALL time, never bound as a default argument, for the
+    reason `load_known_repos` is: a `path: Path = MENTION_TARGET_PATH` default
+    is evaluated once at import, and `monkeypatch.setattr` on the module
+    constant would then be inert.
+    """
+    p = MENTION_TARGET_PATH if path is None else path
+    try:
+        raw = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    value = raw.strip().lower()
+    return value if value in TARGET_VALUES else ""
+
+
+def open_target(url: str, *, browser: bool = False) -> str:
+    """Which surface this URL opens on. One of `TARGET_VALUES`, always.
+
+    The rungs, in order, and why each sits where it does:
+
+      0. THE URL'S OWN SHAPE. A clawgate task, a ClickUp id, a GitHub release —
+         anything `github_ref` cannot turn into `(repo, number)` — is BROWSER,
+         and no marker file can override that. This is first rather than last
+         because "whatever the marker says" is not a meaningful instruction for
+         a URL the TUI has no way to open: honouring it would produce a window
+         that fails, where the browser would simply have worked.
+      1. `--browser`. The operator's per-click escape hatch, and it wins over
+         their own marker: a flag typed NOW is newer evidence than a file
+         written once.
+      2. THE MARKER FILE. See `MENTION_TARGET_PATH` for why it is a file and
+         can never be an environment variable.
+      3. THE DEFAULT: the TUI when this host actually has it, the browser when
+         it does not. SILENT in the second case, deliberately — a host with no
+         `nvim-octo` has not lost anything it had, and toasting on every click
+         to say so is the noise this handler must not make. The announcement
+         belongs where the TUI was actually ASKED for and could not run, which
+         is `open_tui`'s pre-flight.
+    """
+    if not github_ref(url)[0]:
+        return TARGET_BROWSER
+    if browser:
+        return TARGET_BROWSER
+    marked = read_target_marker()
+    if marked:
+        return marked
+    return TARGET_TUI if tui_available() else TARGET_BROWSER
+
+
+def open_tui(url: str) -> int:
+    """Open a GitHub reference in the review TUI. Falls back to the browser.
+
+    🔴 THE `which` PRE-FLIGHT IS LOAD-BEARING, NOT DEFENSIVE POLISH, AND A
+    POST-SPAWN FALLBACK STRUCTURALLY CANNOT REPLACE IT. Alacritty exits 0
+    whether its `-e` command exits 0 or 127, and `Popen` never waits — so a
+    missing or broken `nvim-octo` is a window that flashes and vanishes, with
+    nothing for this process to observe. That is the identical silent dead end
+    `pick()` pre-flights `fzf` for, one surface over.
+
+    🔴 THE NUMBER IS PASSED, NOT THE URL, AND THAT IS A CORRECTNESS FIX RATHER
+    THAN A STYLE CHOICE. `openable()` builds `/pull/{id}` for every GitHub
+    mention because the handler cannot know whether `#N` is an issue or a pull
+    request — github.com resolves that by redirecting. Handing octo a `/pull/`
+    URL asserts the kind, and it would assert it WRONGLY for every issue
+    mention. `Octo <N> <owner/repo>` instead fires one `issueOrPullRequest`
+    GraphQL query and opens whatever the server says it is.
+
+    ⚠ `repo` IS PASSED EXPLICITLY so the invocation is cwd-independent: the
+    float terminal's working directory is whatever the display manager handed
+    the hint wrapper, which is not a checkout of anything in particular.
+    """
+    repo, num = github_ref(url)
+    if not repo:
+        # Unreachable through `open_target` (rung 0 answers it), and kept
+        # because a direct caller is not unreachable. Silent: the browser IS
+        # the right answer for this URL and nothing went wrong.
+        return open_browser(url)
+    if not tui_available():
+        notify("the mention opened in the browser instead",
+               f"{REVIEW_EXE} is not on this handler's PATH. The hint wrapper "
+               f"pins it, so this is a DEPLOY gap, not a config one — run "
+               f"`home-manager switch --flake ~/workspace/devrc --impure`")
+        return open_browser(url)
+    try:
+        # 🔴 A LIST LITERAL WHOSE argv[0] IS THE CONSTANT `"alacritty"`, for the
+        # reason `run_picker`'s argv carries at length: the AST ledger in
+        # `test_mention_open.py` reads exactly that, and a variable there
+        # reports `<computed>` and reddens a guard about something else
+        # entirely.
+        #
+        # 🔴 THE `-c "Octo …"` STRING IS BUILT INSIDE THE NIX WRAPPER, NOT HERE.
+        # `nvim-octo` takes `<owner/repo> <number>` as two ordinary argv
+        # entries and assembles the ex-command itself, so no quoting hazard
+        # reaches this file and argv[0] stays the constant the ledger needs.
+        subprocess.Popen(
+            ["alacritty", "--class", REVIEW_CLASS,
+             "-o", f"window.dimensions.columns={REVIEW_COLUMNS}",
+             "-o", f"window.dimensions.lines={REVIEW_LINES}",
+             "-e", REVIEW_EXE, repo, num],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.SubprocessError) as exc:
+        notify("could not open the review TUI",
+               f"{type(exc).__name__}: {exc} — opening the browser instead")
+        return open_browser(url)
+    return 0
+
+
+def open_url(url: str, *, browser: bool = False) -> int:
+    """Open a resolved mention on whichever surface `open_target` names.
+
+    🔴 THE DISPATCH LIVES HERE AND NOWHERE ELSE. `main()` has two call sites —
+    the single-candidate auto-open and the post-picker open — and a predicate
+    open-coded at both is wrong at one of them. Both still call `open_url`.
+    """
+    if open_target(url, browser=browser) == TARGET_TUI:
+        return open_tui(url)
+    return open_browser(url)
 
 
 # --------------------------------------------------------------------------- #
@@ -1700,6 +1960,11 @@ def build_parser() -> argparse.ArgumentParser:
                         "the repository picker: it is non-interactive, so an "
                         "unresolvable reference exits 1 with a named reason "
                         "rather than listing every repo on the host")
+    p.add_argument("--browser", action="store_true",
+                   help="open in the browser even when this host would have "
+                        "used the review TUI. The per-click escape hatch; the "
+                        "durable one is the marker file at "
+                        "~/.config/mention-open/target")
     p.add_argument("--no-discovery", action="store_true",
                    help="do not read git remotes or ask tmux — resolve only "
                         "what the text itself carries")
@@ -2436,7 +2701,7 @@ def main(argv: list[str] | None = None) -> int:
     # and a host that happens to know exactly one repository must not have that
     # option opened for it.
     if len(candidates) == 1 and not offered_universe and not guessed:
-        return open_url(candidates[0]["url"])
+        return open_url(candidates[0]["url"], browser=args.browser)
 
     # 🔴 THE NOTE IS ATTACHED ONLY WHEN THE PICKER WOULD OTHERWISE BE
     # UNEXPLAINED, and there are exactly two such pickers: one carrying a GUESS
@@ -2505,7 +2770,7 @@ def main(argv: list[str] | None = None) -> int:
     picked_repo = repo_of_github_url(url)
     if picked_repo:
         record_pick(picked_repo, num)
-    return open_url(url)
+    return open_url(url, browser=args.browser)
 
 
 def guarded_main(argv: list[str] | None = None) -> int:

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -38,9 +38,18 @@ browser tab. Everything else (a clawgate task, a ClickUp id, any GitHub URL
 that is not `/issues/N` or `/pull/N`) is always `xdg-open`.
 
 The TUI is taken only when this host HAS it, and the browser stays reachable
-from three directions: `--browser` on the command line, `browser` in the marker
-file at `~/.config/mention-open/target`, and `open_tui`'s own pre-flight, which
-falls back and says so. Read `open_target`'s docstring for the rung order.
+from two directions: `browser` in the marker file at
+`~/.config/mention-open/target`, and `open_tui`'s own pre-flight, which falls
+back and says so. Read `open_target`'s docstring for the rung order.
+
+⚠ A `--browser` FLAG WAS BUILT HERE AND DELETED BEFORE IT SHIPPED, AND THE
+REASON IS WORTH KEEPING SO IT IS NOT RE-ADDED. It called itself "the operator's
+per-click escape hatch", and it was UNREACHABLE FROM A CLICK: the only
+production caller is the Alacritty hint, whose `command` gets the matched text
+and nothing else, and whose regex cannot produce a token starting with `-`. So
+its sole caller was a human typing it in a shell — a second spelling of what the
+marker file already does, reachable from strictly fewer places. The marker file
+is the one rung, and it is the reachable one.
 
 🔴 THE CLICK PATH MAKES NO NETWORK CALL. This is a hard property, not a target,
 and it is pinned by `test_the_resolution_path_spawns_ONLY_these_local_commands`.
@@ -1393,7 +1402,7 @@ def read_target_marker(path: Path | None = None) -> str:
     return value if value in TARGET_VALUES else ""
 
 
-def open_target(url: str, *, browser: bool = False) -> str:
+def open_target(url: str) -> str:
     """Which surface this URL opens on. One of `TARGET_VALUES`, always.
 
     The rungs, in order, and why each sits where it does:
@@ -1404,12 +1413,12 @@ def open_target(url: str, *, browser: bool = False) -> str:
          because "whatever the marker says" is not a meaningful instruction for
          a URL the TUI has no way to open: honouring it would produce a window
          that fails, where the browser would simply have worked.
-      1. `--browser`. The operator's per-click escape hatch, and it wins over
-         their own marker: a flag typed NOW is newer evidence than a file
-         written once.
-      2. THE MARKER FILE. See `MENTION_TARGET_PATH` for why it is a file and
-         can never be an environment variable.
-      3. THE DEFAULT: the TUI when this host actually has it, the browser when
+      1. THE MARKER FILE. See `MENTION_TARGET_PATH` for why it is a file and
+         can never be an environment variable — and see the module docstring
+         for why the `--browser` FLAG that used to sit above this rung was
+         deleted rather than shipped: it could not be reached from a click, so
+         it was a second spelling of this rung with a strictly smaller reach.
+      2. THE DEFAULT: the TUI when this host actually has it, the browser when
          it does not. SILENT in the second case, deliberately — a host with no
          `nvim-octo` has not lost anything it had, and toasting on every click
          to say so is the noise this handler must not make. The announcement
@@ -1417,8 +1426,6 @@ def open_target(url: str, *, browser: bool = False) -> str:
          is `open_tui`'s pre-flight.
     """
     if not github_ref(url)[0]:
-        return TARGET_BROWSER
-    if browser:
         return TARGET_BROWSER
     marked = read_target_marker()
     if marked:
@@ -1484,14 +1491,20 @@ def open_tui(url: str) -> int:
     return 0
 
 
-def open_url(url: str, *, browser: bool = False) -> int:
+def open_url(url: str) -> int:
     """Open a resolved mention on whichever surface `open_target` names.
 
-    🔴 THE DISPATCH LIVES HERE AND NOWHERE ELSE. `main()` has two call sites —
-    the single-candidate auto-open and the post-picker open — and a predicate
-    open-coded at both is wrong at one of them. Both still call `open_url`.
+    🔴 THE DISPATCH LIVES HERE AND NOWHERE ELSE, AND THE SIGNATURE IS UNCHANGED
+    FROM BEFORE THE TUI EXISTED — deliberately. `main()` has two call sites (the
+    single-candidate auto-open and the post-picker open) and neither had to
+    change, so this whole feature is PURELY ADDITIVE to the decision path: a
+    concurrent branch rewriting either call site cannot silently drop half of
+    it, because there is no half to drop. An earlier revision threaded a
+    `browser=` keyword through both sites and produced exactly that hazard
+    against PR #1569 — measured: 418 tests green, two seam guards red. The flag
+    is gone (see the module docstring) and with it the hazard.
     """
-    if open_target(url, browser=browser) == TARGET_TUI:
+    if open_target(url) == TARGET_TUI:
         return open_tui(url)
     return open_browser(url)
 
@@ -1960,11 +1973,6 @@ def build_parser() -> argparse.ArgumentParser:
                         "the repository picker: it is non-interactive, so an "
                         "unresolvable reference exits 1 with a named reason "
                         "rather than listing every repo on the host")
-    p.add_argument("--browser", action="store_true",
-                   help="open in the browser even when this host would have "
-                        "used the review TUI. The per-click escape hatch; the "
-                        "durable one is the marker file at "
-                        "~/.config/mention-open/target")
     p.add_argument("--no-discovery", action="store_true",
                    help="do not read git remotes or ask tmux — resolve only "
                         "what the text itself carries")
@@ -2701,7 +2709,7 @@ def main(argv: list[str] | None = None) -> int:
     # and a host that happens to know exactly one repository must not have that
     # option opened for it.
     if len(candidates) == 1 and not offered_universe and not guessed:
-        return open_url(candidates[0]["url"], browser=args.browser)
+        return open_url(candidates[0]["url"])
 
     # 🔴 THE NOTE IS ATTACHED ONLY WHEN THE PICKER WOULD OTHERWISE BE
     # UNEXPLAINED, and there are exactly two such pickers: one carrying a GUESS
@@ -2770,7 +2778,7 @@ def main(argv: list[str] | None = None) -> int:
     picked_repo = repo_of_github_url(url)
     if picked_repo:
         record_pick(picked_repo, num)
-    return open_url(url, browser=args.browser)
+    return open_url(url)
 
 
 def guarded_main(argv: list[str] | None = None) -> int:

--- a/scripts/testlib/launcher_scan.py
+++ b/scripts/testlib/launcher_scan.py
@@ -42,6 +42,15 @@ HAZARD_VOCABULARY = (
     "systemd-run", "systemctl", "loginctl",
     "notify-send", "dunstify", "dunstctl",
     "rofi", "yad", "zenity", "wmctrl", "xdotool", "i3-msg", "alacritty",
+    # nvim-octo — neovim + octo.nvim as a GitHub review TUI. It is in THIS
+    # vocabulary rather than only in the ledger because a bare invocation takes
+    # over whatever terminal it is run in and, once a PR buffer is open, is one
+    # typed `:Octo pr merge` from a WRITE against a real repository. A launcher
+    # whose blast radius is a merge belongs on the list of names that must be
+    # accounted for, even though the handler only ever reaches it as
+    # `alacritty`'s `-e` payload (which is why it is ACKNOWLEDGED rather than
+    # stubbed — see test_no_real_launchers.py).
+    "nvim-octo",
     "xdg-open", "openrgb", "ddcutil", "brightnessctl", "xset",
     "pactl", "playerctl", "espanso",
     "home-manager", "nixos-rebuild",

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -536,8 +536,15 @@ MUTANTS: list[tuple] = [
                         "`sh -c` line prints `fzf: not found` into a terminal "
                         "that immediately closes — a silent dead click, green "
                         "in every suite",
-     "      pkgs.alacritty pkgs.fzf\n",
-     "      pkgs.alacritty\n",
+     # ⚠ RE-ANCHORED when `pkgs.nvim-octo` joined this line (the review TUI).
+     # The anchor is the WHOLE line, so it went to 0x the moment the line grew
+     # a third package — and an anchor at 0x reports `NOT APPLIED` and scores as
+     # a SURVIVOR without testing anything, which is the silent green
+     # test_mutation_battery_anchors.py exists to catch. It did.
+     # The mutation itself is unchanged in KIND: drop `pkgs.fzf` and keep the
+     # rest, so the row still means "the picker's `sh -c` line cannot find fzf".
+     "      pkgs.alacritty pkgs.fzf pkgs.nvim-octo\n",
+     "      pkgs.alacritty pkgs.nvim-octo\n",
      "the wrapper's PATH is MISSING"),
     # ---- F15: the round-1 audit's findings, as mutants ----------------------
     ("K54", "deletion", "the picker loses `-i`, so fzf is SMART-CASE: a query "

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -6548,8 +6548,8 @@ def test_the_marker_file_can_pin_the_browser_on_a_host_that_HAS_the_tui(tui):
 
 
 def test_the_marker_file_can_pin_the_TUI_on_a_host_that_would_not_default_to_it(tui):
-    """The other direction, which is what makes rung 2 a rung rather than a
-    no-op: `tui_available()` is FALSE here, so rung 3 would have said browser."""
+    """The other direction, which is what makes rung 1 a rung rather than a
+    no-op: `tui_available()` is FALSE here, so rung 2 would have said browser."""
     tui.available = False
     assert MO.open_target(GH_PULL_URL) == MO.TARGET_BROWSER
     tui.marker.write_text("tui")

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -745,7 +745,7 @@ def spy(monkeypatch):
                         {"talos-infra": "civitai/talos-infra"})
     monkeypatch.setattr(MO, "tmux_pane_repo",
                         lambda: calls.append("tmux") or "civitai/talos-infra")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: calls.append(("open", url)) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: calls.append(("open", url)) or 0)
     # `mesg=""` mirrors the real signature: `main()` hands the picker a note to
     # show above the list when the universe is the answer. A stub that took only
     # `candidates` would raise TypeError on that path — which is a kill, but for
@@ -1460,7 +1460,7 @@ def test_a_mapping_ONLY_name_resolves_end_to_end_through_main(tmp_path, monkeypa
     monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main(["plotwidget#42"]) == 0
     assert opened == ["https://github.com/gardenersguild/plotwidget/pull/42"]
 
@@ -3386,8 +3386,7 @@ def test_a_GUESSED_repo_is_never_auto_opened_whatever_the_shape(monkeypatch, tex
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     monkeypatch.setattr(MO, "open_url",
-                        lambda url, **kw: pytest.fail(
-                            f"AUTO-OPENED a guessed repo: {url}"))
+                        lambda url: pytest.fail(f"AUTO-OPENED a guessed repo: {url}"))
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(
@@ -3492,7 +3491,7 @@ def test_a_repo_the_TEXT_named_still_opens_with_no_picker(monkeypatch, text,
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": pytest.fail(f"asked about {text}"))
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main([text]) == 0
     assert opened == [expected], opened
 
@@ -3521,7 +3520,7 @@ def test_an_audit_pr_reference_with_NO_pane_repo_offers_the_PICKER(
     reference becomes a CHOICE over the local universe — never a guess, and never
     the dead-end toast."""
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: pytest.fail(f"opened {url}"))
+    monkeypatch.setattr(MO, "open_url", lambda url: pytest.fail(f"opened {url}"))
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(rows=len(c), mesg=mesg) or "")
@@ -3620,7 +3619,7 @@ def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     picks, opens, notices = [], [], []
     monkeypatch.setattr(MO, "pick", lambda c, mesg="": picks.append(len(c)) or "")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opens.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opens.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
     assert MO.main(["zzznosuchrepo#12"]) == 1
     assert notices[-1][0] == "cannot resolve zzznosuchrepo#12"
@@ -3874,7 +3873,7 @@ def test_the_universe_picker_EXPLAINS_ITSELF_above_the_list(universe, monkeypatc
     plus how many rows are offered, when the mapping was generated, and the
     remedy. Never a row from the universe."""
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 3.0))
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: 0)
     seen = {}
 
     def note_pick(cands, mesg=""):
@@ -4455,7 +4454,7 @@ def test_the_universe_file_is_NOT_read_on_a_click_that_resolves(monkeypatch):
     reads = []
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: reads.append(1) or [])
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: reads.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: reads.append(url) or 0)
     assert MO.main(["--no-discovery", "civitai/talos-infra#1065"]) == 0
     assert reads == ["https://github.com/civitai/talos-infra/pull/1065"], (
         f"expected exactly one open and no universe read, got {reads}")
@@ -4710,7 +4709,7 @@ def test_the_guessed_repo_is_still_NEVER_opened_unconfirmed(monkeypatch):
     opening it unconfirmed is the confident-wrong-page failure the whole handler
     is anchored against. `open_url` must not be reached without a selection."""
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY])
     assert opened == [], f"a guessed repo was opened without a selection: {opened}"
 
@@ -4725,7 +4724,7 @@ def test_an_EXPLICIT_owner_still_opens_directly_and_gets_NO_picker(monkeypatch):
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     picked, opened = [], []
     monkeypatch.setattr(MO, "pick", lambda c, mesg="": picked.append(c) or "")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main(["civitai/talos-infra#1065"]) == 0
     assert picked == [], "an explicit owner must not raise a picker"
     assert opened == ["https://github.com/civitai/talos-infra/pull/1065"], opened
@@ -4845,7 +4844,7 @@ def test_the_bare_hash_N_guess_is_NEVER_opened_unconfirmed(monkeypatch):
     catch the widening WEAKENING it, which is a different failure from the one
     being fixed."""
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     _guessed_picker(monkeypatch, text="#1291", universe=[UNIVERSE_ONLY])
     assert opened == [], f"a guessed repo was opened without a selection: {opened}"
 
@@ -4976,7 +4975,7 @@ def test_the_TEXTS_OWN_evidence_still_opens_with_ZERO_keystrokes(monkeypatch,
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": pytest.fail(f"asked about {text}"))
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     assert MO.main([text]) == 0
     assert opened == [expected], opened
 
@@ -5617,7 +5616,7 @@ def test_a_RAISING_compaction_does_not_cost_the_OPEN(monkeypatch):
                             RuntimeError("compaction exploded")))
     opened: list = []
     said: list = []
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: said.append(a))
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
@@ -6012,7 +6011,7 @@ def test_main_RECORDS_the_repository_the_operator_PICKED(monkeypatch):
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: ["acme/chosen", "acme/other"])
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: 0)
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
                                                 if "acme/chosen" in x["url"]))
@@ -6039,7 +6038,7 @@ def test_a_CLAWGATE_pick_is_NOT_recorded_as_a_repository(monkeypatch):
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: ["acme/one"])
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: 0)
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
                                                 if x["platform"] == "clawgate"))
@@ -6072,7 +6071,7 @@ def test_an_EXPLICIT_click_pays_NOTHING_for_the_ORDERING(monkeypatch, tmp_path):
     monkeypatch.setattr(MO, "load_picks", lambda *a, **k: reads.append("picks") or [])
     monkeypatch.setattr(MO, "ranges_age_days",
                         lambda *a, **k: reads.append("age") or 1.0)
-    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url: 0)
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: ["acme/onlyone"])
@@ -6514,14 +6513,25 @@ def test_a_PINNED_tui_that_cannot_run_falls_back_and_says_so_EXACTLY_ONCE(tui):
     assert len(tui.notifies) == 1, tui.notifies
 
 
-def test_the_browser_flag_wins_even_for_a_github_reference(tui):
-    """The per-click escape hatch. It beats the marker file too: a flag typed
-    NOW is newer evidence than a file written once."""
-    tui.available = True
-    tui.marker.write_text(MO.TARGET_TUI)
-    assert MO.open_url(GH_PULL_URL, browser=True) == 0
-    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
-    assert tui.notifies == [], "an explicit --browser is not a failure"
+def test_open_url_takes_NO_argument_but_the_url(tui):
+    """🔴 A DELETION, PINNED SO IT IS NOT QUIETLY UNDONE.
+
+    A `--browser` flag was built here and removed before it shipped: it was
+    UNREACHABLE from a click (the Alacritty hint hands the handler the matched
+    text and nothing else, and its regex cannot produce a token starting with
+    `-`), so its only caller was a human typing it in a shell — a second
+    spelling of the marker file with a strictly smaller reach.
+
+    The signature is what makes this feature purely additive to `main()`: both
+    call sites are byte-identical to the pre-TUI code, so a concurrent branch
+    rewriting either one cannot drop half of it. Re-adding a keyword here
+    re-opens that cross-PR hazard, which is why the shape is asserted rather
+    than left to a comment."""
+    import inspect
+    params = list(inspect.signature(MO.open_url).parameters)
+    assert params == ["url"], params
+    assert list(inspect.signature(MO.open_target).parameters) == ["url"]
+    assert "--browser" not in MO.build_parser().format_help()
 
 
 def test_the_marker_file_can_pin_the_browser_on_a_host_that_HAS_the_tui(tui):
@@ -6706,48 +6716,33 @@ def test_main_routes_an_unambiguous_github_click_through_the_review_TUI(
     assert spawns[0][-2:] == ["civitai/talos-infra", "1065"], spawns
 
 
-def test_main_honours_the_browser_flag_on_the_auto_open_path(
+def test_main_routes_a_PICKED_github_row_through_the_review_TUI(
         monkeypatch, tmp_path):
-    """🔴 THE FLAG MUST SURVIVE THE CALL SITE. `open_url` growing a keyword that
-    `main()` never passes is a feature that is 100% dead with a green suite —
-    the fix-direction trap RULES.md names: adding it to the parser changes
-    NOTHING while no call site forwards it."""
-    spawns = _spawn_recorder(monkeypatch, tmp_path)
-    assert MO.main(["--browser", "civitai/talos-infra#1065"]) == 0
-    assert [a[0] for a in spawns] == ["xdg-open"], spawns
+    """🔴 THE SECOND CALL SITE, WHICH NO TEST ABOVE REACHES — and the one a
+    concurrent branch is also rewriting. A rewrite that opened the browser
+    directly instead of going through `open_url` would take this red; nothing
+    else in the file would notice.
 
-
-def test_main_honours_the_browser_flag_on_the_PICKER_path(
-        monkeypatch, tmp_path):
-    """The SECOND call site, which no test above reaches. Both sites forward the
-    flag or neither does — and a predicate that is right at one site and wrong
-    at the other is the shape this repo keeps paying for."""
+    🔴 THE PANE REPO IS WHAT MAKES THIS REACH THE PICKER AT ALL, AND THE FIRST
+    VERSION OF THIS TEST DID NOT HAVE IT. With `tmux_pane_repo` returning "", a
+    bare `#370` has exactly ONE candidate — the clawgate task — so `main()`
+    takes the single-candidate AUTO-OPEN branch and `pick` is never called. The
+    assertions still passed, because a clawgate URL opens in the browser either
+    way: a test of the picker call site that never reached it, green for the
+    wrong reason. MEASURED, not reasoned about. The `picks` assertion below is
+    what keeps that from recurring."""
     spawns = _spawn_recorder(monkeypatch, tmp_path)
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     monkeypatch.setattr(MO, "record_pick", lambda *a, **k: None)
-    # 🔴 THE PANE REPO IS WHAT MAKES THIS REACH THE PICKER AT ALL, AND THE FIRST
-    # VERSION OF THIS TEST DID NOT HAVE IT. With `tmux_pane_repo` returning "",
-    # a bare `#370` has exactly ONE candidate — the clawgate task — so `main()`
-    # takes the single-candidate AUTO-OPEN branch and `pick` is never called.
-    # Both assertions still passed, because a clawgate URL opens in the browser
-    # with or without the flag: a test of the picker call site that never
-    # reached it, green either way. MEASURED, not reasoned about — it failed on
-    # the positive control below, which is the only reason it was caught.
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "gardenersguild/trowelcast")
     picks: list[int] = []
     monkeypatch.setattr(
         MO, "pick",
         lambda c, mesg="": picks.append(len(c)) or GH_PULL_URL)
-    assert MO.main(["--browser", "#370"]) == 0
-    assert picks, "the PICKER was never reached — this test proves nothing"
-    assert [a[0] for a in spawns] == ["xdg-open"], spawns
-    # POSITIVE CONTROL on the same path: WITHOUT the flag it takes the TUI, so
-    # the browser above is the flag's doing and not the picker path's.
-    spawns.clear()
-    picks.clear()
     assert MO.main(["#370"]) == 0
-    assert picks, "the PICKER was never reached on the control run either"
+    assert picks, "the PICKER was never reached — this test proves nothing"
     assert [a[0] for a in spawns] == ["alacritty"], spawns
+    assert spawns[0][-2:] == ["gardenersguild/trowelcast", "1559"], spawns
 
 
 def test_tui_available_asks_about_the_REVIEW_EXE_and_nothing_else(monkeypatch):

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -365,6 +365,20 @@ def _mapping_is_never_the_operators(monkeypatch, tmp_path):
     picks = tmp_path / "autouse-picks.jsonl"
     monkeypatch.setattr(MO, "PICKS_PATH", picks)
     monkeypatch.setenv("MENTION_OPEN_PICKS", str(picks))
+
+    # 🔴 THE FIFTH, AND IT IS A DIFFERENT HAZARD FROM THE FOUR ABOVE. The marker
+    # names no repository, so nothing here is about disclosure. What an
+    # unredirected read would do is let the OPERATOR'S OWN pinned target decide
+    # a test's answer: `open_target` reads this file BEFORE it consults
+    # `tui_available()`, so a workbench with `tui` in it would flip every test
+    # that opens a GitHub URL onto the review-TUI path — a suite that behaves
+    # differently on the two hosts, for a reason no failure message would name.
+    # ⚠ NOT WRITTEN, for the same reason as the two above: absent means
+    # "unpinned", which is the default state and the correct one for a test that
+    # says nothing about the target.
+    target = tmp_path / "autouse-target"
+    monkeypatch.setattr(MO, "MENTION_TARGET_PATH", target)
+    monkeypatch.setenv("MENTION_OPEN_TARGET", str(target))
     return p
 
 
@@ -410,6 +424,15 @@ HOST_STATE_CONSTANTS = {
     "KNOWN_UNIVERSE_PATH": "MENTION_OPEN_KNOWN_UNIVERSE",
     "KNOWN_RANGES_PATH": "MENTION_OPEN_KNOWN_RANGES",
     "PICKS_PATH": "MENTION_OPEN_PICKS",
+    # The review-target marker. ⚠ IT IS THE ONE ENTRY HERE THAT NAMES NO
+    # REPOSITORY — it holds the literal word `tui` or `browser` — so the
+    # DISCLOSURE argument the other four rest on does not apply to it. It is
+    # ledgered anyway, and must be: it sits in the same directory, and an
+    # unredirected read would let the OPERATOR'S OWN marker decide a test's
+    # answer, silently moving the whole suite onto the TUI path on a host where
+    # they had pinned it. That is a different hazard from disclosure and it is
+    # the one this row closes.
+    "MENTION_TARGET_PATH": "MENTION_OPEN_TARGET",
 }
 
 
@@ -722,7 +745,7 @@ def spy(monkeypatch):
                         {"talos-infra": "civitai/talos-infra"})
     monkeypatch.setattr(MO, "tmux_pane_repo",
                         lambda: calls.append("tmux") or "civitai/talos-infra")
-    monkeypatch.setattr(MO, "open_url", lambda url: calls.append(("open", url)) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: calls.append(("open", url)) or 0)
     # `mesg=""` mirrors the real signature: `main()` hands the picker a note to
     # show above the list when the universe is the answer. A stub that took only
     # `candidates` would raise TypeError on that path — which is a kill, but for
@@ -1180,6 +1203,89 @@ def _shell_child_commands(source: str) -> set[str]:
     return out
 
 
+def _exec_payload_commands(source: str) -> set[str]:
+    """The binaries a spawn hands a terminal to RUN — the first word of the
+    argument following a literal `"-e"` inside a spawn's argv list.
+
+    🔴 A THIRD READER, AND IT IS NOT A SPELLING VARIANT OF THE SECOND. argv[0]
+    covers the terminal; `_shell_child_commands` covers a command inside a
+    `sh -c` SCRIPT; this covers a command alacritty execs DIRECTLY. The review
+    TUI is `alacritty … -e nvim-octo <repo> <num>` — no shell, no `-c` — so the
+    `-c` reader sees nothing at all, and without this the wrapper's PATH would
+    carry `pkgs.nvim-octo` with nothing in the ledger requiring it (which the
+    `listed <= needed` direction of the test below would then call dead weight
+    and delete).
+
+    The failure it guards against is the same one `fzf` taught: alacritty exits
+    0 whether its `-e` command exits 0 or 127, so a missing binary is a window
+    that flashes and vanishes — invisible to the handler and green in every
+    suite.
+
+    Resolves ONE level of module-level `NAME = "…"`, because `mention-open.py`
+    spells it as the constant `REVIEW_EXE` rather than a literal — deliberately,
+    so the name `shutil.which` pre-flights and the name that is spawned cannot
+    drift apart. Absolute paths are skipped for the same reason as above:
+    `/bin/sh` is not resolved through PATH.
+    """
+    out: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("run", "Popen") or not node.args:
+            continue
+        argv = node.args[0]
+        if not isinstance(argv, (ast.List, ast.Tuple)):
+            continue
+        elts = list(argv.elts)
+        for i, elt in enumerate(elts[:-1]):
+            if not (isinstance(elt, ast.Constant) and elt.value == "-e"):
+                continue
+            payload = elts[i + 1]
+            text = None
+            if isinstance(payload, ast.Constant) and isinstance(payload.value, str):
+                text = payload.value
+            elif isinstance(payload, ast.Name):
+                text = _module_str_constant(source, payload.id)
+            if not text:
+                out.add("<computed>")
+                continue
+            word = text.split()[0] if text.split() else ""
+            if word and not word.startswith("/"):
+                out.add(word)
+    return out
+
+
+def test_the_exec_payload_reader_can_actually_fire():
+    """POSITIVE **AND** NEGATIVE CONTROL on the third reader, before its verdict
+    is believed — a reader that matched nothing would report a clean empty set
+    forever and `test_the_alacritty_wrapper_PATH_…` would silently stop covering
+    the one binary the review TUI cannot run without."""
+    # A bare command after `-e`, which is how the review terminal spells it.
+    assert _exec_payload_commands(
+        "import subprocess\n"
+        "subprocess.Popen(['alacritty', '-e', 'nvim-octo', 'o/r', '7'])\n"
+    ) == {"nvim-octo"}
+    # Through a module constant, which is how the handler actually spells it.
+    assert _exec_payload_commands(
+        "import subprocess\n"
+        "E = 'nvim-octo'\n"
+        "subprocess.Popen(['alacritty', '-e', E, 'o/r', '7'])\n"
+    ) == {"nvim-octo"}
+    # 🔴 THE PICKER'S OWN `-e` PAYLOAD IS `/bin/sh`, AN ABSOLUTE PATH, AND MUST
+    # NOT BE REPORTED — it is not resolved through PATH and needs no package.
+    # Without this arm the reader would demand a `pkgs./bin/sh`.
+    assert _exec_payload_commands(
+        "import subprocess\n"
+        "subprocess.Popen(['alacritty', '-e', '/bin/sh', '-c', 'fzf'])\n") == set()
+    # A spawn with no `-e` contributes nothing…
+    assert _exec_payload_commands(
+        "import subprocess\nsubprocess.run(['git', 'rev-parse'])\n") == set()
+    # …and a payload it cannot read is reported, never silently dropped.
+    assert _exec_payload_commands(
+        "import subprocess\n"
+        "subprocess.Popen(['alacritty', '-e', pick()])\n") == {"<computed>"}
+
+
 def _module_str_constant(source: str, name: str) -> str | None:
     """The value of a module-level `NAME = "…"` (implicit-concatenation
     included), or None. Deliberately NOT `getattr(MO, name)`: reading it off the
@@ -1265,7 +1371,14 @@ def test_the_alacritty_wrapper_PATH_covers_every_executable_the_handler_spawns()
     # executable -> the nix attribute that must provide it.
     PROVIDER = {"git": "pkgs.git", "tmux": "pkgs.tmux",
                 "xdg-open": "pkgs.xdg-utils", "notify-send": "pkgs.libnotify",
-                "alacritty": "pkgs.alacritty", "fzf": "pkgs.fzf"}
+                "alacritty": "pkgs.alacritty", "fzf": "pkgs.fzf",
+                # nvim-octo — the review TUI, supplied by the OVERLAY in
+                # flake.nix rather than by nixpkgs. It is spelled `pkgs.X` for
+                # exactly this reader: a `let`-bound derivation would not match
+                # the `pkgs\.[A-Za-z0-9_-]+` scan below, so the wrapper would
+                # look like it pins nothing and this seam would stop covering
+                # the binary the review click cannot run without.
+                "nvim-octo": "pkgs.nvim-octo"}
     # python312 is the interpreter the wrapper `exec`s by store path.
     INTERPRETER = {"pkgs.python312"}
 
@@ -1279,12 +1392,18 @@ def test_the_alacritty_wrapper_PATH_covers_every_executable_the_handler_spawns()
     assert listed, "positive control: the wrapper DOES pin a PATH"
 
     src = HANDLER.read_text()
-    spawned = _spawned_executables(src) | _shell_child_commands(src)
+    spawned = (_spawned_executables(src) | _shell_child_commands(src)
+               | _exec_payload_commands(src))
     assert spawned, "positive control: the module DOES spawn things"
     assert "fzf" in spawned, (
         "positive control on the SECOND reader: the picker's `sh -c` line must "
         "still be visible to _shell_child_commands, or this test silently stops "
         "covering the binary the picker cannot run without")
+    assert "nvim-octo" in spawned, (
+        "positive control on the THIRD reader: the review terminal's `-e` "
+        "payload must still be visible to _exec_payload_commands, or this test "
+        "silently stops covering the binary a review click cannot run without "
+        "— and `pkgs.nvim-octo` in the wrapper would then read as dead weight")
     needed = {PROVIDER[e] for e in spawned if e in PROVIDER}
     unknown = spawned - set(PROVIDER)
     assert not unknown, (
@@ -1341,7 +1460,7 @@ def test_a_mapping_ONLY_name_resolves_end_to_end_through_main(tmp_path, monkeypa
     monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     assert MO.main(["plotwidget#42"]) == 0
     assert opened == ["https://github.com/gardenersguild/plotwidget/pull/42"]
 
@@ -3267,7 +3386,8 @@ def test_a_GUESSED_repo_is_never_auto_opened_whatever_the_shape(monkeypatch, tex
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     monkeypatch.setattr(MO, "open_url",
-                        lambda url: pytest.fail(f"AUTO-OPENED a guessed repo: {url}"))
+                        lambda url, **kw: pytest.fail(
+                            f"AUTO-OPENED a guessed repo: {url}"))
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(
@@ -3372,7 +3492,7 @@ def test_a_repo_the_TEXT_named_still_opens_with_no_picker(monkeypatch, text,
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": pytest.fail(f"asked about {text}"))
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     assert MO.main([text]) == 0
     assert opened == [expected], opened
 
@@ -3401,7 +3521,7 @@ def test_an_audit_pr_reference_with_NO_pane_repo_offers_the_PICKER(
     reference becomes a CHOICE over the local universe — never a guess, and never
     the dead-end toast."""
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url: pytest.fail(f"opened {url}"))
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: pytest.fail(f"opened {url}"))
     seen = {}
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": seen.update(rows=len(c), mesg=mesg) or "")
@@ -3500,7 +3620,7 @@ def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
     picks, opens, notices = [], [], []
     monkeypatch.setattr(MO, "pick", lambda c, mesg="": picks.append(len(c)) or "")
-    monkeypatch.setattr(MO, "open_url", lambda url: opens.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opens.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
     assert MO.main(["zzznosuchrepo#12"]) == 1
     assert notices[-1][0] == "cannot resolve zzznosuchrepo#12"
@@ -3754,7 +3874,7 @@ def test_the_universe_picker_EXPLAINS_ITSELF_above_the_list(universe, monkeypatc
     plus how many rows are offered, when the mapping was generated, and the
     remedy. Never a row from the universe."""
     monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", _mapping_aged(tmp_path, 3.0))
-    monkeypatch.setattr(MO, "open_url", lambda url: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
     seen = {}
 
     def note_pick(cands, mesg=""):
@@ -4335,7 +4455,7 @@ def test_the_universe_file_is_NOT_read_on_a_click_that_resolves(monkeypatch):
     reads = []
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: reads.append(1) or [])
-    monkeypatch.setattr(MO, "open_url", lambda url: reads.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: reads.append(url) or 0)
     assert MO.main(["--no-discovery", "civitai/talos-infra#1065"]) == 0
     assert reads == ["https://github.com/civitai/talos-infra/pull/1065"], (
         f"expected exactly one open and no universe read, got {reads}")
@@ -4413,13 +4533,20 @@ _SPAWN_FUNCS = {"run", "Popen", "call", "check_output", "check_call", "system",
 #   tmux        — asking the pane for its repo
 #   notify-send — the refusal toast
 #   xdg-open    — opening the chosen URL
-#   alacritty   — the float terminal the fzf picker runs in (was `rofi` until
-#                 2026-09-09; see `PICKER_SH` for the ranking measurement that
-#                 forced the swap). ⚠ `fzf` itself is NOT here and must not be:
-#                 this set is argv[0] literals, and fzf is one level down, in
-#                 the `-c` script. `_shell_child_commands` is the reader that
-#                 sees it, and `test_the_alacritty_wrapper_PATH_covers_every_
-#                 executable_the_handler_spawns` is where it is pinned.
+#   alacritty   — the float terminal for BOTH of this handler's windows: the
+#                 fzf picker (was `rofi` until 2026-09-09; see `PICKER_SH` for
+#                 the ranking measurement that forced the swap) and, since the
+#                 review TUI landed, the `nvim-octo` review window. TWO call
+#                 sites, ONE argv[0] — which is why this set did not move when
+#                 the second arrived, and why it cannot be read as a count of
+#                 the things this module can launch.
+#                 ⚠ NEITHER `fzf` NOR `nvim-octo` IS HERE, AND NEITHER MAY BE:
+#                 this set is argv[0] literals, and both are one level down —
+#                 fzf inside the `-c` script, nvim-octo as the `-e` payload.
+#                 `_shell_child_commands` and `_exec_payload_commands` are the
+#                 readers that see them, and `test_the_alacritty_wrapper_PATH_
+#                 covers_every_executable_the_handler_spawns` is where both are
+#                 pinned.
 EXPECTED_ARGV0 = {"git", "tmux", "notify-send", "xdg-open", "alacritty"}
 
 
@@ -4583,7 +4710,7 @@ def test_the_guessed_repo_is_still_NEVER_opened_unconfirmed(monkeypatch):
     opening it unconfirmed is the confident-wrong-page failure the whole handler
     is anchored against. `open_url` must not be reached without a selection."""
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     _guessed_picker(monkeypatch, universe=[UNIVERSE_ONLY])
     assert opened == [], f"a guessed repo was opened without a selection: {opened}"
 
@@ -4598,7 +4725,7 @@ def test_an_EXPLICIT_owner_still_opens_directly_and_gets_NO_picker(monkeypatch):
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "wrongorg/wrongrepo")
     picked, opened = [], []
     monkeypatch.setattr(MO, "pick", lambda c, mesg="": picked.append(c) or "")
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     assert MO.main(["civitai/talos-infra#1065"]) == 0
     assert picked == [], "an explicit owner must not raise a picker"
     assert opened == ["https://github.com/civitai/talos-infra/pull/1065"], opened
@@ -4718,7 +4845,7 @@ def test_the_bare_hash_N_guess_is_NEVER_opened_unconfirmed(monkeypatch):
     catch the widening WEAKENING it, which is a different failure from the one
     being fixed."""
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     _guessed_picker(monkeypatch, text="#1291", universe=[UNIVERSE_ONLY])
     assert opened == [], f"a guessed repo was opened without a selection: {opened}"
 
@@ -4849,7 +4976,7 @@ def test_the_TEXTS_OWN_evidence_still_opens_with_ZERO_keystrokes(monkeypatch,
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": pytest.fail(f"asked about {text}"))
     opened = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     assert MO.main([text]) == 0
     assert opened == [expected], opened
 
@@ -5490,7 +5617,7 @@ def test_a_RAISING_compaction_does_not_cost_the_OPEN(monkeypatch):
                             RuntimeError("compaction exploded")))
     opened: list = []
     said: list = []
-    monkeypatch.setattr(MO, "open_url", lambda url: opened.append(url) or 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: opened.append(url) or 0)
     monkeypatch.setattr(MO, "notify", lambda *a, **k: said.append(a))
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
@@ -5885,7 +6012,7 @@ def test_main_RECORDS_the_repository_the_operator_PICKED(monkeypatch):
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: ["acme/chosen", "acme/other"])
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
                                                 if "acme/chosen" in x["url"]))
@@ -5912,7 +6039,7 @@ def test_a_CLAWGATE_pick_is_NOT_recorded_as_a_repository(monkeypatch):
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     monkeypatch.setattr(MO, "load_known_universe", lambda *a, **k: ["acme/one"])
     monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
-    monkeypatch.setattr(MO, "open_url", lambda url: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
     monkeypatch.setattr(MO, "pick",
                         lambda c, mesg="": next(x["url"] for x in c
                                                 if x["platform"] == "clawgate"))
@@ -5945,7 +6072,7 @@ def test_an_EXPLICIT_click_pays_NOTHING_for_the_ORDERING(monkeypatch, tmp_path):
     monkeypatch.setattr(MO, "load_picks", lambda *a, **k: reads.append("picks") or [])
     monkeypatch.setattr(MO, "ranges_age_days",
                         lambda *a, **k: reads.append("age") or 1.0)
-    monkeypatch.setattr(MO, "open_url", lambda url: 0)
+    monkeypatch.setattr(MO, "open_url", lambda url, **kw: 0)
     monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     monkeypatch.setattr(MO, "load_known_universe",
                         lambda *a, **k: ["acme/onlyone"])
@@ -6206,3 +6333,432 @@ def _fzf_filter(rows: list[str], query: str) -> list[str]:
     out = subprocess.run(["fzf", "--filter", query, *_picker_flags()],
                          input="\n".join(rows), capture_output=True, text=True)
     return [r for r in out.stdout.split("\n") if r]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE REVIEW TUI — `open_target` / `open_tui` / `open_browser`
+#
+# NOTHING BELOW RAISES A WINDOW OR STARTS AN EDITOR. The hermetic boundary is
+# the `Popen` call: its argv is assertable, and nothing after it is. Everything
+# past that boundary — that alacritty maps a window, that neovim starts, that
+# `setup()` ran, that `Octo <N> <repo>` resolved the right BUFFER KIND (a live
+# GraphQL call), that the merge mappings are gone from the LIVE buffer — is
+# stated as unverified in the PR rather than implied by a green test here.
+#
+# ⚠ `nvim-octo` IS DELIBERATELY NOT STUBBED ONTO PATH BY THE SUITE. It is in
+# `nolaunch.ACKNOWLEDGED_UNSTUBBED`, not `HOST_LAUNCHERS`, because it is only
+# ever reached as `alacritty`'s `-e` payload and alacritty IS stubbed. A
+# consequence worth naming: `tui_available()` is FALSE by default in every test
+# in this file, so every test that does not say otherwise exercises the browser
+# path. Each test below that wants the TUI says so explicitly.
+# --------------------------------------------------------------------------- #
+GH_PULL_URL = "https://github.com/gardenersguild/trowelcast/pull/1559"
+GH_ISSUE_URL = "https://github.com/gardenersguild/trowelcast/issues/1559"
+CLAWGATE_URL = "https://clawgate.zacx.dev/tasks/7"
+CLICKUP_URL = "https://app.clickup.com/t/868abc123"
+
+
+@pytest.fixture
+def tui(monkeypatch, tmp_path):
+    """Drive `open_url` with every impure edge recorded and nothing launched.
+
+    Returns a namespace whose `spawns` is the argv list of every `Popen`,
+    `notifies` every toast summary, and `available`/`marker` the two levers
+    `open_target` reads. The marker path is redirected into `tmp_path` so no
+    test can read — or be decided by — the operator's real
+    `~/.config/mention-open/target`.
+    """
+    spawns: list[list[str]] = []
+    notifies: list[str] = []
+
+    def record(argv, *a, **k):
+        spawns.append(list(argv))
+        return types.SimpleNamespace(poll=lambda: 0, terminate=lambda: None)
+
+    monkeypatch.setattr(MO.subprocess, "Popen", record)
+    monkeypatch.setattr(MO, "notify",
+                        lambda summary, body="": notifies.append(summary))
+    marker = tmp_path / "target"
+    monkeypatch.setattr(MO, "MENTION_TARGET_PATH", marker)
+    state = types.SimpleNamespace(spawns=spawns, notifies=notifies,
+                                  marker=marker, available=False)
+    monkeypatch.setattr(MO, "tui_available", lambda: state.available)
+    return state
+
+
+# --------------------------------------------------------------------------- #
+# 1. ARGV CONSTRUCTION
+# --------------------------------------------------------------------------- #
+def test_the_review_terminal_runs_the_TUI_with_the_repo_then_the_number(tui):
+    """🔴 THE ONE ASSERTABLE FACT ABOUT THE SPAWN, AND ALL THREE PARTS MATTER.
+
+    argv[0] must stay the constant `alacritty` (the AST ledger reads exactly
+    that); the `-e` payload must be the review wrapper (alacritty exits 0 for a
+    payload that does not exist, so nothing downstream can notice); and the last
+    two arguments must be the REPOSITORY and then the NUMBER, in that order,
+    because the wrapper assembles `Octo <num> <repo>` from their POSITIONS.
+    Swap them and octo is handed a repository where it expects a number, which
+    takes a completely different branch of `M.octo`.
+
+    The fixtures are pairwise distinct and distinct from every constant this
+    assertion names — `gardenersguild/trowelcast` and `1559`, never `owner/1`
+    and `1` — so a mutant that hardcodes a literal cannot survive by landing on
+    the expected value.
+    """
+    tui.available = True
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert len(tui.spawns) == 1, tui.spawns
+    argv = tui.spawns[0]
+    assert argv[0] == "alacritty", argv
+    assert argv[-3] == MO.REVIEW_EXE == "nvim-octo", argv
+    assert argv[-2:] == ["gardenersguild/trowelcast", "1559"], argv
+    # The `-e` really is what introduces the payload, not a coincidence of
+    # position: a future flag inserted after it would break the wrapper.
+    assert argv[argv.index("-e") + 1] == MO.REVIEW_EXE, argv
+
+
+def test_the_review_terminal_carries_its_own_window_class_and_geometry(tui):
+    """The instance half of the class names THIS window, so an i3 rule can size
+    a review without catching the fzf picker — which uses the SAME general
+    class. Asserted as a pair for that reason: `float` alone would be satisfied
+    by the picker's own class."""
+    tui.available = True
+    MO.open_url(GH_PULL_URL)
+    argv = tui.spawns[0]
+    assert argv[argv.index("--class") + 1] == MO.REVIEW_CLASS
+    assert MO.REVIEW_CLASS == "float,mention-review"
+    assert MO.REVIEW_CLASS != MO.PICKER_CLASS
+    assert f"window.dimensions.columns={MO.REVIEW_COLUMNS}" in argv
+    assert f"window.dimensions.lines={MO.REVIEW_LINES}" in argv
+
+
+# --------------------------------------------------------------------------- #
+# 2. DISPATCH CHOICE — and BOTH branches carry a positive control
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("url,expected", [
+    (GH_PULL_URL, MO.TARGET_TUI),
+    (GH_ISSUE_URL, MO.TARGET_TUI),
+    (CLAWGATE_URL, MO.TARGET_BROWSER),
+    (CLICKUP_URL, MO.TARGET_BROWSER),
+    # A github.com URL that is NOT an issue or a pull request. The TUI has
+    # nothing to open here, and `repo_of_github_url` — the looser reader used
+    # for the pick log — WOULD have said "gardenersguild/trowelcast".
+    ("https://github.com/gardenersguild/trowelcast/releases/tag/v2",
+     MO.TARGET_BROWSER),
+    ("https://github.com/gardenersguild/trowelcast/", MO.TARGET_BROWSER),
+])
+def test_the_target_is_decided_by_the_URL_SHAPE(tui, url, expected):
+    """🔴 THE TABLE IS ONLY EVIDENCE BECAUSE THE TUI ROWS ARE POSITIVE.
+
+    "zero TUI calls for a clawgate URL" is indistinguishable from a dispatcher
+    wired to nothing at all, so the same table asserts that the GitHub rows DO
+    reach the TUI under identical conditions. One parametrisation, both
+    directions, and the browser rows cannot pass vacuously.
+    """
+    tui.available = True
+    assert MO.open_target(url) == expected
+
+
+def test_a_clawgate_click_reaches_the_BROWSER_and_the_TUI_is_never_spawned(tui):
+    """The behavioural half of the table above: `open_target` returning a string
+    is a claim about a function; this is a claim about what was LAUNCHED."""
+    tui.available = True
+    assert MO.open_url(CLAWGATE_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+    assert MO.REVIEW_EXE not in str(tui.spawns)
+    assert tui.notifies == [], (
+        "a clawgate click took the ordinary path and must say nothing")
+
+
+def test_a_github_click_reaches_the_TUI_under_the_SAME_fixture(tui):
+    """🔴 THE POSITIVE CONTROL FOR THE TEST ABOVE. Same fixture, same
+    availability, one field changed — so the clawgate zero is a fact about the
+    URL rather than about a handler that cannot reach the TUI at all."""
+    tui.available = True
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["alacritty"], tui.spawns
+    assert "xdg-open" not in str(tui.spawns)
+
+
+# --------------------------------------------------------------------------- #
+# 3. FALLBACK SELECTION
+# --------------------------------------------------------------------------- #
+def test_a_host_without_the_TUI_opens_the_browser_and_says_NOTHING(tui):
+    """🔴 SILENT ON PURPOSE, AND THIS IS THE ARM MOST LIKELY TO BE "FIXED" INTO
+    NOISE. A host with no `nvim-octo` has not lost anything it had — every click
+    behaves exactly as it did before this feature existed. Toasting on each one
+    to announce a capability the operator never asked for is the noise this
+    handler must not make. The announcement belongs where the TUI was ASKED for
+    and could not run, which is the test below."""
+    tui.available = False
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+    assert tui.notifies == [], tui.notifies
+
+
+def test_a_PINNED_tui_that_cannot_run_falls_back_and_says_so_EXACTLY_ONCE(tui):
+    """🔴 THE PRE-FLIGHT IS MANDATORY, NOT DEFENSIVE POLISH, AND A POST-SPAWN
+    FALLBACK STRUCTURALLY CANNOT REPLACE IT. alacritty 0.17.0 exits 0 whether
+    its `-e` command exits 0 or 127, and `Popen` never waits — so a missing
+    `nvim-octo` is a window that flashes and vanishes with nothing for this
+    process to observe. The operator asked for the TUI (the marker file), so the
+    refusal must be announced; a silent refusal is worse than the dead end it
+    replaces.
+
+    EXACTLY ONE toast, asserted as a count rather than as membership: a fallback
+    that also fired the browser's own failure toast would be two."""
+    tui.available = False
+    tui.marker.write_text(MO.TARGET_TUI)
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+    assert len(tui.notifies) == 1, tui.notifies
+
+
+def test_the_browser_flag_wins_even_for_a_github_reference(tui):
+    """The per-click escape hatch. It beats the marker file too: a flag typed
+    NOW is newer evidence than a file written once."""
+    tui.available = True
+    tui.marker.write_text(MO.TARGET_TUI)
+    assert MO.open_url(GH_PULL_URL, browser=True) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+    assert tui.notifies == [], "an explicit --browser is not a failure"
+
+
+def test_the_marker_file_can_pin_the_browser_on_a_host_that_HAS_the_tui(tui):
+    """The durable escape hatch, and the direction that proves the marker is
+    read at all: this host WOULD have taken the TUI by default."""
+    tui.available = True
+    assert MO.open_target(GH_PULL_URL) == MO.TARGET_TUI, (
+        "positive control: without the marker this host takes the TUI, so the "
+        "assertion below is about the FILE and not about availability")
+    tui.marker.write_text("browser\n")
+    assert MO.open_target(GH_PULL_URL) == MO.TARGET_BROWSER
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+
+
+def test_the_marker_file_can_pin_the_TUI_on_a_host_that_would_not_default_to_it(tui):
+    """The other direction, which is what makes rung 2 a rung rather than a
+    no-op: `tui_available()` is FALSE here, so rung 3 would have said browser."""
+    tui.available = False
+    assert MO.open_target(GH_PULL_URL) == MO.TARGET_BROWSER
+    tui.marker.write_text("tui")
+    assert MO.open_target(GH_PULL_URL) == MO.TARGET_TUI
+
+
+@pytest.mark.parametrize("content", ["", "   \n", "TUI-ish", "browserr",
+                                     "tui browser", "0"])
+def test_an_UNREADABLE_marker_reads_as_unpinned_rather_than_wedging_a_click(
+        tui, content):
+    """A marker file that cannot be understood must not be able to break
+    clicking. Anything that is not exactly one of `TARGET_VALUES` falls through
+    to the default rung, which here means the browser."""
+    tui.available = False
+    tui.marker.write_text(content)
+    assert MO.read_target_marker() == ""
+    assert MO.open_target(GH_PULL_URL) == MO.TARGET_BROWSER
+
+
+def test_a_marker_that_is_a_DIRECTORY_is_not_an_exception(tui):
+    """`IsADirectoryError` is an `OSError`; the reader must treat it as unpinned
+    rather than let it reach `guarded_main`'s last-resort toast."""
+    tui.available = True
+    tui.marker.mkdir()
+    assert MO.read_target_marker() == ""
+
+
+def test_the_marker_is_read_at_CALL_time_not_bound_at_import(tui, tmp_path):
+    """A `path: Path = MENTION_TARGET_PATH` default is evaluated once, at
+    import, so `monkeypatch.setattr` on the module constant would be inert and
+    the whole fixture above would be testing the operator's real file."""
+    other = tmp_path / "elsewhere"
+    other.write_text("tui")
+    assert MO.read_target_marker(other) == MO.TARGET_TUI
+    assert MO.read_target_marker() == "", (
+        "the redirected default path was not honoured — this reader bound its "
+        "path at import and every marker test above is inert")
+
+
+def test_a_case_or_whitespace_variant_of_the_marker_still_counts(tui):
+    """The operator writes this file by hand; `echo TUI > target` must work."""
+    tui.available = False
+    tui.marker.write_text("  TUI \n")
+    assert MO.read_target_marker() == MO.TARGET_TUI
+
+
+def test_a_spawn_failure_falls_back_to_the_browser_rather_than_dying(
+        monkeypatch, tmp_path):
+    """🔴 THE FALLBACK IS THE WHOLE POINT OF THE FEATURE'S SHAPE. A terminal
+    that cannot be spawned at all (no DISPLAY, a GC'd store path) must still
+    open the link — the browser stays reachable from every arm."""
+    marker = tmp_path / "target"
+    monkeypatch.setattr(MO, "MENTION_TARGET_PATH", marker)
+    monkeypatch.setattr(MO, "tui_available", lambda: True)
+    notifies: list[str] = []
+    monkeypatch.setattr(MO, "notify",
+                        lambda summary, body="": notifies.append(summary))
+    seen: list[list[str]] = []
+
+    def flaky(argv, *a, **k):
+        if argv[0] == "alacritty":
+            raise OSError("no DISPLAY")
+        seen.append(list(argv))
+        return types.SimpleNamespace(poll=lambda: 0)
+
+    monkeypatch.setattr(MO.subprocess, "Popen", flaky)
+    assert MO.open_url(GH_PULL_URL) == 0
+    assert [a[0] for a in seen] == ["xdg-open"], seen
+    assert len(notifies) == 1, notifies
+
+
+# --------------------------------------------------------------------------- #
+# 4. REPO / NUMBER EXTRACTION
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("url", [GH_PULL_URL, GH_ISSUE_URL])
+def test_both_pull_and_issues_yield_the_same_repo_and_number(url):
+    """🔴 THE REASON THE NUMBER IS PASSED RATHER THAN THE URL. `openable()`
+    builds `/pull/{id}` for EVERY GitHub mention because the handler cannot know
+    whether `#N` is an issue or a PR — github.com resolves that by redirecting.
+    So the kind segment carries no information, and both spellings must extract
+    identically. Handing octo a `/pull/` URL instead would assert the kind, and
+    would assert it WRONGLY for every issue mention.
+
+    The fixtures are pairwise distinct and distinct from the constants asserted
+    — a mutant returning a hardcoded `("owner/repo", "1")` cannot survive.
+    """
+    assert MO.github_ref(url) == ("gardenersguild/trowelcast", "1559")
+
+
+@pytest.mark.parametrize("url", [
+    CLAWGATE_URL,
+    CLICKUP_URL,
+    "https://github.com/gardenersguild/trowelcast",
+    "https://github.com/gardenersguild/trowelcast/",
+    "https://github.com/gardenersguild/trowelcast/pull/",
+    "https://github.com/gardenersguild/trowelcast/pull/abc",
+    "https://github.com/gardenersguild/trowelcast/releases/tag/v2",
+    "https://github.com/gardenersguild/trowelcast/pull/12/files",
+    "https://evil.example/github.com/gardenersguild/trowelcast/pull/12",
+    "",
+])
+def test_a_url_the_TUI_cannot_open_yields_no_repo_and_no_number(url):
+    """Both halves empty, never a half-answer: a caller that got a repo but no
+    number would build `Octo  <repo>`."""
+    assert MO.github_ref(url) == ("", "")
+
+
+def test_the_NUMBER_reaches_the_wrapper_INTACT(tui):
+    """A four-digit id distinct from every other number in this file, asserted
+    at the LAST argv position rather than by substring, so a mutant that
+    truncates it or reuses a neighbouring value cannot land on the expectation
+    by accident."""
+    tui.available = True
+    MO.open_url("https://github.com/rivalorg/spadeworks/issues/9042")
+    assert tui.spawns[0][-2:] == ["rivalorg/spadeworks", "9042"], tui.spawns
+
+
+def test_www_and_http_spellings_still_extract():
+    """The hint can hand over a URL the operator pasted, not only one this
+    module built."""
+    assert MO.github_ref("http://www.github.com/rivalorg/spadeworks/pull/22") == (
+        "rivalorg/spadeworks", "22")
+
+
+def test_open_tui_called_directly_with_an_unopenable_url_uses_the_browser(tui):
+    """Unreachable through `open_target` (rung 0 answers it first), and kept
+    because a DIRECT caller is not unreachable. Silent: the browser is the right
+    answer for this URL and nothing went wrong."""
+    tui.available = True
+    assert MO.open_tui(CLAWGATE_URL) == 0
+    assert [a[0] for a in tui.spawns] == ["xdg-open"], tui.spawns
+    assert tui.notifies == [], tui.notifies
+
+
+# --------------------------------------------------------------------------- #
+# 5. THE SEAM: main() actually reaches the dispatcher
+#
+# Every test above calls `open_url` directly, so none of them notices if
+# `main()` stops calling it — or calls it without the operator's flag.
+# --------------------------------------------------------------------------- #
+def _spawn_recorder(monkeypatch, tmp_path):
+    """Stub every impure edge `main()` touches and return the spawn log."""
+    monkeypatch.setattr(MO, "MENTION_TARGET_PATH", tmp_path / "target")
+    monkeypatch.setattr(MO, "tui_available", lambda: True)
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: None)
+    spawns: list[list[str]] = []
+    monkeypatch.setattr(
+        MO.subprocess, "Popen",
+        lambda argv, *a, **k: spawns.append(list(argv))
+        or types.SimpleNamespace(poll=lambda: 0))
+    return spawns
+
+
+def test_main_routes_an_unambiguous_github_click_through_the_review_TUI(
+        monkeypatch, tmp_path):
+    """🔴 END TO END THROUGH THE DECISION, with only the impure edges stubbed.
+    This is the test that goes red if the auto-open call site stops routing
+    through `open_url` at all — which is exactly the line a concurrent branch is
+    also rewriting."""
+    spawns = _spawn_recorder(monkeypatch, tmp_path)
+    assert MO.main(["civitai/talos-infra#1065"]) == 0
+    assert len(spawns) == 1, spawns
+    assert spawns[0][0] == "alacritty", spawns
+    assert spawns[0][-2:] == ["civitai/talos-infra", "1065"], spawns
+
+
+def test_main_honours_the_browser_flag_on_the_auto_open_path(
+        monkeypatch, tmp_path):
+    """🔴 THE FLAG MUST SURVIVE THE CALL SITE. `open_url` growing a keyword that
+    `main()` never passes is a feature that is 100% dead with a green suite —
+    the fix-direction trap RULES.md names: adding it to the parser changes
+    NOTHING while no call site forwards it."""
+    spawns = _spawn_recorder(monkeypatch, tmp_path)
+    assert MO.main(["--browser", "civitai/talos-infra#1065"]) == 0
+    assert [a[0] for a in spawns] == ["xdg-open"], spawns
+
+
+def test_main_honours_the_browser_flag_on_the_PICKER_path(
+        monkeypatch, tmp_path):
+    """The SECOND call site, which no test above reaches. Both sites forward the
+    flag or neither does — and a predicate that is right at one site and wrong
+    at the other is the shape this repo keeps paying for."""
+    spawns = _spawn_recorder(monkeypatch, tmp_path)
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+    monkeypatch.setattr(MO, "record_pick", lambda *a, **k: None)
+    # 🔴 THE PANE REPO IS WHAT MAKES THIS REACH THE PICKER AT ALL, AND THE FIRST
+    # VERSION OF THIS TEST DID NOT HAVE IT. With `tmux_pane_repo` returning "",
+    # a bare `#370` has exactly ONE candidate — the clawgate task — so `main()`
+    # takes the single-candidate AUTO-OPEN branch and `pick` is never called.
+    # Both assertions still passed, because a clawgate URL opens in the browser
+    # with or without the flag: a test of the picker call site that never
+    # reached it, green either way. MEASURED, not reasoned about — it failed on
+    # the positive control below, which is the only reason it was caught.
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "gardenersguild/trowelcast")
+    picks: list[int] = []
+    monkeypatch.setattr(
+        MO, "pick",
+        lambda c, mesg="": picks.append(len(c)) or GH_PULL_URL)
+    assert MO.main(["--browser", "#370"]) == 0
+    assert picks, "the PICKER was never reached — this test proves nothing"
+    assert [a[0] for a in spawns] == ["xdg-open"], spawns
+    # POSITIVE CONTROL on the same path: WITHOUT the flag it takes the TUI, so
+    # the browser above is the flag's doing and not the picker path's.
+    spawns.clear()
+    picks.clear()
+    assert MO.main(["#370"]) == 0
+    assert picks, "the PICKER was never reached on the control run either"
+    assert [a[0] for a in spawns] == ["alacritty"], spawns
+
+
+def test_tui_available_asks_about_the_REVIEW_EXE_and_nothing_else(monkeypatch):
+    """🔴 ONE NAME, ONE PLACE. The pre-flight and the spawn must ask about the
+    same binary: a pre-flight that checks a name nothing spawns is a guard that
+    is always green and never reached."""
+    import shutil as _shutil
+    asked: list[str] = []
+    monkeypatch.setattr(_shutil, "which",
+                        lambda name: asked.append(name) or None)
+    assert MO.tui_available() is False
+    assert asked == [MO.REVIEW_EXE], asked
+    monkeypatch.setattr(_shutil, "which", lambda name: "/somewhere/" + name)
+    assert MO.tui_available() is True

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -243,6 +243,36 @@ def test_the_stubbed_launcher_set_is_pinned():
 # were wrong too: this entry used to say "ship.sh/drift-check.sh only" while
 # seven scripts named it.
 ACKNOWLEDGED_UNSTUBBED = {
+    "nvim-octo": (
+        {"mention-open.py"},
+        "UNREACHABLE BY CONSTRUCTION, not by measurement-of-absence: it is "
+        "NEVER argv[0] of anything this repo spawns. `mention-open.py` reaches "
+        "it only as the `-e` PAYLOAD of an `alacritty` spawn — `alacritty "
+        "--class float,mention-review … -e nvim-octo <owner/repo> <number>` — "
+        "and `alacritty` IS in HOST_LAUNCHERS, so the suite's stub intercepts "
+        "the parent and the payload is never exec'd at all. Stubbing it "
+        "instead would be actively WRONG, and not merely redundant: the stub "
+        "dir is on PATH, so a `nvim-octo` stub would make `shutil.which` "
+        "succeed and flip `tui_available()` to TRUE for every test in "
+        "test_mention_open.py that does not override it — silently moving the "
+        "whole file off the browser path it has always exercised. "
+        "🔴 THE PIN, arriving WITH the entry rather than after an audit, "
+        "because this acknowledgement would otherwise blind the guard exactly "
+        "as the tmux-reply-agent paragraph below records: "
+        "test_mention_open.py::test_mention_open_SPAWNS_these_argv0_AND_"
+        "NOTHING_ELSE walks the handler's AST and asserts its spawn argv[0] "
+        "set is EXACTLY {git, tmux, notify-send, xdg-open, alacritty}, "
+        "grows-or-shrinks, with a `<computed>` sentinel — so a direct "
+        "`subprocess.Popen(['nvim-octo', …])` added here fails THAT test "
+        "rather than hiding behind this row. A SECOND pin covers the payload "
+        "position itself: test_the_alacritty_wrapper_PATH_covers_every_"
+        "executable_the_handler_spawns reads the first word after a literal "
+        "`-e` out of the syntax tree (_exec_payload_commands) and requires "
+        "`pkgs.nvim-octo` on the hint wrapper's PATH, in BOTH directions — so "
+        "the payload cannot silently move, and the package cannot be listed "
+        "without a call site. Both controls WATCHED: clean tree passes, and "
+        "_exec_payload_commands' own positive/negative controls are asserted "
+        "in test_the_exec_payload_reader_can_actually_fire."),
     "systemctl": (
         {"airvpn-menu", "keylog-spin-capture.sh", "main-status-watch.py",
          "mention-open.py",

--- a/scripts/tests/test_nvim_octo.py
+++ b/scripts/tests/test_nvim_octo.py
@@ -1,0 +1,491 @@
+"""`nvim-octo` — the review TUI a clicked GitHub mention opens in.
+
+🔴 WHAT THIS FILE CAN AND CANNOT SEE, STATED FIRST SO A GREEN RUN IS NOT READ
+AS MORE THAN IT IS.
+
+It asserts two things, both from files in this repo:
+
+  * the octo.nvim configuration the wrapper ships — parsed STRUCTURALLY, so the
+    claim is about the table that will be handed to `setup()`, not about words
+    in a comment;
+  * the wrapper's argument validation — by RUNNING the shell text with `nvim`
+    stubbed, so a rejection is watched rather than reasoned about.
+
+It cannot see, and does not claim: that alacritty maps a window; that neovim
+starts; that `setup()` ran; that `Octo <N> <owner/repo>` resolved the right
+buffer KIND (a live GraphQL call); or that the merge mappings are absent from a
+LIVE PR buffer. A config file saying a mapping is gone is a claim about the
+file — only a running editor proves the buffer. Those were measured by hand on
+the built derivation and recorded in the PR; they are deliberately NOT asserted
+here, because the measurement needs a nix build and a headless editor, and a
+test that skips itself when it cannot get one is worse than no test.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PKG = ROOT / "nix" / "pkgs" / "tools" / "nvim-octo"
+INIT_LUA = PKG / "octo-init.lua"
+WRAPPER_SH = PKG / "nvim-octo.sh"
+PKG_NIX = PKG / "default.nix"
+
+# 🔴 THE MERGE FAMILY, READ OFF octo 2026-08-28's OWN `get_default_values()`.
+# Four of these are keymaps that merge IMMEDIATELY — octo's `pr merge` calls
+# `gh.pr.merge(opts)` with no confirmation of any kind — and three queue a merge.
+# The brief named four; the other three were found by reading the defaults, and
+# they are here for the same reason the first four are.
+MERGE_MAPPINGS = (
+    "merge_pr",
+    "squash_and_merge_pr",
+    "rebase_and_merge_pr",
+    "merge_pr_stack",
+    "merge_pr_queue",
+    "squash_and_merge_queue",
+    "rebase_and_merge_queue",
+)
+
+# `pr_options` is `<CR>` — ONE keystroke — and its menu (octo's `mappings.lua`)
+# offers "Merge PR", "Squash and Merge PR" and "Delete Branch". Stripping every
+# merge KEYMAP while re-declaring this would be a guard that reads as coverage
+# and provides none, so it is treated as part of the same family.
+MERGE_MENUS = ("pr_options",)
+
+
+# --------------------------------------------------------------------------- #
+# A STRUCTURAL LUA TABLE READER
+#
+# 🔴 NOT A GREP, AND THE DIFFERENCE IS THE WHOLE POINT. A `grep` for
+# `mappings_disable_default = true` is walkable two ways: by rewording, and —
+# far worse — by a later `mappings.pull_request` table re-adding `merge_pr`
+# UNDERNEATH it, which the grep would never see. The reader below answers "which
+# keys does this table declare", which is the state that decides what is bound.
+# --------------------------------------------------------------------------- #
+def _strip_comments(source: str) -> str:
+    """Lua source with every `--` line comment removed, strings left intact.
+
+    🔴 THIS IS NOT TIDINESS — WITHOUT IT EVERY READER BELOW IS WRONG, AND IT WAS.
+    MEASURED on the first run of this file: `_scalar(lua, "picker")` returned
+    `-- "fzf-lua"`: MEASURED against octo 2026-08-28` — a sentence out of the
+    comment that EXPLAINS the setting, not the setting. The comments here are
+    prose ABOUT the config and name every value they discuss, so reading them as
+    config makes a passing test a fact about documentation. The alacritty
+    `makeBinPath` ledger in test_mention_open.py strips comments for exactly
+    this reason, and hit exactly this bug.
+
+    ⚠ A `--` INSIDE A STRING IS NOT A COMMENT, so this tracks quoting rather
+    than cutting at the first `--` on a line. Nothing in the config uses that
+    today; a `desc = "foo -- bar"` added tomorrow would silently truncate the
+    line and drop whatever followed it on that line from every reader.
+    Long-bracket comments (`--[[ … ]]`) are NOT handled and do not occur here —
+    if one is added, this returns its body as code and the control test below is
+    what should be extended first.
+    """
+    out: list[str] = []
+    for line in source.split("\n"):
+        quote = None
+        i = 0
+        cut = len(line)
+        while i < len(line):
+            ch = line[i]
+            if quote:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == quote:
+                    quote = None
+            elif ch in ('"', "'"):
+                quote = ch
+            elif ch == "-" and line[i + 1:i + 2] == "-":
+                cut = i
+                break
+            i += 1
+        out.append(line[:cut])
+    return "\n".join(out)
+
+
+def _table_body(source: str, key: str, *, start: int = 0) -> tuple[str, int]:
+    """The brace-balanced body of `key = { … }`, and the index just past it.
+
+    Raises rather than returning a sentinel: a table this cannot find means the
+    config was restructured, and an empty string would make every "the merge
+    keys are absent" assertion below pass VACUOUSLY. That is the exact shape of
+    a reassuring zero, so it fails loudly instead.
+    """
+    m = re.search(r"(?<![\w.])" + re.escape(key) + r"\s*=\s*\{", source[start:])
+    if not m:
+        raise AssertionError(
+            f"no `{key} = {{` table in the config — it was restructured, and "
+            f"every assertion about its contents would now pass vacuously")
+    open_at = start + m.end() - 1
+    depth = 0
+    for i in range(open_at, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_at + 1:i], i + 1
+    raise AssertionError(f"unbalanced braces after `{key} = {{`")
+
+
+def _top_level_keys(body: str) -> set[str]:
+    """The `name =` keys declared at depth 0 of a table body.
+
+    Depth-tracked, so a nested `{ lhs = …, desc = … }` contributes nothing —
+    `lhs` and `desc` appear under every single entry and would otherwise swamp
+    the answer.
+    """
+    keys: set[str] = set()
+    depth = 0
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        elif depth == 0:
+            m = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*=", body[i:])
+            if m and (i == 0 or not re.match(r"[\w.]", body[i - 1])):
+                keys.add(m.group(1))
+                i += m.end()
+                continue
+        i += 1
+    return keys
+
+
+def _scalar(source: str, key: str) -> str:
+    """The literal a top-level `key = <value>` is set to, comments stripped."""
+    m = re.search(r"(?<![\w.])" + re.escape(key) + r"\s*=\s*([^,\n]+)", source)
+    assert m, f"`{key}` is not set in {INIT_LUA.name} — it takes the upstream default"
+    return m.group(1).strip().strip('"').strip("'")
+
+
+def test_the_lua_table_reader_can_actually_fire():
+    """🔴 POSITIVE **AND** NEGATIVE CONTROL ON THE INSTRUMENT, before any verdict
+    it produces is believed. A reader that matched nothing would report an empty
+    key set forever, and every "no merge key is declared" assertion below would
+    be a fact about the reader rather than about the config."""
+    sample = """
+    mappings = {
+      pull_request = {
+        checkout_pr = { lhs = "<localleader>po", desc = "checkout PR" },
+        merge_pr = { lhs = "<localleader>pm", desc = "merge commit PR" },
+      },
+      issue = {
+        close_issue = { lhs = "<localleader>ic", desc = "close issue" },
+      },
+    }
+    """
+    body, _ = _table_body(sample, "pull_request")
+    keys = _top_level_keys(body)
+    # POSITIVE: it finds the keys that ARE there…
+    assert keys == {"checkout_pr", "merge_pr"}, keys
+    # …and does NOT report the nested `lhs`/`desc` of every entry.
+    assert "lhs" not in keys and "desc" not in keys
+    # NEGATIVE: it can see a merge key when one is present. Without this, "no
+    # merge key found" would be indistinguishable from a reader wired to
+    # nothing — the reassuring zero this repo keeps paying for.
+    assert MERGE_MAPPINGS[0] in keys
+    # It also does not leak into the SIBLING table.
+    assert "close_issue" not in keys
+    # A table that is not there is an ERROR, never an empty set.
+    with pytest.raises(AssertionError):
+        _table_body(sample, "no_such_table")
+
+
+def test_the_comment_stripper_can_actually_fire():
+    """🔴 THE CONTROL FOR THE BUG THIS FILE ALREADY HIT ONCE. Before the
+    stripper existed, `_scalar(lua, "picker")` read a value out of the comment
+    that explains the setting. Both directions are asserted: prose goes, code
+    stays, and a `--` inside a STRING is not a comment."""
+    src = '\n'.join([
+        '-- picker = "telescope" is what upstream defaults to',
+        'picker = "fzf-lua",           -- and this is the real one',
+        'desc = "a -- b",              -- a double dash inside a string',
+    ])
+    out = _strip_comments(src)
+    # The prose value is gone…
+    assert "telescope" not in out, out
+    # …the real one survives, with its trailing comment removed…
+    assert _scalar(out, "picker") == "fzf-lua"
+    assert "the real one" not in out, out
+    # …and a `--` inside a string is NOT treated as a comment start.
+    assert 'desc = "a -- b"' in out, out
+    # NEGATIVE CONTROL: on source with no comments it changes nothing, so a
+    # stripper that simply deleted lines could not pass this pair.
+    assert _strip_comments('picker = "fzf-lua",') == 'picker = "fzf-lua",'
+
+
+# --------------------------------------------------------------------------- #
+# THE CONFIG — asserted as STATE
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def lua() -> str:
+    assert INIT_LUA.exists(), f"{INIT_LUA} is missing — was it `git add`ed?"
+    raw = INIT_LUA.read_text(encoding="utf-8")
+    stripped = _strip_comments(raw)
+    # 🔴 A CHECK ON THE STRIPPER ITSELF, AGAINST THE REAL FILE RATHER THAN A
+    # FIXTURE. The comments in this config quote every value they discuss, so a
+    # stripper that silently stopped working would hand every reader below the
+    # prose again — and the readers would happily find the right answers in the
+    # wrong place. The file is heavily commented by design, so "something was
+    # removed" is a safe and meaningful invariant.
+    assert len(stripped) < len(raw) * 0.75, (
+        "the comment stripper removed almost nothing — every reader below is "
+        "now at risk of reading prose as configuration")
+    return stripped
+
+
+@pytest.fixture(scope="module")
+def pr_keys(lua: str) -> set[str]:
+    # Anchored INSIDE the `mappings = {` table, so a future top-level key
+    # called `pull_request` somewhere else cannot be read instead.
+    mappings_body, _ = _table_body(lua, "mappings")
+    pr_body, _ = _table_body(mappings_body, "pull_request")
+    return _top_level_keys(pr_body)
+
+
+def test_the_pull_request_table_is_NOT_empty(pr_keys: set[str]):
+    """🔴 THE POSITIVE CONTROL FOR EVERY ABSENCE ASSERTED BELOW. "No merge key
+    is declared" is trivially true of a table that declares nothing at all —
+    which would also mean reviewing is impossible, and would pass every other
+    test in this section. Reviewing is the point of the feature, so the table
+    must be substantial AND must carry the keys a review actually needs."""
+    assert len(pr_keys) > 30, sorted(pr_keys)
+    for needed in ("review_start", "review_resume", "approve_pr",
+                   "add_comment", "list_changed_files", "show_pr_diff",
+                   "toggle_checks", "resolve_thread"):
+        assert needed in pr_keys, (
+            f"`{needed}` is not declared, so the review surface this feature "
+            f"exists for is incomplete: {sorted(pr_keys)}")
+
+
+@pytest.mark.parametrize("key", MERGE_MAPPINGS + MERGE_MENUS)
+def test_no_merge_keystroke_is_declared_for_a_pull_request_buffer(
+        pr_keys: set[str], key: str):
+    """🔴 THE OPERATOR REQUIREMENT, ASSERTED AS STATE: merging must require
+    TYPING `:Octo pr merge`, never a keystroke.
+
+    Upstream binds four immediate-merge keymaps and three merge-queue ones, and
+    puts "Merge PR" / "Squash and Merge PR" / "Delete Branch" behind `<CR>` via
+    `pr_options`. `mappings_disable_default = true` clears the whole default
+    table, so what this file declares is the complete set — and none of it may
+    be one of these.
+    """
+    assert key not in pr_keys, (
+        f"`{key}` is declared in mappings.pull_request, which puts a merge "
+        f"back one keystroke away. Merging must require typing "
+        f"`:Octo pr merge`.")
+
+
+def test_the_default_mappings_are_cleared_before_ours_are_merged(lua: str):
+    """Without this flag `vim.tbl_deep_extend` MERGES our table into upstream's,
+    so every merge keymap survives and the test above would be asserting the
+    absence of something that is nonetheless bound. Structural: the flag and the
+    declared-key set are two halves of one guarantee, and neither alone is it."""
+    assert _scalar(lua, "mappings_disable_default") == "true"
+
+
+def test_the_merge_method_is_squash(lua: str):
+    """Upstream defaults to `"merge"` — a merge commit. These repositories
+    squash, so left at the default the FIRST merge made from this TUI would
+    produce the wrong commit shape."""
+    assert _scalar(lua, "default_merge_method") == "squash"
+
+
+def test_the_branch_is_NOT_deleted_on_merge(lua: str):
+    """Also upstream's default, and kept EXPLICIT because it is load-bearing
+    here rather than incidental: these repos set `delete_branch_on_merge`, and
+    deleting a STACKED PARENT's branch makes GitHub auto-close the child PR and
+    then refuse to reopen it — the branch is restorable, the PR object is
+    not."""
+    assert _scalar(lua, "default_delete_branch") == "false"
+
+
+def test_the_review_never_wants_a_local_checkout(lua: str):
+    """octo offers to check a PR out only when this is true. A review opened
+    from a clicked link must never touch a working tree — other sessions share
+    these checkouts."""
+    assert _scalar(lua, "use_local_fs") == "false"
+
+
+def test_the_picker_is_fzf_lua_which_is_a_SAFETY_setting(lua: str):
+    """🔴 A SECOND, SEPARATE MERGE PATH THAT `mappings_disable_default` DOES NOT
+    TOUCH. `picker_config.mappings` lives OUTSIDE the `mappings` table that flag
+    clears, so upstream's `merge_pr = { lhs = "<C-r>" }` for the picker survives
+    it — MEASURED on the built derivation: after setup,
+    `picker_config.mappings.merge_pr.lhs` is still `<C-r>`.
+
+    What closes it is the picker CHOICE: measured against octo 2026-08-28, the
+    whole `lua/octo/pickers/fzf-lua/` tree contains no occurrence of "merge" at
+    all, while `pickers/telescope/provider.lua` wires
+    `cfg.picker_config.mappings.merge_pr.lhs` to a merge action in two places.
+    So this line is the guard, and switching pickers silently re-opens the
+    path."""
+    assert _scalar(lua, "picker") == "fzf-lua"
+
+
+def test_every_other_mapping_table_the_flag_cleared_is_re_declared(lua: str):
+    """`mappings_disable_default` empties NINE tables, not just
+    `pull_request`. A table left undeclared is a surface with no keymaps at
+    all — `submit_win` is how a review is approved or has changes requested, and
+    an empty one would make the feature's stated scope unreachable while every
+    merge-safety test above stayed green."""
+    mappings_body, _ = _table_body(lua, "mappings")
+    declared = _top_level_keys(mappings_body)
+    for table in ("pull_request", "issue", "review_thread", "submit_win",
+                  "review_diff", "file_panel", "repo", "release",
+                  "discussion"):
+        assert table in declared, (
+            f"`{table}` is cleared by mappings_disable_default and never "
+            f"re-declared, so it has NO keymaps at all")
+    submit, _ = _table_body(mappings_body, "submit_win")
+    submit_keys = _top_level_keys(submit)
+    assert {"approve_review", "request_changes"} <= submit_keys, submit_keys
+
+
+def test_the_config_is_referenced_by_the_derivation(lua: str):
+    """The seam between the two files. A config nothing loads is a config that
+    describes no editor — and the failure would be silent, because every
+    assertion above reads the FILE."""
+    nix = PKG_NIX.read_text(encoding="utf-8")
+    assert "./octo-init.lua" in nix, nix
+    assert "luafile" in nix, (
+        "the derivation no longer sources the init file, so the merge-safety "
+        "settings asserted above reach no editor")
+    assert "octo-nvim" in nix and "fzf-lua" in nix, (
+        "octo.nvim declares NO runtime dependencies (a bare buildVimPlugin), "
+        "so each plugin must be listed explicitly or the config errors at "
+        "startup")
+
+
+# --------------------------------------------------------------------------- #
+# THE WRAPPER — driven, not read
+# --------------------------------------------------------------------------- #
+def _run_wrapper(tmp_path: Path, *args: str):
+    """Run the wrapper's shell text with `nvim` STUBBED.
+
+    🔴 THE STUB IS WHAT MAKES THIS SAFE AND WHAT MAKES IT A MEASUREMENT. The
+    real binary would take over a terminal and reach GitHub; the stub records
+    its argv into a file, so the ex-command the wrapper composes is observable.
+    `bash -euo pipefail` reproduces the preamble `writeShellApplication` adds —
+    verified against the built derivation, whose first four lines are the
+    shebang plus exactly those three `set -o` lines.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "nvim-argv"
+    stub = bindir / "nvim"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" > {log}\n'
+        "exit 0\n")
+    stub.chmod(0o755)
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    proc = subprocess.run(
+        ["bash", "-euo", "pipefail", str(WRAPPER_SH), *args],
+        capture_output=True, text=True, env=env, timeout=60)
+    argv = log.read_text().splitlines() if log.exists() else []
+    return proc, argv
+
+
+def test_a_good_invocation_composes_the_NUMBER_FIRST_ex_command(tmp_path):
+    """🔴 THE ORDER IS THE CONTRACT, AND IT IS INVERTED FROM THE WRAPPER'S OWN
+    ARGUMENTS. The wrapper takes `<owner/repo> <number>` because that is the
+    order `mention-open.py` has them in, and it must emit `Octo <number>
+    <owner/repo>` because octo's `M.octo(object, action, …)` does
+    `tonumber(object)` and treats the SECOND word as the repository. Get it
+    backwards and octo takes an entirely different branch.
+
+    The fixtures are pairwise distinct and distinct from every constant the
+    assertion names, so a mutant hardcoding a literal cannot survive.
+    """
+    proc, argv = _run_wrapper(tmp_path, "gardenersguild/trowelcast", "1559")
+    assert proc.returncode == 0, proc.stderr
+    assert argv == ["-c", "Octo 1559 gardenersguild/trowelcast"], argv
+
+
+def test_a_number_is_passed_rather_than_a_url(tmp_path):
+    """A URL would assert the reference KIND, which the handler cannot know —
+    `mention-open.py` builds `/pull/{id}` for every mention and lets github.com
+    redirect. Pinned as an absence beside the positive above, because "it
+    happens to work today" is not the claim."""
+    _proc, argv = _run_wrapper(tmp_path, "rivalorg/spadeworks", "42")
+    assert "http" not in " ".join(argv), argv
+    assert "/pull/" not in " ".join(argv), argv
+
+
+@pytest.mark.parametrize("repo", [
+    "notarepo",                     # no slash at all
+    "too/many/slashes",
+    "/leadingslash",
+    "trailing/",
+    "../../etc/passwd",             # traversal, and it HAS a slash
+    "owner/repo;rm -rf /",          # shell metacharacters
+    "owner/repo with space",
+    "owner/$(whoami)",
+    "",
+])
+def test_a_bad_repository_is_REJECTED_and_nvim_is_never_reached(tmp_path, repo):
+    """Non-zero exit AND no editor. Both halves: an exit code alone would be
+    satisfied by a wrapper that launched first and complained after."""
+    proc, argv = _run_wrapper(tmp_path, repo, "1559")
+    assert proc.returncode != 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert argv == [], argv
+
+
+@pytest.mark.parametrize("num", ["", "abc", "12a", "-1", "1.5", "1 2",
+                                 "$(id)", "42;ls"])
+def test_a_bad_number_is_REJECTED_and_nvim_is_never_reached(tmp_path, num):
+    proc, argv = _run_wrapper(tmp_path, "gardenersguild/trowelcast", num)
+    assert proc.returncode != 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert argv == [], argv
+
+
+@pytest.mark.parametrize("args", [(), ("only-one",),
+                                  ("a/b", "1", "extra")])
+def test_the_wrong_number_of_arguments_is_REJECTED(tmp_path, args):
+    """🔴 `set -u` MAKES THE ARITY CHECK LOAD-BEARING RATHER THAN POLITE. Without
+    it, `"$1"` on a zero-argument call is an unbound-variable error whose message
+    says nothing about usage — and with `set -e` it is still non-zero, so a test
+    asserting only the exit code would pass while the operator got
+    `nvim-octo.sh: line 23: $1: unbound variable`."""
+    proc, argv = _run_wrapper(tmp_path, *args)
+    assert proc.returncode != 0
+    assert argv == []
+    assert "usage:" in proc.stderr, proc.stderr
+
+
+@pytest.mark.parametrize("repo", [
+    "gardenersguild/trowelcast",
+    "civitai/talos-infra",
+    "ZacxDev/naida-ai",
+    "innovation-upstream/devrc",
+    "a-b.c/d_e.f",
+])
+def test_real_shaped_repository_names_are_ACCEPTED(tmp_path, repo):
+    """🔴 THE NEGATIVE CONTROL ON THE VALIDATOR, built from REALISTIC data. A
+    rejector that refused everything would pass every rejection test above —
+    which is the instrument-validation trap RULES.md names. Dots, dashes,
+    underscores and mixed case all occur in these owners' real repository
+    names."""
+    proc, argv = _run_wrapper(tmp_path, repo, "7")
+    assert proc.returncode == 0, proc.stderr
+    assert argv == ["-c", f"Octo 7 {repo}"], argv
+
+
+def test_the_wrapper_text_carries_no_shebang_and_no_set_line():
+    """`writeShellApplication` prepends both. A second copy here would be
+    harmless in production and would make `_run_wrapper`'s `bash -euo pipefail`
+    a claim about a file that sets its own options — i.e. the harness would stop
+    reproducing the deployed preamble."""
+    text = WRAPPER_SH.read_text(encoding="utf-8")
+    assert not text.startswith("#!"), text.splitlines()[:1]
+    assert not re.search(r"^\s*set\s+-", text, re.M), text

--- a/scripts/tests/test_nvim_octo.py
+++ b/scripts/tests/test_nvim_octo.py
@@ -24,10 +24,23 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+# Resolved once, to an ABSOLUTE path, for the same reason the sibling suites do
+# it: `/usr/bin/env` does not exist in the nix build sandbox, and a bare "bash"
+# would be looked up in the child's PATH — which this harness deliberately
+# front-loads with a stub directory.
+_BASH = shutil.which("bash")
 
 ROOT = Path(__file__).resolve().parents[2]
 PKG = ROOT / "nix" / "pkgs" / "tools" / "nvim-octo"
@@ -393,15 +406,21 @@ def _run_wrapper(tmp_path: Path, *args: str):
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     log = tmp_path / "nvim-argv"
-    stub = bindir / "nvim"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f'printf "%s\\n" "$@" > {log}\n'
-        "exit 0\n")
-    stub.chmod(0o755)
+    # 🔴 `write_exec`, NOT `write_text` + a hand-written shebang. It owns the
+    # shebang precisely so a call site cannot reintroduce `#!/usr/bin/env`,
+    # which does not exist in the nix build sandbox — the flake's
+    # `patchShebangs src/scripts` is there for the same reason.
+    #
+    # This is a TWO-TIER blind spot, caught by the repo-wide guard
+    # `test_no_test_writes_a_usr_bin_env_shebang_at_runtime` running in CI and
+    # NOT by any dev-host run of this file: `/usr/bin/env` resolves on the
+    # workbench, so the stub executed and every test here was green while the
+    # sandbox tier could not have run them at all.
+    write_exec(bindir / "nvim", f'printf "%s\\n" "$@" > {log}\nexit 0\n')
     env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    assert _BASH, "bash is not on PATH — this harness cannot run the wrapper"
     proc = subprocess.run(
-        ["bash", "-euo", "pipefail", str(WRAPPER_SH), *args],
+        [_BASH, "-euo", "pipefail", str(WRAPPER_SH), *args],
         capture_output=True, text=True, env=env, timeout=60)
     argv = log.read_text().splitlines() if log.exists() else []
     return proc, argv

--- a/scripts/tests/test_nvim_octo.py
+++ b/scripts/tests/test_nvim_octo.py
@@ -378,7 +378,18 @@ def _run_wrapper(tmp_path: Path, *args: str):
     `bash -euo pipefail` reproduces the preamble `writeShellApplication` adds —
     verified against the built derivation, whose first four lines are the
     shebang plus exactly those three `set -o` lines.
+
+    🔴 THE EXISTENCE CHECK IS NOT DEFENSIVE — IT CLOSES A MEASURED VACUOUS
+    GREEN. Run against a tree where `nvim-octo.sh` does not exist (the base
+    commit of the branch that added it), `bash` exits non-zero with an empty
+    argv log, which satisfied every "rejected, and nvim was never reached"
+    assertion below exactly as a correct wrapper does: 18 of them passed on a
+    tree with NO WRAPPER AT ALL. That is why the callers now assert the
+    wrapper's OWN exit code and OWN message rather than "non-zero".
     """
+    assert WRAPPER_SH.exists(), (
+        f"{WRAPPER_SH} is missing — was it `git add`ed? Without this check a "
+        f"missing wrapper makes every rejection test below pass vacuously")
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     log = tmp_path / "nvim-argv"
@@ -415,11 +426,26 @@ def test_a_good_invocation_composes_the_NUMBER_FIRST_ex_command(tmp_path):
 def test_a_number_is_passed_rather_than_a_url(tmp_path):
     """A URL would assert the reference KIND, which the handler cannot know —
     `mention-open.py` builds `/pull/{id}` for every mention and lets github.com
-    redirect. Pinned as an absence beside the positive above, because "it
-    happens to work today" is not the claim."""
-    _proc, argv = _run_wrapper(tmp_path, "rivalorg/spadeworks", "42")
+    redirect.
+
+    ⚠ THE POSITIVE ASSERTION COMES FIRST, AND IT HAS TO. An earlier version of
+    this test asserted only that `http` and `/pull/` were ABSENT from the argv,
+    which an EMPTY argv satisfies — and an empty argv is what a missing wrapper
+    produces. Pin what was passed, then observe what it is not."""
+    proc, argv = _run_wrapper(tmp_path, "rivalorg/spadeworks", "42")
+    assert proc.returncode == 0, proc.stderr
+    assert argv == ["-c", "Octo 42 rivalorg/spadeworks"], argv
     assert "http" not in " ".join(argv), argv
     assert "/pull/" not in " ".join(argv), argv
+
+
+# The wrapper's own exit codes. Asserted by VALUE rather than as "non-zero",
+# because non-zero is also what a missing file, a syntax error and an unbound
+# variable produce — see `_run_wrapper`'s note on the 18 tests that passed
+# against a tree with no wrapper at all.
+RC_USAGE = 64
+RC_BAD_REPO = 65
+RC_BAD_NUM = 66
 
 
 @pytest.mark.parametrize("repo", [
@@ -434,18 +460,27 @@ def test_a_number_is_passed_rather_than_a_url(tmp_path):
     "",
 ])
 def test_a_bad_repository_is_REJECTED_and_nvim_is_never_reached(tmp_path, repo):
-    """Non-zero exit AND no editor. Both halves: an exit code alone would be
-    satisfied by a wrapper that launched first and complained after."""
+    """Three halves, and the first is what makes the other two mean anything:
+    THIS guard's own exit code, THIS guard's own message, and no editor. An exit
+    code alone would be satisfied by a wrapper that launched first and
+    complained after — or by no wrapper at all."""
     proc, argv = _run_wrapper(tmp_path, repo, "1559")
-    assert proc.returncode != 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert proc.returncode == RC_BAD_REPO, (proc.returncode, proc.stderr)
+    assert "not an owner/repo" in proc.stderr, proc.stderr
     assert argv == [], argv
 
 
 @pytest.mark.parametrize("num", ["", "abc", "12a", "-1", "1.5", "1 2",
                                  "$(id)", "42;ls"])
 def test_a_bad_number_is_REJECTED_and_nvim_is_never_reached(tmp_path, num):
+    """🔴 A DIFFERENT EXIT CODE FROM THE REPOSITORY GUARD, ON PURPOSE. A mutation
+    test that broke the repository check and watched "a test fail" would
+    otherwise be green for the wrong reason if the NUMBER guard was the one that
+    fired. Distinct codes plus distinct messages make each guard's kill
+    attributable to itself."""
     proc, argv = _run_wrapper(tmp_path, "gardenersguild/trowelcast", num)
-    assert proc.returncode != 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert proc.returncode == RC_BAD_NUM, (proc.returncode, proc.stderr)
+    assert "not a reference number" in proc.stderr, proc.stderr
     assert argv == [], argv
 
 
@@ -458,7 +493,7 @@ def test_the_wrong_number_of_arguments_is_REJECTED(tmp_path, args):
     asserting only the exit code would pass while the operator got
     `nvim-octo.sh: line 23: $1: unbound variable`."""
     proc, argv = _run_wrapper(tmp_path, *args)
-    assert proc.returncode != 0
+    assert proc.returncode == RC_USAGE, (proc.returncode, proc.stderr)
     assert argv == []
     assert "usage:" in proc.stderr, proc.stderr
 

--- a/scripts/tests/test_runtime_shebangs.py
+++ b/scripts/tests/test_runtime_shebangs.py
@@ -115,6 +115,24 @@ ALLOWLIST = [
     ("scripts/tests/test_cairn_split.py", "assert first.startswith(",
      "ASSERTS the cairn-who launcher's shebang shape to justify its executable "
      "bit; writes no stub and execs nothing"),
+    # Shape (b), and the INVERSE of the three entries above: they assert a
+    # shebang is PRESENT, this asserts one is ABSENT. `nvim-octo.sh` is the body
+    # of a `writeShellApplication`, which prepends the shebang and the `set -o`
+    # lines itself; a second copy in the source would be harmless in production
+    # but would make the test harness's `bash -euo pipefail` a claim about a
+    # file that sets its own options — i.e. the harness would silently stop
+    # reproducing the deployed preamble. The test READS the repo file off disk
+    # and checks its first two characters; it writes no stub and execs nothing
+    # through this line, so `testlib.mockbin.write_exec` has nothing to own
+    # here. (The same file's stub-writing site DOES use `write_exec`, and its
+    # subprocess execs a `shutil.which("bash")` absolute path — this pin covers
+    # the assertion only.)
+    # 🔴 The needle deliberately does not spell the two-character prefix, or
+    # `test_this_guards_source_does_not_match_itself` would flag this entry —
+    # the same trap the three entries above record.
+    ("scripts/tests/test_nvim_octo.py", "assert not text.startswith(",
+     "ASSERTS the wrapper body carries NO shebang (writeShellApplication owns "
+     "it); writes no stub and execs nothing"),
     ("scripts/tests/test_playwright_nixos.py", "/bin/sh",
      "writes /bin/sh directly — absolute, present in the sandbox"),
     ("scripts/tests/test_notify_failure.py", "_bash",


### PR DESCRIPTION
A clicked GitHub `repo#N` mention opens in **octo.nvim** — a full review-and-merge TUI — instead of a browser tab. Everything else (clawgate tasks, ClickUp ids, any GitHub URL that is not `/issues/N` or `/pull/N`) opens exactly as before, and the browser stays reachable.

> **`/audit-pr` ROUND 0 ran and its deletions are applied** (commit `421631b3`). Three things came out before the correctness ladder spent a round on them; the detail is at the bottom. The headline: **`main()` is now byte-identical to base**, so this change is purely additive to the decision path and the cross-PR conflict with #1569 is gone — verified, not assumed.

## What changed

**`scripts/mention-open.py`** — `open_url` keeps its exact pre-TUI signature and becomes a dispatcher:

```python
def open_url(url):
    if open_target(url) == TARGET_TUI:
        return open_tui(url)
    return open_browser(url)          # the old body, renamed
```

`open_target` rungs: **(0)** the URL's own shape — anything `github_ref` cannot turn into `(repo, number)` is browser, and no marker can override that; **(1)** a marker file at `~/.config/mention-open/target`; **(2)** the TUI iff this host has it, silently browser otherwise.

**The number is passed, not the URL.** `openable()` builds `/pull/{id}` for *every* GitHub mention because the handler cannot know whether `#N` is an issue or a PR — github.com resolves that by redirecting. `Octo <N> <owner/repo>` fires one `issueOrPullRequest` GraphQL query and dispatches on the `__typename` the server returns. A `/pull/` URL would have asserted the kind, wrongly, for every issue.

**A marker file, not an env var.** Alacritty spawns the hint handler with the *display manager's* environment, so a shell-set variable can never reach a click. `~/.server-mode` is the precedent.

**`shutil.which` pre-flight is mandatory.** alacritty exits 0 whether its `-e` command exits 0 or 127, and `Popen` never waits — a missing `nvim-octo` is a window that flashes and vanishes, invisible to the caller. A post-spawn fallback is structurally impossible. On failure: browser + exactly one toast.

**`nix/pkgs/tools/nvim-octo/`** — a `writeShellApplication` wrapping `pkgs.neovim.override { configure = … }` with octo-nvim, plenary, fzf-lua, nvim-web-devicons and gruvbox on the packpath (octo declares no runtime deps), plus `gh` pinned by store path. Exposed as `pkgs.nvim-octo` through an overlay in `flake.nix` — that spelling is load-bearing for the AST ledger.

## Merge safety

`mappings_disable_default = true`, then only non-destructive mappings re-declared. Merging requires typing `:Octo pr merge`.

Three findings beyond the brief, each measured against octo 2026-08-28:

1. **There are seven merge mappings, not four.** Besides `merge_pr`, `squash_and_merge_pr`, `rebase_and_merge_pr`, `merge_pr_stack`, upstream also binds `merge_pr_queue`, `squash_and_merge_queue`, `rebase_and_merge_queue`. All seven withheld.
2. **`pr_options` is `<CR>` and its menu contains "Merge PR", "Squash and Merge PR" and "Delete Branch".** Re-declaring it would have left merge one keystroke away with every merge *keymap* gone — a guard that reads as coverage and provides none. Not re-declared. `issue_options` is, because its menu carries neither.
3. **`mappings_disable_default` does NOT clear `picker_config.mappings`.** Measured on the built derivation: after setup, `picker_config.mappings.merge_pr.lhs` is still `<C-r>`. What closes it is `picker = "fzf-lua"` — that picker tree contains no occurrence of "merge", while telescope wires that lhs to a merge action in two places. The picker choice is a safety setting and the suite asserts it as one.

Also `default_merge_method = "squash"` (upstream defaults to a merge commit), `default_delete_branch = false` (deleting a stacked parent's branch auto-closes the child PR, which GitHub then refuses to reopen), `use_local_fs = false`.

**One upstream bug worked around.** octo's `gh` guard is `if not vim.fn.executable(cfg.gh_cmd)`, and `vim.fn.executable()` returns the *number* `0`, truthy in Lua — so the guard never fires and `setup()` throws inside plenary instead. With the setup call last, that traceback aborted the rest of the init: no colorscheme, no options. Options and colours now run first and the call is wrapped, with a message naming the cause.

## Ledgers

- **`test_mention_open.py`'s wrapper-PATH seam.** `nvim-octo` is neither argv[0] nor inside a `sh -c` script — it is alacritty's `-e` payload, invisible to both existing readers. A third reader, `_exec_payload_commands`, reads the first word after a literal `-e` out of the syntax tree (resolving the `REVIEW_EXE` module constant), with its own positive *and* negative controls. `PROVIDER` gains `pkgs.nvim-octo`.
- **`launcher_scan.HAZARD_VOCABULARY`** gains `nvim-octo`.
- **`nolaunch.ACKNOWLEDGED_UNSTUBBED`** gains it bound to `{"mention-open.py"}`. **Not** `HOST_LAUNCHERS`: the stub dir is on PATH, so a `nvim-octo` stub would make `shutil.which` succeed and flip `tui_available()` true for every test in the file that does not override it — silently moving the whole suite off the browser path. Ships with its pin, per the tmux-reply-agent lesson.

`EXPECTED_ARGV0` and `SPAWNABLE_EXECUTABLES` did **not** move: argv[0] is still `alacritty`. Their comments now say there are two alacritty call sites, so the set cannot be read as a count.

## Verification

**Mutation: every guard killed by its own named guard.** Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` swept between mutants, against a `.git`-free `git archive` copy. Negative control (clean tree green) and positive control (a mutant caught by a pre-existing unrelated test) both watched. Covers every `open_target` rung, the pre-flight, argv order, `REVIEW_EXE`, `github_ref`, both `main()` call sites routing *around* `open_url`, the deletion pin, all five octo settings, all four wrapper guards, and the ledgers (dropping `pkgs.nvim-octo` from the wrapper PATH, dropping the vocabulary name, a direct `Popen(["nvim-octo", …])`).

**Red-at-base found a vacuous green in my own tests** (`cf519a1d`). Against `61f41adf`, where `nvim-octo.sh` does not exist, 18 rejection tests **passed** — `bash` exits non-zero with an empty argv log for a missing script exactly as a correct wrapper does for a bad argument. Each rejection now pins the wrapper's own exit code (64/65/66, distinct per guard so a kill is attributable) and its own message. Red-at-base went from 20 passed to 2 — the two self-contained instrument controls.

**Live measurement, headless, no window and no network** (`gh` stubbed so octo returns before `gh auth status`): 44 `pull_request` mappings with all seven merge keys and `pr_options` absent; `default_merge_method=squash`, `default_delete_branch=false`, `use_local_fs=false`, `picker=fzf-lua`; `exists(':Octo')` → 2; colorscheme gruvbox; every other mapping table non-empty. Re-run after the deletions: unchanged.

## Concurrent work — #1569, before and after the deletions

| | conflicts in `mention-open.py` | resolution needed | result |
|---|---|---|---|
| **before** (`cf519a1d`) | 3, two of them **modify/modify** at the call sites | naive = **silently drops the flag**; correct = re-apply keyword + widen 5 stubs | naive: 418 pass, **2 seam guards red**; correct: 546 pass |
| **after** (`421631b3`) | 1, **add/add with an empty base** | **none — union only** | **564 pass, 0 fail** |

The union resolver *refuses* on any non-empty base, so "purely additive" is a checked property rather than a claim. Whoever merges second has nothing to re-apply.

## What ROUND 0 deleted

- **D1 — `--browser` and its `open_target` rung.** Unreachable in production: the only production caller is the Alacritty hint, whose `command` gets the matched text and nothing else, and whose regex cannot produce a token starting with `-`; the diff adds no new `[[hints.enabled]]` entry. Its sole caller was a human typing it in a shell, while its docstring called it "the operator's per-click escape hatch". The marker file already does this job and *is* reachable. It was also the sole cause of the #1569 conflict. The deletion is **pinned** (`test_open_url_takes_NO_argument_but_the_url` asserts both signatures and the parser help) because re-adding a keyword re-opens the cross-PR hazard. The picker-call-site seam guard survives as `test_main_routes_a_PICKED_github_row_through_the_review_TUI`.
- **D2 — the `home.packages` entry.** Its own comment conceded it was not what the click uses. The overlay already forces the build; it bought a hand-typed invocation nobody asked for at the cost of a known collision surface with imperative `nix profile` installs and a second wrapped-neovim closure.
- **D3 — `pkgs.git` from `runtimeInputs`.** octo reads a remote only for a buffer opened *without* an explicit repo, and `nvim-octo.sh` refuses that invocation (exit 64). It served a call shape that cannot happen. Verified gone from the built wrapper's PATH.

**Declined, with reasons** (D4/D5, marked marginal): the `discussion` mapping table *is* reachable from `Octo <N> <repo>` — `utils.open_buffer` dispatches on `__typename` and has a `Discussion` arm, so round 0's premise is wrong there; deleting `repo`/`release` would redden `test_every_other_mapping_table_the_flag_cleared_is_re_declared`, which pins table *names*; and `open_tui`'s `if not repo` arm is 3 lines guarding against spawning `nvim-octo "" ""` in a module-public function.

Net: 10 files, and the **total set of pre-existing lines this diff removes is 12**, six of which are one comment block being rewritten.

## The #1569 surface seam — found here, and now INTEGRATED

#1569 is merged, and this branch now carries the integration (`afb0d3d2`).

**The defect.** #1569's `open_reference` ended `return open_url(url), CLICK_SURFACE_BROWSER` — a measurement wrapper whose measurement is a literal, which is exactly what its own docstring warns against one level up. Correct while the browser was the only opener; wrong the moment this PR adds a second. Union-merged it made **every TUI click record `surface=browser`** with the whole suite green. Measured on the merged tree, before and after:

```
before   A  spawned=alacritty  reported='browser'   WRONG
         B  spawned=xdg-open   reported='browser'   open_target()='tui'
after    A  spawned=alacritty  reported='tui'       OK
         B  spawned=xdg-open   reported='browser'   open_target()='tui'
```

**The fix.** `open_tui` now returns `(rc, surface)` and every arm reports the surface that *actually ran*. `open_reference` propagates that tuple on the TUI arm and delegates to `open_url` on the browser arm. The surface is never re-derived from `open_target()` — row B is why: the routing decision says `tui` while `xdg-open` is what opened the link, so a derived value would be a claim rather than a measurement.

⚠ **`open_url` still routes, deliberately.** Making `open_reference` the sole dispatch broke 30 tests, the decisive one being #1569's *own* seam guard, which stubs `open_url` and asserts the browser arm delegates to it — bypassing it turns a real guard inert. Both route; the duplication is documented and paid for by `test_open_url_and_open_reference_ROUTE_THE_SAME_WAY`, a 6-row table driving both and asserting the spawn and the reported surface name the same opener.

**#1569's invariants kept, verified not asserted:** the exit code is still `open_url`'s and a failure names the surface it *tried*; a dismissal emits no `surface=` at all; both emit sites pass `surface=surface`, never a literal.

**Rebuilt against the real merge, not replayed.** The conflict was *seen* — git printed `Recorded preimage`, never "Resolved using previous resolution". `rr-cache` was checked preimage-only beforehand, and the commit used `rerere.enabled=false` so no resolution was recorded after.

**Mutation: 7/7 killed by a behavioural case**, twice, independently, on an uncontended tree; negative control `passed=454 failed=0`. A structural-only kill was scored as a failure. All four `open_tui` arms are covered and each is uniquely anchored — three share a byte-identical line, so a mutant anchored on it alone is refused and an arm can silently end up untested. ⚠ **S5 survived round 1**: the spawn-failure arm had no behavioural surface assertion and the suite stayed green at 453 while that arm reported the wrong surface.

## Merging with #1569 — the record of how this was found

Re-measured against #1569's newer head `6f6a0101`, which adds `open_reference` — a wrapper that returns `(rc, surface)` for click telemetry. **All four conflict hunks are add/add with an empty base, the union merge applies with no manual decision, and 486 tests pass — and the result is WRONG.** Measured on the merged tree:

```
A  spawned=alacritty  reported_surface='browser'   WRONG
B  spawned=xdg-open   reported_surface='browser'   open_target()='tui'
```

`open_reference` hardcodes `return open_url(url), CLICK_SURFACE_BROWSER`, so **every TUI click is recorded as a browser click** while the whole suite stays green. That is precisely the failure its own docstring predicts ("the literal version would keep reporting `browser` from a branch that no longer uses one, and every suite would stay green"), arriving through the merge rather than through an edit.

Good news: #1569 pre-wired the slot — `CLICK_SURFACE_TUI` exists and is in `CLICK_SURFACES`, and the docstring names `open_reference` as the single integration point for #1582.

⚠ **But it is not a one-liner.** Case B above is the trap: deriving the surface from `open_target()` would report `'tui'` while `xdg-open` actually opened it, because `open_tui`'s pre-flight falls back. #1569's rule is "the surface is MEASURED FROM THE OPENER THAT RAN, NOT ASSERTED AT THE CALL SITE" — so the integration must have `open_tui` report which surface it actually used. Whoever merges second should do that, not union-and-go.

This corrects my own earlier "union only, nothing to re-apply" claim, which was textually right and semantically incomplete — a clean `git merge` is not a clean merge.

## CI caught a real defect in this branch

`tekton/devrc-pytests` failed `test_every_mutation_anchor_occurs_exactly_once_in_its_target[mutation_battery_mentions.py]`, reproduced locally. **Mine, not inherited.** The repo-tracked battery's row **K53** anchors on the WHOLE `makeBinPath` line, so adding `pkgs.nvim-octo` took that anchor to **0 occurrences** — and an anchor at 0x does not fail loudly: the row reports `!! PATTERN OCCURS 0x — NOT APPLIED` and scores as a **SURVIVOR without testing anything**. Exactly the silent green `test_mutation_battery_anchors.py` exists to catch, and it caught it.

Re-anchored on the line as it now reads, with the mutation unchanged in kind (drop `pkgs.fzf`, keep the rest). Per that test's own instruction the **battery row** was fixed, never the test. Then verified it still *kills* rather than merely parses:

```
P1   control      KILLED              f=20  p=634   positive control — the battery can observe
K53  deletion     KILLED(attributed)  f=1   p=653   killed by test_the_alacritty_wrapper_PATH_covers_every_executa…
2/2 killed for the stated reason; problems: none        restore: OK
```

`tekton/devrc-nodetests` passed (1449 tests) and `tekton/devrc-cairn-client-runs` passed on the same head.

## Not verified — stated plainly

- That alacritty maps a window, that the review terminal is usable, that i3 floats it.
- That `Octo <N> <repo>` resolves the correct buffer kind against real GitHub — that needs a live GraphQL call.
- That the merge mappings are absent from a **live PR buffer**. The headless probe measured the merged *config*; only an open buffer proves the keymaps.
- That a broken `nvim-octo` is noticed in production — the pre-flight is tested, the deployed failure mode is not.
- **Nothing is deployed.** Verified `nvim-octo` is not on PATH and no marker file exists, so rung 2 yields the browser: **this merges inert** until `home-manager switch` / `ship.sh`, which is the operator's call.
- `test_runner_bound_ledger.py::test_every_site_writing_its_OWN_runner_bound_is_in_the_ledger` is **inherited red** from `622fc2d8` (#1536) on `main` — measured failing identically at this branch's base, in a file this diff never touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MK5m7J2Z3h698wMPczJH4
