### PR TITLE
chore(audit-pr): cut 36% of what every --round 0 brief inlines — it was editor-facing history billed to the auditor

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -134,6 +134,15 @@ deleted is the waste this exists to catch. Work them in order; do not skip ahead
    "report, do not act" while pointing at a gate that already acts. What survives is the ORDERING
    claim, which is the half that does work. Recorded so the pair is not re-derived as ceremony.
 
+✅ **TRIAL RECORD — CLOSED 2026-09-12 at `ran: 6 · changed the outcome: 3`. The section STAYS; do
+not re-open the question.** 🔴 **The finding was the ROUTING, not the pass** — every zero was a
+dispatch that arrived after the merge decision was already taken, so the fix was a TRIGGER
+(`audit-pr-nudge.py` routes round 0 at `gh pr create`), not an edit to this section. ⚠ **Keep
+reporting the pair on each PR** — not to re-decide this section, but because it is now the only
+signal for whether that trigger works; `C` alone cannot distinguish "it ran and was useless" from
+"nobody invoked it". Decomposition, the per-PR timings, the fourth corroborating instance and the
+trigger's first pre-decision catch: `reference/round-ladder-evidence.md`.
+
 🔴 **ROUND 0 REPORTS; IT DOES NOT MOVE THE LADDER.** Its verdict is one of `proceed to the
 checklist` / `requirement questioned — <which>` / `deletion candidate — <what>` / `close, do not
 audit`. It is **not** a finding for the findings-keyed stop rule, it cannot end a ladder, and it
@@ -142,47 +151,7 @@ cannot license skipping a round. Every stop rule below is unchanged by it.
 **Ledger:** `round 0 · requirements: N (unattributed: U) · deletion candidates: D`. Deleting
 nothing at all is reportable — say what you examined to get there.
 
-⚠ **There is deliberately NO add-back percentage here.** An earlier draft asked for `deleted: X ·
-re-added: Y (Y/X = Z%)` "from the same `--numstat` command the attribution gate already runs", and
-that was **false**: `--numstat` reports added and deleted counts per file and cannot tell you that
-an added line is one previously deleted, so `Y` is undefined by the instrument named. The 10%
-add-back heuristic needs a measurement nothing here performs — and the sentence that followed it
-("an add-back of 0% means the deletion pass was too timid") asserted a direction measured nowhere,
-which is the shape this skill tells you to delete rather than reverse. Recorded so nobody derives
-it again.
-
-✅ **TRIAL RECORD — CLOSED 2026-09-12 at `ran: 6 · changed the outcome: 3`. The section STAYS. Do
-not re-open the question; read what it found instead.** The retirement condition that stood here
-said *"if it ran and changed nothing, DELETE this section"*. It ran and it changed things, so the
-condition is spent and is recorded rather than left standing — a trial nobody can close is how a
-judgement call becomes permanent by attrition.
-
-Decomposition, because the PAIR is the record and `C` alone is meaningless: trials 1–2 → 2/2 ·
-trials 3–5 → **3/0** · a peer session's round 0 on `#1518` → 1/1 (it closed that PR unmerged).
-
-🔴 **THE FINDING WAS THE ROUTING, NOT THE SECTION — and every zero above says so.** All three of
-trials 3–5 produced a verdict and none could act, because each was dispatched after the decision
-was already taken: `#1523` merged **27 min BEFORE** its audit was dispatched, `#1510` merged **+6
-min after**, `#1518` was closed **5 min before** the report returned. Audit runtimes were
-459/920/776 s, so no speedup reaches any of them. **Round 0's question is only actionable while the
-merge decision is open**, so the fix was a trigger, not an edit to this section:
-`scripts/claude-hooks/audit-pr-nudge.py` now routes round 0 as step 1 of the nudge it fires on
-`gh pr create` (pinned by `scripts/claude-hooks/tests/test_audit_pr_nudge.py`). Full evidence:
-`claudedocs/handoff-audit-pr-ladder.md`.
-
-⚠ **CORROBORATED FROM OUTSIDE THE TRIAL, which is why the pair is not re-opened to count it.** A
-different session hit the same thing after this record closed: `#1568` merged **6 min** after it
-opened (`04:11:19Z` → `04:17:24Z`, re-derived here, not taken from its PR body), so its round-0
-audit landed **after** the merge and every candidate it found became a follow-up. That is a
-FOURTH independent instance of the post-decision dispatch, and it is evidence about the ROUTING,
-not a seventh trial — **do not fold it into `R`.** It is here because the thing most likely to
-happen next is someone re-deriving this finding from fresh trials instead of reading it.
-
-⚠ **Keep reporting `ran: R · changed the outcome: C` on each PR** — not to decide this section's
-fate, which is settled, but because it is the only record of whether the TRIGGER is working. A bare
-`C` cannot distinguish "it ran and was useless" from "nobody invoked it", and those have opposite
-conclusions; `--round` still defaults to 1, so a silent zero is more likely a routing failure than a
-verdict about the pass.
+## THE CHECKLIST — the nine axes (runs AFTER round 0)
 
 <!-- 🔴 LOAD-BEARING HEADING, NOT NAVIGATION. `_read_round_zero` in
      scripts/audit-dispatch.py captures the ROUND 0 section up to the next
@@ -191,8 +160,6 @@ verdict about the pass.
      correctness axes it exists to withhold — measured: 3,367 chars -> 4,057.
      Pinned by test_the_round_zero_section_the_script_reads_is_the_one_the_
      skill_ships. Reword it freely; keep it a `## `. -->
-
-## THE CHECKLIST — the nine axes (runs AFTER round 0)
 
 **Audit for:**
 1. **Risks** — what breaks in production.

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -588,3 +588,47 @@ committed in prose.
 
 **And the `| tail` trap, on the battery's own output.** 28 verdicts piped through `tail -8`; four
 were read as the whole run and the missing 24 as "did not run". Redirect to a file and read the file.
+
+## 2026-09-12 · the ROUND 0 trial — the full record, demoted from the skill body
+
+The skill carries the pair and the finding; this is the evidence behind them. Demoted because
+round 0 on the skill itself measured that **40% of every `--round 0` brief's inlined payload was
+editor-facing history** — a retraction addressed to a future editor of the file, a closed trial's
+decomposition, and a maintainer comment about a capture regex — none of which changes anything the
+auditor does, all of it billed per dispatch.
+
+**The pair: `ran: 6 · changed the outcome: 3`.** Decomposition, because `C` alone is meaningless:
+trials 1–2 → 2/2 · trials 3–5 → **3/0** · a peer session's round 0 on `#1518` → 1/1 (it closed that
+PR unmerged).
+
+**Every zero was a post-decision dispatch, and that is the whole finding.** All three of trials 3–5
+produced a verdict and none could act: `#1523` merged **27 min BEFORE** its audit was dispatched,
+`#1510` merged **+6 min after**, `#1518` was closed **5 min before** the report returned. Audit
+runtimes were 459 / 920 / 776 s, so no achievable speedup reaches any of them. Round 0's question —
+should this change EXIST — is actionable only while the merge decision is open, so the fix was a
+TRIGGER, not an edit to the section: `scripts/claude-hooks/audit-pr-nudge.py` routes round 0 as step
+1 of the nudge it fires on `gh pr create`, pinned by
+`scripts/claude-hooks/tests/test_audit_pr_nudge.py`.
+
+⚠ **A FOURTH independent instance, corroborating from outside the trial — and deliberately NOT
+folded into `R`.** A different session hit it after the record closed: `#1568` merged **6 min** after
+opening (`04:11:19Z` → `04:17:24Z`, re-derived rather than taken from its PR body), so its round-0
+audit landed after the merge and every candidate it found became a follow-up. It is evidence about
+the ROUTING, not a seventh trial. A record that grows every time someone hits the same thing is not
+a record.
+
+✅ **The trigger then worked on its first real test.** Round 0 fired at create time on `#1581`, ~16
+min after open with the PR still OPEN and CI pending, returned `deletion candidate`, and **three of
+that PR's seven appended bullets were cut as restatements** — the first pre-decision instance in the
+whole arc.
+
+## 2026-09-12 · why there is NO add-back percentage in the deletion pass
+
+An earlier draft of ROUND 0 asked for `deleted: X · re-added: Y (Y/X = Z%)` "from the same
+`--numstat` command the attribution gate already runs". That was **false**: `--numstat` reports added
+and deleted counts per file and cannot tell you that an added line is one previously deleted, so `Y`
+is undefined by the instrument named. The 10% add-back heuristic needs a measurement nothing in the
+skill performs — and the sentence that followed it ("an add-back of 0% means the deletion pass was
+too timid") asserted a direction measured nowhere, which is the shape the skill tells you to delete
+rather than reverse. Recorded here so nobody derives it again; it was cut from the body because it
+addresses a future EDITOR of the skill, not an auditor.


### PR DESCRIPTION
Rank 4 of `claudedocs/handoff-audit-pr-ladder.md`: **round 0 run on `audit-pr/SKILL.md` itself** — the file's own highest-scrutiny class, and nobody had ever questioned it.

## The measurement that made this actionable

`audit-dispatch.py` inlines only **two regions** of this 35 KB file. A reach table over **two real briefs** — with positive controls that moved (1/0 and 0/1) — found a `--round 0` brief inlines 8,216 chars, of which **40% was addressed to a future EDITOR of the skill, not to the auditor**: a retraction about an add-back percentage, a closed trial's decomposition and timings, and an HTML comment about a capture regex. Every `--round 0` dispatch shipped all three to someone auditing an unrelated PR.

The file grew **1.23×** since `d16bfd7a` while that one inlined region grew **2.42×** — accretion billed per invocation, with no ceiling and no eviction rule.

⚠ **And the largest piece was mine, written 90 minutes earlier.** The TRIAL RECORD I added when closing the round-0 trial was 2,507 chars — **30% of the inlined section**.

## Three changes

| block | action | test cost |
|---|---|---|
| add-back retraction (695 ch) | → `reference/round-ladder-evidence.md` | none (pinned by nothing, verified) |
| TRIAL RECORD (2,507 → 744 ch) | compressed to what the pin requires | none — bounded by the existing asserts |
| maintainer comment (506 ch) | **relocated**, not deleted | none |

The compression is bounded, not chosen: `test_the_round_zero_section_the_script_reads_is_the_one_the_skill_ships` asserts `ran: 6`, `changed the outcome: 3` and `ROUTING` are **inside the captured section**, so the record keeps exactly what an auditor acts on and the evidence moves to the reference file. The comment documents why `## THE CHECKLIST` is load-bearing, so it now sits under that heading — and since `_read_checklist` anchors on `**Audit for:**`, it is in **neither** capture while still guarding what it describes.

## Measured effect, not asserted

- round-0 brief **19,074 → 16,664 B** (−12.6%)
- inlined section **8,216 → 5,252 chars (−36%)**
- the three editor-facing blocks probe **0** in both briefs
- the pin's three requirements still probe **1** in the round-0 brief
- `**Audit for:**` still probes **1** in a round-1 brief — the control
- `test_audit_dispatch.py` + `test_audit_ladder_stop_rule.py` → **151 passed**

⚠ This skill has **no enforced byte ceiling** (the `MIN_HEADROOM|st_size <=` union names `browser`, `prune-skill`, `session-manager`, `handoff`, `RULES.md`, `clawgate` — not `audit-pr`), so the case rests on per-dispatch cost to the auditor, not on a ratchet. I checked rather than implying a limit.

## What I did NOT do, filed rather than dropped

Round 0's other 🔴: three *"brief the auditor on X"* requirements in `## What to do` instruct the **dispatcher** to retype content into the Agent prompt, and they probe **absent from both real briefs (0/0)** — the exact class `audit-dispatch.py` exists to eliminate, whose own docstring measures hand-retyped clauses at 5/14–11/14 of dispatches. Worse, `SKILL_ENVIRONMENT_BRIEF` is **pinned**, so a green suite certifies the sentence exists and never that any auditor was briefed. Fixing it means migrating the clauses **into** the assembler plus its two-way clause ledger — a real change, ranked next rather than bundled here.

🔴 For the record: I am the dispatcher who retyped those clauses by hand into every subagent this session. The requirement was met by my diligence, which is precisely why it should not depend on it.